### PR TITLE
feat: inline package manifests for `pixi global`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6909,6 +6909,7 @@ dependencies = [
  "toml_edit",
  "tracing",
  "url",
+ "xxhash-rust",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6875,6 +6875,7 @@ dependencies = [
  "miette 7.6.0",
  "once_cell",
  "ordermap",
+ "pixi_build_discovery",
  "pixi_build_frontend",
  "pixi_command_dispatcher",
  "pixi_config",

--- a/crates/pixi_cli/src/global/add.rs
+++ b/crates/pixi_cli/src/global/add.rs
@@ -1,4 +1,3 @@
-use crate::global::eventual_environment_channels;
 use crate::global::global_specs::GlobalSpecs;
 use crate::global::revert_environment_after_error;
 
@@ -6,6 +5,7 @@ use clap::Parser;
 use pixi_config::{Config, ConfigCli};
 use pixi_global::project::GlobalSpec;
 use pixi_global::{EnvironmentName, Mapping, Project, StateChange, StateChanges};
+use rattler_conda_types::NamedChannelOrUrl;
 
 /// Adds dependencies to an environment
 ///
@@ -40,12 +40,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .with_cli_config(config.clone());
 
-    if project_original.environment(&args.environment).is_none() {
+    let Some(environment) = project_original.environment(&args.environment) else {
         miette::bail!(
             "Environment {} doesn't exist. You can create a new environment with `pixi global install`.",
             &args.environment
         );
-    }
+    };
+    // Name inference solves the build backend against the channels of the
+    // environment the packages are added to.
+    let environment_channels: Vec<NamedChannelOrUrl> =
+        environment.channels().into_iter().cloned().collect();
 
     async fn apply_changes(
         env_name: &EnvironmentName,
@@ -103,8 +107,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         Ok(state_changes)
     }
 
-    let environment_channels =
-        eventual_environment_channels(&project_original, Some(&args.environment), &[], false);
     let specs = args
         .packages
         .to_global_specs(

--- a/crates/pixi_cli/src/global/add.rs
+++ b/crates/pixi_cli/src/global/add.rs
@@ -1,3 +1,4 @@
+use crate::global::eventual_environment_channels;
 use crate::global::global_specs::GlobalSpecs;
 use crate::global::revert_environment_after_error;
 
@@ -102,12 +103,15 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         Ok(state_changes)
     }
 
+    let environment_channels =
+        eventual_environment_channels(&project_original, Some(&args.environment), &[], false);
     let specs = args
         .packages
         .to_global_specs(
             project_original.global_channel_config(),
             &project_original.root,
             &project_original,
+            &environment_channels,
         )
         .await?;
 

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -10,8 +10,8 @@ use pixi_consts::consts;
 use pixi_global::project::FromMatchSpecError;
 use pixi_spec::{PixiSpec, Subdirectory, SubdirectoryError};
 use rattler_conda_types::{
-    ChannelConfig, MatchSpec, PackageName, ParseMatchSpecError, ParseMatchSpecOptions,
-    RepodataRevision,
+    ChannelConfig, MatchSpec, NamedChannelOrUrl, PackageName, ParseMatchSpecError,
+    ParseMatchSpecOptions, RepodataRevision,
 };
 use typed_path::Utf8NativePathBuf;
 
@@ -249,12 +249,15 @@ impl GlobalSpecs {
         Ok(Some(pixi_global::project::InlinePackageValue::new(package)))
     }
 
-    /// Convert GlobalSpecs to a vector of GlobalSpec instances
+    /// Convert GlobalSpecs to a vector of GlobalSpec instances. `channels`
+    /// are the channels of the environment the specs are destined for; name
+    /// inference solves the build backend against them.
     pub async fn to_global_specs(
         &self,
         channel_config: &ChannelConfig,
         manifest_root: &Path,
         project: &pixi_global::Project,
+        channels: &[NamedChannelOrUrl],
     ) -> Result<Vec<pixi_global::project::GlobalSpec>, GlobalSpecsConversionError> {
         let git_or_path_spec = if let Some(git_url) = &self.git {
             let git_spec = pixi_spec::GitSpec::new(
@@ -356,7 +359,7 @@ impl GlobalSpecs {
                     })
                     .transpose()?;
                 let inferred_name = project
-                    .infer_package_name_from_spec(&pixi_spec, inline_manifest.as_ref())
+                    .infer_package_name_from_spec(&pixi_spec, inline_manifest.as_ref(), channels)
                     .await?;
                 let mut spec = pixi_global::project::GlobalSpec::new(inferred_name, pixi_spec);
                 if let Some(inline) = inline {
@@ -443,7 +446,7 @@ mod tests {
         let project = isolated_project(temp_dir.path()).await;
 
         let global_specs = specs
-            .to_global_specs(&channel_config, &manifest_root, &project)
+            .to_global_specs(&channel_config, &manifest_root, &project, &[])
             .await
             .unwrap();
 
@@ -467,7 +470,7 @@ mod tests {
         let project = isolated_project(temp_dir.path()).await;
 
         let global_specs = specs
-            .to_global_specs(&channel_config, &manifest_root, &project)
+            .to_global_specs(&channel_config, &manifest_root, &project, &[])
             .await
             .unwrap();
 
@@ -506,7 +509,7 @@ mod tests {
                 };
 
                 let global_specs = specs
-                    .to_global_specs(&channel_config, &manifest_root, &project)
+                    .to_global_specs(&channel_config, &manifest_root, &project, &[])
                     .await
                     .unwrap();
 
@@ -553,7 +556,7 @@ mod tests {
         let project = isolated_project(temp_dir.path()).await;
 
         let global_specs = specs
-            .to_global_specs(&channel_config, &manifest_root, &project)
+            .to_global_specs(&channel_config, &manifest_root, &project, &[])
             .await;
         assert!(global_specs.is_err());
     }
@@ -644,7 +647,7 @@ mod tests {
         let manifest_root = PathBuf::from(".");
         let project = pixi_global::Project::discover_or_create().await.unwrap();
         let global_specs = specs
-            .to_global_specs(&channel_config, &manifest_root, &project)
+            .to_global_specs(&channel_config, &manifest_root, &project, &[])
             .await
             .unwrap();
         assert_eq!(global_specs.len(), 2);
@@ -666,7 +669,7 @@ mod tests {
         let manifest_root = PathBuf::from(".");
         let project = pixi_global::Project::discover_or_create().await.unwrap();
         let err = specs
-            .to_global_specs(&channel_config, &manifest_root, &project)
+            .to_global_specs(&channel_config, &manifest_root, &project, &[])
             .await
             .unwrap_err();
         assert!(

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -158,25 +158,16 @@ fn merge_inline_tables(
 }
 
 /// Parses a single `--package DOTTED_KEY=TOML_VALUE` fragment into an inline
-/// table. The value is parsed as a TOML value with a bare-string fallback, so
-/// `--package build.config.profile=release` works without inner quotes.
+/// table. The right-hand side must be a valid TOML value, so strings need
+/// their quotes: `--package 'build.config.profile="release"'`.
 fn parse_package_fragment(
     input: &str,
 ) -> Result<toml_edit::InlineTable, GlobalSpecsConversionError> {
-    let document = input.parse::<toml_edit::DocumentMut>().or_else(|error| {
-        // Bare-string fallback: quote the right-hand side and try again.
-        let Some((key, value)) = input.split_once('=') else {
-            return Err(GlobalSpecsConversionError::InvalidPackageFragment {
-                input: input.to_string(),
-                reason: error.message().to_string(),
-            });
-        };
-        format!("{key} = {}", toml_edit::Value::from(value.trim()))
-            .parse::<toml_edit::DocumentMut>()
-            .map_err(|_| GlobalSpecsConversionError::InvalidPackageFragment {
-                input: input.to_string(),
-                reason: error.message().to_string(),
-            })
+    let document = input.parse::<toml_edit::DocumentMut>().map_err(|error| {
+        GlobalSpecsConversionError::InvalidPackageFragment {
+            input: input.to_string(),
+            reason: error.message().to_string(),
+        }
     })?;
     Ok(document.as_table().clone().into_inline_table())
 }
@@ -598,15 +589,14 @@ mod tests {
         );
     }
 
-    /// `--package` fragments merge into the definition, with a bare-string
-    /// fallback so a right-hand side needs no inner quotes.
+    /// `--package` fragments merge into the definition.
     #[test]
     fn test_package_fragments_merge() {
         let specs = GlobalSpecs {
             build_backend: Some("pixi-build-python".to_string()),
             package: vec![
                 "host-dependencies.hatchling=\"*\"".to_string(),
-                "build.config.profile=release".to_string(),
+                "build.config.profile=\"release\"".to_string(),
             ],
             ..Default::default()
         };
@@ -640,6 +630,30 @@ mod tests {
     fn test_no_inline_definition() {
         let specs = GlobalSpecs::default();
         assert!(specs.inline_package_value().unwrap().is_none());
+    }
+
+    /// One inline definition given next to several named packages is attached
+    /// to each of them.
+    #[tokio::test]
+    async fn test_inline_applies_to_all_named_packages() {
+        let specs = GlobalSpecs {
+            specs: vec!["foo".to_string(), "bar".to_string()],
+            git: Some("https://github.com/user/repo.git".parse().unwrap()),
+            build_backend: Some("pixi-build-rust".to_string()),
+            ..Default::default()
+        };
+        let channel_config = ChannelConfig::default_with_root_dir(PathBuf::from("."));
+        let manifest_root = PathBuf::from(".");
+        let project = pixi_global::Project::discover_or_create().await.unwrap();
+        let global_specs = specs
+            .to_global_specs(&channel_config, &manifest_root, &project)
+            .await
+            .unwrap();
+        assert_eq!(global_specs.len(), 2);
+        assert!(
+            global_specs.iter().all(|spec| spec.inline.is_some()),
+            "every named package should carry the inline definition"
+        );
     }
 
     /// `--build-backend`/`--package` without a source location is an error.
@@ -684,10 +698,18 @@ mod tests {
         }
     }
 
-    /// A `--package` fragment that isn't a `DOTTED_KEY=TOML_VALUE` pair is rejected.
+    /// A `--package` fragment that isn't a `DOTTED_KEY=TOML_VALUE` pair is
+    /// rejected. In particular, the right-hand side must be a valid TOML
+    /// value: unquoted strings and malformed arrays error instead of being
+    /// silently recorded as strings.
     #[test]
     fn test_invalid_package_fragment() {
-        for fragment in ["no-equals-sign", "=novalue"] {
+        for fragment in [
+            "no-equals-sign",
+            "=novalue",
+            "build.config.profile=release",
+            "build.config.extra-args=[1,2",
+        ] {
             let specs = GlobalSpecs {
                 package: vec![fragment.to_string()],
                 ..Default::default()

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -662,4 +662,137 @@ mod tests {
             "expected an inline-requires-source error, got {err:?}"
         );
     }
+
+    /// `--build-backend` accepts only a name and a version constraint; any other
+    /// matchspec component (channel, build string, subdir, ...) is rejected.
+    #[test]
+    fn test_build_backend_rejects_non_version_matchspec() {
+        for input in [
+            "conda-forge::pixi-build-rust",
+            "pixi-build-rust[build=foo]",
+            "pixi-build-rust[subdir=noarch]",
+        ] {
+            let specs = GlobalSpecs {
+                build_backend: Some(input.to_string()),
+                ..Default::default()
+            };
+            let err = specs.inline_package_value().unwrap_err();
+            assert!(
+                matches!(err, GlobalSpecsConversionError::InvalidBuildBackend { .. }),
+                "expected an invalid-build-backend error for '{input}', got {err:?}"
+            );
+        }
+    }
+
+    /// A `--package` fragment that isn't a `DOTTED_KEY=TOML_VALUE` pair is rejected.
+    #[test]
+    fn test_invalid_package_fragment() {
+        for fragment in ["no-equals-sign", "=novalue"] {
+            let specs = GlobalSpecs {
+                package: vec![fragment.to_string()],
+                ..Default::default()
+            };
+            let err = specs.inline_package_value().unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    GlobalSpecsConversionError::InvalidPackageFragment { .. }
+                ),
+                "expected an invalid-package-fragment error for '{fragment}', got {err:?}"
+            );
+        }
+    }
+
+    /// Two `--package` fragments setting the same leaf key collide.
+    #[test]
+    fn test_two_package_fragments_collide() {
+        let specs = GlobalSpecs {
+            package: vec![
+                "host-dependencies.hatchling=\"1\"".to_string(),
+                "host-dependencies.hatchling=\"2\"".to_string(),
+            ],
+            ..Default::default()
+        };
+        let err = specs.inline_package_value().unwrap_err();
+        assert!(
+            matches!(err, GlobalSpecsConversionError::PackageKeyCollision { .. }),
+            "expected a collision error, got {err:?}"
+        );
+    }
+
+    /// `--build-backend NAME` records the same definition as
+    /// `--package 'build.backend.name="NAME"'`.
+    #[test]
+    fn test_build_backend_equivalent_to_package() {
+        let sugar = GlobalSpecs {
+            build_backend: Some("pixi-build-rust".to_string()),
+            ..Default::default()
+        };
+        let explicit = GlobalSpecs {
+            package: vec!["build.backend.name=\"pixi-build-rust\"".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            sugar
+                .inline_package_value()
+                .unwrap()
+                .unwrap()
+                .to_toml_value()
+                .to_string(),
+            explicit
+                .inline_package_value()
+                .unwrap()
+                .unwrap()
+                .to_toml_value()
+                .to_string(),
+        );
+    }
+
+    /// The inline definition may not set `name` (it comes from the dependency
+    /// key) nor `build.source` (it comes from the dependency spec). Both checks
+    /// live past the `build.backend` requirement, so a backend must be present
+    /// for the definition to parse far enough to reach them.
+    #[test]
+    fn test_inline_definition_rejects_reserved_keys() {
+        let name = PackageName::new_unchecked("xsv");
+        let root = std::path::Path::new(".");
+
+        let explicit_name = GlobalSpecs {
+            build_backend: Some("pixi-build-rust".to_string()),
+            package: vec!["name=\"other\"".to_string()],
+            ..Default::default()
+        };
+        let err = explicit_name
+            .inline_package_value()
+            .unwrap()
+            .unwrap()
+            .to_inline_manifest(&name, root)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                pixi_global::project::InlinePackageValueError::ExplicitName
+            ),
+            "expected an explicit-name error, got {err:?}"
+        );
+
+        let explicit_source = GlobalSpecs {
+            build_backend: Some("pixi-build-rust".to_string()),
+            package: vec!["build.source.path=\"elsewhere\"".to_string()],
+            ..Default::default()
+        };
+        let err = explicit_source
+            .inline_package_value()
+            .unwrap()
+            .unwrap()
+            .to_inline_manifest(&name, root)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                pixi_global::project::InlinePackageValueError::ExplicitBuildSource
+            ),
+            "expected an explicit-build-source error, got {err:?}"
+        );
+    }
 }

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -10,7 +10,8 @@ use pixi_consts::consts;
 use pixi_global::project::FromMatchSpecError;
 use pixi_spec::{PixiSpec, Subdirectory, SubdirectoryError};
 use rattler_conda_types::{
-    ChannelConfig, MatchSpec, ParseMatchSpecError, ParseMatchSpecOptions, RepodataRevision,
+    ChannelConfig, MatchSpec, PackageName, ParseMatchSpecError, ParseMatchSpecOptions,
+    RepodataRevision,
 };
 use typed_path::Utf8NativePathBuf;
 
@@ -37,6 +38,20 @@ pub struct GlobalSpecs {
     /// The path to the local package
     #[clap(long, conflicts_with = "git")]
     pub path: Option<Utf8NativePathBuf>,
+
+    /// The build backend to build the source with, when the source does not
+    /// provide its own package manifest (or to override the one it has).
+    /// Accepts a name with an optional version constraint, e.g.
+    /// `pixi-build-rust` or `"pixi-build-rust>=0.3,<0.4"`.
+    #[clap(long, value_name = "BUILD_BACKEND")]
+    pub build_backend: Option<String>,
+
+    /// Additional fields of the inline package definition, as
+    /// `DOTTED_KEY=TOML_VALUE` pairs that are recorded under the `package`
+    /// key of the dependency, e.g. `host-dependencies.hatchling="*"` or
+    /// `build.config.extra-args=["--all-features"]`.
+    #[clap(long = "package", value_name = "KEY=VALUE")]
+    pub package: Vec<String>,
 }
 
 impl HasSpecs for GlobalSpecs {
@@ -56,6 +71,25 @@ pub enum GlobalSpecsConversionError {
         help = "Use a full package specification like `python==3.12` instead of just `==3.12`"
     )]
     NameRequired,
+    #[error("`--build-backend` and `--package` require a source location")]
+    #[diagnostic(help = "Add `--git <URL>` or `--path <PATH>` to specify where the source lives")]
+    InlineRequiresSource,
+    #[error("invalid `--build-backend` value '{input}': {reason}")]
+    #[diagnostic(
+        help = "Pass a package name with an optional version constraint, e.g. `pixi-build-rust` or `\"pixi-build-rust>=0.3,<0.4\"`"
+    )]
+    InvalidBuildBackend { input: String, reason: String },
+    #[error("invalid `--package` value '{input}': {reason}")]
+    #[diagnostic(
+        help = "Pass a `DOTTED_KEY=TOML_VALUE` pair, e.g. `--package 'host-dependencies.hatchling=\"*\"'`"
+    )]
+    InvalidPackageFragment { input: String, reason: String },
+    #[error("the key '{key}' of the inline package definition is set more than once")]
+    #[diagnostic(help = "Each `--package` key (and `--build-backend`) may only be set once")]
+    PackageKeyCollision { key: String },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InlinePackageValue(#[from] pixi_global::project::InlinePackageValueError),
     #[error("couldn't construct a relative path from {} to {}", .0, .1)]
     RelativePath(String, String),
     #[error("could not absolutize path: {0}")]
@@ -86,7 +120,146 @@ pub enum GlobalSpecsConversionError {
     InvalidSubdirectory(#[from] SubdirectoryError),
 }
 
+/// Merges `source` into `target` one level at a time: when both sides hold a
+/// table under the same key, those tables are merged as well, while a key that
+/// is already set to anything else is a collision and errors out. That way
+/// several `--package` fragments can build up a single definition without
+/// silently overwriting each other's keys.
+/// `path` is the dotted key of the table being merged right now, for example
+/// `build.backend`, so a collision can be reported as the full key.
+fn merge_inline_tables(
+    target: &mut toml_edit::InlineTable,
+    source: toml_edit::InlineTable,
+    path: &str,
+) -> Result<(), GlobalSpecsConversionError> {
+    for (key, value) in source.into_iter() {
+        let key_path = if path.is_empty() {
+            key.to_string()
+        } else {
+            format!("{path}.{key}")
+        };
+        match target.get_mut(&key) {
+            None => {
+                target.insert(&key, value);
+            }
+            Some(toml_edit::Value::InlineTable(existing)) => {
+                if let toml_edit::Value::InlineTable(source) = value {
+                    merge_inline_tables(existing, source, &key_path)?;
+                } else {
+                    return Err(GlobalSpecsConversionError::PackageKeyCollision { key: key_path });
+                }
+            }
+            Some(_) => {
+                return Err(GlobalSpecsConversionError::PackageKeyCollision { key: key_path });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Parses a single `--package DOTTED_KEY=TOML_VALUE` fragment into an inline
+/// table. The value is parsed as a TOML value with a bare-string fallback, so
+/// `--package build.config.profile=release` works without inner quotes.
+fn parse_package_fragment(
+    input: &str,
+) -> Result<toml_edit::InlineTable, GlobalSpecsConversionError> {
+    let document = input.parse::<toml_edit::DocumentMut>().or_else(|error| {
+        // Bare-string fallback: quote the right-hand side and try again.
+        let Some((key, value)) = input.split_once('=') else {
+            return Err(GlobalSpecsConversionError::InvalidPackageFragment {
+                input: input.to_string(),
+                reason: error.message().to_string(),
+            });
+        };
+        format!("{key} = {}", toml_edit::Value::from(value.trim()))
+            .parse::<toml_edit::DocumentMut>()
+            .map_err(|_| GlobalSpecsConversionError::InvalidPackageFragment {
+                input: input.to_string(),
+                reason: error.message().to_string(),
+            })
+    })?;
+    Ok(document.as_table().clone().into_inline_table())
+}
+
+/// Renders a chain of single-entry tables as dotted keys, so a definition
+/// shows up as `package.build.backend.name = "pixi-build-rust"` instead of
+/// `package = { build = { backend = { name = "pixi-build-rust" } } }`.
+/// Tables with several entries keep their braces.
+fn collapse_to_dotted_keys(table: &mut toml_edit::InlineTable) {
+    if table.len() != 1 {
+        return;
+    }
+    if let Some((_, value)) = table.iter_mut().next()
+        && let Some(nested) = value.as_inline_table_mut()
+    {
+        collapse_to_dotted_keys(nested);
+    }
+    table.set_dotted(true);
+}
+
 impl GlobalSpecs {
+    /// Builds the inline package definition from `--build-backend` and
+    /// `--package`, or `None` when neither is given.
+    fn inline_package_value(
+        &self,
+    ) -> Result<Option<pixi_global::project::InlinePackageValue>, GlobalSpecsConversionError> {
+        if self.build_backend.is_none() && self.package.is_empty() {
+            return Ok(None);
+        }
+
+        let mut package = toml_edit::InlineTable::new();
+
+        // `--build-backend NAME` is sugar for
+        // `--package 'build.backend.name="NAME"'` (plus the version
+        // constraint when one is given).
+        if let Some(input) = &self.build_backend {
+            let match_spec =
+                MatchSpec::from_str(input, ParseMatchSpecOptions::lenient()).map_err(|e| {
+                    GlobalSpecsConversionError::InvalidBuildBackend {
+                        input: input.clone(),
+                        reason: e.to_string(),
+                    }
+                })?;
+            let name = match_spec.name.as_exact().cloned().ok_or_else(|| {
+                GlobalSpecsConversionError::InvalidBuildBackend {
+                    input: input.clone(),
+                    reason: "a package name is required".to_string(),
+                }
+            })?;
+            if match_spec.build.is_some()
+                || match_spec.build_number.is_some()
+                || match_spec.channel.is_some()
+                || match_spec.subdir.is_some()
+                || match_spec.md5.is_some()
+                || match_spec.sha256.is_some()
+                || match_spec.url.is_some()
+            {
+                return Err(GlobalSpecsConversionError::InvalidBuildBackend {
+                    input: input.clone(),
+                    reason: "only a name and a version constraint are supported".to_string(),
+                });
+            }
+
+            let mut backend = toml_edit::InlineTable::new();
+            backend.insert("name", name.as_source().into());
+            if let Some(version) = &match_spec.version {
+                backend.insert("version", version.to_string().into());
+            }
+            let mut build = toml_edit::InlineTable::new();
+            build.insert("backend", toml_edit::Value::InlineTable(backend));
+            package.insert("build", toml_edit::Value::InlineTable(build));
+        }
+
+        for fragment in &self.package {
+            let table = parse_package_fragment(fragment)?;
+            merge_inline_tables(&mut package, table, "")?;
+        }
+
+        collapse_to_dotted_keys(&mut package);
+
+        Ok(Some(pixi_global::project::InlinePackageValue::new(package)))
+    }
+
     /// Convert GlobalSpecs to a vector of GlobalSpec instances
     pub async fn to_global_specs(
         &self,
@@ -173,14 +346,34 @@ impl GlobalSpecs {
             }
             None
         };
+        // The inline package definition assembled from `--build-backend` and
+        // `--package`, if any. It only makes sense next to a source location.
+        let inline = self.inline_package_value()?;
+
         if let Some(pixi_spec) = git_or_path_spec {
             if self.specs.is_empty() {
-                // Infer the package name from the path/git spec
-                let inferred_name = project.infer_package_name_from_spec(&pixi_spec).await?;
-                return Ok(vec![pixi_global::project::GlobalSpec::new(
-                    inferred_name,
-                    pixi_spec,
-                )]);
+                // Infer the package name from the path/git spec. With an
+                // inline definition present, backend discovery uses it
+                // instead of reading a manifest from the checkout; the
+                // placeholder name only serves the inference call, the
+                // definition is re-anchored to the inferred name below.
+                let inline_manifest = inline
+                    .as_ref()
+                    .map(|value| {
+                        value.to_inline_manifest(
+                            &PackageName::new_unchecked("uninferred-package"),
+                            manifest_root,
+                        )
+                    })
+                    .transpose()?;
+                let inferred_name = project
+                    .infer_package_name_from_spec(&pixi_spec, inline_manifest.as_ref())
+                    .await?;
+                let mut spec = pixi_global::project::GlobalSpec::new(inferred_name, pixi_spec);
+                if let Some(inline) = inline {
+                    spec = spec.with_inline(inline);
+                }
+                return Ok(vec![spec]);
             }
 
             self.specs
@@ -195,12 +388,20 @@ impl GlobalSpecs {
                     .as_exact()
                     .cloned()
                     .ok_or(GlobalSpecsConversionError::NameRequired)?;
-                    Ok(pixi_global::project::GlobalSpec::new(
-                        name,
-                        pixi_spec.clone(),
-                    ))
+                    // Validate the inline definition early, before anything
+                    // is recorded in the manifest.
+                    if let Some(inline) = &inline {
+                        inline.to_inline_manifest(&name, manifest_root)?;
+                    }
+                    let mut spec = pixi_global::project::GlobalSpec::new(name, pixi_spec.clone());
+                    if let Some(inline) = &inline {
+                        spec = spec.with_inline(inline.clone());
+                    }
+                    Ok(spec)
                 })
                 .collect()
+        } else if inline.is_some() {
+            Err(GlobalSpecsConversionError::InlineRequiresSource)
         } else {
             self.specs
                 .iter()
@@ -241,10 +442,7 @@ mod tests {
     async fn test_to_global_specs_named() {
         let specs = GlobalSpecs {
             specs: vec!["numpy==1.21.0".to_string(), "scipy>=1.7".to_string()],
-            git: None,
-            rev: None,
-            subdir: None,
-            path: None,
+            ..Default::default()
         };
 
         let channel_config = ChannelConfig::default_with_root_dir(PathBuf::from("."));
@@ -268,9 +466,7 @@ mod tests {
         let specs = GlobalSpecs {
             specs: vec!["mypackage".to_string()],
             git: Some("https://github.com/user/repo.git".parse().unwrap()),
-            rev: None,
-            subdir: None,
-            path: None,
+            ..Default::default()
         };
 
         let channel_config = ChannelConfig::default_with_root_dir(PathBuf::from("."));
@@ -357,10 +553,7 @@ mod tests {
     async fn test_to_global_specs_nameless() {
         let specs = GlobalSpecs {
             specs: vec![">=1.0".to_string()],
-            git: None,
-            rev: None,
-            subdir: None,
-            path: None,
+            ..Default::default()
         };
 
         let channel_config = ChannelConfig::default_with_root_dir(PathBuf::from("."));
@@ -374,5 +567,99 @@ mod tests {
             .to_global_specs(&channel_config, &manifest_root, &project)
             .await;
         assert!(global_specs.is_err());
+    }
+
+    /// `--build-backend NAME` is sugar for a `build.backend.name` entry in the
+    /// inline package definition.
+    #[test]
+    fn test_build_backend_sugar() {
+        let specs = GlobalSpecs {
+            build_backend: Some("pixi-build-rust".to_string()),
+            ..Default::default()
+        };
+        let inline = specs.inline_package_value().unwrap().unwrap();
+        assert_eq!(
+            inline.to_toml_value().to_string(),
+            r#"{ build.backend.name = "pixi-build-rust" }"#
+        );
+    }
+
+    /// A version constraint on `--build-backend` lands as `build.backend.version`.
+    #[test]
+    fn test_build_backend_with_version() {
+        let specs = GlobalSpecs {
+            build_backend: Some("pixi-build-rust>=0.3,<0.4".to_string()),
+            ..Default::default()
+        };
+        let inline = specs.inline_package_value().unwrap().unwrap();
+        assert_eq!(
+            inline.to_toml_value().to_string(),
+            r#"{ build.backend = { name = "pixi-build-rust", version = ">=0.3,<0.4" } }"#
+        );
+    }
+
+    /// `--package` fragments merge into the definition, with a bare-string
+    /// fallback so a right-hand side needs no inner quotes.
+    #[test]
+    fn test_package_fragments_merge() {
+        let specs = GlobalSpecs {
+            build_backend: Some("pixi-build-python".to_string()),
+            package: vec![
+                "host-dependencies.hatchling=\"*\"".to_string(),
+                "build.config.profile=release".to_string(),
+            ],
+            ..Default::default()
+        };
+        let inline = specs.inline_package_value().unwrap().unwrap();
+        let rendered = inline.to_toml_value().to_string();
+        assert!(
+            rendered.contains(r#"name = "pixi-build-python""#),
+            "{rendered}"
+        );
+        assert!(rendered.contains(r#"hatchling = "*""#), "{rendered}");
+        assert!(rendered.contains(r#"profile = "release""#), "{rendered}");
+    }
+
+    /// Setting the same key via `--build-backend` and `--package` is an error.
+    #[test]
+    fn test_package_collision_with_build_backend() {
+        let specs = GlobalSpecs {
+            build_backend: Some("pixi-build-rust".to_string()),
+            package: vec!["build.backend.name=\"other\"".to_string()],
+            ..Default::default()
+        };
+        let err = specs.inline_package_value().unwrap_err();
+        assert!(
+            matches!(err, GlobalSpecsConversionError::PackageKeyCollision { .. }),
+            "expected a collision error, got {err:?}"
+        );
+    }
+
+    /// Neither flag means no inline definition.
+    #[test]
+    fn test_no_inline_definition() {
+        let specs = GlobalSpecs::default();
+        assert!(specs.inline_package_value().unwrap().is_none());
+    }
+
+    /// `--build-backend`/`--package` without a source location is an error.
+    #[tokio::test]
+    async fn test_inline_requires_source() {
+        let specs = GlobalSpecs {
+            specs: vec!["xsv".to_string()],
+            build_backend: Some("pixi-build-rust".to_string()),
+            ..Default::default()
+        };
+        let channel_config = ChannelConfig::default_with_root_dir(PathBuf::from("."));
+        let manifest_root = PathBuf::from(".");
+        let project = pixi_global::Project::discover_or_create().await.unwrap();
+        let err = specs
+            .to_global_specs(&channel_config, &manifest_root, &project)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, GlobalSpecsConversionError::InlineRequiresSource),
+            "expected an inline-requires-source error, got {err:?}"
+        );
     }
 }

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -217,14 +217,12 @@ impl GlobalSpecs {
                     reason: "a package name is required".to_string(),
                 }
             })?;
-            if match_spec.build.is_some()
-                || match_spec.build_number.is_some()
-                || match_spec.channel.is_some()
-                || match_spec.subdir.is_some()
-                || match_spec.md5.is_some()
-                || match_spec.sha256.is_some()
-                || match_spec.url.is_some()
-            {
+            let name_and_version_only = MatchSpec {
+                name: match_spec.name.clone(),
+                version: match_spec.version.clone(),
+                ..MatchSpec::default()
+            };
+            if match_spec != name_and_version_only {
                 return Err(GlobalSpecsConversionError::InvalidBuildBackend {
                     input: input.clone(),
                     reason: "only a name and a version constraint are supported".to_string(),

--- a/crates/pixi_cli/src/global/install.rs
+++ b/crates/pixi_cli/src/global/install.rs
@@ -8,8 +8,8 @@ use miette::Report;
 use rattler_conda_types::{MatchSpec, NamedChannelOrUrl, Platform};
 
 use crate::global::{
-    EnvironmentAction, global_specs::GlobalSpecs, report_failed_environments,
-    revert_environment_after_error,
+    EnvironmentAction, eventual_environment_channels, global_specs::GlobalSpecs,
+    report_failed_environments, revert_environment_after_error,
 };
 use pixi_config::{self, Config, ConfigCli};
 use pixi_global::{
@@ -97,9 +97,20 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
     let channel_config = project_original.global_channel_config().clone();
 
+    let inference_channels = eventual_environment_channels(
+        &project_original,
+        args.environment.as_ref(),
+        &args.channels,
+        args.force_reinstall,
+    );
     let specs = args
         .packages
-        .to_global_specs(&channel_config, &project_original.root, &project_original)
+        .to_global_specs(
+            &channel_config,
+            &project_original.root,
+            &project_original,
+            &inference_channels,
+        )
         .await?;
     let env_to_specs: IndexMap<EnvironmentName, Vec<GlobalSpec>> = match &args.environment {
         Some(env_name) => IndexMap::from([(env_name.clone(), specs)]),
@@ -182,11 +193,12 @@ async fn setup_environment(
         state_changes |= project.remove_environment(env_name).await?;
     }
 
-    let channels = if args.channels.is_empty() {
-        project.config().default_channels()
-    } else {
-        args.channels.clone()
-    };
+    let channels = eventual_environment_channels(
+        project,
+        Some(env_name),
+        &args.channels,
+        args.force_reinstall,
+    );
 
     // Modify the project to include the new environment
     if !project.manifest.parsed.envs.contains_key(env_name) {

--- a/crates/pixi_cli/src/global/mod.rs
+++ b/crates/pixi_cli/src/global/mod.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use miette::{IntoDiagnostic, Report, WrapErr};
+use rattler_conda_types::NamedChannelOrUrl;
 use tokio::fs as tokio_fs;
 
 use pixi_global::EnvironmentName;
@@ -125,6 +126,30 @@ fn report_failed_environments(
     ))
 }
 
+/// The channels an environment ends up with once it is set up: an
+/// environment that already exists in the manifest keeps its channels
+/// (unless `--force-reinstall` recreates it), a new one gets the
+/// `--channel` arguments or the config's default channels. Name inference
+/// runs before the manifest is touched and has to solve the build backend
+/// against these same channels.
+fn eventual_environment_channels(
+    project: &pixi_global::Project,
+    environment: Option<&EnvironmentName>,
+    cli_channels: &[NamedChannelOrUrl],
+    force_reinstall: bool,
+) -> Vec<NamedChannelOrUrl> {
+    if !force_reinstall
+        && let Some(environment) = environment.and_then(|name| project.environment(name))
+    {
+        return environment.channels().into_iter().cloned().collect();
+    }
+    if cli_channels.is_empty() {
+        project.config().default_channels()
+    } else {
+        cli_channels.to_vec()
+    }
+}
+
 /// Reverts the changes made to the project for a specific environment after an error occurred.
 async fn revert_environment_after_error(
     env_name: &EnvironmentName,
@@ -150,4 +175,92 @@ async fn revert_environment_after_error(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    /// Create a project in an isolated `PIXI_HOME` so tests never read the
+    /// global manifest of the machine they run on.
+    async fn isolated_project(temp_dir: &std::path::Path) -> pixi_global::Project {
+        let pixi_home_dir = temp_dir.join("pixi-home");
+        temp_env::async_with_vars(
+            [("PIXI_HOME", Some(pixi_home_dir.to_str().unwrap()))],
+            pixi_global::Project::discover_or_create(),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_eventual_environment_channels() {
+        let temp_dir = tempdir().unwrap();
+        let mut project = isolated_project(temp_dir.path()).await;
+
+        let existing = EnvironmentName::from_str("existing").unwrap();
+        let missing = EnvironmentName::from_str("missing").unwrap();
+        let env_channel = NamedChannelOrUrl::from_str("env-channel").unwrap();
+        let cli_channel = NamedChannelOrUrl::from_str("cli-channel").unwrap();
+        project
+            .manifest
+            .add_environment(&existing, Some(vec![env_channel.clone()]))
+            .unwrap();
+
+        let defaults = project.config().default_channels();
+
+        // No target environment: --channel arguments or the defaults.
+        assert_eq!(
+            eventual_environment_channels(&project, None, &[], false),
+            defaults
+        );
+        assert_eq!(
+            eventual_environment_channels(
+                &project,
+                None,
+                std::slice::from_ref(&cli_channel),
+                false
+            ),
+            vec![cli_channel.clone()]
+        );
+
+        // A named environment that does not exist yet behaves the same.
+        assert_eq!(
+            eventual_environment_channels(
+                &project,
+                Some(&missing),
+                std::slice::from_ref(&cli_channel),
+                false
+            ),
+            vec![cli_channel.clone()]
+        );
+
+        // An existing environment keeps its manifest channels; --channel
+        // arguments are not applied to it.
+        assert_eq!(
+            eventual_environment_channels(
+                &project,
+                Some(&existing),
+                std::slice::from_ref(&cli_channel),
+                false
+            ),
+            vec![env_channel]
+        );
+
+        // --force-reinstall recreates the environment, so the manifest
+        // channels no longer apply.
+        assert_eq!(
+            eventual_environment_channels(
+                &project,
+                Some(&existing),
+                std::slice::from_ref(&cli_channel),
+                true
+            ),
+            vec![cli_channel]
+        );
+    }
 }

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -1146,6 +1146,18 @@ pub enum BuildBackendMetadataError {
     NormalizePath(Arc<pixi_path::NormalizeError>),
 }
 
+impl BuildBackendMetadataError {
+    /// Returns the backend discovery failure this error ultimately stems
+    /// from, if any.
+    pub fn discovery_error(&self) -> Option<&pixi_build_discovery::DiscoveryError> {
+        match self {
+            BuildBackendMetadataError::Discovery(err) => Some(err),
+            BuildBackendMetadataError::Initialize(err) => err.discovery_error(),
+            _ => None,
+        }
+    }
+}
+
 impl From<pixi_build_discovery::DiscoveryError> for BuildBackendMetadataError {
     fn from(err: pixi_build_discovery::DiscoveryError) -> Self {
         Self::Discovery(Arc::new(err))

--- a/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/dev_source_metadata/mod.rs
@@ -59,6 +59,17 @@ pub enum DevSourceMetadataError {
     PackageNotProvided(#[from] PackageNotProvidedError),
 }
 
+impl DevSourceMetadataError {
+    /// Returns the backend discovery failure this error ultimately stems
+    /// from, if any.
+    pub fn discovery_error(&self) -> Option<&pixi_build_discovery::DiscoveryError> {
+        match self {
+            DevSourceMetadataError::BuildBackendMetadata(err) => err.discovery_error(),
+            _ => None,
+        }
+    }
+}
+
 /// Error for when a package is not provided by the source.
 #[derive(Debug, Clone, Error)]
 pub struct PackageNotProvidedError {

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -260,6 +260,44 @@ pub enum SolvePixiEnvironmentError {
     SourceMetadata(SourceMetadataError),
 }
 
+impl SolvePixiEnvironmentError {
+    /// Returns the backend discovery failure this solve error ultimately
+    /// stems from, if any. Walks the typed error chain, including the solve
+    /// errors of nested build and host environments.
+    pub fn discovery_error(&self) -> Option<&pixi_build_discovery::DiscoveryError> {
+        match self {
+            SolvePixiEnvironmentError::SourceMetadata(err) => err.discovery_error(),
+            SolvePixiEnvironmentError::DevSourceMetadataError(err) => err.discovery_error(),
+            _ => None,
+        }
+    }
+}
+
+impl SourceMetadataError {
+    /// Returns the backend discovery failure this error ultimately stems
+    /// from, if any.
+    pub fn discovery_error(&self) -> Option<&pixi_build_discovery::DiscoveryError> {
+        match self {
+            SourceMetadataError::BuildBackendMetadata(err) => err.discovery_error(),
+            SourceMetadataError::SourceRecord(err) => err.discovery_error(),
+            _ => None,
+        }
+    }
+}
+
+impl SourceRecordError {
+    /// Returns the backend discovery failure this error ultimately stems
+    /// from, if any.
+    pub fn discovery_error(&self) -> Option<&pixi_build_discovery::DiscoveryError> {
+        match self {
+            SourceRecordError::BuildBackendMetadata(err) => err.discovery_error(),
+            SourceRecordError::SolveBuildEnvironment(err)
+            | SourceRecordError::SolveHostEnvironment(err) => err.discovery_error(),
+            _ => None,
+        }
+    }
+}
+
 impl From<SourceMetadataError> for SolvePixiEnvironmentError {
     fn from(err: SourceMetadataError) -> Self {
         // Preserve cycle-error identity when the SourceMetadata error
@@ -334,5 +372,70 @@ impl From<SolveCondaEnvironmentError> for SolvePixiEnvironmentError {
 impl From<crate::DevSourceMetadataError> for SolvePixiEnvironmentError {
     fn from(err: crate::DevSourceMetadataError) -> Self {
         Self::DevSourceMetadataError(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BuildBackendMetadataError;
+
+    fn discovery_failure() -> pixi_build_discovery::DiscoveryError {
+        pixi_build_discovery::DiscoveryError::FailedToDiscover {
+            path: "/some/source".to_string(),
+            help: "help".to_string(),
+        }
+    }
+
+    fn metadata_error() -> BuildBackendMetadataError {
+        BuildBackendMetadataError::Discovery(Arc::new(discovery_failure()))
+    }
+
+    #[test]
+    fn discovery_error_is_found_behind_build_backend_metadata() {
+        let err = SolvePixiEnvironmentError::SourceMetadata(
+            SourceMetadataError::BuildBackendMetadata(metadata_error()),
+        );
+        assert!(matches!(
+            err.discovery_error(),
+            Some(pixi_build_discovery::DiscoveryError::FailedToDiscover { .. })
+        ));
+    }
+
+    #[test]
+    fn discovery_error_is_found_behind_source_record() {
+        let err = SolvePixiEnvironmentError::SourceMetadata(SourceMetadataError::SourceRecord(
+            SourceRecordError::BuildBackendMetadata(metadata_error()),
+        ));
+        assert!(err.discovery_error().is_some());
+    }
+
+    #[test]
+    fn discovery_error_is_found_behind_nested_build_environment_solve() {
+        // A discovery failure while solving the build environment of another
+        // source dependency nests a full solve error inside the outer one.
+        let inner = SolvePixiEnvironmentError::SourceMetadata(
+            SourceMetadataError::BuildBackendMetadata(metadata_error()),
+        );
+        let err = SolvePixiEnvironmentError::SourceMetadata(SourceMetadataError::SourceRecord(
+            SourceRecordError::SolveBuildEnvironment(Box::new(inner)),
+        ));
+        assert!(err.discovery_error().is_some());
+    }
+
+    #[test]
+    fn discovery_error_is_found_behind_backend_initialization() {
+        let err = SolvePixiEnvironmentError::SourceMetadata(
+            SourceMetadataError::BuildBackendMetadata(BuildBackendMetadataError::Initialize(
+                InstantiateBackendError::Discovery(Arc::new(discovery_failure())),
+            )),
+        );
+        assert!(err.discovery_error().is_some());
+    }
+
+    #[test]
+    fn unrelated_solve_error_has_no_discovery_error() {
+        let err = SolvePixiEnvironmentError::Cycle(Cycle { stack: Vec::new() });
+        assert!(err.discovery_error().is_none());
     }
 }

--- a/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
@@ -198,6 +198,17 @@ pub enum InstantiateBackendError {
     Canonicalize(PathBuf, #[source] Arc<std::io::Error>),
 }
 
+impl InstantiateBackendError {
+    /// Returns the backend discovery failure this error ultimately stems
+    /// from, if any.
+    pub fn discovery_error(&self) -> Option<&DiscoveryError> {
+        match self {
+            InstantiateBackendError::Discovery(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 /// Handle to a spawned backend. Wrapped in a [`Mutex`] because the
 /// JSON-RPC transport serializes request/response over one stdio pipe
 /// and the `InMemoryBackend` trait object is not `Sync`.

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -20,7 +20,7 @@ use rattler_lock::{LockFile, LockedPackage};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     hash::{Hash, Hasher},
     io::ErrorKind,
     path::{Path, PathBuf},
@@ -395,8 +395,8 @@ pub struct EnvironmentFile {
     /// environments and environments written by an older pixi — for
     /// environments with source dependencies that means out-of-sync, which
     /// degrades gracefully to a one-time rebuild.
-    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    pub source_fingerprints: std::collections::BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub source_fingerprints: BTreeMap<String, u64>,
 }
 
 /// The path to the environment file in the `conda-meta` directory of the

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -392,7 +392,7 @@ pub struct EnvironmentFile {
     /// file; `pixi global sync` compares them against the manifest to decide
     /// whether a source dependency's *specification* changed (source content
     /// changes are `pixi global update`'s job). Empty for workspace
-    /// environments and environments written by an older pixi — for
+    /// environments and environments written by an older pixi. For
     /// environments with source dependencies that means out-of-sync, which
     /// degrades gracefully to a one-time rebuild.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -386,6 +386,17 @@ pub struct EnvironmentFile {
     /// be weaker than [`Self::resolved_platform`]. `None` as above.
     #[serde(default)]
     pub minimum_supported_platform: Option<PlatformData>,
+    /// Fingerprints of the manifest's source dependencies at install time,
+    /// keyed by package name: a hash of the source spec plus any inline
+    /// package definition. Only written by `pixi global`, which has no lock
+    /// file; `pixi global sync` compares them against the manifest to decide
+    /// whether a source dependency's *specification* changed (source content
+    /// changes are `pixi global update`'s job). Empty for workspace
+    /// environments and environments written by an older pixi — for
+    /// environments with source dependencies that means out-of-sync, which
+    /// degrades gracefully to a one-time rebuild.
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub source_fingerprints: std::collections::BTreeMap<String, u64>,
 }
 
 /// The path to the environment file in the `conda-meta` directory of the
@@ -434,9 +445,7 @@ pub fn write_environment_file(
 
 /// Reading the environment file of the environment.
 /// Removing it if it's not valid.
-pub(crate) fn read_environment_file(
-    environment_dir: &Path,
-) -> miette::Result<Option<EnvironmentFile>> {
+pub fn read_environment_file(environment_dir: &Path) -> miette::Result<Option<EnvironmentFile>> {
     let path = environment_file_path(environment_dir);
 
     let contents = match fs_err::read_to_string(&path) {

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -810,6 +810,7 @@ impl<'p> LockFileDerivedData<'p> {
                 environment_lock_file_hash: hash,
                 resolved_platform,
                 minimum_supported_platform,
+                source_fingerprints: Default::default(),
             },
         )?;
 

--- a/crates/pixi_global/Cargo.toml
+++ b/crates/pixi_global/Cargo.toml
@@ -22,6 +22,7 @@ itertools = { workspace = true }
 miette = { workspace = true }
 once_cell = { workspace = true }
 ordermap = { workspace = true }
+pixi_build_discovery = { workspace = true }
 pixi_build_frontend = { workspace = true }
 pixi_command_dispatcher = { workspace = true }
 pixi_config = { workspace = true }

--- a/crates/pixi_global/Cargo.toml
+++ b/crates/pixi_global/Cargo.toml
@@ -56,6 +56,7 @@ toml-span = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 zstd = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/pixi_global/src/project/global_spec.rs
+++ b/crates/pixi_global/src/project/global_spec.rs
@@ -1,4 +1,10 @@
 //! This module makes it a bit easier to pass around a package name and the pixi specification
+use std::path::Path;
+
+use pixi_manifest::{
+    InlinePackageManifest, KnownPreviewFeature, Preview,
+    toml::{TomlPackage, WorkspacePackageProperties},
+};
 use pixi_spec::PixiSpec;
 use rattler_conda_types::{
     MatchSpec, NamelessMatchSpec, PackageName, ParseMatchSpecOptions, RepodataRevision,
@@ -10,6 +16,10 @@ use rattler_conda_types::{
 pub struct GlobalSpec {
     pub name: PackageName,
     pub spec: PixiSpec,
+    /// An inline package definition (`package = { ... }`) accompanying a
+    /// source spec: it describes how the source is built when the source does
+    /// not provide its own package manifest (or to override the one it has).
+    pub inline: Option<InlinePackageValue>,
 }
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
@@ -23,7 +33,17 @@ pub enum FromMatchSpecError {
 impl GlobalSpec {
     /// Creates a new `GlobalSpec` with a package name and a Pixi specification.
     pub fn new(name: PackageName, spec: PixiSpec) -> Self {
-        Self { name, spec }
+        Self {
+            name,
+            spec,
+            inline: None,
+        }
+    }
+
+    /// Attaches an inline package definition to this spec.
+    pub fn with_inline(mut self, inline: InlinePackageValue) -> Self {
+        self.inline = Some(inline);
+        self
     }
 
     /// Returns the package name.
@@ -61,5 +81,90 @@ impl GlobalSpec {
             .ok_or_else(|| FromMatchSpecError::NameRequired(Box::new(nameless_spec.clone())))?;
         let pixi_spec = PixiSpec::from_nameless_matchspec(nameless_spec, channel_config);
         Ok(GlobalSpec::new(name.clone(), pixi_spec))
+    }
+}
+
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+pub enum InlinePackageValueError {
+    #[error("failed to parse the inline package definition: {0}")]
+    Parse(String),
+    #[error("an inline package definition cannot set `name`; it is taken from the dependency key")]
+    ExplicitName,
+    #[error(
+        "an inline package definition cannot set `build.source`; the source is taken from the dependency spec"
+    )]
+    ExplicitBuildSource,
+    #[error("failed to convert the inline package definition: {0}")]
+    Convert(String),
+}
+
+/// An inline package definition as the TOML value of the `package` key of a
+/// dependency entry (e.g. `package.build.backend.name = "pixi-build-rust"`).
+///
+/// The raw TOML representation is kept so the definition can be written
+/// verbatim into the global manifest document; [`Self::to_inline_manifest`]
+/// converts it into the resolved [`InlinePackageManifest`] when it is needed
+/// before the manifest is saved and re-parsed (e.g. for package name
+/// inference).
+#[derive(Debug, Clone)]
+pub struct InlinePackageValue(toml_edit::InlineTable);
+
+impl InlinePackageValue {
+    /// Wraps a `package` table.
+    pub fn new(table: toml_edit::InlineTable) -> Self {
+        Self(table)
+    }
+
+    /// Returns the definition as a TOML value, for insertion into a dependency
+    /// entry under the `package` key.
+    pub fn to_toml_value(&self) -> toml_edit::Value {
+        toml_edit::Value::InlineTable(self.0.clone())
+    }
+
+    /// Parses and converts the definition into an [`InlinePackageManifest`]
+    /// for the dependency `name`, mirroring the checks of the manifest parser:
+    /// the definition may not set `name` (it comes from the dependency key)
+    /// nor `build.source` (it comes from the dependency spec).
+    pub fn to_inline_manifest(
+        &self,
+        name: &PackageName,
+        root_directory: &Path,
+    ) -> Result<InlinePackageManifest, InlinePackageValueError> {
+        let source = format!("package = {}", self.0);
+        let mut value =
+            toml_span::parse(&source).map_err(|e| InlinePackageValueError::Parse(e.to_string()))?;
+        let mut th = toml_span::de_helpers::TableHelper::new(&mut value)
+            .map_err(|e| InlinePackageValueError::Parse(e.to_string()))?;
+        let (_, mut package_value) = th
+            .take("package")
+            .expect("the `package` key was just serialized");
+        let package = <TomlPackage as toml_span::Deserialize>::deserialize(&mut package_value)
+            .map_err(|e| {
+                InlinePackageValueError::Parse(
+                    e.errors
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join("; "),
+                )
+            })?;
+
+        if package.name.is_some() {
+            return Err(InlinePackageValueError::ExplicitName);
+        }
+        if package.build.source.is_some() {
+            return Err(InlinePackageValueError::ExplicitBuildSource);
+        }
+
+        let preview = Preview::from_iter([KnownPreviewFeature::PixiBuild]);
+        InlinePackageManifest::from_toml_package(
+            name,
+            package,
+            WorkspacePackageProperties::default(),
+            &preview,
+            root_directory,
+        )
+        .map(|with_warnings| with_warnings.value)
+        .map_err(|e| InlinePackageValueError::Convert(e.to_string()))
     }
 }

--- a/crates/pixi_global/src/project/manifest.rs
+++ b/crates/pixi_global/src/project/manifest.rs
@@ -162,20 +162,13 @@ impl Manifest {
             }
         };
 
-        // Update self.parsed
-        {
-            let env = self.parsed.envs.get_mut(env_name).ok_or_else(|| {
-                miette::miette!("Environment {} doesn't exist.", env_name.fancy_display())
-            })?;
-            env.dependencies.specs.insert(name.clone(), spec.clone());
-            // A previously recorded inline definition no longer applies when
-            // the dependency is overwritten without one.
-            env.inline_packages.swap_remove(name);
+        if !self.parsed.envs.contains_key(env_name) {
+            miette::bail!("Environment {} doesn't exist.", env_name.fancy_display());
         }
 
-        // Update self.document. Look up the existing key so a non-normalized
-        // spelling in the document (e.g. "PyTest" vs "pytest") is overwritten
-        // in place instead of inserted a second time.
+        // Look up the existing key so a non-normalized spelling in the
+        // document (e.g. "PyTest" vs "pytest") is overwritten in place
+        // instead of inserted a second time.
         let existing_key = self
             .document
             .get_nested_table(&["envs", env_name.as_str(), "dependencies"])
@@ -187,24 +180,49 @@ impl Manifest {
                 })
             });
         let key = existing_key.as_deref().unwrap_or(name.as_normalized());
-        self.document.insert_into_inline_table(
-            &["envs", env_name.as_str(), "dependencies"],
-            key,
-            toml_value.clone(),
-        )?;
 
-        // Inline package definitions are converted with root-directory
-        // context by the manifest parser; re-parse the document so
-        // `self.parsed` picks up the converted definition.
         if named_spec.inline.is_some() {
-            let contents = self.document.to_string();
+            // Inline package definitions are converted with root-directory
+            // context by the manifest parser, so `self.parsed` has to come
+            // from a re-parse of the document. Apply the edit to a scratch
+            // copy first and only commit document and parsed manifest
+            // together once the re-parse succeeds, keeping both consistent
+            // when it doesn't.
+            let mut document = self.document.clone();
+            document.insert_into_inline_table(
+                &["envs", env_name.as_str(), "dependencies"],
+                key,
+                toml_value.clone(),
+            )?;
+            let contents = document.to_string();
             let root_directory = self.path.parent().unwrap_or(Path::new(""));
-            self.parsed = match ParsedManifest::from_toml_str(&contents, root_directory) {
-                Ok(parsed) => parsed,
+            match ParsedManifest::from_toml_str(&contents, root_directory) {
+                Ok(parsed) => {
+                    self.document = document;
+                    self.parsed = parsed;
+                }
                 Err(e) => {
                     return e.to_fancy(consts::GLOBAL_MANIFEST_DEFAULT_NAME, &contents, &self.path);
                 }
-            };
+            }
+        } else {
+            // Update self.parsed
+            let env = self
+                .parsed
+                .envs
+                .get_mut(env_name)
+                .expect("environment existence was checked above");
+            env.dependencies.specs.insert(name.clone(), spec.clone());
+            // A previously recorded inline definition no longer applies when
+            // the dependency is overwritten without one.
+            env.inline_packages.swap_remove(name);
+
+            // Update self.document
+            self.document.insert_into_inline_table(
+                &["envs", env_name.as_str(), "dependencies"],
+                key,
+                toml_value.clone(),
+            )?;
         }
 
         tracing::debug!(
@@ -1213,6 +1231,41 @@ mod tests {
                 .inline_packages
                 .is_empty(),
             "parsed inline definition lingered after overwrite"
+        );
+    }
+
+    /// Removing a source dependency also drops its parsed inline definition.
+    #[test]
+    fn test_remove_dependency_drops_inline_definition() {
+        let contents = r#"
+        [envs.xsv]
+        channels = ["conda-forge"]
+        [envs.xsv.dependencies]
+        xsv = { path = "some-source", package.build.backend.name = "pixi-build-rust" }
+        "#;
+        let mut manifest =
+            Manifest::from_str(std::path::Path::new("pixi-global.toml"), contents).unwrap();
+
+        let env_name = EnvironmentName::from_str("xsv").unwrap();
+        let name = rattler_conda_types::PackageName::from_str("xsv").unwrap();
+        assert!(
+            manifest
+                .parsed
+                .envs
+                .get(&env_name)
+                .unwrap()
+                .inline_packages
+                .contains_key(&name),
+            "inline definition should be parsed from the manifest"
+        );
+
+        manifest.remove_dependency(&env_name, &name).unwrap();
+
+        let env = manifest.parsed.envs.get(&env_name).unwrap();
+        assert!(env.dependencies.specs.is_empty());
+        assert!(
+            env.inline_packages.is_empty(),
+            "parsed inline definition lingered after removal"
         );
     }
 

--- a/crates/pixi_global/src/project/manifest.rs
+++ b/crates/pixi_global/src/project/manifest.rs
@@ -51,7 +51,8 @@ impl Manifest {
     /// Creates a new manifest from a string
     pub fn from_str(manifest_path: &Path, contents: impl Into<String>) -> miette::Result<Self> {
         let contents = contents.into();
-        let parsed = ParsedManifest::from_toml_str(&contents);
+        let root_directory = manifest_path.parent().unwrap_or(Path::new(""));
+        let parsed = ParsedManifest::from_toml_str(&contents, root_directory);
 
         let (manifest, document) = match parsed.and_then(|manifest| {
             contents
@@ -143,16 +144,34 @@ impl Manifest {
         let name = named_spec.name();
         let spec = named_spec.spec();
 
+        // The value to write into the document: the source spec, extended
+        // with the inline package definition under the `package` key when one
+        // is supplied.
+        let toml_value = match &named_spec.inline {
+            None => spec.to_toml_value(),
+            Some(inline) => {
+                let toml_edit::Value::InlineTable(mut table) = spec.to_toml_value() else {
+                    miette::bail!(
+                        "an inline package definition requires a source spec, but the spec of '{}' is `{}`",
+                        name.as_normalized(),
+                        spec.to_toml_value()
+                    );
+                };
+                table.insert("package", inline.to_toml_value());
+                toml_edit::Value::InlineTable(table)
+            }
+        };
+
         // Update self.parsed
-        self.parsed
-            .envs
-            .get_mut(env_name)
-            .ok_or_else(|| {
+        {
+            let env = self.parsed.envs.get_mut(env_name).ok_or_else(|| {
                 miette::miette!("Environment {} doesn't exist.", env_name.fancy_display())
-            })?
-            .dependencies
-            .specs
-            .insert(name.clone(), spec.clone());
+            })?;
+            env.dependencies.specs.insert(name.clone(), spec.clone());
+            // A previously recorded inline definition no longer applies when
+            // the dependency is overwritten without one.
+            env.inline_packages.swap_remove(name);
+        }
 
         // Update self.document. Look up the existing key so a non-normalized
         // spelling in the document (e.g. "PyTest" vs "pytest") is overwritten
@@ -171,13 +190,27 @@ impl Manifest {
         self.document.insert_into_inline_table(
             &["envs", env_name.as_str(), "dependencies"],
             key,
-            spec.to_toml_value(),
+            toml_value.clone(),
         )?;
+
+        // Inline package definitions are converted with root-directory
+        // context by the manifest parser; re-parse the document so
+        // `self.parsed` picks up the converted definition.
+        if named_spec.inline.is_some() {
+            let contents = self.document.to_string();
+            let root_directory = self.path.parent().unwrap_or(Path::new(""));
+            self.parsed = match ParsedManifest::from_toml_str(&contents, root_directory) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    return e.to_fancy(consts::GLOBAL_MANIFEST_DEFAULT_NAME, &contents, &self.path);
+                }
+            };
+        }
 
         tracing::debug!(
             "Added dependency {}={} to toml document for environment {}",
             name.as_normalized(),
-            spec.to_toml_value().to_string(),
+            toml_value.to_string(),
             env_name.fancy_display()
         );
         Ok(())
@@ -190,12 +223,10 @@ impl Manifest {
         name: &PackageName,
     ) -> miette::Result<PackageName> {
         // Update self.parsed
-        self.parsed
-            .envs
-            .get_mut(env_name)
-            .ok_or_else(|| {
-                miette::miette!("Environment {} doesn't exist.", env_name.fancy_display())
-            })?
+        let parsed_env = self.parsed.envs.get_mut(env_name).ok_or_else(|| {
+            miette::miette!("Environment {} doesn't exist.", env_name.fancy_display())
+        })?;
+        parsed_env
             .dependencies
             .specs
             .swap_remove(name)
@@ -204,6 +235,7 @@ impl Manifest {
                 console::style(name.as_normalized()).green(),
                 env_name.fancy_display()
             ))?;
+        parsed_env.inline_packages.swap_remove(name);
 
         // Update self.document
         let item = self.document.get_or_insert_nested_item(&[

--- a/crates/pixi_global/src/project/manifest.rs
+++ b/crates/pixi_global/src/project/manifest.rs
@@ -1147,6 +1147,75 @@ mod tests {
         );
     }
 
+    /// Re-adding a source dependency replaces its inline `package` definition
+    /// wholesale: attaching a definition records it, and re-adding without one
+    /// removes it rather than leaving a stale table behind.
+    #[test]
+    fn test_add_dependency_overwrites_inline_definition() {
+        let contents = r#"
+        [envs.xsv]
+        channels = ["conda-forge"]
+        [envs.xsv.dependencies]
+        xsv = { path = "some-source" }
+        "#;
+        let mut manifest =
+            Manifest::from_str(std::path::Path::new("pixi-global.toml"), contents).unwrap();
+
+        let env_name = EnvironmentName::from_str("xsv").unwrap();
+        let name = rattler_conda_types::PackageName::from_str("xsv").unwrap();
+        let source_spec = manifest
+            .parsed
+            .envs
+            .get(&env_name)
+            .unwrap()
+            .dependencies
+            .specs
+            .get(&name)
+            .unwrap()
+            .clone();
+
+        let dependency_toml = |manifest: &mut Manifest| {
+            manifest
+                .document
+                .get_or_insert_nested_table(&["envs", env_name.as_str(), "dependencies"])
+                .unwrap()
+                .get(name.as_normalized())
+                .unwrap()
+                .to_string()
+        };
+
+        // Attach an inline definition to the existing source spec.
+        let value: toml_edit::Value = r#"{ build = { backend = { name = "pixi-build-rust" } } }"#
+            .parse()
+            .unwrap();
+        let inline =
+            crate::project::InlinePackageValue::new(value.as_inline_table().unwrap().clone());
+        let with_inline = GlobalSpec::new(name.clone(), source_spec.clone()).with_inline(inline);
+        manifest.add_dependency(&env_name, &with_inline).unwrap();
+        assert!(
+            dependency_toml(&mut manifest).contains("package"),
+            "inline definition was not recorded"
+        );
+
+        // Re-add the same dependency without an inline definition.
+        let without_inline = GlobalSpec::new(name.clone(), source_spec);
+        manifest.add_dependency(&env_name, &without_inline).unwrap();
+        assert!(
+            !dependency_toml(&mut manifest).contains("package"),
+            "stale inline definition lingered after overwrite"
+        );
+        assert!(
+            manifest
+                .parsed
+                .envs
+                .get(&env_name)
+                .unwrap()
+                .inline_packages
+                .is_empty(),
+            "parsed inline definition lingered after overwrite"
+        );
+    }
+
     #[test]
     fn test_set_platform() {
         let mut manifest = Manifest::default();

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{BTreeMap, HashSet},
     ffi::OsStr,
     fmt::{Debug, Formatter},
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -56,6 +57,7 @@ use rattler_virtual_packages::{
 };
 use tokio::sync::Semaphore;
 use toml_edit::DocumentMut;
+use xxhash_rust::xxh3::Xxh3;
 
 use self::trampoline::{Configuration, ConfigurationParseError, Trampoline};
 use super::{
@@ -1780,10 +1782,6 @@ fn workspace_manifest_with_channels(
 /// changed (e.g. an edited git `rev` or inline `package.*` table). Binary
 /// dependencies are matched against the prefix directly and are not included.
 fn source_fingerprints_for_environment(environment: &ParsedEnvironment) -> BTreeMap<String, u64> {
-    use std::hash::{Hash, Hasher};
-
-    use xxhash_rust::xxh3::Xxh3;
-
     environment
         .dependencies
         .specs

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -104,14 +104,12 @@ pub enum InferPackageNameError {
     BuildBackendMetadata(#[source] Box<dyn Diagnostic + Send + Sync>),
     #[error("no package outputs found in the specified path/repository")]
     NoPackageOutputs,
-    #[error("multiple package outputs found: {package_names}")]
+    #[error("multiple package outputs found: {}", .package_names.join(", "))]
     #[diagnostic(help(
-        "Specify which package(s) to install by naming them explicitly, e.g. `pixi global install {example} ...`"
+        "Specify which package(s) to install by naming them explicitly, e.g. `pixi global install {} ...`",
+        .package_names.first().map(String::as_str).unwrap_or_default()
     ))]
-    MultiplePackageOutputs {
-        package_names: String,
-        example: String,
-    },
+    MultiplePackageOutputs { package_names: Vec<String> },
 }
 
 pub(crate) const MANIFESTS_DIR: &str = "manifests";
@@ -603,7 +601,7 @@ impl Project {
     /// recorded in the manifest (e.g. for package name inference). The
     /// synthesized workspace manifest carries the channels the backend's
     /// dependencies fall back to.
-    pub fn inline_package_for_channels(
+    fn inline_package_for_channels(
         &self,
         inline: &InlinePackageManifest,
         channels: impl IntoIterator<Item = NamedChannelOrUrl>,
@@ -652,7 +650,7 @@ impl Project {
                 help = format!(
                     "Remove `platform = \"{platform}\"` from the environment, or install the package from a channel instead of from source."
                 ),
-                "Environment {} requests platform '{platform}', but '{}' is a source dependency that has to be built on the current machine ('{}'). Cross-platform source builds are not supported.",
+                "environment {} requests platform '{platform}', but '{}' is a source dependency that has to be built on the current machine ('{}'); cross-platform source builds are not supported",
                 env_name.fancy_display(),
                 source_package.as_normalized(),
                 Platform::current(),
@@ -709,8 +707,10 @@ impl Project {
         // Solve via SolvePixiEnvironmentKey (new keys path).
         //
         // A source dependency without an inline package definition relies on
-        // the source providing its own manifest. When it doesn't, discovery
-        // fails; point the user at `--build-backend` in that case.
+        // the source providing its own manifest. When it doesn't, backend
+        // discovery fails; point the user at `--build-backend` in that case,
+        // but leave unrelated solve errors (unsatisfiable specs, network
+        // failures, ...) unwrapped.
         let has_source_without_inline =
             environment.dependencies.specs.iter().any(|(name, spec)| {
                 spec.is_source() && !environment.inline_packages.contains_key(name)
@@ -722,7 +722,15 @@ impl Project {
             .map_err_into_dispatcher(std::convert::identity)
             .map_err(miette::Report::from)
             .map_err(|err| {
-                if has_source_without_inline {
+                // Matches `DiscoveryError::FailedToDiscover`, which is
+                // forwarded transparently through the dispatcher's error
+                // wrappers.
+                let is_discovery_failure = err.chain().any(|cause| {
+                    cause
+                        .to_string()
+                        .contains("does not contain a supported manifest")
+                });
+                if has_source_without_inline && is_discovery_failure {
                     err.wrap_err(
                         "If the source does not provide a pixi package manifest, specify how to build it with `--build-backend`, e.g. `--build-backend pixi-build-rust`.",
                     )
@@ -1700,16 +1708,9 @@ impl Project {
         match packages.len() {
             0 => Err(InferPackageNameError::NoPackageOutputs),
             1 => Ok(packages[0].clone()),
-            _ => {
-                let package_names: Vec<_> = packages.iter().map(|p| p.as_source()).collect();
-                Err(InferPackageNameError::MultiplePackageOutputs {
-                    example: package_names
-                        .first()
-                        .map(ToString::to_string)
-                        .unwrap_or_default(),
-                    package_names: package_names.join(", "),
-                })
-            }
+            _ => Err(InferPackageNameError::MultiplePackageOutputs {
+                package_names: packages.iter().map(|p| p.as_source().to_string()).collect(),
+            }),
         }
     }
 

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -19,11 +19,12 @@ pub use manifest::{ExposedType, Manifest, Mapping};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use once_cell::sync::OnceCell;
 pub use parsed_manifest::{ExposedName, ParsedEnvironment, ParsedManifest};
+use pixi_build_discovery::DiscoveryError;
 use pixi_build_frontend::BackendOverride;
 use pixi_command_dispatcher::{
-    BuildBackendMetadataSpec, BuildEnvironment, CommandDispatcher, ComputeResultExt,
-    EnvironmentRef, EnvironmentSpec, EphemeralEnv, InlinePackage, InstallPixiEnvironmentSpec,
-    Limits, SourceCheckoutExt,
+    BuildBackendMetadataSpec, BuildEnvironment, CommandDispatcher,
+    CommandDispatcherError as DispatcherError, ComputeResultExt, EnvironmentRef, EnvironmentSpec,
+    EphemeralEnv, InlinePackage, InstallPixiEnvironmentSpec, Limits, SourceCheckoutExt,
     keys::{SolvePixiEnvironmentKey, SolvePixiEnvironmentSpec},
 };
 use pixi_config::{Config, RunPostLinkScripts, default_channel_config, pixi_home};
@@ -720,22 +721,27 @@ impl Project {
             .compute(&SolvePixiEnvironmentKey::new(solve_spec))
             .await
             .map_err_into_dispatcher(std::convert::identity)
-            .map_err(miette::Report::from)
             .map_err(|err| {
-                // Matches `DiscoveryError::FailedToDiscover`, which is
-                // forwarded transparently through the dispatcher's error
-                // wrappers.
-                let is_discovery_failure = err.chain().any(|cause| {
-                    cause
-                        .to_string()
-                        .contains("does not contain a supported manifest")
-                });
-                if has_source_without_inline && is_discovery_failure {
-                    err.wrap_err(
+                // A missing or package-less manifest is the case
+                // `--build-backend` exists for; other discovery failures
+                // (disabled protocols, invalid manifests, ...) are not.
+                let missing_manifest = matches!(
+                    &err,
+                    DispatcherError::Failed(solve_err) if matches!(
+                        solve_err.discovery_error(),
+                        Some(
+                            DiscoveryError::FailedToDiscover { .. }
+                                | DiscoveryError::NotAPackage(_)
+                        )
+                    )
+                );
+                let report = miette::Report::from(err);
+                if has_source_without_inline && missing_manifest {
+                    report.wrap_err(
                         "If the source does not provide a pixi package manifest, specify how to build it with `--build-backend`, e.g. `--build-backend pixi-build-rust`.",
                     )
                 } else {
-                    err
+                    report
                 }
             })?;
         let pixi_records: Vec<_> = (*records_arc).clone();

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -682,7 +682,7 @@ impl Project {
         // Inline package definitions from the manifest, threaded into the
         // solve and install so backend discovery uses them instead of reading
         // a manifest from the source checkout.
-        let inline_packages = inline_packages_for_environment(&environment);
+        let inline_packages = inline_packages_for_environment(environment);
 
         // Create solve spec (compute-engine keys path).
         let solve_spec = SolvePixiEnvironmentSpec {
@@ -788,7 +788,7 @@ impl Project {
             platform,
             solve_virtual_packages,
             &resolved_depends,
-            source_fingerprints_for_environment(&environment),
+            source_fingerprints_for_environment(environment),
         )?;
 
         let install_changes = get_install_changes(result.transaction);
@@ -1123,7 +1123,7 @@ impl Project {
         // implies. A missing record (older pixi, or never installed) counts as
         // out of sync, which triggers a one-time rebuild.
         if !source_package_names.is_empty() {
-            let expected_fingerprints = source_fingerprints_for_environment(&environment);
+            let expected_fingerprints = source_fingerprints_for_environment(environment);
             let recorded_fingerprints =
                 pixi_core::environment::read_environment_file(env_dir.path())
                     .ok()

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -1132,12 +1132,20 @@ impl Project {
         // out of sync, which triggers a one-time rebuild.
         if !source_package_names.is_empty() {
             let expected_fingerprints = source_fingerprints_for_environment(environment);
-            let recorded_fingerprints =
-                pixi_core::environment::read_environment_file(env_dir.path())
-                    .ok()
-                    .flatten()
+            let recorded_fingerprints = match pixi_core::environment::read_environment_file(
+                env_dir.path(),
+            ) {
+                Ok(env_file) => env_file
                     .map(|env_file| env_file.source_fingerprints)
-                    .unwrap_or_default();
+                    .unwrap_or_default(),
+                Err(e) => {
+                    tracing::debug!(
+                        "Failed to read environment file of environment {}, treating source dependency fingerprints as missing: {e}",
+                        env_name.fancy_display()
+                    );
+                    Default::default()
+                }
+            };
 
             if expected_fingerprints != recorded_fingerprints {
                 tracing::debug!(

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -1660,10 +1660,14 @@ impl Project {
     /// Infer the package name from a SourceSpec by examining build outputs.
     /// When `inline` is set, backend discovery uses the inline package
     /// definition instead of reading a manifest from the checkout.
+    /// `channels` are the channels of the environment the package is
+    /// destined for; the backend and its dependencies are solved against
+    /// them.
     async fn infer_package_name_from_source_spec(
         &self,
         source_spec: pixi_spec::SourceSpec,
         inline: Option<InlinePackage>,
+        channels: &[NamedChannelOrUrl],
     ) -> Result<PackageName, InferPackageNameError> {
         let command_dispatcher = self.command_dispatcher()?;
         let checkout = command_dispatcher
@@ -1676,9 +1680,7 @@ impl Project {
         let pinned_source_spec = checkout.pinned;
 
         // Create the metadata spec
-        let channels = self
-            .config()
-            .default_channels()
+        let channels = channels
             .iter()
             .filter_map(|c| c.clone().into_base_url(self.global_channel_config()).ok())
             .collect();
@@ -1725,18 +1727,19 @@ impl Project {
     /// Infer the package name from a PixiSpec (path or git) by examining build
     /// outputs. When `inline` carries an inline package definition, backend
     /// discovery uses it instead of reading a manifest from the source
-    /// checkout.
+    /// checkout. `channels` are the channels of the environment the package
+    /// is destined for.
     pub async fn infer_package_name_from_spec(
         &self,
         pixi_spec: &pixi_spec::PixiSpec,
         inline: Option<&InlinePackageManifest>,
+        channels: &[NamedChannelOrUrl],
     ) -> Result<PackageName, InferPackageNameError> {
         match pixi_spec.clone().into_source_or_binary() {
             Either::Left(source_spec) => {
-                let inline = inline.map(|inline| {
-                    self.inline_package_for_channels(inline, self.config().default_channels())
-                });
-                self.infer_package_name_from_source_spec(source_spec, inline)
+                let inline = inline
+                    .map(|inline| self.inline_package_for_channels(inline, channels.to_vec()));
+                self.infer_package_name_from_source_spec(source_spec, inline, channels)
                     .await
             }
             Either::Right(binary_spec) => match binary_spec {

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -22,8 +22,8 @@ pub use parsed_manifest::{ExposedName, ParsedEnvironment, ParsedManifest};
 use pixi_build_frontend::BackendOverride;
 use pixi_command_dispatcher::{
     BuildBackendMetadataSpec, BuildEnvironment, CommandDispatcher, ComputeResultExt,
-    EnvironmentRef, EnvironmentSpec, EphemeralEnv, InstallPixiEnvironmentSpec, Limits,
-    SourceCheckoutExt,
+    EnvironmentRef, EnvironmentSpec, EphemeralEnv, InlinePackage, InstallPixiEnvironmentSpec,
+    Limits, SourceCheckoutExt,
     keys::{SolvePixiEnvironmentKey, SolvePixiEnvironmentSpec},
 };
 use pixi_config::{Config, RunPostLinkScripts, default_channel_config, pixi_home};
@@ -33,7 +33,7 @@ use pixi_core::environment::{
 };
 use pixi_core::lock_file::virtual_packages::minimal_required_virtual_packages;
 use pixi_core::repodata::Repodata;
-use pixi_manifest::PrioritizedChannel;
+use pixi_manifest::{InlinePackageManifest, PrioritizedChannel, WorkspaceManifest};
 use pixi_path::AbsPathBuf;
 use pixi_reporters::TopLevelProgress;
 use pixi_spec::{BinarySpec, PathBinarySpec};
@@ -45,8 +45,8 @@ use pixi_utils::{
     rlimit::try_increase_rlimit_to_sensible,
 };
 use rattler_conda_types::{
-    ChannelConfig, GenericVirtualPackage, MatchSpec, PackageName, Platform, PrefixRecord,
-    menuinst::MenuMode, package::CondaArchiveIdentifier,
+    ChannelConfig, GenericVirtualPackage, MatchSpec, NamedChannelOrUrl, PackageName, Platform,
+    PrefixRecord, menuinst::MenuMode, package::CondaArchiveIdentifier,
 };
 use rattler_networking::LazyClient;
 use rattler_repodata_gateway::Gateway;
@@ -77,7 +77,9 @@ mod environment;
 mod global_spec;
 mod manifest;
 mod parsed_manifest;
-pub use global_spec::{FromMatchSpecError, GlobalSpec};
+pub use global_spec::{
+    FromMatchSpecError, GlobalSpec, InlinePackageValue, InlinePackageValueError,
+};
 use pixi_utils::reqwest::{LazyReqwestClient, build_lazy_reqwest_clients};
 
 #[derive(Debug, thiserror::Error, miette::Diagnostic)]
@@ -96,20 +98,20 @@ pub enum CommandDispatcherError {
 pub enum InferPackageNameError {
     #[error("only source specifications are supported")]
     UnsupportedSpecType,
-    #[error(
-        "git package name inference is not yet supported. Please specify the package name explicitly"
-    )]
-    GitNotSupported,
     #[error("failed to get command dispatcher")]
     CommandDispatcher(#[from] CommandDispatcherError),
     #[error("failed to get build backend metadata for package name inference")]
     BuildBackendMetadata(#[source] Box<dyn Diagnostic + Send + Sync>),
     #[error("no package outputs found in the specified path/repository")]
     NoPackageOutputs,
-    #[error(
-        "multiple package outputs found: {package_names}. Please specify the package name explicitly"
-    )]
-    MultiplePackageOutputs { package_names: String },
+    #[error("multiple package outputs found: {package_names}")]
+    #[diagnostic(help(
+        "Specify which package(s) to install by naming them explicitly, e.g. `pixi global install {example} ...`"
+    ))]
+    MultiplePackageOutputs {
+        package_names: String,
+        example: String,
+    },
 }
 
 pub(crate) const MANIFESTS_DIR: &str = "manifests";
@@ -596,6 +598,25 @@ impl Project {
         self.install_environment_with_options(env_name, false).await
     }
 
+    /// Builds the [`InlinePackage`] to thread through the command dispatcher
+    /// for a CLI-supplied inline package definition, before the definition is
+    /// recorded in the manifest (e.g. for package name inference). The
+    /// synthesized workspace manifest carries the channels the backend's
+    /// dependencies fall back to.
+    pub fn inline_package_for_channels(
+        &self,
+        inline: &InlinePackageManifest,
+        channels: impl IntoIterator<Item = NamedChannelOrUrl>,
+    ) -> InlinePackage {
+        InlinePackage {
+            manifest: Arc::new(inline.manifest.clone()),
+            workspace: Arc::new(workspace_manifest_with_channels(
+                channels.into_iter().map(PrioritizedChannel::from),
+            )),
+            content_hash: inline.content_hash,
+        }
+    }
+
     pub async fn install_environment_with_options(
         &self,
         env_name: &EnvironmentName,
@@ -616,6 +637,28 @@ impl Project {
             .into_diagnostic()?;
 
         let platform = environment.platform.unwrap_or_else(Platform::current);
+
+        // Source dependencies are built on this machine, so they can only
+        // target the platform we are running on.
+        if platform != Platform::current()
+            && let Some(source_package) = environment
+                .dependencies
+                .specs
+                .iter()
+                .find(|(_, spec)| spec.is_source())
+                .map(|(name, _)| name)
+        {
+            return Err(miette::miette!(
+                help = format!(
+                    "Remove `platform = \"{platform}\"` from the environment, or install the package from a channel instead of from source."
+                ),
+                "Environment {} requests platform '{platform}', but '{}' is a source dependency that has to be built on the current machine ('{}'). Cross-platform source builds are not supported.",
+                env_name.fancy_display(),
+                source_package.as_normalized(),
+                Platform::current(),
+            ));
+        }
+
         let solve_virtual_packages = Self::virtual_packages_for(&platform).into_diagnostic()?;
 
         // Convert dependency specs to binary specs for CommandDispatcher
@@ -635,6 +678,12 @@ impl Project {
             .collect::<Vec<_>>();
 
         let build_environment = BuildEnvironment::simple(platform, solve_virtual_packages.clone());
+
+        // Inline package definitions from the manifest, threaded into the
+        // solve and install so backend discovery uses them instead of reading
+        // a manifest from the source checkout.
+        let inline_packages = inline_packages_for_environment(&environment);
+
         // Create solve spec (compute-engine keys path).
         let solve_spec = SolvePixiEnvironmentSpec {
             dependencies: pixi_specs,
@@ -654,15 +703,33 @@ impl Project {
                     channel_priority: Default::default(),
                 },
             )),
-            inline_packages: Default::default(),
+            inline_packages: Arc::new(inline_packages.clone()),
         };
 
         // Solve via SolvePixiEnvironmentKey (new keys path).
+        //
+        // A source dependency without an inline package definition relies on
+        // the source providing its own manifest. When it doesn't, discovery
+        // fails; point the user at `--build-backend` in that case.
+        let has_source_without_inline =
+            environment.dependencies.specs.iter().any(|(name, spec)| {
+                spec.is_source() && !environment.inline_packages.contains_key(name)
+            });
         let records_arc = command_dispatcher
             .engine()
             .compute(&SolvePixiEnvironmentKey::new(solve_spec))
             .await
-            .map_err_into_dispatcher(std::convert::identity)?;
+            .map_err_into_dispatcher(std::convert::identity)
+            .map_err(miette::Report::from)
+            .map_err(|err| {
+                if has_source_without_inline {
+                    err.wrap_err(
+                        "If the source does not provide a pixi package manifest, specify how to build it with `--build-backend`, e.g. `--build-backend pixi-build-rust`.",
+                    )
+                } else {
+                    err
+                }
+            })?;
         let pixi_records: Vec<_> = (*records_arc).clone();
 
         // Move this to a separate function to avoid code duplication
@@ -711,7 +778,7 @@ impl Project {
                 force_reinstall: force_reinstall_packages,
                 variant_configuration: None,
                 variant_files: None,
-                inline_packages: Default::default(),
+                inline_packages: inline_packages.into_iter().collect(),
             })
             .await?;
 
@@ -721,6 +788,7 @@ impl Project {
             platform,
             solve_virtual_packages,
             &resolved_depends,
+            source_fingerprints_for_environment(&environment),
         )?;
 
         let install_changes = get_install_changes(result.transaction);
@@ -732,7 +800,8 @@ impl Project {
     /// write. The resolved platform is the subdir plus the virtual packages the
     /// solve ran against (machine detection honoring `CONDA_OVERRIDE_*`); the
     /// minimum-supported platform keeps only the virtual packages some installed
-    /// record actually depends on.
+    /// record actually depends on. `source_fingerprints` records the source
+    /// dependency specifications so `pixi global sync` can detect edits.
     fn write_environment_file(
         &self,
         env_name: &EnvironmentName,
@@ -740,6 +809,7 @@ impl Project {
         platform: Platform,
         resolved_virtual_packages: Vec<GenericVirtualPackage>,
         resolved_depends: &[String],
+        source_fingerprints: BTreeMap<String, u64>,
     ) -> miette::Result<()> {
         let resolved_platform = PlatformData::new(platform, resolved_virtual_packages);
         let depends: Vec<&str> = resolved_depends.iter().map(String::as_str).collect();
@@ -757,6 +827,7 @@ impl Project {
                 environment_lock_file_hash: LockedEnvironmentHash::invalid(),
                 resolved_platform: Some(resolved_platform),
                 minimum_supported_platform: Some(minimum_supported_platform),
+                source_fingerprints,
             },
         )?;
         Ok(())
@@ -1044,6 +1115,30 @@ impl Project {
 
         let env_dir =
             EnvDir::from_path(self.env_root.clone().path().join(env_name.clone().as_str()));
+
+        // Source dependencies are matched by name against the prefix, so an
+        // edit to a source spec (git rev, path, inline `package.*` table)
+        // wouldn't otherwise register as out of sync. Compare the fingerprints
+        // recorded at install time against the ones the current manifest
+        // implies. A missing record (older pixi, or never installed) counts as
+        // out of sync, which triggers a one-time rebuild.
+        if !source_package_names.is_empty() {
+            let expected_fingerprints = source_fingerprints_for_environment(&environment);
+            let recorded_fingerprints =
+                pixi_core::environment::read_environment_file(env_dir.path())
+                    .ok()
+                    .flatten()
+                    .map(|env_file| env_file.source_fingerprints)
+                    .unwrap_or_default();
+
+            if expected_fingerprints != recorded_fingerprints {
+                tracing::debug!(
+                    "Environment {} out of sync because source dependency fingerprints changed",
+                    env_name.fancy_display()
+                );
+                return Ok(false);
+            }
+        }
 
         let prefix = self.environment_prefix(env_name).await?;
         let prefix_records = prefix.find_installed_packages()?;
@@ -1546,10 +1641,13 @@ impl Project {
         })
     }
 
-    /// Infer the package name from a SourceSpec by examining build outputs
+    /// Infer the package name from a SourceSpec by examining build outputs.
+    /// When `inline` is set, backend discovery uses the inline package
+    /// definition instead of reading a manifest from the checkout.
     async fn infer_package_name_from_source_spec(
         &self,
         source_spec: pixi_spec::SourceSpec,
+        inline: Option<InlinePackage>,
     ) -> Result<PackageName, InferPackageNameError> {
         let command_dispatcher = self.command_dispatcher()?;
         let checkout = command_dispatcher
@@ -1583,7 +1681,7 @@ impl Project {
             )),
             build_string_prefix: None,
             build_number: None,
-            inline: None,
+            inline,
         };
 
         // Get the metadata using the command dispatcher
@@ -1593,9 +1691,11 @@ impl Project {
             .await
             .map_err(|e| InferPackageNameError::BuildBackendMetadata(Box::new(e)))?;
 
-        // Get the available outputs and use exactly_one to handle the single output
-        // case
-        let packages = metadata.metadata.output_names();
+        // Get the available output names. Several outputs may share one name
+        // (e.g. variant builds of the same package); those describe a single
+        // package, so dedupe before deciding whether the source is ambiguous.
+        let packages: IndexSet<PackageName> =
+            metadata.metadata.output_names().into_iter().collect();
 
         match packages.len() {
             0 => Err(InferPackageNameError::NoPackageOutputs),
@@ -1603,6 +1703,10 @@ impl Project {
             _ => {
                 let package_names: Vec<_> = packages.iter().map(|p| p.as_source()).collect();
                 Err(InferPackageNameError::MultiplePackageOutputs {
+                    example: package_names
+                        .first()
+                        .map(ToString::to_string)
+                        .unwrap_or_default(),
                     package_names: package_names.join(", "),
                 })
             }
@@ -1610,14 +1714,21 @@ impl Project {
     }
 
     /// Infer the package name from a PixiSpec (path or git) by examining build
-    /// outputs
+    /// outputs. When `inline` carries an inline package definition, backend
+    /// discovery uses it instead of reading a manifest from the source
+    /// checkout.
     pub async fn infer_package_name_from_spec(
         &self,
         pixi_spec: &pixi_spec::PixiSpec,
+        inline: Option<&InlinePackageManifest>,
     ) -> Result<PackageName, InferPackageNameError> {
         match pixi_spec.clone().into_source_or_binary() {
             Either::Left(source_spec) => {
-                self.infer_package_name_from_source_spec(source_spec).await
+                let inline = inline.map(|inline| {
+                    self.inline_package_for_channels(inline, self.config().default_channels())
+                });
+                self.infer_package_name_from_source_spec(source_spec, inline)
+                    .await
             }
             Either::Right(binary_spec) => match binary_spec {
                 BinarySpec::Path(PathBinarySpec { path }) => path
@@ -1629,6 +1740,78 @@ impl Project {
             },
         }
     }
+}
+
+/// Synthesizes the minimal [`WorkspaceManifest`] that inline package
+/// definitions need: there is no real workspace behind a global environment,
+/// and backend discovery only consults the workspace's channels (as the
+/// fallback for the build backend's own dependencies when the definition
+/// doesn't pin `build.backend.channels`).
+fn workspace_manifest_with_channels(
+    channels: impl IntoIterator<Item = PrioritizedChannel>,
+) -> WorkspaceManifest {
+    let mut workspace_manifest = WorkspaceManifest::default();
+    workspace_manifest.workspace.channels = channels.into_iter().collect();
+    workspace_manifest
+}
+
+/// Computes a fingerprint for each source dependency in the environment: a
+/// hash of the source spec together with any inline package definition's
+/// content hash. `pixi global sync` compares these against the ones recorded
+/// at install time to detect when a source dependency's *specification*
+/// changed (e.g. an edited git `rev` or inline `package.*` table). Binary
+/// dependencies are matched against the prefix directly and are not included.
+fn source_fingerprints_for_environment(environment: &ParsedEnvironment) -> BTreeMap<String, u64> {
+    use std::hash::{Hash, Hasher};
+
+    use xxhash_rust::xxh3::Xxh3;
+
+    environment
+        .dependencies
+        .specs
+        .iter()
+        .filter(|(_, spec)| spec.is_source())
+        .map(|(name, spec)| {
+            let mut hasher = Xxh3::new();
+            // The source spec's TOML form is a stable, complete rendering of
+            // the source location (git url + rev, path, ...).
+            spec.to_toml_value().to_string().hash(&mut hasher);
+            // Fold in the inline package definition, if any, via its content
+            // hash so edits to `package.*` invalidate the fingerprint.
+            if let Some(inline) = environment.inline_packages.get(name) {
+                inline.content_hash.as_u64().hash(&mut hasher);
+            }
+            (name.as_normalized().to_string(), hasher.finish())
+        })
+        .collect()
+}
+
+/// Converts an environment's inline package definitions into the
+/// [`InlinePackage`]s the command dispatcher threads through solve, metadata
+/// and build keys.
+fn inline_packages_for_environment(
+    environment: &ParsedEnvironment,
+) -> BTreeMap<PackageName, InlinePackage> {
+    if environment.inline_packages.is_empty() {
+        return BTreeMap::new();
+    }
+    let workspace = Arc::new(workspace_manifest_with_channels(
+        environment.channels.iter().cloned(),
+    ));
+    environment
+        .inline_packages
+        .iter()
+        .map(|(name, inline)| {
+            (
+                name.clone(),
+                InlinePackage {
+                    manifest: Arc::new(inline.manifest.clone()),
+                    workspace: workspace.clone(),
+                    content_hash: inline.content_hash,
+                },
+            )
+        })
+        .collect()
 }
 
 impl Repodata for Project {

--- a/crates/pixi_global/src/project/parsed_manifest.rs
+++ b/crates/pixi_global/src/project/parsed_manifest.rs
@@ -455,7 +455,7 @@ impl ParsedEnvironment {
     }
 
     /// Returns the channels associated with this environment.
-    pub(crate) fn channels(&self) -> IndexSet<&NamedChannelOrUrl> {
+    pub fn channels(&self) -> IndexSet<&NamedChannelOrUrl> {
         PrioritizedChannel::sort_channels_by_priority(&self.channels).collect()
     }
 

--- a/crates/pixi_global/src/project/parsed_manifest.rs
+++ b/crates/pixi_global/src/project/parsed_manifest.rs
@@ -6,7 +6,11 @@ use indexmap::{IndexMap, IndexSet};
 use itertools::{Either, Itertools};
 use miette::{Context, Diagnostic, IntoDiagnostic, LabeledSpan, NamedSource, Report};
 use pixi_consts::consts;
-use pixi_manifest::{PrioritizedChannel, toml::TomlPlatform, utils::package_map::UniquePackageMap};
+use pixi_manifest::{
+    InlinePackageManifest, KnownPreviewFeature, Preview, PrioritizedChannel,
+    toml::{TomlPlatform, WorkspacePackageProperties},
+    utils::package_map::{DependencyTable, UniquePackageMap},
+};
 use pixi_spec::PixiSpec;
 use pixi_toml::{TomlFromStr, TomlIndexMap, TomlIndexSet, TomlWith};
 use rattler_conda_types::{NamedChannelOrUrl, PackageName, Platform};
@@ -118,7 +122,15 @@ pub struct ParsedManifest {
     pub envs: IndexMap<EnvironmentName, ParsedEnvironment>,
 }
 
-impl<'de> toml_span::Deserialize<'de> for ParsedManifest {
+/// The toml-stage of [`ParsedManifest`]: deserialized as-is from the document,
+/// before inline package definitions are converted (which requires the
+/// manifest's root directory as context).
+struct TomlParsedManifest {
+    version: ManifestVersion,
+    envs: IndexMap<EnvironmentName, TomlParsedEnvironment>,
+}
+
+impl<'de> toml_span::Deserialize<'de> for TomlParsedManifest {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
         let mut th = TableHelper::new(value)?;
 
@@ -127,7 +139,7 @@ impl<'de> toml_span::Deserialize<'de> for ParsedManifest {
             .map(ManifestVersion)
             .unwrap_or_default();
         let envs = th
-            .optional::<TomlIndexMap<_, ParsedEnvironment>>("envs")
+            .optional::<TomlIndexMap<_, TomlParsedEnvironment>>("envs")
             .map(TomlIndexMap::into_inner)
             .unwrap_or_default();
 
@@ -142,7 +154,7 @@ impl<'de> toml_span::Deserialize<'de> for ParsedManifest {
 
 fn ensure_unique_exposed_names(
     value: &mut Value<'_>,
-    envs: &IndexMap<EnvironmentName, ParsedEnvironment>,
+    envs: &IndexMap<EnvironmentName, TomlParsedEnvironment>,
 ) -> Result<(), DeserError> {
     let mut exposed_names = IndexSet::new();
     let mut duplicates = IndexMap::new();
@@ -176,7 +188,7 @@ fn ensure_unique_exposed_names(
 
 fn ensure_unique_shortcut_names(
     value: &mut Value<'_>,
-    envs: &IndexMap<EnvironmentName, ParsedEnvironment>,
+    envs: &IndexMap<EnvironmentName, TomlParsedEnvironment>,
 ) -> Result<(), DeserError> {
     let mut shortcut_names = IndexSet::new();
     let mut duplicates = IndexMap::new();
@@ -207,7 +219,14 @@ fn ensure_unique_shortcut_names(
 
 impl ParsedManifest {
     /// Parses a toml string into a project manifest.
-    pub(crate) fn from_toml_str(source: &str) -> Result<Self, ManifestParsingError> {
+    ///
+    /// `root_directory` is the directory containing the manifest file; it is
+    /// used to resolve and convert inline package definitions attached to
+    /// source dependencies.
+    pub(crate) fn from_toml_str(
+        source: &str,
+        root_directory: &Path,
+    ) -> Result<Self, ManifestParsingError> {
         let mut toml_value = toml_span::parse(source)?;
 
         let version = toml_value
@@ -215,8 +234,8 @@ impl ParsedManifest {
             .and_then(|table| table.get("version"))
             .and_then(|version| version.as_integer());
 
-        match ParsedManifest::deserialize(&mut toml_value) {
-            Ok(manifest) => Ok(manifest),
+        match TomlParsedManifest::deserialize(&mut toml_value) {
+            Ok(manifest) => manifest.into_parsed_manifest(root_directory),
             Err(e) => {
                 let error = e
                     .errors
@@ -238,6 +257,82 @@ impl ParsedManifest {
                 }
             }
         }
+    }
+}
+
+impl TomlParsedManifest {
+    /// Converts the toml-stage manifest into a [`ParsedManifest`], turning
+    /// each environment's inline package definitions into
+    /// [`InlinePackageManifest`]s.
+    fn into_parsed_manifest(
+        self,
+        root_directory: &Path,
+    ) -> Result<ParsedManifest, ManifestParsingError> {
+        // The global manifest has no preview mechanism; source dependencies
+        // (and with them inline package definitions) are simply supported, so
+        // conversion runs with the pixi-build feature enabled.
+        let preview = Preview::from_iter([KnownPreviewFeature::PixiBuild]);
+
+        let mut envs = IndexMap::with_capacity(self.envs.len());
+        for (env_name, env) in self.envs {
+            let DependencyTable {
+                specs: dependencies,
+                inline_packages: inline_toml,
+            } = env.dependencies;
+
+            // The global manifest has no `[workspace.dependencies]` pool to
+            // inherit from, so `{ workspace = true }` entries are rejected.
+            let dependencies = dependencies.into_direct().map_err(|e| {
+                ManifestParsingError::TomlError(
+                    e.errors
+                        .into_iter()
+                        .next()
+                        .expect("there should be at least one error"),
+                )
+            })?;
+
+            let mut inline_packages = IndexMap::with_capacity(inline_toml.len());
+            for (name, package) in inline_toml {
+                let span = package.span.clone();
+                // There is no workspace to inherit from, so `{ workspace =
+                // true }` fields in inline definitions fail to resolve, and
+                // package defaults stay empty.
+                let converted = InlinePackageManifest::from_toml_package(
+                    &name,
+                    package.value,
+                    WorkspacePackageProperties::default(),
+                    &preview,
+                    root_directory,
+                )
+                .map_err(|e| {
+                    ManifestParsingError::TomlError(toml_span::Error {
+                        kind: toml_span::ErrorKind::Custom(e.to_string().into()),
+                        span: span
+                            .map(|range| toml_span::Span::new(range.start, range.end))
+                            .unwrap_or_default(),
+                        line_info: None,
+                    })
+                })?;
+                inline_packages.insert(name, converted.value);
+            }
+
+            envs.insert(
+                env_name,
+                ParsedEnvironment {
+                    channels: env.channels,
+                    platform: env.platform,
+                    dependencies,
+                    inline_packages,
+                    exposed: env.exposed,
+                    shortcuts: env.shortcuts,
+                },
+            );
+        }
+
+        Ok(ParsedManifest {
+            version: self.version,
+            envs,
+        })
     }
 }
 
@@ -297,12 +392,30 @@ pub struct ParsedEnvironment {
     /// Platform used by the environment.
     pub platform: Option<Platform>,
     pub dependencies: UniquePackageMap,
+    /// Inline package definitions attached to source dependencies. Keyed by
+    /// dependency name; the matching source spec lives in
+    /// [`Self::dependencies`].
+    #[serde(skip)]
+    pub inline_packages: IndexMap<PackageName, InlinePackageManifest>,
     #[serde(default, serialize_with = "serialize_expose_mappings")]
     pub exposed: IndexSet<Mapping>,
     pub shortcuts: Option<IndexSet<PackageName>>,
 }
 
-impl<'de> toml_span::Deserialize<'de> for ParsedEnvironment {
+/// The toml-stage of [`ParsedEnvironment`]: inline package definitions are
+/// still raw [`TomlPackage`](pixi_manifest::toml::TomlPackage)s inside the
+/// [`DependencyTable`]; they are converted by
+/// [`TomlParsedManifest::into_parsed_manifest`], which has the root directory
+/// as context.
+struct TomlParsedEnvironment {
+    channels: IndexSet<PrioritizedChannel>,
+    platform: Option<Platform>,
+    dependencies: DependencyTable,
+    exposed: IndexSet<Mapping>,
+    shortcuts: Option<IndexSet<PackageName>>,
+}
+
+impl<'de> toml_span::Deserialize<'de> for TomlParsedEnvironment {
     fn deserialize(value: &mut toml_span::Value<'de>) -> Result<Self, DeserError> {
         let mut th = TableHelper::new(value)?;
 
@@ -413,9 +526,12 @@ impl AsRef<str> for ExposedName {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
+    use std::str::FromStr;
 
-    use super::ParsedManifest;
+    use insta::assert_snapshot;
+    use rattler_conda_types::PackageName;
+
+    use super::{EnvironmentName, ParsedManifest};
 
     #[test]
     fn test_invalid_key() {
@@ -427,9 +543,11 @@ mod tests {
         assert_snapshot!(
             examples
                 .into_iter()
-                .map(|example| ParsedManifest::from_toml_str(example)
-                    .unwrap_err()
-                    .to_string())
+                .map(
+                    |example| ParsedManifest::from_toml_str(example, std::path::Path::new(""))
+                        .unwrap_err()
+                        .to_string()
+                )
                 .collect::<Vec<_>>()
                 .join("\n")
         )
@@ -453,7 +571,7 @@ mod tests {
         "python" = "python"
         "python3" = "python"
         "#;
-        let manifest = ParsedManifest::from_toml_str(contents);
+        let manifest = ParsedManifest::from_toml_str(contents, std::path::Path::new(""));
 
         fn remove_ansi_escape_sequences(input: &str) -> String {
             use regex::Regex;
@@ -482,7 +600,7 @@ mod tests {
         [envs.python.exposed]
         python = "python"
         "#;
-        let manifest = ParsedManifest::from_toml_str(contents);
+        let manifest = ParsedManifest::from_toml_str(contents, std::path::Path::new(""));
 
         assert!(manifest.is_err());
         assert_snapshot!(manifest.unwrap_err());
@@ -501,7 +619,7 @@ mod tests {
 
         // Replace the pixi-bin-name with the actual executable name that can be variable at runtime in tests
         let contents = contents.replace("pixi-bin-name", pixi_utils::executable_name());
-        let manifest = ParsedManifest::from_toml_str(contents.as_str());
+        let manifest = ParsedManifest::from_toml_str(contents.as_str(), std::path::Path::new(""));
 
         assert!(manifest.is_err());
         // Replace back the executable name with "pixi" to satisfy the snapshot
@@ -541,6 +659,47 @@ mod tests {
         [envs.python3-10.exposed]
         "python3.10" = "python"
         "#;
-        let _manifest = ParsedManifest::from_toml_str(contents).unwrap();
+        let _manifest = ParsedManifest::from_toml_str(contents, std::path::Path::new("")).unwrap();
+    }
+
+    /// An inline package definition attached to a git source dependency is
+    /// parsed into an `InlinePackageManifest`, and the surrounding spec
+    /// remains a source spec in the dependency map.
+    #[test]
+    fn test_inline_package_definition() {
+        let contents = r#"
+        [envs.xsv]
+        channels = ["conda-forge"]
+        [envs.xsv.dependencies]
+        xsv = { git = "https://github.com/BurntSushi/xsv.git", package.build.backend.name = "pixi-build-rust" }
+        "#;
+        let manifest = ParsedManifest::from_toml_str(contents, std::path::Path::new("")).unwrap();
+
+        let env_name = EnvironmentName::from_str("xsv").unwrap();
+        let env = manifest.envs.get(&env_name).unwrap();
+        let name = PackageName::from_str("xsv").unwrap();
+
+        // The source spec is retained as a dependency.
+        assert!(env.dependencies.specs.get(&name).unwrap().is_source());
+
+        // The inline definition is converted and keyed by dependency name.
+        let inline = env.inline_packages.get(&name).unwrap();
+        assert_eq!(
+            inline.manifest.build.backend.name.as_normalized(),
+            "pixi-build-rust"
+        );
+    }
+
+    /// An inline definition without a source location is meaningless and
+    /// rejected, matching the workspace inline syntax.
+    #[test]
+    fn test_inline_package_requires_source() {
+        let contents = r#"
+        [envs.xsv]
+        channels = ["conda-forge"]
+        [envs.xsv.dependencies]
+        xsv = { version = "*", package.build.backend.name = "pixi-build-rust" }
+        "#;
+        assert!(ParsedManifest::from_toml_str(contents, std::path::Path::new("")).is_err());
     }
 }

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -12,6 +12,7 @@ use pixi_spec::PixiSpec;
 use pixi_spec_containers::DependencyMap;
 use pixi_stable_hash::StableHashBuilder;
 use rattler_conda_types::{PackageName, ParsePlatformError, Platform};
+use xxhash_rust::xxh3::Xxh3;
 
 use super::error::DependencyError;
 use crate::{
@@ -109,8 +110,6 @@ impl InlinePackageManifest {
         preview: &crate::Preview,
         root_directory: &std::path::Path,
     ) -> Result<crate::WithWarnings<Self>, crate::TomlError> {
-        use xxhash_rust::xxh3::Xxh3;
-
         let crate::WithWarnings {
             value: manifest,
             warnings,

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -90,6 +90,54 @@ pub struct InlinePackageManifest {
     pub content_hash: InlineContentHash,
 }
 
+impl InlinePackageManifest {
+    /// Converts a parsed inline `package` table into an
+    /// [`InlinePackageManifest`], fingerprinting the assembled manifest so
+    /// editing the inline definition invalidates the content-addressed build
+    /// caches it feeds. The dependency name is folded in so two identical
+    /// inline tables declared under different names stay distinct.
+    ///
+    /// The manifest's build source is taken from the surrounding dependency
+    /// spec, so the converted manifest carries no `build.source` of its own.
+    /// Package defaults stay empty: an inline definition describes a
+    /// dependency, not the consuming project, so it must not pick up the
+    /// consumer's metadata implicitly.
+    pub fn from_toml_package(
+        dependency_name: &PackageName,
+        package: crate::toml::TomlPackage,
+        workspace_package_properties: crate::toml::WorkspacePackageProperties,
+        preview: &crate::Preview,
+        root_directory: &std::path::Path,
+    ) -> Result<crate::WithWarnings<Self>, crate::TomlError> {
+        use xxhash_rust::xxh3::Xxh3;
+
+        let crate::WithWarnings {
+            value: manifest,
+            warnings,
+        } = package.into_manifest(
+            workspace_package_properties,
+            crate::toml::PackageDefaults::default(),
+            preview,
+            root_directory,
+        )?;
+
+        let content_hash = {
+            let mut hasher = Xxh3::new();
+            dependency_name.as_normalized().hash(&mut hasher);
+            manifest.hash(&mut hasher);
+            InlineContentHash(hasher.finish())
+        };
+
+        Ok(crate::WithWarnings {
+            value: InlinePackageManifest {
+                manifest,
+                content_hash,
+            },
+            warnings,
+        })
+    }
+}
+
 /// A package target describes the dependencies for a specific platform.
 #[derive(Default, Debug, Clone)]
 pub struct PackageTarget {

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -1,24 +1,16 @@
-use std::{
-    collections::HashMap,
-    hash::{Hash, Hasher},
-    path::Path,
-};
+use std::{collections::HashMap, path::Path};
 
 use indexmap::IndexMap;
 use pixi_spec::{PixiSpec, TomlLocationSpec, TomlSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_toml::{TomlHashMap, TomlIndexMap};
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
-use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
-    Activation, InlineContentHash, InlinePackageManifest, KnownPreviewFeature, SpecType,
-    TargetSelector, Task, TaskName, TomlError, Warning, WithWarnings, WorkspaceTarget,
+    Activation, InlinePackageManifest, KnownPreviewFeature, SpecType, TargetSelector, Task,
+    TaskName, TomlError, Warning, WithWarnings, WorkspaceTarget,
     error::GenericError,
-    toml::{
-        PackageDefaults, TomlPackage, WorkspacePackageProperties, preview::TomlPreview,
-        task::TomlTask,
-    },
+    toml::{TomlPackage, WorkspacePackageProperties, preview::TomlPreview, task::TomlTask},
     utils::{
         PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
         package_map::UniquePackageMap,
@@ -143,34 +135,18 @@ impl TomlTarget {
         let mut inline_packages: IndexMap<PackageName, InlinePackageManifest> = IndexMap::new();
         for (name, package) in inline_toml {
             let WithWarnings {
-                value: manifest,
+                value: inline_manifest,
                 warnings: mut package_warnings,
-            } = package.value.into_manifest(
+            } = InlinePackageManifest::from_toml_package(
+                &name,
+                package.value,
                 workspace_package_properties.clone(),
-                PackageDefaults::default(),
                 &full_preview,
                 root_directory,
             )?;
             warnings.append(&mut package_warnings);
 
-            // Fingerprint the assembled manifest so editing the inline
-            // definition invalidates the content-addressed build caches it
-            // feeds. The dependency name is folded in so two identical inline
-            // tables declared under different names stay distinct.
-            let content_hash = {
-                let mut hasher = Xxh3::new();
-                name.as_normalized().hash(&mut hasher);
-                manifest.hash(&mut hasher);
-                InlineContentHash(hasher.finish())
-            };
-
-            inline_packages.insert(
-                name,
-                InlinePackageManifest {
-                    manifest,
-                    content_hash,
-                },
-            );
+            inline_packages.insert(name, inline_manifest);
         }
 
         // Convert dev dependencies from TomlLocationSpec to SourceLocationSpec

--- a/docs/global_tools/introduction.md
+++ b/docs/global_tools/introduction.md
@@ -130,6 +130,15 @@ In this case, we have to specify which output we want to install:
 pixi global install --path /path/to/package foobar
 ```
 
+So far the source always came with a package manifest.
+If it doesn't have one, like in an ordinary Rust, Python or C++ repository, you can name the build backend on the command line:
+
+```shell
+pixi global install --git https://github.com/BurntSushi/xsv.git --build-backend pixi-build-rust
+```
+
+This records an inline package definition in the global manifest, which is described under [source dependencies](manifest.md#source-dependencies).
+
 ## Shell Completions
 
 When you work in a terminal, you are using a shell and shells can process completions of command line tools.
@@ -248,6 +257,8 @@ platforms = ["osx-64"]
 dependencies = { python = "*" }
 # ...
 ```
+
+Environments that contain a source dependency can only target the current platform, since they are built on your machine.
 
 ## Packaging
 

--- a/docs/global_tools/manifest.md
+++ b/docs/global_tools/manifest.md
@@ -125,6 +125,66 @@ pixi global remove --environment my-env package-a package-b
 ```
 
 
+## Source dependencies
+
+Instead of a Conda package from a channel, you can install a tool built from source.
+Point `pixi global install` at a git repository or a local path:
+
+```shell
+pixi global install --git https://github.com/prefix-dev/rattler-build rattler-build
+pixi global install --path ./my-tool
+```
+
+If the source contains a pixi package manifest, that's all you need.
+If it doesn't, tell pixi how to build it with `--build-backend`:
+
+```shell
+pixi global install --git https://github.com/BurntSushi/xsv.git --build-backend pixi-build-rust
+```
+
+This records an *inline package definition* under the `package` key of the dependency:
+
+```toml
+[envs.xsv]
+channels = ["conda-forge"]
+[envs.xsv.dependencies]
+xsv = { git = "https://github.com/BurntSushi/xsv.git", package.build.backend.name = "pixi-build-rust" }
+```
+
+When pixi can infer the package name from the source you can omit it, so the command above
+installs the `xsv` environment without naming it explicitly.
+If a source produces several differently-named packages, name the ones you want:
+
+```shell
+pixi global install --path ./workspace foo bar
+```
+
+The `--build-backend` value accepts an optional version constraint, e.g.
+`--build-backend "pixi-build-rust>=0.3,<0.4"`.
+Any other field of the package definition can be set with `--package DOTTED_KEY=TOML_VALUE`,
+which maps directly onto the keys under `package`:
+
+```shell
+pixi global install --git https://github.com/some/tool \
+  --build-backend pixi-build-python \
+  --package 'host-dependencies.hatchling="*"'
+```
+
+Anything expressible in a [pixi package manifest](../build/getting_started.md) is allowed here;
+the CLI flags are just a shortcut for editing the definition by hand with
+[`pixi global edit`](../reference/cli/pixi/global/edit.md).
+
+!!! note
+    Source dependencies are built on your machine, so an environment that contains one
+    can only target your current platform. Setting a different `platform` for such an
+    environment is an error.
+
+`pixi global sync` rebuilds a source dependency when its *specification* changes
+(for example an edited git revision or `package` table).
+To pick up new commits of an unpinned git dependency or new content of a local path,
+run [`pixi global update`](../reference/cli/pixi/global/update.md).
+
+
 ## Platform
 
 Each environment is solved for a single platform, defaulting to your current one.

--- a/docs/global_tools/manifest.md
+++ b/docs/global_tools/manifest.md
@@ -159,10 +159,14 @@ If a source produces several differently-named packages, name the ones you want:
 pixi global install --path ./workspace foo bar
 ```
 
+When `--build-backend` or `--package` is combined with several named packages,
+the same inline definition is recorded for each of them.
+
 The `--build-backend` value accepts an optional version constraint, e.g.
 `--build-backend "pixi-build-rust>=0.3,<0.4"`.
 Any other field of the package definition can be set with `--package DOTTED_KEY=TOML_VALUE`,
-which maps directly onto the keys under `package`:
+which maps directly onto the keys under `package`.
+The value must be valid TOML, so strings need their quotes:
 
 ```shell
 pixi global install --git https://github.com/some/tool \

--- a/docs/reference/cli/pixi/global/add.md
+++ b/docs/reference/cli/pixi/global/add.md
@@ -21,6 +21,11 @@ pixi global add [OPTIONS] --environment <ENVIRONMENT> [PACKAGE]...
 ## Options
 - <a id="arg---path" href="#arg---path">`--path <PATH>`</a>
 :  The path to the local package
+- <a id="arg---build-backend" href="#arg---build-backend">`--build-backend <BUILD_BACKEND>`</a>
+:  The build backend to build the source with, when the source does not provide its own package manifest (or to override the one it has). Accepts a name with an optional version constraint, e.g. `pixi-build-rust` or `"pixi-build-rust>=0.3,<0.4"`
+- <a id="arg---package" href="#arg---package">`--package <KEY=VALUE>`</a>
+:  Additional fields of the inline package definition, as `DOTTED_KEY=TOML_VALUE` pairs that are recorded under the `package` key of the dependency, e.g. `host-dependencies.hatchling="*"` or `build.config.extra-args=["--all-features"]`
+<br>May be provided more than once.
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  Specifies the environment that the dependencies need to be added to
 <br>**required**: `true`

--- a/docs/reference/cli/pixi/global/install.md
+++ b/docs/reference/cli/pixi/global/install.md
@@ -21,6 +21,11 @@ pixi global install [OPTIONS] [PACKAGE]...
 ## Options
 - <a id="arg---path" href="#arg---path">`--path <PATH>`</a>
 :  The path to the local package
+- <a id="arg---build-backend" href="#arg---build-backend">`--build-backend <BUILD_BACKEND>`</a>
+:  The build backend to build the source with, when the source does not provide its own package manifest (or to override the one it has). Accepts a name with an optional version constraint, e.g. `pixi-build-rust` or `"pixi-build-rust>=0.3,<0.4"`
+- <a id="arg---package" href="#arg---package">`--package <KEY=VALUE>`</a>
+:  Additional fields of the inline package definition, as `DOTTED_KEY=TOML_VALUE` pairs that are recorded under the `package` key of the dependency, e.g. `host-dependencies.hatchling="*"` or `build.config.extra-args=["--all-features"]`
+<br>May be provided more than once.
 - <a id="arg---channel" href="#arg---channel">`--channel (-c) <CHANNEL>`</a>
 :  The channels to consider as a name or a url. Multiple channels can be specified by using this field multiple times
 <br>May be provided more than once.

--- a/tests/data/pixi-build/inline-package/recipe.yaml
+++ b/tests/data/pixi-build/inline-package/recipe.yaml
@@ -1,0 +1,17 @@
+package:
+  name: simple-package
+  version: 0.1.0
+
+build:
+  number: 0
+  script:
+    - if: win
+      then:
+        - if not exist "%PREFIX%\bin" mkdir "%PREFIX%\bin"
+        - echo @echo off > %PREFIX%\bin\simple-package.bat
+        - echo echo hello from simple-package >> %PREFIX%\bin\simple-package.bat
+      else:
+        - mkdir -p $PREFIX/bin
+        - echo "#!/usr/bin/env bash" > $PREFIX/bin/simple-package
+        - echo "echo hello from simple-package" >> $PREFIX/bin/simple-package
+        - chmod +x $PREFIX/bin/simple-package

--- a/tests/integration_python/pixi_build/test_global.py
+++ b/tests/integration_python/pixi_build/test_global.py
@@ -5,6 +5,7 @@ import tomli_w
 import tomllib
 
 from .common import (
+    CURRENT_PLATFORM,
     ExitCode,
     copy_manifest,
     copytree_with_local_backend,
@@ -305,6 +306,130 @@ def test_install_multi_output_multiple(
     bizbar = pixi_home / "bin" / exec_extension("bizbar")
     verify_cli_command([foobar], env=env, stdout_contains="Hello from foobar")
     verify_cli_command([bizbar], env=env, stdout_contains="Hello from bizbar")
+
+
+def test_install_inline_package(
+    pixi: Path,
+    tmp_path: Path,
+    build_data: Path,
+) -> None:
+    """Install a source that has no pixi manifest, supplying the build backend
+    with `--build-backend` so an inline package definition is recorded."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    # A directory with only a `recipe.yaml`, i.e. no pixi package manifest.
+    source_project = build_data.joinpath("inline-package")
+
+    # The package name is inferred from the recipe by the backend.
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--path",
+            source_project,
+            "--build-backend",
+            "pixi-build-rattler-build",
+        ],
+        env=env,
+    )
+
+    # The manifest records the inline package definition under the `package`
+    # key of the dependency.
+    manifest_path = pixi_home.joinpath("manifests", "pixi-global.toml")
+    manifest = tomllib.loads(manifest_path.read_text())
+    dependency = manifest["envs"]["simple-package"]["dependencies"]["simple-package"]
+    assert dependency["package"]["build"]["backend"]["name"] == "pixi-build-rattler-build"
+
+    # The tool was built and installed.
+    simple_package = pixi_home / "bin" / exec_extension("simple-package")
+    verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
+
+
+def test_install_inline_package_collision(
+    pixi: Path,
+    tmp_path: Path,
+    build_data: Path,
+) -> None:
+    """Setting the same inline key via `--build-backend` and `--package` fails."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    source_project = build_data.joinpath("inline-package")
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--path",
+            source_project,
+            "--build-backend",
+            "pixi-build-rattler-build",
+            "--package",
+            'build.backend.name="other"',
+        ],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="set more than once",
+    )
+
+
+def test_install_build_backend_requires_source(
+    pixi: Path,
+    tmp_path: Path,
+) -> None:
+    """`--build-backend` without a source location is an error."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "xsv",
+            "--build-backend",
+            "pixi-build-rust",
+        ],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="require a source location",
+    )
+
+
+def test_install_source_platform_guard(
+    pixi: Path,
+    tmp_path: Path,
+    build_data: Path,
+) -> None:
+    """A source dependency cannot be installed for a non-current platform."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    source_project = build_data.joinpath("simple-package")
+
+    # Pick a platform that is never the current one.
+    other_platform = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "win-64"
+
+    # Pass the name explicitly so the guard (which fires before any solve or
+    # build) is reached without needing the backend for name inference.
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--path",
+            source_project,
+            "simple-package",
+            "--platform",
+            other_platform,
+        ],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="source dependency",
+    )
 
 
 @pytest.mark.slow

--- a/tests/integration_python/pixi_build/test_global_inline.py
+++ b/tests/integration_python/pixi_build/test_global_inline.py
@@ -16,6 +16,7 @@ import tomli_w
 import tomllib
 
 from .common import (
+    CONDA_FORGE_CHANNEL,
     copy_manifest,
     copytree_with_local_backend,
     exec_extension,
@@ -162,6 +163,67 @@ def test_add_inline_to_existing_environment(
 
     simple_package = pixi_home / "bin" / exec_extension("simple-package")
     verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
+
+
+@pytest.mark.slow
+def test_inference_uses_environment_channels(
+    pixi: Path, tmp_path: Path, build_data: Path, dummy_channel_1: str
+) -> None:
+    """Name inference solves the build backend against the channels the
+    environment ends up with, not the config's default channels. The defaults
+    point at a dummy channel that does not carry the backend, so both commands
+    below only succeed when the environment channels reach inference.
+
+    The backend override is disabled because it bypasses the backend
+    environment solve this test is about; the backend comes from conda-forge
+    instead."""
+    pixi_home = tmp_path / "pixi_home"
+    pixi_home.mkdir()
+    pixi_home.joinpath("config.toml").write_text(f'default-channels = ["{dummy_channel_1}"]\n')
+    env = {"PIXI_HOME": str(pixi_home), "PIXI_BUILD_BACKEND_OVERRIDE": ""}
+
+    # `install`: the --channel argument has to reach inference.
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--channel",
+            CONDA_FORGE_CHANNEL,
+            "--path",
+            build_data.joinpath("inline-package"),
+            "--build-backend",
+            RATTLER_BUILD,
+        ],
+        env=env,
+    )
+    simple_package = pixi_home / "bin" / exec_extension("simple-package")
+    verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
+
+    # `add` has no --channel flag; the channels of the target environment
+    # have to reach inference.
+    second_source = tmp_path / "second-src"
+    copytree_with_local_backend(build_data.joinpath("inline-package"), second_source)
+    recipe = second_source / "recipe.yaml"
+    recipe.write_text(recipe.read_text().replace("simple-package", "second-package"))
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "add",
+            "--environment",
+            "simple-package",
+            "--path",
+            second_source,
+            "--build-backend",
+            RATTLER_BUILD,
+        ],
+        env=env,
+    )
+
+    manifest = tomllib.loads(pixi_home.joinpath("manifests", "pixi-global.toml").read_text())
+    assert "second-package" in manifest["envs"]["simple-package"]["dependencies"]
 
 
 def test_sync_unchanged_inline_env_is_noop(pixi: Path, tmp_path: Path, build_data: Path) -> None:

--- a/tests/integration_python/pixi_build/test_global_inline.py
+++ b/tests/integration_python/pixi_build/test_global_inline.py
@@ -1,0 +1,116 @@
+"""Integration tests for inline package definitions in `pixi global`
+(`--build-backend` / `--package`), introduced in #6521.
+
+These cover the end-to-end paths that can't be unit-tested in Rust: building a
+manifest-less source through the real backend, name inference, and the
+fingerprint-driven rebuild. The pure spec-conversion and manifest-overwrite
+logic is covered by Rust unit tests in `pixi_cli`/`pixi_global`.
+
+Run a single one with `pixi run test-specific-test <substring>`.
+"""
+
+from pathlib import Path
+
+import pytest
+import tomli_w
+import tomllib
+
+from .common import (
+    copy_manifest,
+    copytree_with_local_backend,
+    exec_extension,
+    git_test_repo,
+    verify_cli_command,
+)
+
+# The hermetic fixture is a directory with only a `recipe.yaml` (no pixi
+# package manifest); `pixi-build-rattler-build` builds it into a
+# `simple-package` tool that prints "hello from simple-package".
+RATTLER_BUILD = "pixi-build-rattler-build"
+
+
+def _modifiable_recipe_source(build_data: Path, dest: Path) -> Path:
+    """Copy the recipe-only fixture so its recipe can be edited between builds.
+    `copy_manifest` bumps the mtime so a stale build cache isn't reused."""
+    copytree_with_local_backend(
+        build_data.joinpath("inline-package"),
+        dest,
+        copy_function=copy_manifest,
+    )
+    return dest
+
+
+def _rewrite_recipe_message(source_project: Path, old: str, new: str) -> None:
+    recipe_path = source_project / "recipe.yaml"
+    recipe_path.write_text(recipe_path.read_text().replace(old, new))
+
+
+def test_install_inline_from_git_infers_name(pixi: Path, tmp_path: Path, build_data: Path) -> None:
+    """A git source with no pixi manifest builds via `--build-backend`, and the
+    package name is inferred from the recipe."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    git_url = git_test_repo(build_data.joinpath("inline-package"), "inline-git", tmp_path)
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--git",
+            git_url,
+            "--build-backend",
+            RATTLER_BUILD,
+        ],
+        env=env,
+    )
+
+    simple_package = pixi_home / "bin" / exec_extension("simple-package")
+    verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
+
+
+@pytest.mark.slow
+def test_manifest_inline_edit_triggers_rebuild(
+    pixi: Path, tmp_path: Path, build_data: Path
+) -> None:
+    """Hand-editing the inline `package` table in the manifest changes the source
+    fingerprint, so `sync` detects the env as out of sync and rebuilds. Guards the
+    new behavior that source fingerprints include the inline definition."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+    source_project = _modifiable_recipe_source(build_data, tmp_path / "src")
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--path",
+            source_project,
+            "simple-package",
+            "--build-backend",
+            RATTLER_BUILD,
+        ],
+        env=env,
+    )
+    simple_package = pixi_home / "bin" / exec_extension("simple-package")
+
+    # Edit the source; `sync` alone would ignore this (the spec is unchanged) ...
+    _rewrite_recipe_message(
+        source_project, "hello from simple-package", "goodbye from simple-package"
+    )
+
+    # ... and edit the inline definition in the manifest. This changes the
+    # recorded fingerprint, which should mark the env out of sync.
+    manifest_path = pixi_home.joinpath("manifests", "pixi-global.toml")
+    manifest = tomllib.loads(manifest_path.read_text())
+    backend = manifest["envs"]["simple-package"]["dependencies"]["simple-package"]["package"][
+        "build"
+    ]["backend"]
+    assert "version" not in backend
+    backend["version"] = "*"
+    manifest_path.write_text(tomli_w.dumps(manifest))
+
+    verify_cli_command([pixi, "global", "sync"], env=env)
+    verify_cli_command([simple_package], env=env, stdout_contains="goodbye from simple-package")

--- a/tests/integration_python/pixi_build/test_global_inline.py
+++ b/tests/integration_python/pixi_build/test_global_inline.py
@@ -17,6 +17,7 @@ import tomllib
 
 from .common import (
     CONDA_FORGE_CHANNEL,
+    ExitCode,
     copy_manifest,
     copytree_with_local_backend,
     exec_extension,
@@ -163,6 +164,43 @@ def test_add_inline_to_existing_environment(
 
     simple_package = pixi_home / "bin" / exec_extension("simple-package")
     verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
+
+
+def test_missing_manifest_hints_at_build_backend(pixi: Path, tmp_path: Path) -> None:
+    """Installing a named source dependency whose checkout contains no
+    manifest at all fails with a hint pointing at `--build-backend`."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+    source = tmp_path / "src"
+    source.mkdir()
+    source.joinpath("README.md").write_text("no manifest here")
+
+    verify_cli_command(
+        [pixi, "global", "install", "--path", source, "simple-package"],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="--build-backend",
+    )
+
+
+def test_package_less_manifest_hints_at_build_backend(pixi: Path, tmp_path: Path) -> None:
+    """A source with a workspace-only `pixi.toml` (no `[package]` section)
+    cannot be built either; the failure carries the same `--build-backend`
+    hint."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+    source = tmp_path / "src"
+    source.mkdir()
+    source.joinpath("pixi.toml").write_text(
+        '[workspace]\nchannels = []\nplatforms = []\npreview = ["pixi-build"]\n'
+    )
+
+    verify_cli_command(
+        [pixi, "global", "install", "--path", source, "simple-package"],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains="--build-backend",
+    )
 
 
 @pytest.mark.slow

--- a/tests/integration_python/pixi_build/test_global_inline.py
+++ b/tests/integration_python/pixi_build/test_global_inline.py
@@ -114,3 +114,84 @@ def test_manifest_inline_edit_triggers_rebuild(
 
     verify_cli_command([pixi, "global", "sync"], env=env)
     verify_cli_command([simple_package], env=env, stdout_contains="goodbye from simple-package")
+
+
+def test_add_inline_to_existing_environment(
+    pixi: Path, tmp_path: Path, build_data: Path, dummy_channel_1: str
+) -> None:
+    """`pixi global add --build-backend` records an inline definition for a
+    source added to an existing environment and builds it."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--channel",
+            dummy_channel_1,
+            "--environment",
+            "test-env",
+            "dummy-f",
+        ],
+        env=env,
+    )
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "add",
+            "--environment",
+            "test-env",
+            "--path",
+            build_data.joinpath("inline-package"),
+            "--build-backend",
+            RATTLER_BUILD,
+            "--expose",
+            "simple-package=simple-package",
+        ],
+        env=env,
+    )
+
+    manifest_path = pixi_home.joinpath("manifests", "pixi-global.toml")
+    manifest = tomllib.loads(manifest_path.read_text())
+    dependency = manifest["envs"]["test-env"]["dependencies"]["simple-package"]
+    assert dependency["package"]["build"]["backend"]["name"] == RATTLER_BUILD
+
+    simple_package = pixi_home / "bin" / exec_extension("simple-package")
+    verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
+
+
+def test_sync_unchanged_inline_env_is_noop(pixi: Path, tmp_path: Path, build_data: Path) -> None:
+    """`pixi global sync` leaves an unchanged source environment alone. The
+    fingerprints recorded at install time must match the ones recomputed from
+    the manifest; if they ever diverge for an unchanged manifest, every sync
+    rebuilds every source environment."""
+    pixi_home = tmp_path / "pixi_home"
+    env = {"PIXI_HOME": str(pixi_home)}
+
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--path",
+            build_data.joinpath("inline-package"),
+            "--build-backend",
+            RATTLER_BUILD,
+        ],
+        env=env,
+    )
+
+    # The environment file is rewritten whenever the environment is
+    # (re)installed, so a stable mtime means the sync was a no-op.
+    env_file = pixi_home.joinpath("envs", "simple-package", "conda-meta", "pixi")
+    mtime_before = env_file.stat().st_mtime_ns
+
+    verify_cli_command([pixi, "global", "sync"], env=env)
+
+    assert env_file.stat().st_mtime_ns == mtime_before, (
+        "sync rebuilt an unchanged source environment"
+    )


### PR DESCRIPTION
### Description

This PR implements inline package manifests in `pixi global`, enabling users to install tools from source repositories that don't contain pixi manifests by supplying the package definition via CLI flags or the global manifest.

It covers:

* **Manifest syntax**: Reusing workspace inline-manifest syntax in `pixi-global.toml` under `[envs.<env>.dependencies]`, with full `package.*` grammar support
* **CLI interface**:
  * `--build-backend <MATCHSPEC>` flag for the obvious case (e.g., `pixi global install --git <url> --build-backend pixi-build-rust`)
  * Generic `--package <DOTTED_KEY>=<TOML_VALUE>` escape hatch for advanced configuration
* **Name inference**: Automatic package naming by querying the build backend's outputs, with support for multi-output sources
* **Sync semantics**: Spec-fingerprint tracking to detect when inline definitions or source specs change, ensuring `pixi global sync` properly rebuilds when needed
* **Platform safety**: Hard error for cross-platform source builds
* **Precedence**: Inline definitions override discovered manifests when both are present

Fixes prefix-dev/pixi#6610