### PR TITLE
fix(completion): complete tasks after options in `pixi run`

### DIFF
--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -64,7 +64,7 @@ pub fn execute(args: Args) -> miette::Result<()> {
 
     // For supported shells, modify the script to include more context sensitive completions.
     let script = match args.shell {
-        Shell::Bash => replace_bash_completion(&script),
+        Shell::Bash => replace_bash_completion(&script, pixi_utils::executable_name()),
         Shell::Zsh => replace_zsh_completion(&script),
         Shell::Fish => replace_fish_completion(&script),
         Shell::Nushell => replace_nushell_completion(&script),
@@ -88,31 +88,32 @@ fn get_completion_script(shell: Shell) -> String {
 }
 
 /// Replace the parts of the bash completion script that need different functionality.
-fn replace_bash_completion(script: &str) -> Cow<'_, str> {
+fn replace_bash_completion<'a>(script: &'a str, bin_name: &str) -> Cow<'a, str> {
     // Adds tab completion to the pixi run command.
     // NOTE THIS IS FORMATTED BY HAND
     // Replace the '-' with '__' since that's what clap's generator does as well for Bash Shell completion.
-    let bin_name: &str = pixi_utils::executable_name();
     let clap_name = bin_name.replace("-", "__");
     // clap_complete >=4.6.2 separates each segment of the bin name from each
     // subcommand with an explicit `__subcmd__` marker, so the function for the
     // `run` subcommand of `pixi` is `pixi__subcmd__run`.
     let func_prefix = clap_name.replace("__", "__subcmd__");
+    // Keep the generated `case "${prev}"` block (option-value completion) and
+    // run task completion after it, so tasks complete at any position.
     let pattern = format!(
-        r#"(?s){}__subcmd__run\).*?opts="(.*?)".*?(if.*?fi)"#,
+        r#"(?s){}__subcmd__run\).*?opts="(.*?)".*?if.*?fi\s*(case.*?esac)"#,
         func_prefix
     );
     let replacement = r#"FUNC_PREFIX__subcmd__run)
             opts="$1"
             if [[ $${cur} == -* ]] ; then
-               COMPREPLY=( $$(compgen -W "$${opts}" -- "$${cur}") )
-               return 0
-            elif [[ $${COMP_CWORD} -eq 2 ]]; then
-               local tasks=$$(BIN_NAME task list --machine-readable 2> /dev/null)
-               if [[ $$? -eq 0 ]]; then
-                   COMPREPLY=( $$(compgen -W "$${tasks}" -- "$${cur}") )
-                   return 0
-               fi
+                COMPREPLY=( $$(compgen -W "$${opts}" -- "$${cur}") )
+                return 0
+            fi
+            $2
+            local tasks
+            if tasks=$$(BIN_NAME task list --machine-readable 2> /dev/null) && [[ -n "$${tasks}" ]]; then
+                COMPREPLY=( $$(compgen -W "$${tasks}" -- "$${cur}") )
+                return 0
             fi"#;
     let re = Regex::new(pattern.as_str()).expect("should be able to compile the regex");
     re.replace(
@@ -334,27 +335,29 @@ _arguments "${_arguments_options[@]}" \
 
     #[test]
     pub(crate) fn test_bash_completion() {
-        // NOTE THIS IS FORMATTED BY HAND!
+        // Trimmed excerpt of what clap_complete >=4.6.2 generates for `pixi`.
         let script = r#"
-        pixi__project__help__help)
+        pixi__subcmd__project__subcmd__help__subcmd__help)
             opts=""
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        pixi__run)
-            opts="-v -q -h --manifest-path --locked --frozen --verbose --quiet --color --help [TASK]..."
-            if [[ ${cur} == -* ]] ; then
+        pixi__subcmd__run)
+            opts="-e -v -q -h --manifest-path --locked --frozen --environment --verbose --quiet --color --help [TASK]..."
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
-            elif [[ ${COMP_CWORD} -eq 2 ]]; then
-               local tasks=$(pixi task list --machine-readable 2> /dev/null)
-               if [[ $? -eq 0 ]]; then
-                   COMPREPLY=( $(compgen -W "${tasks}" -- "${cur}") )
-                   return 0
-               fi
             fi
             case "${prev}" in
                 --manifest-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --environment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -e)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -369,27 +372,28 @@ _arguments "${_arguments_options[@]}" \
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        pixi__search)
+        pixi__subcmd__search)
             opts="-c -l -v -q -h --channel --color --help <PACKAGE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
             fi
             case "${prev}" in
                 --channel)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
             esac
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-
+            return 0
             ;;
         "#;
