### PR TITLE
fix(platforms): compose sysreq platforms from customisations only

### DIFF
--- a/crates/pixi_manifest/src/platform_composition.rs
+++ b/crates/pixi_manifest/src/platform_composition.rs
@@ -76,14 +76,24 @@ fn referenced_platforms<'a>(
         .collect()
 }
 
-/// Union the declared virtual packages of `platforms`, keyed by name with the
-/// highest version winning. Ordered by name so the composed name is stable.
+/// Union the customised virtual packages of `platforms`, the declared entries
+/// minus the subdir defaults, keyed by name with the highest version winning.
+/// Ordered by name so the composed name is stable.
+///
+/// The materialised subdir defaults must not participate: a bare subdir
+/// platform pinned by a feature carries them as declared entries, and the
+/// default `__glibc=2.28` would override an explicit `libc = "2.17"` from
+/// another feature. As in the legacy system-requirements union, a platform
+/// that does not customise a virtual package does not constrain it.
 fn union_virtual_packages(platforms: &[&PixiPlatform]) -> Vec<GenericVirtualPackage> {
     let mut union: BTreeMap<String, GenericVirtualPackage> = BTreeMap::new();
-    for package in platforms
-        .iter()
-        .flat_map(|platform| platform.declared_virtual_packages())
-    {
+    for package in platforms.iter().flat_map(|platform| {
+        let subdir = platform.subdir();
+        platform
+            .declared_virtual_packages()
+            .iter()
+            .filter(move |gvp| !crate::platform::is_subdir_default(gvp, subdir))
+    }) {
         union
             .entry(package.name.as_normalized().to_string())
             .and_modify(|existing| {
@@ -98,7 +108,9 @@ fn union_virtual_packages(platforms: &[&PixiPlatform]) -> Vec<GenericVirtualPack
 
 /// The name of the platform `features` resolve to on `subdir`: the bare subdir
 /// when nothing is pinned, the single pinned platform's name, or the name
-/// synthesised from the union when several are pinned.
+/// synthesised from the union when several are pinned. When the union is
+/// empty the name collapses to the bare subdir, whose platform carries
+/// exactly the same virtual packages.
 pub(crate) fn combined_platform_name(
     features: &[&Feature],
     subdir: Platform,
@@ -110,14 +122,7 @@ pub(crate) fn combined_platform_name(
         [single] => single.name().as_str().to_string(),
         many => {
             let union = union_virtual_packages(many);
-            let name = synthesize_name_string(subdir, &union);
-            // A union that collapses to the subdir defaults can't reuse the
-            // reserved bare-subdir name on a virtual-package-bearing platform.
-            if !union.is_empty() && name == subdir.as_str() {
-                format!("{name}-generic")
-            } else {
-                name
-            }
+            synthesize_name_string(subdir, &union)
         }
     }
 }

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -678,7 +678,7 @@ fn register_referenced_originals(
 /// For a feature that carries `[system-requirements]`, synthesise one
 /// `PixiPlatform` per subdir the feature targets, register it in
 /// `workspace.platforms`, and rewrite the feature's platforms list to those
-/// synthetic names (the default feature keeps `platforms = None`).
+/// synthetic names (the default feature included).
 fn synthesise_for_feature(
     originals: &IndexSet<PixiPlatform>,
     feature: &mut Feature,
@@ -713,13 +713,19 @@ fn synthesise_for_feature(
             })
             .cloned()
             .collect();
-        let mut name_str = crate::toml::platform::synthesize_name_string(subdir, &declared);
+        let name_str = crate::toml::platform::synthesize_name_string(subdir, &declared);
         // A sysreq that matches the subdir defaults collapses the name to the
-        // bare subdir, a reserved name a platform entry can't carry. Keep the
-        // declaration under a distinct `-generic` name instead of failing the
-        // subdir-platform invariant.
-        if !declared.is_empty() && name_str == subdir.as_str() {
-            name_str = format!("{name_str}-generic");
+        // bare subdir. Such a platform would be indistinguishable from the
+        // bare subdir platform for solving and for lock-file identity
+        // matching, so register the bare platform instead of minting a
+        // distinctly named twin the lock-file rename passes cannot tell apart
+        // from it.
+        if name_str == subdir.as_str() {
+            let platform = PixiPlatform::from_subdir(subdir);
+            let name = platform.name().clone();
+            target.insert(platform);
+            synthesised_names.insert(name);
+            continue;
         }
         let name = PixiPlatformName::try_from(name_str.as_str()).map_err(|e| {
             TomlError::from(GenericError::new(format!(
@@ -1052,12 +1058,12 @@ mod test {
     }
 
     /// A legacy sysreq that exactly matches the subdir defaults (glibc on
-    /// linux-64) collapses the synthesised name to the bare subdir, a reserved
-    /// name a platform entry can't carry. The migration must fall back to
-    /// `-generic` rather than failing with `IsSubdirPlatform`. Regression for
-    /// a real `pixi install` failure on such manifests.
+    /// linux-64) collapses the synthesised name to the bare subdir. The
+    /// migration must register the bare subdir platform itself rather than
+    /// failing with `IsSubdirPlatform` or minting a twin whose identity the
+    /// lock-file rename passes cannot distinguish from the bare platform.
     #[test]
-    fn test_system_requirements_migration_default_matching_sysreq_uses_generic_name() {
+    fn test_system_requirements_migration_default_matching_sysreq_uses_bare_subdir() {
         let glibc = pixi_default_versions::default_glibc_version();
         let workspace_manifest = WorkspaceManifest::from_toml_str_with_base_dir(
             format!(
@@ -1081,7 +1087,57 @@ mod test {
             .iter()
             .map(|p| p.name().as_str())
             .collect();
-        assert_eq!(names, vec!["linux-64-generic"], "got {names:?}");
+        assert_eq!(names, vec!["linux-64"], "got {names:?}");
+        // The default feature points at the bare platform.
+        let default = workspace_manifest
+            .features
+            .get(&FeatureName::DEFAULT)
+            .unwrap();
+        let default_platforms: Vec<&str> = default
+            .platforms
+            .as_ref()
+            .expect("default feature carries the migrated platforms")
+            .iter()
+            .map(|name| name.as_str())
+            .collect();
+        assert_eq!(default_platforms, vec!["linux-64"]);
+    }
+
+    /// The default collapse is not specific to glibc: a linux or macos sysreq
+    /// that restates the subdir default migrates to the bare subdir platform
+    /// the same way.
+    #[test]
+    fn test_system_requirements_migration_linux_and_macos_defaults_use_bare_subdir() {
+        let linux = pixi_default_versions::default_linux_version();
+        let macos = pixi_default_versions::default_mac_os_version(Platform::OsxArm64);
+        for (subdir, requirement) in [
+            ("linux-64", format!("linux = \"{linux}\"")),
+            ("osx-arm64", format!("macos = \"{macos}\"")),
+        ] {
+            let workspace_manifest = WorkspaceManifest::from_toml_str_with_base_dir(
+                format!(
+                    r#"
+                [workspace]
+                name = "test"
+                channels = []
+                platforms = ["{subdir}"]
+
+                [system-requirements]
+                {requirement}
+                "#
+                ),
+                Path::new(""),
+            )
+            .unwrap();
+
+            let names: Vec<&str> = workspace_manifest
+                .workspace
+                .platforms
+                .iter()
+                .map(|p| p.name().as_str())
+                .collect();
+            assert_eq!(names, vec![subdir], "got {names:?}");
+        }
     }
 
     #[test]

--- a/tests/data/satisfiability/sysreq-platform-restriction-composition/pixi.lock
+++ b/tests/data/satisfiability/sysreq-platform-restriction-composition/pixi.lock
@@ -1,0 +1,30 @@
+version: 7
+platforms:
+- name: p1
+  subdir: linux-64
+  virtual-packages:
+  - __glibc=2.17
+  - __unix=0=0
+  - __linux=4.18
+  - __archspec=0=x86_64
+environments:
+  default:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    packages:
+      p1:
+      - conda: https://prefix.dev/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+  restricted:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    packages:
+      p1:
+      - conda: https://prefix.dev/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+packages:
+- conda: https://prefix.dev/conda-forge/noarch/_r-mutex-1.0.1-anacondar_1.tar.bz2
+  sha256: e58f9eeb416b92b550e824bcb1b9fb1958dee69abfe3089dfd1a9173e3a0528a
+  md5: 19f9db5f4f1b7f5ef5f6d67207f25f38
+  license: BSD
+  run_exports: {}
+  size: 3566
+  timestamp: 1562343890778

--- a/tests/data/satisfiability/sysreq-platform-restriction-composition/pixi.toml
+++ b/tests/data/satisfiability/sysreq-platform-restriction-composition/pixi.toml
@@ -1,0 +1,16 @@
+[workspace]
+channels = ["https://prefix.dev/conda-forge"]
+name = "sysreq-platform-restriction-composition"
+platforms = ["linux-64"]
+
+[system-requirements]
+libc = "2.17"
+
+[dependencies]
+_r-mutex = "*"
+
+[feature.x86-only]
+platforms = ["linux-64"]
+
+[environments]
+restricted = { features = ["x86-only"] }

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -230,3 +230,44 @@ task1 = "echo task1"
         ExitCode.SUCCESS,
         stdout_contains="task1",
     )
+
+
+def test_sysreq_platform_restriction_lock_check_converges(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """A ``[system-requirements]`` table combined with a feature that restricts
+    platforms must produce a lock file that passes ``pixi lock --check``.
+
+    Repro of the never-converging lock: the environment combining both
+    features was composed from the subdir default virtual packages instead of
+    the declared baseline, identity-equal to the bare subdir platform, so the
+    lock-file name restore was ambiguous and every check re-solved to the
+    same lock. No host gating: locking solves the declared platforms, and
+    ``linux-64`` is declared literally so the libc requirement applies.
+    """
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "sysreq-restriction"
+channels = ["{virtual_packages_channel}"]
+platforms = ["linux-64"]
+
+[system-requirements]
+libc = "2.17"
+
+[dependencies]
+no-deps = "*"
+
+[feature.x86-only]
+platforms = ["linux-64"]
+
+[environments]
+restricted = {{ features = ["x86-only"] }}
+""",
+    )
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest], ExitCode.SUCCESS)
+    verify_cli_command(
+        [pixi, "lock", "--check", "--dry-run", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+    )


### PR DESCRIPTION
### Description

A workspace that still uses the deprecated `[system-requirements]` table together with a feature that restricts platforms writes a lock file it then rejects forever, and the affected environment is solved against pixi's default virtual packages instead of the declared ones.

Reproducer, any host OS, current main:

```toml
[workspace]
name = "repro"
channels = ["conda-forge"]
platforms = ["linux-64", "linux-aarch64"]

[system-requirements]
libc = "2.17"

[dependencies]
zlib = "*"

[feature.x86-only]
platforms = ["linux-64"]

[environments]
restricted = { features = ["x86-only"] }
```

```console
$ pixi lock                    # exit 0, writes pixi.lock
$ pixi lock --check --dry-run  # exit 1: lock file would be updated
$ pixi install --locked        # lock file not up-to-date with the workspace
```

Relocking writes byte-identical content and the check keeps failing. The lock also contains a `linux-64` row with `__glibc=2.28` although the manifest declares `2.17`. pixi 0.70.2 locks the same manifest and passes its own check.

Two defects on the `[system-requirements]` migration path cooperate:

- `union_virtual_packages` unioned the referenced platforms' declared virtual packages. A bare `linux-64` pinned by the feature carries the materialised default `__glibc=2.28` as a declared entry, which overrides the explicit `2.17` under highest-version-wins. The union then equals exactly the subdir defaults.
- Such a union, and equally a migrated sysreq that restates the subdir defaults, was given a distinct `-generic` name. That platform is identity-equal (subdir plus customised virtual packages) to bare `linux-64`, so the identity-based name restore in the lock-file rename pass is ambiguous and skipped, the environment's rows are never found again, and every check re-solves to the identical lock.

The fix unions only the customised virtual packages (declared minus subdir defaults), matching the legacy `SystemRequirements::union` semantics where an absent requirement constrains nothing, and registers the bare subdir platform instead of minting a `-generic` twin when a sysreq collapses to exactly the defaults. With the customised-only union an empty union ~can only name the bare subdir, which is then the correct platform~ resolves to the existing bare subdir platform (`new_with_defaults` routes `name == subdir` with no customisations through `from_subdir`). No new platform is created and no customised platform takes a subdir or family name.

Behavior notes:

- A lock file written by an affected pixi is flagged once and heals after one relock.
- System requirements that exactly restate a subdir default (`libc`, `linux`, or `macos`) now migrate to the bare subdir platform. An environment that combines such a feature with a lower explicit requirement solves at the lower value, where pre-0.71 took the max. The solved environment stays compatible with every declared target.
- Windows is unaffected: `[system-requirements]` has no key that maps to `__win`, and `__cuda` has no subdir default to restate.
- Hand-written duplicate platform identities (two named platforms with the same subdir and virtual packages) still fail the check loop. That predates this change; rejecting duplicate identities at parse time would be the follow-up.

### How Has This Been Tested?

- New satisfiability data case `sysreq-platform-restriction-composition` (manifest plus converged lock). Without the fix it fails with "the requirement '_r-mutex *' could not be satisfied".
- New integration test `test_sysreq_platform_restriction_lock_check_converges` in `test_richer_platform_bugs.py`. Network-free via the in-repo `virtual_packages` channel, runs on every host since it only locks, fails without the fix.
- Unit tests cover the migration collapse for the glibc, linux, and macos defaults.
- `cargo test -p pixi_manifest` and `cargo test -p pixi_core --lib` pass. The reproducer above converges with the fix, as does the macos analogue on osx-arm64, and a lock written by an unfixed build heals after one relock.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code with Fable 5 and Codex with GPT 5.5

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
