### PR TITLE
fix(build): register run-export-introduced source deps on the assembled record

### DIFF
--- a/crates/pixi_build_backend/src/dependencies.rs
+++ b/crates/pixi_build_backend/src/dependencies.rs
@@ -142,7 +142,11 @@ fn convert_dependency(
     let match_spec = match dependency {
         Dependency::Spec(spec) => {
             let spec = *spec;
-            // Convert back to source spec if it is a source spec.
+            // Convert back to source spec if it is a source spec. The URL
+            // encodes only the location; the matchspec selectors travel on
+            // the spec itself and must be carried back over. The exhaustive
+            // construction forces revisiting this when `SourcePackageSpec`
+            // gains a selector field.
             if let Some(source_package) =
                 spec.url.clone().and_then(from_source_url_to_source_package)
             {
@@ -151,7 +155,17 @@ fn convert_dependency(
                 };
                 return Ok(pbt::NamedSpec {
                     name: pbt::SourcePackageName::from(name.clone()),
-                    spec: pbt::PackageSpec::Source(source_package),
+                    spec: pbt::PackageSpec::Source(pbt::SourcePackageSpec {
+                        location: source_package.location,
+                        version: spec.version.clone(),
+                        build: spec.build.clone(),
+                        build_number: spec.build_number.clone(),
+                        extras: spec.extras.clone(),
+                        flags: spec.flags.clone(),
+                        subdir: spec.subdir.clone(),
+                        license: spec.license.clone(),
+                        condition: spec.condition.clone(),
+                    }),
                 });
             }
 
@@ -198,17 +212,34 @@ fn convert_dependency(
         .get(name.as_source())
         .or_else(|| sources.get(name.as_normalized()))
     {
-        let mut source_spec = source_spec.clone();
-        // Merge in the spec details
-        source_spec.version = spec.version.or(source_spec.version);
-        source_spec.build = spec.build.or(source_spec.build);
-        source_spec.build_number = spec.build_number.or(source_spec.build_number);
-        source_spec.subdir = spec.subdir.or(source_spec.subdir);
-        source_spec.license = spec.license.or(source_spec.license);
+        // Merge the dependency's own selectors over the source mapping's.
+        // The exhaustive destructure forces revisiting this when
+        // `SourcePackageSpec` gains a selector field.
+        let pbt::SourcePackageSpec {
+            location,
+            version,
+            build,
+            build_number,
+            extras,
+            flags,
+            subdir,
+            license,
+            condition,
+        } = source_spec.clone();
 
         Ok(pbt::NamedSpec {
             name: pbt::SourcePackageName::from(name.clone()),
-            spec: pbt::PackageSpec::Source(source_spec),
+            spec: pbt::PackageSpec::Source(pbt::SourcePackageSpec {
+                location,
+                version: spec.version.or(version),
+                build: spec.build.or(build),
+                build_number: spec.build_number.or(build_number),
+                extras: spec.extras.or(extras),
+                flags: spec.flags.or(flags),
+                subdir: spec.subdir.or(subdir),
+                license: spec.license.or(license),
+                condition: spec.condition.or(condition),
+            }),
         })
     } else {
         Ok(pbt::NamedSpec {

--- a/crates/pixi_build_backend/src/specs_conversion.rs
+++ b/crates/pixi_build_backend/src/specs_conversion.rs
@@ -47,8 +47,47 @@ pub fn from_source_url_to_source_package(source_url: Url) -> Option<SourcePackag
 pub fn from_source_matchspec_into_package_spec(
     source_matchspec: SourceMatchSpec,
 ) -> miette::Result<SourcePackageSpec> {
-    from_source_url_to_source_package(source_matchspec.location)
-        .ok_or_else(|| miette::miette!("Only file, http/https and git are supported for now"))
+    let location = from_source_url_to_source_package(source_matchspec.location)
+        .ok_or_else(|| miette::miette!("Only file, http/https and git are supported for now"))?
+        .location;
+
+    // The encoded URL carries only the location; the matchspec selectors
+    // travel on the accompanying spec (see
+    // `source_package_spec_to_package_dependency`). Both destructures are
+    // intentionally exhaustive so that adding a selector field to either
+    // type forces revisiting this round-trip.
+    let MatchSpec {
+        name: _,
+        version,
+        build,
+        build_number,
+        extras,
+        flags,
+        subdir,
+        license,
+        condition,
+        // Binary-only selectors that cannot be expressed on a source spec.
+        file_name: _,
+        channel: _,
+        namespace: _,
+        md5: _,
+        sha256: _,
+        url: _,
+        track_features: _,
+        license_family: _,
+    } = source_matchspec.spec;
+
+    Ok(SourcePackageSpec {
+        location,
+        version,
+        build,
+        build_number,
+        extras,
+        flags,
+        subdir,
+        license,
+        condition,
+    })
 }
 
 pub fn convert_variant_from_pixi_build_types(variant: pixi_build_types::VariantValue) -> Variable {
@@ -192,9 +231,42 @@ pub(crate) fn source_package_spec_to_package_dependency(
     name: PackageName,
     source_spec: SourcePackageSpec,
 ) -> miette::Result<SourceMatchSpec> {
+    // The encoded URL carries only the location; the matchspec selectors
+    // (version, build, flags, ...) must ride on the spec or they are lost
+    // in the conversion back to a `SourcePackageSpec`, silently widening
+    // the dependency (e.g. `python = { git = ..., flags = ["asan"] }`
+    // degrading to any python variant from that source). The destructure is
+    // intentionally exhaustive so that adding a selector field to
+    // `SourcePackageSpec` forces revisiting this round-trip.
+    let SourcePackageSpec {
+        location: _, // encoded in the URL below
+        version,
+        build,
+        build_number,
+        extras,
+        flags,
+        subdir,
+        license,
+        condition,
+    } = source_spec.clone();
     let spec = MatchSpec {
         name: PackageNameMatcher::Exact(name),
-        ..Default::default()
+        version,
+        build,
+        build_number,
+        extras,
+        flags,
+        subdir,
+        license,
+        condition,
+        file_name: None,
+        channel: None,
+        namespace: None,
+        md5: None,
+        sha256: None,
+        url: None,
+        track_features: None,
+        license_family: None,
     };
 
     Ok(SourceMatchSpec {
@@ -482,6 +554,55 @@ mod test {
     use rattler_conda_types::ParseMatchSpecOptions;
 
     use super::*;
+
+    /// A source dependency's matchspec selectors (version, build, flags, ...)
+    /// must survive the full round-trip through the recipe intermediate:
+    /// typed spec -> `SourceMatchSpec` -> matchspec string (as rendered into
+    /// the generated recipe) -> re-parsed spec -> `SourcePackageSpec`.
+    /// Regression guard for `python = { git = ..., flags = ["asan"] }`
+    /// silently degrading to "any python variant from that source".
+    #[test]
+    fn test_source_package_selectors_roundtrip() {
+        let source_spec = SourcePackageSpec {
+            location: pixi_build_types::SourcePackageLocationSpec::Git(pixi_build_types::GitSpec {
+                git: "https://github.com/example/repo".parse().unwrap(),
+                rev: Some(pixi_build_types::GitReference::Rev("1234abcd".into())),
+                subdirectory: Some("subdir".into()),
+            }),
+            version: Some("3.16.*".parse().unwrap()),
+            build: Some("*_asan*".parse().unwrap()),
+            build_number: None,
+            extras: None,
+            flags: Some(vec!["asan".parse().unwrap()]),
+            subdir: None,
+            license: None,
+            condition: None,
+        };
+
+        let name = PackageName::new_unchecked("python");
+        let dependency = PackageDependency::Source(
+            source_package_spec_to_package_dependency(name, source_spec.clone()).unwrap(),
+        );
+
+        // Through the string form used inside the generated recipe. The
+        // stage1 parser runs with the V3 syntax surface when the recipe uses
+        // v3 features (see `recipe_source_uses_v3`).
+        let rendered = dependency.to_string();
+        let reparsed = MatchSpec::from_str(
+            &rendered,
+            ParseMatchSpecOptions::strict()
+                .with_repodata_revision(rattler_conda_types::RepodataRevision::V3),
+        )
+        .unwrap_or_else(|err| panic!("rendered spec `{rendered}` must re-parse: {err}"));
+        let PackageDependency::Source(source_matchspec) =
+            PackageDependency::from(SerializableMatchSpec(reparsed))
+        else {
+            panic!("re-parsed dependency must still be a source dependency");
+        };
+
+        let roundtripped = from_source_matchspec_into_package_spec(source_matchspec).unwrap();
+        assert_eq!(roundtripped, source_spec);
+    }
 
     #[test]
     fn test_binary_package_conversion() {

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -20,7 +20,7 @@ use pixi_build_frontend::{
 };
 use pixi_build_types::{
     BackendCapabilities, BinaryPackageSpec, ConstraintSpec, ExtraGroupName, NamedSpec, PackageSpec,
-    ProjectModel, SourcePackageName, Target, Targets, VariantValue,
+    ProjectModel, SourcePackageName, SourcePackageSpec, Target, Targets, VariantValue,
     procedures::{
         conda_build_v1::{CondaBuildV1Params, CondaBuildV1Result},
         conda_outputs::{
@@ -628,10 +628,12 @@ fn create_output(
         ignore_run_exports: Default::default(),
         // The output's own run-exports: prefer those read from a pre-built
         // package, otherwise fall back to an instantiator-configured entry
-        // under this package's own name.
+        // under this package's own name. Exported names the project model
+        // declares as source dependencies are emitted as source specs,
+        // mirroring real backends' `local_source_packages` mapping.
         run_exports: package_run_exports
             .or_else(|| run_exports_config.get(name.as_source()))
-            .map(convert_run_exports_json)
+            .map(|re| convert_run_exports_json(re, &model_source_specs(&project_model.targets)))
             .unwrap_or_default(),
         input_globs: None,
         input_glob_sets: None,
@@ -807,11 +809,39 @@ fn convert_extra_depends(
         .collect()
 }
 
+/// Collects the names the project model declares as source dependencies
+/// (build/host/run), so run-exports referencing them can be emitted as source
+/// specs, mirroring real backends' `local_source_packages` mapping.
+fn model_source_specs(targets: &Option<Targets>) -> BTreeMap<String, SourcePackageSpec> {
+    let mut map = BTreeMap::new();
+    for target in applicable_targets(targets) {
+        for deps in [
+            target.build_dependencies.as_ref(),
+            target.host_dependencies.as_ref(),
+            target.run_dependencies.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            for (name, spec) in deps {
+                if let PackageSpec::Source(source) = spec {
+                    map.insert(name.as_str().to_string(), source.clone());
+                }
+            }
+        }
+    }
+    map
+}
+
 /// Converts a `RunExportsJson` (from a conda package) to `CondaOutputRunExports`.
 fn convert_run_exports_json(
     run_exports: &RunExportsJson,
+    source_specs: &BTreeMap<String, SourcePackageSpec>,
 ) -> pixi_build_types::procedures::conda_outputs::CondaOutputRunExports {
-    fn convert_specs(specs: &[String]) -> Vec<NamedSpec<PackageSpec>> {
+    fn convert_specs(
+        specs: &[String],
+        source_specs: &BTreeMap<String, SourcePackageSpec>,
+    ) -> Vec<NamedSpec<PackageSpec>> {
         specs
             .iter()
             .filter_map(|spec_str| {
@@ -822,6 +852,16 @@ fn convert_run_exports_json(
                 .ok()?;
 
                 let pkg_name = match_spec.name.as_exact()?.clone();
+
+                if let Some(source) = source_specs.get(pkg_name.as_source()) {
+                    let mut source = source.clone();
+                    source.version = match_spec.version.clone().or(source.version);
+                    source.build = match_spec.build.clone().or(source.build);
+                    return Some(NamedSpec {
+                        name: SourcePackageName::from(pkg_name),
+                        spec: PackageSpec::Source(source),
+                    });
+                }
 
                 Some(NamedSpec {
                     name: SourcePackageName::from(pkg_name),
@@ -865,9 +905,9 @@ fn convert_run_exports_json(
     }
 
     pixi_build_types::procedures::conda_outputs::CondaOutputRunExports {
-        weak: convert_specs(&run_exports.weak),
-        strong: convert_specs(&run_exports.strong),
-        noarch: convert_specs(&run_exports.noarch),
+        weak: convert_specs(&run_exports.weak, source_specs),
+        strong: convert_specs(&run_exports.strong, source_specs),
+        noarch: convert_specs(&run_exports.noarch, source_specs),
         weak_constrains: convert_constraint_specs(&run_exports.weak_constrains),
         strong_constrains: convert_constraint_specs(&run_exports.strong_constrains),
     }

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -542,6 +542,12 @@ fn create_output(
             }
         });
 
+    let name = project_model
+        .name
+        .as_ref()
+        .map(|name| PackageName::try_from(name.as_str()).unwrap())
+        .unwrap_or_else(|| index_json.name.clone());
+
     // Track if there were actual variants before we add target_platform.
     // We only compute a build hash when there are real variants (not just target_platform).
     let has_real_variants = !variant.is_empty();
@@ -600,11 +606,7 @@ fn create_output(
         run_dependencies,
         extra_dependencies,
         metadata: CondaOutputMetadata {
-            name: project_model
-                .name
-                .as_ref()
-                .map(|name| PackageName::try_from(name.as_str()).unwrap())
-                .unwrap_or_else(|| index_json.name.clone()),
+            name: name.clone(),
             version: project_model
                 .version
                 .as_ref()
@@ -624,7 +626,11 @@ fn create_output(
             variant,
         },
         ignore_run_exports: Default::default(),
+        // The output's own run-exports: prefer those read from a pre-built
+        // package, otherwise fall back to an instantiator-configured entry
+        // under this package's own name.
         run_exports: package_run_exports
+            .or_else(|| run_exports_config.get(name.as_source()))
             .map(convert_run_exports_json)
             .unwrap_or_default(),
         input_globs: None,

--- a/crates/pixi_command_dispatcher/src/build/dependencies.rs
+++ b/crates/pixi_command_dispatcher/src/build/dependencies.rs
@@ -12,7 +12,10 @@ use pixi_build_types::{
     },
 };
 use pixi_record::PixiRecord;
-use pixi_spec::{BinarySpec, DetailedSpec, PixiSpec, SourceAnchor, UrlBinarySpec};
+use pixi_spec::{
+    BinarySpec, DetailedSpec, MatchspecFields, PixiSpec, SourceAnchor, SourceLocationSpec,
+    SourceSpec, UrlBinarySpec,
+};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::{
     InvalidPackageNameError, MatchSpec, NamedChannelOrUrl, NamelessMatchSpec, PackageName,
@@ -283,6 +286,22 @@ impl Dependencies {
     ) -> Result<Vec<(PackageName, PixiRunExports)>, RunExportExtractorError> {
         let mut combined_run_exports = Vec::new();
 
+        // Map every source-built package in the solved environment to its
+        // pinned source location. A run-export naming one of these packages
+        // must stay a source dependency on the assembled record; converted to
+        // a plain binary matchspec, the consuming environment would look for
+        // a channel package that doesn't exist.
+        let source_locations: BTreeMap<PackageName, SourceLocationSpec> = records
+            .iter()
+            .filter_map(|record| match record {
+                PixiRecord::Source(source) => Some((
+                    source.package_record().name.clone(),
+                    SourceLocationSpec::from(source.manifest_source().clone()),
+                )),
+                PixiRecord::Binary(_) => None,
+            })
+            .collect();
+
         // Find all the records that are relevant for run exports.
         let mut relevant_records = records
             .iter_mut()
@@ -327,9 +346,17 @@ impl Dependencies {
             };
 
             let filtered_run_exports = PixiRunExports {
-                noarch: filter_match_specs(&run_exports.noarch, ignore),
-                strong: filter_match_specs(&run_exports.strong, ignore),
-                weak: filter_match_specs(&run_exports.weak, ignore),
+                noarch: filter_match_specs_with_sources(
+                    &run_exports.noarch,
+                    ignore,
+                    &source_locations,
+                ),
+                strong: filter_match_specs_with_sources(
+                    &run_exports.strong,
+                    ignore,
+                    &source_locations,
+                ),
+                weak: filter_match_specs_with_sources(&run_exports.weak, ignore, &source_locations),
                 strong_constrains: filter_match_specs(&run_exports.strong_constrains, ignore),
                 weak_constrains: filter_match_specs(&run_exports.weak_constrains, ignore),
             };
@@ -348,84 +375,121 @@ pub fn filter_match_specs<T: From<BinarySpec> + Clone + Hash + Eq + PartialEq>(
     specs
         .iter()
         .filter_map(move |spec| {
-            let (name_matcher, spec) = MatchSpec::from_str(
-                spec,
-                ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3),
-            )
-            .ok()?
-            .into_nameless();
-            let name = name_matcher.as_exact().cloned()?;
-            if ignore.by_name.contains(&name) {
-                return None;
-            }
-
-            let binary_spec = match spec {
-                NamelessMatchSpec {
-                    url: Some(url),
-                    sha256,
-                    md5,
-                    ..
-                } => BinarySpec::Url(UrlBinarySpec { url, sha256, md5 }),
-                NamelessMatchSpec {
-                    version,
-                    build: None,
-                    build_number: None,
-                    file_name: None,
-                    extras: None,
-                    flags: None,
-                    channel: None,
-                    subdir: None,
-                    namespace: None,
-                    md5: None,
-                    sha256: None,
-                    url: _,
-                    license: None,
-                    license_family: None,
-                    condition: None,
-                    track_features: None,
-                } => BinarySpec::Version(version.unwrap_or(VersionSpec::Any)),
-                NamelessMatchSpec {
-                    version,
-                    build,
-                    build_number,
-                    file_name,
-                    extras,
-                    flags,
-                    channel,
-                    subdir,
-                    md5,
-                    sha256,
-                    license,
-                    license_family,
-                    condition,
-                    track_features,
-
-                    // Caught in the above case
-                    url: _,
-
-                    // Explicitly ignored
-                    namespace: _,
-                } => BinarySpec::DetailedVersion(Box::new(DetailedSpec {
-                    version,
-                    build,
-                    build_number,
-                    file_name,
-                    extras,
-                    flags,
-                    channel: channel.map(|c| NamedChannelOrUrl::Url(c.base_url.clone().into())),
-                    subdir,
-                    md5,
-                    sha256,
-                    license,
-                    license_family,
-                    condition,
-                    track_features,
-                })),
-            };
-
-            Some((name, binary_spec.into()))
+            let (name, spec) = parse_run_export_spec(spec, ignore)?;
+            Some((name, binary_spec_from_nameless(spec).into()))
         })
         .collect()
+}
+
+/// Like [`filter_match_specs`], but run-export specs whose package name maps
+/// to an entry in `source_locations` become source specs carrying that
+/// location (the matchspec selectors are preserved). Specs with an explicit
+/// URL stay binary: they pin a concrete artifact.
+fn filter_match_specs_with_sources(
+    specs: &[String],
+    ignore: &CondaOutputIgnoreRunExports,
+    source_locations: &BTreeMap<PackageName, SourceLocationSpec>,
+) -> DependencyMap<PackageName, PixiSpec> {
+    specs
+        .iter()
+        .filter_map(move |spec| {
+            let (name, spec) = parse_run_export_spec(spec, ignore)?;
+            let pixi_spec = match source_locations.get(&name) {
+                Some(location) if spec.url.is_none() => SourceSpec {
+                    location: location.clone(),
+                    matchspec: MatchspecFields::from_nameless_match_spec(&spec),
+                }
+                .into(),
+                _ => PixiSpec::from(binary_spec_from_nameless(spec)),
+            };
+            Some((name, pixi_spec))
+        })
+        .collect()
+}
+
+/// Parse a run-export matchspec string, dropping unparsable specs, non-exact
+/// names, and names listed in `ignore.by_name`.
+fn parse_run_export_spec(
+    spec: &str,
+    ignore: &CondaOutputIgnoreRunExports,
+) -> Option<(PackageName, NamelessMatchSpec)> {
+    let (name_matcher, spec) = MatchSpec::from_str(
+        spec,
+        ParseMatchSpecOptions::lenient().with_repodata_revision(RepodataRevision::V3),
+    )
+    .ok()?
+    .into_nameless();
+    let name = name_matcher.as_exact().cloned()?;
+    if ignore.by_name.contains(&name) {
+        return None;
+    }
+    Some((name, spec))
+}
+
+fn binary_spec_from_nameless(spec: NamelessMatchSpec) -> BinarySpec {
+    match spec {
+        NamelessMatchSpec {
+            url: Some(url),
+            sha256,
+            md5,
+            ..
+        } => BinarySpec::Url(UrlBinarySpec { url, sha256, md5 }),
+        NamelessMatchSpec {
+            version,
+            build: None,
+            build_number: None,
+            file_name: None,
+            extras: None,
+            flags: None,
+            channel: None,
+            subdir: None,
+            namespace: None,
+            md5: None,
+            sha256: None,
+            url: _,
+            license: None,
+            license_family: None,
+            condition: None,
+            track_features: None,
+        } => BinarySpec::Version(version.unwrap_or(VersionSpec::Any)),
+        NamelessMatchSpec {
+            version,
+            build,
+            build_number,
+            file_name,
+            extras,
+            flags,
+            channel,
+            subdir,
+            md5,
+            sha256,
+            license,
+            license_family,
+            condition,
+            track_features,
+
+            // Caught in the above case
+            url: _,
+
+            // Explicitly ignored
+            namespace: _,
+        } => BinarySpec::DetailedVersion(Box::new(DetailedSpec {
+            version,
+            build,
+            build_number,
+            file_name,
+            extras,
+            flags,
+            channel: channel.map(|c| NamedChannelOrUrl::Url(c.base_url.clone().into())),
+            subdir,
+            md5,
+            sha256,
+            license,
+            license_family,
+            condition,
+            track_features,
+        })),
+    }
 }
 
 /// A variant of [`rattler_conda_types::package::RunExportsJson`] but with pixi

--- a/crates/pixi_command_dispatcher/src/build/dependencies.rs
+++ b/crates/pixi_command_dispatcher/src/build/dependencies.rs
@@ -345,18 +345,42 @@ impl Dependencies {
                 continue;
             };
 
+            // The exporting record's own `sources` map takes precedence: it
+            // covers exported packages that are not themselves part of this
+            // solved environment, e.g. a sibling output of the same recipe
+            // (`python` weak-exporting `python_abi`). Its entries are
+            // relative to the exporting record's manifest, so anchor them
+            // before use.
+            let (own_sources, own_anchor) = match &*record {
+                PixiRecord::Source(source) => (
+                    Some(source.sources()),
+                    Some(SourceAnchor::from(SourceLocationSpec::from(
+                        source.manifest_source().clone(),
+                    ))),
+                ),
+                PixiRecord::Binary(_) => (None, None),
+            };
+            let source_location = |name: &PackageName| -> Option<SourceLocationSpec> {
+                if let (Some(sources), Some(anchor)) = (own_sources, &own_anchor)
+                    && let Some(location) = sources.get(name.as_normalized())
+                {
+                    return Some(anchor.resolve_location(location.clone()));
+                }
+                source_locations.get(name).cloned()
+            };
+
             let filtered_run_exports = PixiRunExports {
                 noarch: filter_match_specs_with_sources(
                     &run_exports.noarch,
                     ignore,
-                    &source_locations,
+                    &source_location,
                 ),
                 strong: filter_match_specs_with_sources(
                     &run_exports.strong,
                     ignore,
-                    &source_locations,
+                    &source_location,
                 ),
-                weak: filter_match_specs_with_sources(&run_exports.weak, ignore, &source_locations),
+                weak: filter_match_specs_with_sources(&run_exports.weak, ignore, &source_location),
                 strong_constrains: filter_match_specs(&run_exports.strong_constrains, ignore),
                 weak_constrains: filter_match_specs(&run_exports.weak_constrains, ignore),
             };
@@ -381,22 +405,22 @@ pub fn filter_match_specs<T: From<BinarySpec> + Clone + Hash + Eq + PartialEq>(
         .collect()
 }
 
-/// Like [`filter_match_specs`], but run-export specs whose package name maps
-/// to an entry in `source_locations` become source specs carrying that
-/// location (the matchspec selectors are preserved). Specs with an explicit
-/// URL stay binary: they pin a concrete artifact.
+/// Like [`filter_match_specs`], but run-export specs whose package name has a
+/// known source location (per `source_location`) become source specs carrying
+/// that location (the matchspec selectors are preserved). Specs with an
+/// explicit URL stay binary: they pin a concrete artifact.
 fn filter_match_specs_with_sources(
     specs: &[String],
     ignore: &CondaOutputIgnoreRunExports,
-    source_locations: &BTreeMap<PackageName, SourceLocationSpec>,
+    source_location: &dyn Fn(&PackageName) -> Option<SourceLocationSpec>,
 ) -> DependencyMap<PackageName, PixiSpec> {
     specs
         .iter()
         .filter_map(move |spec| {
             let (name, spec) = parse_run_export_spec(spec, ignore)?;
-            let pixi_spec = match source_locations.get(&name) {
+            let pixi_spec = match source_location(&name) {
                 Some(location) if spec.url.is_none() => SourceSpec {
-                    location: location.clone(),
+                    location,
                     matchspec: MatchspecFields::from_nameless_match_spec(&spec),
                 }
                 .into(),

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -233,14 +233,19 @@ async fn assemble_source_record_inner(
     let mut sources: HashMap<PackageName, SourceLocationSpec> = HashMap::new();
 
     // Record a source-typed PixiSpec's location into `sources`, erroring
-    // if the same (name, location) is registered twice. Only the location
-    // is tracked; the matchspec selectors live on the dependency itself.
-    let mut track_source = |name: &PackageName, spec: &PixiSpec| -> Result<(), SourceRecordError> {
+    // if the same package is registered from two different locations. Only
+    // the location is tracked; the matchspec selectors live on the
+    // dependency itself.
+    fn track_source(
+        sources: &mut HashMap<PackageName, SourceLocationSpec>,
+        name: &PackageName,
+        spec: &PixiSpec,
+    ) -> Result<(), SourceRecordError> {
         if let Either::Left(source) = spec.clone().into_source_or_binary() {
             let location = source.location;
             match sources.entry(name.clone()) {
                 std::collections::hash_map::Entry::Occupied(entry) => {
-                    if entry.get() == &location {
+                    if entry.get() != &location {
                         return Err(SourceRecordError::DuplicateSourceDependency {
                             package: name.clone(),
                             source1: Box::new(entry.get().clone()),
@@ -254,25 +259,24 @@ async fn assemble_source_record_inner(
             }
         }
         Ok(())
-    };
+    }
 
     // Stringify a PixiSpec dep map into a `Vec<String>`, threading source
     // locations through `track_source` for the per-source bookkeeping.
-    let stringify_pixi_specs =
-        |specs: DependencyMap<PackageName, PixiSpec>,
-         track_source: &mut dyn FnMut(&PackageName, &PixiSpec) -> Result<(), SourceRecordError>|
-         -> Result<Vec<String>, SourceRecordError> {
-            specs
-                .into_specs()
-                .map(|(name, spec)| {
-                    track_source(&name, &spec)?;
-                    Ok(spec
-                        .to_match_spec(&name, &channel_config)
-                        .map_err(SourceRecordError::from)?
-                        .to_string())
-                })
-                .collect()
-        };
+    let stringify_pixi_specs = |specs: DependencyMap<PackageName, PixiSpec>,
+                                sources: &mut HashMap<PackageName, SourceLocationSpec>|
+     -> Result<Vec<String>, SourceRecordError> {
+        specs
+            .into_specs()
+            .map(|(name, spec)| {
+                track_source(sources, &name, &spec)?;
+                Ok(spec
+                    .to_match_spec(&name, &channel_config)
+                    .map_err(SourceRecordError::from)?
+                    .to_string())
+            })
+            .collect()
+    };
 
     let stringify_binary_specs =
         |specs: DependencyMap<PackageName, BinarySpec>| -> Result<Vec<String>, SourceRecordError> {
@@ -292,7 +296,23 @@ async fn assemble_source_record_inner(
         .clone()
         .into_specs()
         .map(|(name, withspec)| {
-            track_source(&name, &withspec.value)?;
+            if withspec.source.is_some() {
+                // A run-export-introduced source dependency carries the
+                // pinned location of the build/host env record it was
+                // extracted from, which can spell the same source
+                // differently than an explicit spec (e.g. a pinned commit
+                // vs. a branch). Register it leniently: an explicit source
+                // spec for the same package wins. Pinned path locations are
+                // workspace-root-relative while `sources` entries are read
+                // relative to this record's manifest, so relativize first.
+                if let Either::Left(source) = withspec.value.clone().into_source_or_binary()
+                    && let Some(location) = source_anchor.relativize_location(source.location)
+                {
+                    sources.entry(name.clone()).or_insert(location);
+                }
+            } else {
+                track_source(&mut sources, &name, &withspec.value)?;
+            }
             Ok(withspec
                 .value
                 .to_match_spec(&name, &channel_config)
@@ -318,9 +338,9 @@ async fn assemble_source_record_inner(
             .map_err(SourceRecordError::from)?;
 
     let run_exports = RunExportsJson {
-        weak: stringify_pixi_specs(run_exports_pixi.weak, &mut track_source)?,
-        strong: stringify_pixi_specs(run_exports_pixi.strong, &mut track_source)?,
-        noarch: stringify_pixi_specs(run_exports_pixi.noarch, &mut track_source)?,
+        weak: stringify_pixi_specs(run_exports_pixi.weak, &mut sources)?,
+        strong: stringify_pixi_specs(run_exports_pixi.strong, &mut sources)?,
+        noarch: stringify_pixi_specs(run_exports_pixi.noarch, &mut sources)?,
         weak_constrains: stringify_binary_specs(run_exports_pixi.weak_constrains)?,
         strong_constrains: stringify_binary_specs(run_exports_pixi.strong_constrains)?,
     };
@@ -335,7 +355,7 @@ async fn assemble_source_record_inner(
             .map(|(group, specs)| {
                 Ok((
                     group.into_inner(),
-                    stringify_pixi_specs(specs, &mut track_source)?,
+                    stringify_pixi_specs(specs, &mut sources)?,
                 ))
             })
             .collect::<Result<BTreeMap<String, Vec<String>>, SourceRecordError>>()?;

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -296,23 +296,42 @@ async fn assemble_source_record_inner(
         .clone()
         .into_specs()
         .map(|(name, withspec)| {
-            if withspec.source.is_some() {
-                // A run-export-introduced source dependency carries the
-                // pinned location of the build/host env record it was
-                // extracted from, which can spell the same source
-                // differently than an explicit spec (e.g. a pinned commit
-                // vs. a branch). Register it leniently: an explicit source
-                // spec for the same package wins. Pinned path locations are
-                // workspace-root-relative while `sources` entries are read
-                // relative to this record's manifest, so relativize first.
-                if let Either::Left(source) = withspec.value.clone().into_source_or_binary()
-                    && let Some(location) = source_anchor.relativize_location(source.location)
-                {
-                    sources.entry(name.clone()).or_insert(location);
-                }
-            } else {
+            if withspec.source.is_none() {
                 track_source(&mut sources, &name, &withspec.value)?;
             }
+
+            // Register implied source dependencies leniently (an explicit
+            // source spec registered above wins):
+            // - a run-export-introduced source spec carries the pinned
+            //   location of the build/host env record it was extracted
+            //   from, which can spell the same source differently than an
+            //   explicit spec (e.g. a pinned commit vs. a branch);
+            // - a binary-shaped run dep on a package that was built from
+            //   source in this record's build/host envs (e.g. `python
+            //   >=3.12` while the host env holds a source-built python)
+            //   must resolve to that same source at install time — the
+            //   package was linked against it.
+            // Pinned locations are workspace-root-relative while `sources`
+            // entries are read relative to this record's manifest, so
+            // relativize first.
+            if !sources.contains_key(&name) {
+                let implied_location = match withspec.value.clone().into_source_or_binary() {
+                    Either::Left(source) if withspec.source.is_some() => Some(source.location),
+                    Either::Left(_) => None,
+                    Either::Right(_) => compatibility_map.get(&name).and_then(|r| match r {
+                        PixiRecord::Source(source) => {
+                            Some(SourceLocationSpec::from(source.manifest_source().clone()))
+                        }
+                        PixiRecord::Binary(_) => None,
+                    }),
+                };
+                if let Some(location) =
+                    implied_location.and_then(|loc| source_anchor.relativize_location(loc))
+                {
+                    sources.insert(name.clone(), location);
+                }
+            }
+
             Ok(withspec
                 .value
                 .to_match_spec(&name, &channel_config)

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -665,6 +665,77 @@ pub async fn test_cycle_three_packages() {
     ));
 }
 
+/// Regression test for <https://github.com/prefix-dev/pixi/issues/6482>.
+///
+/// `package_a` (a source dependency of the top-level env) host-depends on
+/// source `package_b`, and `package_b` run-exports itself. The run
+/// dependency this injects into `package_a`'s assembled record has no
+/// explicit spec anywhere, so it must be registered as a *source*
+/// dependency of the record; otherwise the top-level solve walks only
+/// `package_a` and then tries to fetch `package_b` from the (empty) binary
+/// channels.
+#[tokio::test]
+pub async fn test_run_export_on_source_host_dependency() {
+    use rattler_conda_types::package::RunExportsJson;
+
+    let (tool_platform, tool_virtual_packages) = tool_platform();
+    let root_dir = workspaces_dir().join("run-exports-source");
+    let tempdir = test_tempdir();
+
+    // `noarch` exports because the passthrough backend produces NoArch
+    // outputs and only noarch run-exports propagate to a NoArch consumer.
+    let run_exports = RunExportsJson {
+        noarch: vec!["package_b 0.1.0".to_string()],
+        ..Default::default()
+    };
+    let dispatcher = CommandDispatcher::builder()
+        .with_root_dir(to_abs_dir(root_dir.clone()))
+        .with_cache_dirs(default_cache_dirs().with_workspace(to_abs_dir(tempdir.path())))
+        .with_executor(Executor::Serial)
+        .with_tool_platform(tool_platform, tool_virtual_packages)
+        .with_backend_overrides(BackendOverride::from_memory(
+            PassthroughBackend::instantiator().with_run_exports("package_b", run_exports),
+        ))
+        .finish();
+
+    let records = run_pixi_solve(
+        &dispatcher,
+        SolvePixiEnvironmentSpec {
+            dependencies: DependencyMap::from_iter([(
+                "package_a".parse().unwrap(),
+                PathSpec {
+                    path: "package_a".into(),
+                }
+                .into(),
+            )]),
+            env_ref: env_ref_of(vec![], BuildEnvironment::simple(Platform::Linux64, vec![])),
+            ..empty_pixi_env_spec()
+        },
+    )
+    .await
+    .expect("the top-level solve must discover package_b as a source dependency");
+
+    let package_a = records
+        .iter()
+        .find_map(|r| {
+            r.as_source()
+                .filter(|s| s.package_record().name.as_normalized() == "package_a")
+        })
+        .expect("package_a source record is in the solution");
+    assert!(
+        package_a.sources().contains_key("package_b"),
+        "the run-export-introduced dependency must be registered as a source of package_a, got {:?}",
+        package_a.sources()
+    );
+    assert!(
+        records.iter().any(|r| {
+            r.as_source()
+                .is_some_and(|s| s.package_record().name.as_normalized() == "package_b")
+        }),
+        "package_b must be part of the solution as a source record"
+    );
+}
+
 /// Tests that a stale host dependency triggers a rebuild of both the stale
 /// package and any package that specifies it as a host dependency.
 #[tokio::test]

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -668,12 +668,15 @@ pub async fn test_cycle_three_packages() {
 /// Regression test for <https://github.com/prefix-dev/pixi/issues/6482>.
 ///
 /// `package_a` (a source dependency of the top-level env) host-depends on
-/// source `package_b`, and `package_b` run-exports itself. The run
-/// dependency this injects into `package_a`'s assembled record has no
-/// explicit spec anywhere, so it must be registered as a *source*
-/// dependency of the record; otherwise the top-level solve walks only
-/// `package_a` and then tries to fetch `package_b` from the (empty) binary
-/// channels.
+/// source `package_b`, and `package_b` run-exports itself plus `package_c`
+/// (its own source host dependency, mirroring a recipe sibling output like
+/// `python` weak-exporting `python_abi`). The run dependencies this injects
+/// into `package_a`'s assembled record have no explicit spec anywhere, so
+/// they must be registered as *source* dependencies of the record;
+/// otherwise the top-level solve walks only `package_a` and then tries to
+/// fetch `package_b` / `package_c` from the (empty) binary channels.
+/// Notably `package_c` is never part of `package_a`'s host env — its source
+/// link is only discoverable through `package_b`'s record `sources` map.
 #[tokio::test]
 pub async fn test_run_export_on_source_host_dependency() {
     use rattler_conda_types::package::RunExportsJson;
@@ -685,7 +688,7 @@ pub async fn test_run_export_on_source_host_dependency() {
     // `noarch` exports because the passthrough backend produces NoArch
     // outputs and only noarch run-exports propagate to a NoArch consumer.
     let run_exports = RunExportsJson {
-        noarch: vec!["package_b 0.1.0".to_string()],
+        noarch: vec!["package_b 0.1.0".to_string(), "package_c 0.1.0".to_string()],
         ..Default::default()
     };
     let dispatcher = CommandDispatcher::builder()
@@ -722,18 +725,20 @@ pub async fn test_run_export_on_source_host_dependency() {
                 .filter(|s| s.package_record().name.as_normalized() == "package_a")
         })
         .expect("package_a source record is in the solution");
-    assert!(
-        package_a.sources().contains_key("package_b"),
-        "the run-export-introduced dependency must be registered as a source of package_a, got {:?}",
-        package_a.sources()
-    );
-    assert!(
-        records.iter().any(|r| {
-            r.as_source()
-                .is_some_and(|s| s.package_record().name.as_normalized() == "package_b")
-        }),
-        "package_b must be part of the solution as a source record"
-    );
+    for dep in ["package_b", "package_c"] {
+        assert!(
+            package_a.sources().contains_key(dep),
+            "the run-export-introduced dependency {dep} must be registered as a source of package_a, got {:?}",
+            package_a.sources()
+        );
+        assert!(
+            records.iter().any(|r| {
+                r.as_source()
+                    .is_some_and(|s| s.package_record().name.as_normalized() == dep)
+            }),
+            "{dep} must be part of the solution as a source record"
+        );
+    }
 }
 
 /// Tests that a stale host dependency triggers a rebuild of both the stale

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -430,9 +430,12 @@ fn collect_direct_run_exports(
         if !direct_names.contains(name) || ignore.from_package.contains(name) {
             continue;
         }
+        // Read run-exports off both binary and (full) source records,
+        // mirroring the solve path's `extract_run_exports`; partial source
+        // records have no package record and thus contribute nothing.
         let Some(re_json) = record
-            .as_binary()
-            .and_then(|b| b.package_record.run_exports.as_ref())
+            .package_record()
+            .and_then(|pr| pr.run_exports.as_ref())
         else {
             continue;
         };

--- a/crates/pixi_spec/src/source_anchor.rs
+++ b/crates/pixi_spec/src/source_anchor.rs
@@ -122,6 +122,60 @@ impl SourceAnchor {
             }
         }
     }
+
+    /// Inverse of [`SourceAnchor::resolve_location`]: express `target` (a
+    /// location already resolved relative to the workspace root, as pinned
+    /// source locations are) such that `self.resolve_location(result)`
+    /// yields `target` again. Locations that resolve as identity (URL, git,
+    /// absolute or `~`-prefixed paths) are returned unchanged. Returns
+    /// `None` when the target cannot be expressed relative to this anchor.
+    pub fn relativize_location(&self, target: SourceLocationSpec) -> Option<SourceLocationSpec> {
+        let SourceLocationSpec::Path(PathSpec { path: target_path }) = &target else {
+            // URL and git locations resolve as identity.
+            return Some(target);
+        };
+        if target_path.to_path().is_absolute() || target_path.starts_with("~") {
+            return Some(target);
+        }
+        let base = match self {
+            // Workspace-anchored resolution only normalizes the path.
+            SourceAnchor::Workspace => return Some(target),
+            SourceAnchor::Source(SourceLocationSpec::Path(PathSpec { path })) => path.to_path(),
+            // A relative path cannot be expressed against a git or URL base.
+            SourceAnchor::Source(_) => return None,
+        };
+        let base_dir = if is_known_manifest_file(base) {
+            base.parent().unwrap_or(base)
+        } else {
+            base
+        };
+
+        // Both sides are workspace-root-relative and normalized: peel the
+        // common prefix, climb out of what remains of the base, then descend
+        // into the remainder of the target.
+        let base_components: Vec<&str> = base_dir.components().map(|c| c.as_str()).collect();
+        let target_path = target_path.to_path();
+        let target_components: Vec<&str> = target_path.components().map(|c| c.as_str()).collect();
+        let common = base_components
+            .iter()
+            .zip(target_components.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        if base_components[common..].contains(&"..") {
+            // Cannot climb out of an unknown ancestor.
+            return None;
+        }
+        let mut parts: Vec<&str> = vec![".."; base_components.len() - common];
+        parts.extend(&target_components[common..]);
+        let rel = if parts.is_empty() {
+            String::from(".")
+        } else {
+            parts.join("/")
+        };
+        Some(SourceLocationSpec::Path(PathSpec {
+            path: typed_path::Utf8TypedPathBuf::from(rel),
+        }))
+    }
 }
 
 /// Checks if a path's filename matches a known manifest file name.
@@ -134,4 +188,68 @@ fn is_known_manifest_file(path: Utf8TypedPath<'_>) -> bool {
     path.file_name()
         .map(|name| KNOWN_MANIFEST_FILES.contains(&name))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path_location(path: &str) -> SourceLocationSpec {
+        SourceLocationSpec::Path(PathSpec { path: path.into() })
+    }
+
+    #[test]
+    fn relativize_location_roundtrips_through_resolve() {
+        let cases = [
+            // (anchor, workspace-relative target, expected relative)
+            ("package_a/pixi.toml", "package_b", "../package_b"),
+            ("package_a", "package_b", "../package_b"),
+            ("package_a", "package_a/nested", "nested"),
+            ("package_a", "package_a", "."),
+            ("nested/package_a", "libs/package_b", "../../libs/package_b"),
+        ];
+        for (anchor_path, target, expected) in cases {
+            let anchor = SourceAnchor::from(path_location(anchor_path));
+            let relativized = anchor
+                .relativize_location(path_location(target))
+                .unwrap_or_else(|| {
+                    panic!("{target} must be expressible relative to {anchor_path}")
+                });
+            assert_eq!(
+                relativized,
+                path_location(expected),
+                "relativize({anchor_path}, {target})"
+            );
+            assert_eq!(
+                anchor.resolve_location(relativized),
+                path_location(target),
+                "resolve(relativize) must roundtrip for ({anchor_path}, {target})"
+            );
+        }
+    }
+
+    #[test]
+    fn relativize_location_passes_identity_locations_through() {
+        let anchor = SourceAnchor::from(path_location("package_a"));
+        let absolute = path_location("/abs/package_b");
+        assert_eq!(anchor.relativize_location(absolute.clone()), Some(absolute));
+
+        let git = SourceLocationSpec::Git(GitLocationSpec {
+            git: "https://github.com/example/repo".parse().unwrap(),
+            rev: None,
+            subdirectory: Subdirectory::default(),
+        });
+        assert_eq!(anchor.relativize_location(git.clone()), Some(git));
+
+        // A relative path cannot be expressed against a git anchor.
+        let git_anchor = SourceAnchor::from(SourceLocationSpec::Git(GitLocationSpec {
+            git: "https://github.com/example/repo".parse().unwrap(),
+            rev: None,
+            subdirectory: Subdirectory::default(),
+        }));
+        assert_eq!(
+            git_anchor.relativize_location(path_location("package_b")),
+            None
+        );
+    }
 }

--- a/tests/data/workspaces/run-exports-source/README.md
+++ b/tests/data/workspaces/run-exports-source/README.md
@@ -1,0 +1,12 @@
+# run-exports-source
+
+Regression workspace for prefix-dev/pixi#6482: the top-level environment
+depends on source `package_a`, whose host env contains source `package_b`.
+`package_b` declares a strong run-export on itself, so `package_a`'s
+assembled record gains a run dependency on `package_b` that is introduced
+purely via run-exports. That dependency must be registered as a *source*
+dependency of `package_a`'s record; otherwise the top-level solve looks for
+a binary `package_b` in the (empty) channels and fails.
+
+The test configures the in-memory passthrough backend with the strong
+run-export for `package_b` (`PassthroughBackendInstantiator::with_run_exports`).

--- a/tests/data/workspaces/run-exports-source/README.md
+++ b/tests/data/workspaces/run-exports-source/README.md
@@ -1,12 +1,21 @@
 # run-exports-source
 
-Regression workspace for prefix-dev/pixi#6482: the top-level environment
-depends on source `package_a`, whose host env contains source `package_b`.
-`package_b` declares a strong run-export on itself, so `package_a`'s
-assembled record gains a run dependency on `package_b` that is introduced
-purely via run-exports. That dependency must be registered as a *source*
-dependency of `package_a`'s record; otherwise the top-level solve looks for
-a binary `package_b` in the (empty) channels and fails.
+Regression workspace for prefix-dev/pixi#6482: run dependencies introduced
+purely via run-exports of source-built packages must be registered as
+*source* dependencies of the consuming record; otherwise the top-level solve
+looks for a binary package in the (empty) channels and fails.
 
-The test configures the in-memory passthrough backend with the strong
-run-export for `package_b` (`PassthroughBackendInstantiator::with_run_exports`).
+Two shapes are covered:
+
+- `package_a` host-depends on source `package_b`, which run-exports itself.
+  The exported package is present in `package_a`'s host env, so its pinned
+  source location is known there.
+- `package_b` also run-exports `package_c`, which it host-depends on but
+  which never appears in `package_a`'s host env. The source link comes from
+  `package_b`'s own record `sources` map instead (this mirrors a recipe
+  sibling output, like `python` weak-exporting `python_abi`).
+
+The test configures the in-memory passthrough backend with the run-exports
+for `package_b` (`PassthroughBackendInstantiator::with_run_exports`); the
+backend emits the `package_c` export as a source spec because the project
+model declares it as a source dependency.

--- a/tests/data/workspaces/run-exports-source/package_a/pixi.toml
+++ b/tests/data/workspaces/run-exports-source/package_a/pixi.toml
@@ -1,0 +1,9 @@
+[package]
+name = "package_a"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+[package.host-dependencies]
+package_b = { path = "../package_b" }

--- a/tests/data/workspaces/run-exports-source/package_b/pixi.toml
+++ b/tests/data/workspaces/run-exports-source/package_b/pixi.toml
@@ -1,0 +1,6 @@
+[package]
+name = "package_b"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }

--- a/tests/data/workspaces/run-exports-source/package_c/pixi.toml
+++ b/tests/data/workspaces/run-exports-source/package_c/pixi.toml
@@ -1,9 +1,6 @@
 [package]
-name = "package_b"
+name = "package_c"
 version = "0.1.0"
 
 [package.build]
 backend = { name = "in-memory", version = "*" }
-
-[package.host-dependencies]
-package_c = { path = "../package_c" }

--- a/tests/data/workspaces/run-exports-source/pixi.toml
+++ b/tests/data/workspaces/run-exports-source/pixi.toml
@@ -1,0 +1,8 @@
+[workspace]
+channels = []
+name = "run-exports-source"
+platforms = []
+preview = ["pixi-build"]
+
+[dependencies]
+package_a = { path = "package_a" }


### PR DESCRIPTION
Fixes #6482.

## Problem

When a source package's build/host environment contains another source-built package that declares run-exports (e.g. `python_abi` exporting `python_abi 3.16.* *_asan_cp316`), the exported spec is injected into the consumer's run dependencies — but `extract_run_exports` parsed run-export strings into `BinarySpec` unconditionally. The assembled record's `sources` map therefore never learned about the dependency, the parent environment's source walk (`walk_and_resolve`) never recursed into it (`resolved_records=1` in the issue's logs), and the solve failed with:

```
└─ numpy 2.6.0.dev0 would require
   └─ python_abi 3.16.* *_asan_cp316, for which no candidates were found.
```

The host env of `numpy` solved fine only because `python_abi` was an *explicit* host dependency there.

## Changes

- **`extract_run_exports`** now maps each exported package name against the solved environment's records; if the name resolved to a source record, the run-export stays a source spec carrying that record's pinned location (matchspec selectors are preserved, so the stringified `depends` in the lock file are unchanged). This also covers the same hole one layer down, where build-env strong exports feed the nested host solve.
- **`resolve_source_record`** registers run-export-introduced source deps into the record's `sources` map *leniently* — an explicit source spec for the same package wins — since the pinned location can spell the same source differently than a manifest spec (pinned commit vs. branch). Pinned path locations are workspace-root-relative while `sources` entries are read relative to the record's manifest, so they are relativized first via a new `SourceAnchor::relativize_location` (the inverse of `resolve_location`; git/URL locations anchor as identity and pass through).
- **Fix an inverted condition** in the `DuplicateSourceDependency` check: it errored when the same package was registered twice from the *same* location and silently kept the first when the locations genuinely *differed* — the opposite of the error message's intent.
- **Satisfiability mirror**: `collect_direct_run_exports` only read run-exports off binary records while the solve path reads them off source records too; a locked mutable source with a source host dep that has run-exports would look perpetually unsatisfied. It now reads the package record for both shapes.

## Tests

- New integration test `test_run_export_on_source_host_dependency` + `tests/data/workspaces/run-exports-source` workspace modelling the issue: `package_a` host-depends on source `package_b`, which run-exports itself. Without the fix it fails with exactly the issue's error shape; with the fix `package_b` is part of the solution as a source record and registered in `package_a`'s `sources`. The passthrough backend learned to serve an output's own run-exports from the instantiator's `run_exports` map (keyed by the package's own name).
- Roundtrip unit tests for `SourceAnchor::relativize_location`.

Not addressed here: the issue also shows the error nondeterministically naming `*_cp316` vs `*_asan_cp316`, which points at unstable variant selection in the host solve when several variants satisfy a bare spec — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)