-        let result = replace_bash_completion(script);
-        let replacement = format!("{} task list", pixi_utils::executable_name());
-        let zsh_arg_name = format!("{}__", pixi_utils::executable_name().replace("-", "__"));
-        println!("{result}");
-        insta::with_settings!({filters => vec![
-            (replacement.as_str(), "pixi task list"),
-            (zsh_arg_name.as_str(), "[PIXI COMMAND]"),
-        ]}, {
-            insta::assert_snapshot!(result);
-        });
+        let result = replace_bash_completion(script, "pixi");
+        assert_ne!(result, script);
+        insta::assert_snapshot!(result);
     }
 
     #[test]
@@ -436,7 +440,10 @@ _arguments "${_arguments_options[@]}" \
         // Generate the original completion script.
         let script = get_completion_script(Shell::Bash);
         // Test if there was a replacement done on the clap generated completions
-        assert_ne!(replace_bash_completion(&script), script);
+        assert_ne!(
+            replace_bash_completion(&script, pixi_utils::executable_name()),
+            script
+        );
     }
 
     #[test]

--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -100,54 +100,103 @@ fn replace_bash_completion<'a>(script: &'a str, bin_name: &str) -> Cow<'a, str> 
     // Keep the generated `case "${prev}"` block (option-value completion) and
     // run task completion after it, so tasks complete at any position.
     let pattern = format!(
-        r#"(?s){}__subcmd__run\).*?opts="(.*?)".*?if.*?fi\s*(case.*?esac)"#,
+        r#"(?s){}__subcmd__run\).*?opts="(?P<opts>.*?)".*?if.*?fi\s*(?P<case>case.*?esac)"#,
         func_prefix
     );
-    let replacement = r#"FUNC_PREFIX__subcmd__run)
-            opts="$1"
-            if [[ $${cur} == -* ]] ; then
-                COMPREPLY=( $$(compgen -W "$${opts}" -- "$${cur}") )
+    let re = Regex::new(pattern.as_str()).expect("should be able to compile the regex");
+    re.replace(script, |caps: &Captures| {
+        let opts = &caps["opts"];
+        // Complete environment names after `-e`/`--environment` instead of files.
+        let case = complete_bash_environment(&caps["case"], bin_name);
+        format!(
+            r#"{func_prefix}__subcmd__run)
+            opts="{opts}"
+            if [[ ${{cur}} == -* ]] ; then
+                COMPREPLY=( $(compgen -W "${{opts}}" -- "${{cur}}") )
                 return 0
             fi
-            $2
+            {case}
             local tasks
-            if tasks=$$(BIN_NAME task list --machine-readable 2> /dev/null) && [[ -n "$${tasks}" ]]; then
-                COMPREPLY=( $$(compgen -W "$${tasks}" -- "$${cur}") )
+            if tasks=$({bin_name} task list --machine-readable 2> /dev/null) && [[ -n "${{tasks}}" ]]; then
+                COMPREPLY=( $(compgen -W "${{tasks}}" -- "${{cur}}") )
                 return 0
-            fi"#;
-    let re = Regex::new(pattern.as_str()).expect("should be able to compile the regex");
-    re.replace(
-        script,
-        replacement
-            .replace("BIN_NAME", bin_name)
-            .replace("FUNC_PREFIX", &func_prefix),
+            fi"#
+        )
+    })
+}
+
+/// Complete workspace environment names for the `-e`/`--environment` option
+/// value in the bash `case "${prev}"` block, replacing the default file
+/// completion.
+fn complete_bash_environment(case_block: &str, bin_name: &str) -> String {
+    let re = Regex::new(
+        r#"(?m)^(?P<indent>\s*)(?P<label>--environment|-e)\)\n\s*COMPREPLY=\(\$\(compgen -f "\$\{cur\}"\)\)"#,
     )
+    .expect("should be able to compile the regex");
+    re.replace_all(case_block, |caps: &Captures| {
+        let indent = &caps["indent"];
+        let label = &caps["label"];
+        format!(
+            r#"{indent}{label})
+{indent}    local environments
+{indent}    if environments=$({bin_name} workspace environment list --machine-readable 2> /dev/null) && [[ -n "${{environments}}" ]]; then
+{indent}        COMPREPLY=( $(compgen -W "${{environments}}" -- "${{cur}}") )
+{indent}    else
+{indent}        COMPREPLY=($(compgen -f "${{cur}}"))
+{indent}    fi"#
+        )
+    })
+    .into_owned()
 }
 
 /// Replace the parts of the zsh completion script that need different functionality.
 fn replace_zsh_completion(script: &str) -> Cow<'_, str> {
     // Adds tab completion to the pixi run command.
     // NOTE THIS IS FORMATTED BY HAND
-    let pattern = r"(?ms)(\(run\))(?:.*?)(_arguments.*?)(\*::task)";
+    let pattern = r"(?ms)(?P<run>\(run\))(?:.*?)(?P<args>_arguments.*?)(\*::task)";
     let bin_name: &str = pixi_utils::executable_name();
-    let replacement = r#"$1
+    let re = Regex::new(pattern).expect("should be able to compile the regex");
+    re.replace(script, |caps: &Captures| {
+        let run = &caps["run"];
+        // Complete environment names after `-e`/`--environment` instead of files.
+        let args = caps["args"].replace(
+            ":ENVIRONMENT:_default",
+            &format!(
+                ":ENVIRONMENT:($({bin_name} workspace environment list --machine-readable 2> /dev/null))"
+            ),
+        );
+        format!(
+            r#"{run}
 local tasks
-tasks=("$${(@s/ /)$$(BIN_NAME task list --machine-readable 2> /dev/null)}")
+tasks=("${{(@s/ /)$({bin_name} task list --machine-readable 2> /dev/null)}}")
 
-if [[ -n "$$tasks" ]]; then
-    _values 'task' "$${tasks[@]}"
+if [[ -n "$tasks" ]]; then
+    _values 'task' "${{tasks[@]}}"
 else
     return 1
 fi
-$2::task"#;
-
-    let re = Regex::new(pattern).expect("should be able to compile the regex");
-    re.replace(script, replacement.replace("BIN_NAME", bin_name))
+{args}::task"#
+        )
+    })
 }
 
 fn replace_fish_completion(script: &str) -> Cow<'_, str> {
     // Adds tab completion to the pixi run command.
     let bin_name = pixi_utils::executable_name();
+
+    // Complete environment names for the `-e`/`--environment` option of `run`
+    // (and its `r` alias), which clap otherwise completes as file paths.
+    let env_pattern = format!(
+        r#"(?m)^(complete -c {bin_name} -n "__fish_pixi_using_subcommand r(?:un)?" -s e -l environment [^\n]*? -r)$"#
+    );
+    let env_re = Regex::new(&env_pattern).expect("should be able to compile the regex");
+    let script = env_re.replace_all(
+        script,
+        format!(
+            r#"$1 -f -a "(string split ' ' ({bin_name} workspace environment list --machine-readable 2> /dev/null))""#
+        ),
+    );
+
     let addition = format!(
         "complete -c {bin_name} -n \"__fish_seen_subcommand_from run\" -f -a \"(string split ' ' ({bin_name} task list --machine-readable  2> /dev/null))\""
     );

--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -7,6 +7,13 @@ use regex::{Captures, Regex};
 use std::borrow::Cow;
 use std::io::Write;
 
+/// `pixi` subcommand emitting the space-delimited workspace environment names
+/// used for `run` option-value completion in bash, zsh, and fish.
+const ENVIRONMENT_LIST: &str = "workspace environment list --machine-readable";
+/// `pixi` subcommand emitting the space-delimited workspace platform names
+/// used for `run` option-value completion in bash, zsh, and fish.
+const PLATFORM_LIST: &str = "workspace platform list --machine-readable";
+
 /// Generates a completion script for a shell.
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -106,8 +113,26 @@ fn replace_bash_completion<'a>(script: &'a str, bin_name: &str) -> Cow<'a, str> 
     let re = Regex::new(pattern.as_str()).expect("should be able to compile the regex");
     re.replace(script, |caps: &Captures| {
         let opts = &caps["opts"];
-        // Complete environment names after `-e`/`--environment` instead of files.
-        let case = complete_bash_environment(&caps["case"], bin_name);
+        // Complete environment and platform names after their options instead
+        // of files.
+        let case = complete_bash_option(
+            &caps["case"],
+            bin_name,
+            &BashOptionCompletion {
+                labels: "--environment|-e",
+                var: "environments",
+                command: ENVIRONMENT_LIST,
+            },
+        );
+        let case = complete_bash_option(
+            &case,
+            bin_name,
+            &BashOptionCompletion {
+                labels: "--platform|-p",
+                var: "platforms",
+                command: PLATFORM_LIST,
+            },
+        );
         format!(
             r#"{func_prefix}__subcmd__run)
             opts="{opts}"
@@ -125,22 +150,35 @@ fn replace_bash_completion<'a>(script: &'a str, bin_name: &str) -> Cow<'a, str> 
     })
 }
 
-/// Complete workspace environment names for the `-e`/`--environment` option
-/// value in the bash `case "${prev}"` block, replacing the default file
-/// completion.
-fn complete_bash_environment(case_block: &str, bin_name: &str) -> String {
-    let re = Regex::new(
-        r#"(?m)^(?P<indent>\s*)(?P<label>--environment|-e)\)\n\s*COMPREPLY=\(\$\(compgen -f "\$\{cur\}"\)\)"#,
-    )
-    .expect("should be able to compile the regex");
+/// A `run` option whose value bash should complete from the space-delimited
+/// output of a `pixi` subcommand instead of file paths.
+struct BashOptionCompletion<'a> {
+    /// Regex alternation matching the option's `case` labels, e.g.
+    /// `--environment|-e`.
+    labels: &'a str,
+    /// Shell variable holding the candidate list.
+    var: &'a str,
+    /// `pixi` subcommand emitting the candidates.
+    command: &'a str,
+}
+
+/// Complete an option's value in the bash `case "${prev}"` block from a `pixi`
+/// subcommand's output, falling back to file completion when it yields nothing.
+fn complete_bash_option(case_block: &str, bin_name: &str, opt: &BashOptionCompletion) -> String {
+    let pattern = format!(
+        r#"(?m)^(?P<indent>\s*)(?P<label>{})\)\n\s*COMPREPLY=\(\$\(compgen -f "\$\{{cur\}}"\)\)"#,
+        opt.labels
+    );
+    let re = Regex::new(&pattern).expect("should be able to compile the regex");
+    let (var, command) = (opt.var, opt.command);
     re.replace_all(case_block, |caps: &Captures| {
         let indent = &caps["indent"];
         let label = &caps["label"];
         format!(
             r#"{indent}{label})
-{indent}    local environments
-{indent}    if environments=$({bin_name} workspace environment list --machine-readable 2> /dev/null) && [[ -n "${{environments}}" ]]; then
-{indent}        COMPREPLY=( $(compgen -W "${{environments}}" -- "${{cur}}") )
+{indent}    local {var}
+{indent}    if {var}=$({bin_name} {command} 2> /dev/null) && [[ -n "${{{var}}}" ]]; then
+{indent}        COMPREPLY=( $(compgen -W "${{{var}}}" -- "${{cur}}") )
 {indent}    else
 {indent}        COMPREPLY=($(compgen -f "${{cur}}"))
 {indent}    fi"#
@@ -158,13 +196,17 @@ fn replace_zsh_completion(script: &str) -> Cow<'_, str> {
     let re = Regex::new(pattern).expect("should be able to compile the regex");
     re.replace(script, |caps: &Captures| {
         let run = &caps["run"];
-        // Complete environment names after `-e`/`--environment` instead of files.
-        let args = caps["args"].replace(
-            ":ENVIRONMENT:_default",
-            &format!(
-                ":ENVIRONMENT:($({bin_name} workspace environment list --machine-readable 2> /dev/null))"
-            ),
-        );
+        // Complete environment and platform names after their options instead
+        // of files.
+        let args = caps["args"]
+            .replace(
+                ":ENVIRONMENT:_default",
+                &format!(":ENVIRONMENT:($({bin_name} {ENVIRONMENT_LIST} 2> /dev/null))"),
+            )
+            .replace(
+                ":PLATFORM:_default",
+                &format!(":PLATFORM:($({bin_name} {PLATFORM_LIST} 2> /dev/null))"),
+            );
         format!(
             r#"{run}
 local tasks
@@ -184,18 +226,11 @@ fn replace_fish_completion(script: &str) -> Cow<'_, str> {
     // Adds tab completion to the pixi run command.
     let bin_name = pixi_utils::executable_name();
 
-    // Complete environment names for the `-e`/`--environment` option of `run`
-    // (and its `r` alias), which clap otherwise completes as file paths.
-    let env_pattern = format!(
-        r#"(?m)^(complete -c {bin_name} -n "__fish_pixi_using_subcommand r(?:un)?" -s e -l environment [^\n]*? -r)$"#
-    );
-    let env_re = Regex::new(&env_pattern).expect("should be able to compile the regex");
-    let script = env_re.replace_all(
-        script,
-        format!(
-            r#"$1 -f -a "(string split ' ' ({bin_name} workspace environment list --machine-readable 2> /dev/null))""#
-        ),
-    );
+    // Complete environment and platform names for the corresponding options of
+    // `run` (and its `r` alias), which clap otherwise completes as file paths.
+    let script =
+        fish_complete_run_option(script, bin_name, "-s e -l environment", ENVIRONMENT_LIST);
+    let script = fish_complete_run_option(&script, bin_name, "-s p -l platform", PLATFORM_LIST);
 
     let addition = format!(
         "complete -c {bin_name} -n \"__fish_seen_subcommand_from run\" -f -a \"(string split ' ' ({bin_name} task list --machine-readable  2> /dev/null))\""
@@ -206,6 +241,21 @@ fn replace_fish_completion(script: &str) -> Cow<'_, str> {
     let re = Regex::new(pattern).expect("should be able to compile the regex");
     let result = re.replace_all(&new_script, replacement);
     Cow::Owned(result.into_owned())
+}
+
+/// Complete a `run` option's value from a `pixi` subcommand's output by
+/// appending `-f -a "..."` to the clap-generated `complete` line matched by
+/// `flags` (e.g. `-s e -l environment`) for both `run` and its `r` alias.
+fn fish_complete_run_option(script: &str, bin_name: &str, flags: &str, command: &str) -> String {
+    let pattern = format!(
+        r#"(?m)^(complete -c {bin_name} -n "__fish_pixi_using_subcommand r(?:un)?" {flags} [^\n]*? -r)$"#
+    );
+    let re = Regex::new(&pattern).expect("should be able to compile the regex");
+    re.replace_all(
+        script,
+        format!(r#"$1 -f -a "(string split ' ' ({bin_name} {command} 2> /dev/null))""#).as_str(),
+    )
+    .into_owned()
 }
 
 /// Replace the parts of the nushell completion script that need different functionality.
@@ -300,6 +350,10 @@ fn replace_nushell_completion(script: &str) -> Cow<'_, str> {
       ^{bin_name} info --json | from json | get environments_info | get name
     }}
 
+    def "nu-complete {bin_name} run platform" [] {{
+      ^{bin_name} info --json | from json | get environments_info | get platforms | flatten | get name | uniq
+    }}
+
     def "nu-complete {bin_name} run" [] {{
       ^{bin_name} info --json | from json | get environments_info | get tasks | flatten | uniq
     }}
@@ -318,6 +372,12 @@ fn replace_nushell_completion(script: &str) -> Cow<'_, str> {
         } else {
             Some(format!(r#"@"nu-complete {bin_name} run environment""#))
         }
+    });
+
+    // Add completion for `pixi run`'s `--platform(-p)` flag.
+    let script = append_after_type(&script, "--platform(-p)", |cmd, _ty, _extra| {
+        let cmd = cmd.strip_prefix(bin_name)?.trim_start();
+        (cmd == "run").then(|| format!(r#"@"nu-complete {bin_name} run platform""#))
     });
 
     // Add completion for the `...task: string` argument in pixi run.
@@ -347,6 +407,10 @@ _arguments "${_arguments_options[@]}" \
 (run)
 _arguments "${_arguments_options[@]}" \
 '--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
+'-e+[The environment to run the task in]:ENVIRONMENT:_default' \
+'--environment=[The environment to run the task in]:ENVIRONMENT:_default' \
+'-p+[Install and run in the environment for the given platform]:PLATFORM:_default' \
+'--platform=[Install and run in the environment for the given platform]:PLATFORM:_default' \
 '--color=[Whether the log needs to be colored]:COLOR:(always never auto)' \
 '(--frozen)--locked[Require pixi.lock is up-to-date]' \
 '(--locked)--frozen[Don'\''t check if pixi.lock is up-to-date, install as lock file states]' \
@@ -374,9 +438,10 @@ _arguments "${_arguments_options[@]}" \
 
         "#;
         let result = replace_zsh_completion(script);
-        let replacement = format!("{} task list", pixi_utils::executable_name());
+        // Normalize the test binary name (e.g. `pixi_cli-<hash>`) to `pixi` so
+        // the snapshot is stable across builds.
         insta::with_settings!({filters => vec![
-            (replacement.as_str(), "pixi task list"),
+            (pixi_utils::executable_name(), "pixi"),
         ]}, {
             insta::assert_snapshot!(result);
         });
@@ -392,7 +457,7 @@ _arguments "${_arguments_options[@]}" \
             return 0
             ;;
         pixi__subcmd__run)
-            opts="-e -v -q -h --manifest-path --locked --frozen --environment --verbose --quiet --color --help [TASK]..."
+            opts="-e -p -v -q -h --manifest-path --locked --frozen --environment --platform --verbose --quiet --color --help [TASK]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -407,6 +472,14 @@ _arguments "${_arguments_options[@]}" \
                     return 0
                     ;;
                 -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --platform)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -p)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
@@ -8,7 +8,7 @@ expression: result
             return 0
             ;;
         pixi__subcmd__run)
-            opts="-e -v -q -h --manifest-path --locked --frozen --environment --verbose --quiet --color --help [TASK]..."
+            opts="-e -p -v -q -h --manifest-path --locked --frozen --environment --platform --verbose --quiet --color --help [TASK]..."
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -31,6 +31,24 @@ expression: result
                     local environments
                     if environments=$(pixi workspace environment list --machine-readable 2> /dev/null) && [[ -n "${environments}" ]]; then
                         COMPREPLY=( $(compgen -W "${environments}" -- "${cur}") )
+                    else
+                        COMPREPLY=($(compgen -f "${cur}"))
+                    fi
+                    return 0
+                    ;;
+                --platform)
+                    local platforms
+                    if platforms=$(pixi workspace platform list --machine-readable 2> /dev/null) && [[ -n "${platforms}" ]]; then
+                        COMPREPLY=( $(compgen -W "${platforms}" -- "${cur}") )
+                    else
+                        COMPREPLY=($(compgen -f "${cur}"))
+                    fi
+                    return 0
+                    ;;
+                -p)
+                    local platforms
+                    if platforms=$(pixi workspace platform list --machine-readable 2> /dev/null) && [[ -n "${platforms}" ]]; then
+                        COMPREPLY=( $(compgen -W "${platforms}" -- "${cur}") )
                     else
                         COMPREPLY=($(compgen -f "${cur}"))
                     fi

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
@@ -19,11 +19,21 @@ expression: result
                     return 0
                     ;;
                 --environment)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    local environments
+                    if environments=$(pixi workspace environment list --machine-readable 2> /dev/null) && [[ -n "${environments}" ]]; then
+                        COMPREPLY=( $(compgen -W "${environments}" -- "${cur}") )
+                    else
+                        COMPREPLY=($(compgen -f "${cur}"))
+                    fi
                     return 0
                     ;;
                 -e)
-                    COMPREPLY=($(compgen -f "${cur}"))
+                    local environments
+                    if environments=$(pixi workspace environment list --machine-readable 2> /dev/null) && [[ -n "${environments}" ]]; then
+                        COMPREPLY=( $(compgen -W "${environments}" -- "${cur}") )
+                    else
+                        COMPREPLY=($(compgen -f "${cur}"))
+                    fi
                     return 0
                     ;;
                 --color)

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
@@ -1,26 +1,28 @@
 ---
-source: src/cli/completion.rs
+source: crates/pixi_cli/src/completion.rs
 expression: result
 ---
-        pixi__project__help__help)
+        pixi__subcmd__project__subcmd__help__subcmd__help)
             opts=""
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        pixi__run)
-            opts="-v -q -h --manifest-path --locked --frozen --verbose --quiet --color --help [TASK]..."
+        pixi__subcmd__run)
+            opts="-e -v -q -h --manifest-path --locked --frozen --environment --verbose --quiet --color --help [TASK]..."
             if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
-            elif [[ ${COMP_CWORD} -eq 2 ]]; then
-               local tasks=$(pixi task list --machine-readable 2> /dev/null)
-               if [[ $? -eq 0 ]]; then
-                   COMPREPLY=( $(compgen -W "${tasks}" -- "${cur}") )
-                   return 0
-               fi
             fi
             case "${prev}" in
                 --manifest-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --environment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -e)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -32,16 +34,29 @@ expression: result
                     COMPREPLY=()
                     ;;
             esac
+            local tasks
+            if tasks=$(pixi task list --machine-readable 2> /dev/null) && [[ -n "${tasks}" ]]; then
+                COMPREPLY=( $(compgen -W "${tasks}" -- "${cur}") )
+                return 0
+            fi
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        pixi__search)
+        pixi__subcmd__search)
             opts="-c -l -v -q -h --channel --color --help <PACKAGE>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
             fi
             case "${prev}" in
                 --channel)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
             esac
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-
+            return 0
             ;;

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__zsh_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__zsh_completion.snap
@@ -20,6 +20,10 @@ else
 fi
 _arguments "${_arguments_options[@]}" \
 '--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
+'-e+[The environment to run the task in]:ENVIRONMENT:($(pixi workspace environment list --machine-readable 2> /dev/null))' \
+'--environment=[The environment to run the task in]:ENVIRONMENT:($(pixi workspace environment list --machine-readable 2> /dev/null))' \
+'-p+[Install and run in the environment for the given platform]:PLATFORM:($(pixi workspace platform list --machine-readable 2> /dev/null))' \
+'--platform=[Install and run in the environment for the given platform]:PLATFORM:($(pixi workspace platform list --machine-readable 2> /dev/null))' \
 '--color=[Whether the log needs to be colored]:COLOR:(always never auto)' \
 '(--frozen)--locked[Require pixi.lock is up-to-date]' \
 '(--locked)--frozen[Don'\''t check if pixi.lock is up-to-date, install as lock file states]' \

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -396,6 +396,7 @@ async fn list_tasks(
             .values()
             .flat_map(|(_, tasks)| tasks.keys())
             .sorted()
+            .dedup()
             .map(|name| name.as_str())
             .join(" ");
         writeln!(std::io::stdout(), "{unformatted}")

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -54,6 +54,14 @@ pub struct RemoveArgs {
     pub name: String,
 }
 
+#[derive(Parser, Debug, Default)]
+pub struct ListArgs {
+    /// Output the environment names in machine readable format (space
+    /// delimited). This output is used for autocomplete.
+    #[arg(long, hide(true))]
+    pub machine_readable: bool,
+}
+
 #[derive(Parser, Debug)]
 pub enum Command {
     /// Adds an environment to the manifest file.
@@ -61,7 +69,7 @@ pub enum Command {
     Add(AddArgs),
     /// List the environments in the manifest file.
     #[clap(visible_alias = "ls")]
-    List,
+    List(ListArgs),
     /// Remove an environment from the manifest file.
     #[clap(visible_alias = "rm")]
     Remove(RemoveArgs),
@@ -76,8 +84,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
 
     match args.command {
-        Command::List => {
+        Command::List(list_args) => {
             let envs = workspace_ctx.list_environments().await;
+            if list_args.machine_readable {
+                let names = envs.iter().map(|e| e.name().as_str()).join(" ");
+                writeln!(std::io::stdout(), "{names}")
+                    .inspect_err(|e| {
+                        if e.kind() == std::io::ErrorKind::BrokenPipe {
+                            std::process::exit(0);
+                        }
+                    })
+                    .into_diagnostic()?;
+                return Ok(());
+            }
             writeln!(
                 std::io::stdout(),
                 "Environments:\n{}",

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -414,6 +414,11 @@ pub struct ListArgs {
     /// Emit machine-readable JSON instead of the human view.
     #[clap(long)]
     pub json: bool,
+
+    /// Output the workspace platform names in machine readable format (space
+    /// delimited). This output is used for autocomplete.
+    #[arg(long, hide(true), conflicts_with = "json")]
+    pub machine_readable: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -679,6 +684,22 @@ async fn execute_list(
         .iter()
         .cloned()
         .collect();
+
+    if args.machine_readable {
+        let names = workspace_platforms
+            .iter()
+            .map(|p| p.name().as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        writeln!(std::io::stdout(), "{names}")
+            .inspect_err(|e| {
+                if e.kind() == std::io::ErrorKind::BrokenPipe {
+                    std::process::exit(0);
+                }
+            })
+            .into_diagnostic()?;
+        return Ok(());
+    }
 
     if args.json {
         let mut platforms: Vec<serde_json::Value> =

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1,5 +1,7 @@
 import json
+import os
 import platform
+import shlex
 import shutil
 import sys
 import tomllib
@@ -867,6 +869,55 @@ def test_shell_hook_autocompletion(pixi: Path, tmp_pixi_workspace: Path) -> None
             [pixi, "shell-hook", "--manifest-path", manifest, "--shell", "fish"],
             stdout_contains=["for file in", "source", "share/fish/vendor_completions.d"],
         )
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="requires bash")
+def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    manifest = tmp_pixi_workspace.joinpath("pixi.toml")
+    toml = f"""
+        {EMPTY_BOILERPLATE_PROJECT}
+        [tasks]
+        hello = "echo hello"
+        build = "echo build"
+
+        [feature.test.tasks]
+        run-tests = "echo testing"
+
+        [environments]
+        test = ["test"]
+        """
+    manifest.write_text(toml)
+
+    def complete(command_line: list[str]) -> list[str]:
+        """Simulate pressing <TAB> in bash with the given words on the command line."""
+        words = " ".join(shlex.quote(word) for word in command_line)
+        harness = "\n".join(
+            [
+                f'eval "$({shlex.quote(str(pixi))} completion --shell bash)"',
+                f"COMP_WORDS=({words})",
+                "COMP_CWORD=$((${#COMP_WORDS[@]} - 1))",
+                "COMPREPLY=()",
+                '_pixi pixi "${COMP_WORDS[COMP_CWORD]}" "${COMP_WORDS[COMP_CWORD - 1]}"',
+                'echo "${COMPREPLY[@]:-}"',
+            ]
+        )
+        # The completion script invokes a bare `pixi task list`, so the binary
+        # under test must be first on PATH.
+        output = verify_cli_command(
+            ["bash", "-c", harness],
+            env={"PATH": f"{pixi.parent.resolve()}{os.pathsep}{os.environ['PATH']}"},
+            cwd=tmp_pixi_workspace,
+        )
+        return sorted(output.stdout.split())
+
+    all_tasks = ["build", "hello", "run-tests"]
+    assert complete(["pixi", "run", ""]) == all_tasks
+    # Tasks must also complete after flags (https://github.com/prefix-dev/pixi/issues/6494).
+    assert complete(["pixi", "run", "-e", "test", ""]) == all_tasks
+    assert complete(["pixi", "run", "--frozen", ""]) == all_tasks
+    assert complete(["pixi", "run", "-e", "test", "he"]) == ["hello"]
+    # Flags still complete.
+    assert complete(["pixi", "run", "--froz"]) == ["--frozen"]
 
 
 def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -874,8 +874,14 @@ def test_shell_hook_autocompletion(pixi: Path, tmp_pixi_workspace: Path) -> None
 @pytest.mark.skipif(platform.system() == "Windows", reason="requires bash")
 def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
-    toml = f"""
-        {EMPTY_BOILERPLATE_PROJECT}
+    # An explicit multi-platform list (always including the current platform)
+    # keeps the platform-completion assertions deterministic across machines.
+    toml = """
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+
         [tasks]
         hello = "echo hello"
         build = "echo build"
@@ -925,6 +931,12 @@ def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
     assert complete(["pixi", "run", "-e", ""]) == all_environments
     assert complete(["pixi", "run", "--environment", ""]) == all_environments
     assert complete(["pixi", "run", "-e", "te"]) == ["test"]
+
+    # `-p`/`--platform` complete platform names instead of file paths.
+    all_platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+    assert complete(["pixi", "run", "-p", ""]) == all_platforms
+    assert complete(["pixi", "run", "--platform", ""]) == all_platforms
+    assert complete(["pixi", "run", "-p", "osx"]) == ["osx-64", "osx-arm64"]
 
 
 def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -901,8 +901,9 @@ def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
                 'echo "${COMPREPLY[@]:-}"',
             ]
         )
-        # The completion script invokes a bare `pixi task list`, so the binary
-        # under test must be first on PATH.
+        # The completion script invokes bare `pixi task list` and
+        # `pixi workspace environment list`, so the binary under test must be
+        # first on PATH.
         output = verify_cli_command(
             ["bash", "-c", harness],
             env={"PATH": f"{pixi.parent.resolve()}{os.pathsep}{os.environ['PATH']}"},
@@ -918,6 +919,12 @@ def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
     assert complete(["pixi", "run", "-e", "test", "he"]) == ["hello"]
     # Flags still complete.
     assert complete(["pixi", "run", "--froz"]) == ["--frozen"]
+
+    # `-e`/`--environment` complete environment names instead of file paths.
+    all_environments = ["default", "test"]
+    assert complete(["pixi", "run", "-e", ""]) == all_environments
+    assert complete(["pixi", "run", "--environment", ""]) == all_environments
+    assert complete(["pixi", "run", "-e", "te"]) == ["test"]
 
 
 def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:


### PR DESCRIPTION
The bash completion for `pixi run` only suggested task names directly after `run`. Preserve the clap-generated `case "${prev}"` block and run task completion after it, so tasks are suggested at any position, e.g. after `-e <env>` or `--frozen`. Also deduplicate task names that appear in multiple environments.

Fixes #6494

### How Has This Been Tested?

More tests:-)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
