### PR TITLE
fix: invalidate lock file when an inline package definition changes

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -657,6 +657,9 @@ pub enum PlatformUnsat {
     #[error("the metadata of source package '{0}' changed: {1}")]
     SourcePackageMetadataChanged(String, String),
 
+    #[error("the inline package definition of source package '{package}' changed")]
+    InlinePackageDefinitionChanged { package: String },
+
     #[error("the source location '{0}' changed from '{1}' to '{2}'")]
     SourceBuildLocationChanged(String, String, String),
 

--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -657,8 +657,10 @@ pub enum PlatformUnsat {
     #[error("the metadata of source package '{0}' changed: {1}")]
     SourcePackageMetadataChanged(String, String),
 
-    #[error("the inline package definition of source package '{package}' changed")]
-    InlinePackageDefinitionChanged { package: String },
+    #[error(
+        "the identity of source package '{package}' changed (for example its inline package definition was edited, or the lock file was written by a different pixi version)"
+    )]
+    SourcePackageIdentityChanged { package: String },
 
     #[error("the source location '{0}' changed from '{1}' to '{2}'")]
     SourceBuildLocationChanged(String, String, String),

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -41,7 +41,8 @@ use super::legacy;
 use super::pypi::{lock_pypi_packages, pypi_satisfies_editable, pypi_satisfies_requirement};
 use super::pypi_metadata;
 use super::source_record::{
-    verify_build_source_matches_manifest, verify_partial_source_record_against_backend,
+    verify_build_source_matches_manifest, verify_immutable_inline_definition,
+    verify_partial_source_record_against_backend,
 };
 use crate::{
     lock_file::{
@@ -249,9 +250,21 @@ pub async fn verify_platform_satisfiability(
     //
     // Backend checks are independent and IO-bound, so run them concurrently
     // and reassemble in the original order.
+    //
+    // Inline package definitions declared in the current manifest, used to
+    // detect edits against records whose sources are otherwise immutable.
+    let inline_packages =
+        crate::workspace::grouped_environment::GroupedEnvironment::from(ctx.environment.clone())
+            .combined_inline_packages(
+                ctx.environment
+                    .workspace_manifest()
+                    .workspace
+                    .platform_by_name(&ctx.platform),
+            );
     let mut resolve_futures = CancellationAwareFutures::new(ctx.command_dispatcher.executor());
     for (index, record) in unresolved_records.into_iter().enumerate() {
         let platform_setup = &platform_setup;
+        let inline_packages = &inline_packages;
         resolve_futures.push(async move {
             let resolved = match record {
                 UnresolvedPixiRecord::Binary(record) => PixiRecord::Binary(record),
@@ -283,6 +296,20 @@ pub async fn verify_platform_satisfiability(
                         // metadata as-is and avoid contacting the backend
                         // (which would otherwise require it to be available
                         // just to pass satisfiability).
+                        //
+                        // An inline package definition lives in the consuming
+                        // manifest, though, and can change without any
+                        // lock-file-visible signal. Its content hash is folded
+                        // into the record's identifier hash at solve time, so
+                        // recomputing the hash with the definition currently
+                        // in the manifest detects edits.
+                        verify_immutable_inline_definition(
+                            &record,
+                            inline_packages
+                                .get(record.name())
+                                .map(|inline| inline.content_hash.as_u64()),
+                        )
+                        .map_err(CommandDispatcherError::Failed)?;
                         let full_record =
                             Arc::unwrap_or_clone(record).try_map_data(|data| match data {
                                 SourceRecordData::Full(data) => Ok(data),

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -41,7 +41,7 @@ use super::legacy;
 use super::pypi::{lock_pypi_packages, pypi_satisfies_editable, pypi_satisfies_requirement};
 use super::pypi_metadata;
 use super::source_record::{
-    verify_build_source_matches_manifest, verify_immutable_inline_definition,
+    verify_build_source_matches_manifest, verify_immutable_record_identity,
     verify_partial_source_record_against_backend,
 };
 use crate::{
@@ -303,7 +303,7 @@ pub async fn verify_platform_satisfiability(
                         // into the record's identifier hash at solve time, so
                         // recomputing the hash with the definition currently
                         // in the manifest detects edits.
-                        verify_immutable_inline_definition(
+                        verify_immutable_record_identity(
                             &record,
                             inline_packages
                                 .get(record.name())

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -95,23 +95,24 @@ pub(super) fn verify_build_source_matches_manifest(
     }
 }
 
-/// Verify that the inline package definition currently declared for an
-/// immutable source record (if any) still matches the one the record was
-/// resolved with.
+/// Verify that an immutable source record's identity hash still matches the
+/// value it was locked with.
 ///
-/// The lock file does not carry the inline definition itself; its content
-/// hash is folded into the record's `identifier_hash` at solve time. Every
-/// other hash input round-trips verbatim through the lock file, so
+/// The lock file does not carry the inline package definition itself; its
+/// content hash is folded into the record's `identifier_hash` at solve time.
+/// Every other hash input round-trips verbatim through the lock file, so
 /// recomputing the hash with the *current* manifest's inline content hash
 /// reproduces the stored value exactly when the inline definition is
 /// unchanged (or absent on both sides). A mismatch means the inline table
-/// was edited, added, or removed, and the record must be re-resolved.
-pub(super) fn verify_immutable_inline_definition(
+/// was edited, added, or removed - or the stored hash was produced by a
+/// different pixi version with another algorithm - and the record must be
+/// re-resolved.
+pub(super) fn verify_immutable_record_identity(
     record: &pixi_record::UnresolvedSourceRecord,
     current_inline_hash: Option<u64>,
 ) -> Result<(), Box<PlatformUnsat>> {
     if record.compute_identifier_hash(current_inline_hash) != record.identifier_hash {
-        return Err(Box::new(PlatformUnsat::InlinePackageDefinitionChanged {
+        return Err(Box::new(PlatformUnsat::SourcePackageIdentityChanged {
             package: record.name().as_source().to_string(),
         }));
     }
@@ -891,7 +892,7 @@ mod tests {
     use super::super::BuildOrHostEnv;
     use super::{
         build_full_source_record_from_output, variants_equivalent,
-        verify_immutable_inline_definition, verify_locked_against_backend_specs,
+        verify_immutable_record_identity, verify_locked_against_backend_specs,
     };
     use pixi_build_types::{
         BinaryPackageSpec, ExtraGroupName, NamedSpec, PackageSpec, PinCompatibleSpec,
@@ -1460,13 +1461,13 @@ mod tests {
         };
 
         let with_inline = record_with_inline_hash(Some(42));
-        assert!(verify_immutable_inline_definition(&with_inline, Some(42)).is_ok());
-        assert!(verify_immutable_inline_definition(&with_inline, Some(43)).is_err());
-        assert!(verify_immutable_inline_definition(&with_inline, None).is_err());
+        assert!(verify_immutable_record_identity(&with_inline, Some(42)).is_ok());
+        assert!(verify_immutable_record_identity(&with_inline, Some(43)).is_err());
+        assert!(verify_immutable_record_identity(&with_inline, None).is_err());
 
         let without_inline = record_with_inline_hash(None);
-        assert!(verify_immutable_inline_definition(&without_inline, None).is_ok());
-        assert!(verify_immutable_inline_definition(&without_inline, Some(42)).is_err());
+        assert!(verify_immutable_record_identity(&without_inline, None).is_ok());
+        assert!(verify_immutable_record_identity(&without_inline, Some(42)).is_err());
     }
 
     /// Build a Full source record with the supplied `depends` and

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -95,6 +95,29 @@ pub(super) fn verify_build_source_matches_manifest(
     }
 }
 
+/// Verify that the inline package definition currently declared for an
+/// immutable source record (if any) still matches the one the record was
+/// resolved with.
+///
+/// The lock file does not carry the inline definition itself; its content
+/// hash is folded into the record's `identifier_hash` at solve time. Every
+/// other hash input round-trips verbatim through the lock file, so
+/// recomputing the hash with the *current* manifest's inline content hash
+/// reproduces the stored value exactly when the inline definition is
+/// unchanged (or absent on both sides). A mismatch means the inline table
+/// was edited, added, or removed, and the record must be re-resolved.
+pub(super) fn verify_immutable_inline_definition(
+    record: &pixi_record::UnresolvedSourceRecord,
+    current_inline_hash: Option<u64>,
+) -> Result<(), Box<PlatformUnsat>> {
+    if record.compute_identifier_hash(current_inline_hash) != record.identifier_hash {
+        return Err(Box::new(PlatformUnsat::InlinePackageDefinitionChanged {
+            package: record.name().as_source().to_string(),
+        }));
+    }
+    Ok(())
+}
+
 /// Verify that the locked build/host packages of a partial / mutable
 /// source record still satisfy the build backend's declared specs for
 /// the matching output, then return a freshly-assembled full source
@@ -868,7 +891,7 @@ mod tests {
     use super::super::BuildOrHostEnv;
     use super::{
         build_full_source_record_from_output, variants_equivalent,
-        verify_locked_against_backend_specs,
+        verify_immutable_inline_definition, verify_locked_against_backend_specs,
     };
     use pixi_build_types::{
         BinaryPackageSpec, ExtraGroupName, NamedSpec, PackageSpec, PinCompatibleSpec,
@@ -1414,6 +1437,36 @@ mod tests {
         .expect_err("expected drift");
         assert!(diff.added.is_empty());
         assert_eq!(diff.removed, vec!["a >=1".to_string()]);
+    }
+
+    /// The identifier hash of an immutable record folds in the content hash
+    /// of the inline package definition it was resolved with (or `None`).
+    /// Verification recomputes the hash with the definition currently in the
+    /// manifest, so any add / edit / removal of the inline table must
+    /// surface as unsat while an unchanged definition passes.
+    #[test]
+    fn immutable_inline_definition_change_is_detected() {
+        let record_with_inline_hash = |inline_content_hash: Option<u64>| {
+            let partial = make_partial_source_record("pkg", "./pkg", Vec::new(), Vec::new());
+            UnresolvedSourceRecord::new(
+                partial.data,
+                partial.manifest_source,
+                partial.build_source,
+                partial.variants,
+                Vec::new(),
+                Vec::new(),
+                inline_content_hash,
+            )
+        };
+
+        let with_inline = record_with_inline_hash(Some(42));
+        assert!(verify_immutable_inline_definition(&with_inline, Some(42)).is_ok());
+        assert!(verify_immutable_inline_definition(&with_inline, Some(43)).is_err());
+        assert!(verify_immutable_inline_definition(&with_inline, None).is_err());
+
+        let without_inline = record_with_inline_hash(None);
+        assert!(verify_immutable_inline_definition(&without_inline, None).is_ok());
+        assert!(verify_immutable_inline_definition(&without_inline, Some(42)).is_err());
     }
 
     /// Build a Full source record with the supplied `depends` and

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -61,9 +61,11 @@ const IDENTIFIER_HASH_LENGTH: usize = 8;
 /// file's `name[hash] @ location` form to distinguish two records that share
 /// a name and source location but differ in variants, build/host
 /// environments, or other configuration. The exact algorithm is an internal
-/// pixi detail: the only contract is determinism within a single rattler/pixi
-/// build, and the hash is round-tripped verbatim through the lock file so it
-/// stays stable across reads.
+/// pixi detail and the hash is round-tripped verbatim through the lock file,
+/// but satisfiability recomputes it for immutable source records and compares
+/// it against the stored value: any change to the algorithm or its inputs
+/// therefore invalidates such locked records once, surfacing as a one-time
+/// re-lock (or a hard error under `--locked`) after a pixi upgrade.
 ///
 /// Children's identifiers are looked up via their own `identifier_hash`
 /// (source) or location (binary), so callers must compute hashes bottom-up:
@@ -104,17 +106,22 @@ pub fn compute_identifier_hash<D: HashIdentifyingData>(
 /// its own digest and the sorted digests are folded in, so the same set of
 /// records always produces the same hash.
 fn hash_dep_records<H: Hasher>(hasher: &mut H, records: &[crate::UnresolvedPixiRecord]) {
+    // Random constants separating the binary and source hash domains, so the
+    // two variants can never produce identical byte streams.
+    const BINARY_RECORD_TAG: u64 = 0x7c48_a5e3_91d6_0bf2;
+    const SOURCE_RECORD_TAG: u64 = 0xe19b_3d70_246c_f58a;
+
     let mut digests: Vec<u64> = records
         .iter()
         .map(|record| {
             let mut record_hasher = xxhash_rust::xxh3::Xxh3::default();
             match record {
                 crate::UnresolvedPixiRecord::Binary(binary) => {
-                    0u8.hash(&mut record_hasher);
+                    BINARY_RECORD_TAG.hash(&mut record_hasher);
                     binary.url.as_str().hash(&mut record_hasher);
                 }
                 crate::UnresolvedPixiRecord::Source(source) => {
-                    1u8.hash(&mut record_hasher);
+                    SOURCE_RECORD_TAG.hash(&mut record_hasher);
                     source.name().as_source().hash(&mut record_hasher);
                     source.manifest_source.hash(&mut record_hasher);
                     source.identifier_hash.hash(&mut record_hasher);

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -97,21 +97,36 @@ pub fn compute_identifier_hash<D: HashIdentifyingData>(
 /// `name + manifest_source + identifier_hash` for source. The full record
 /// contents are intentionally not visited — each child's `identifier_hash`
 /// already encapsulates them.
+///
+/// The order of the slice is not part of the identity: the lock file
+/// normalizes the order of build/host package references, so the solve-time
+/// order is not reproducible after a round trip. Each record is hashed into
+/// its own digest and the sorted digests are folded in, so the same set of
+/// records always produces the same hash.
 fn hash_dep_records<H: Hasher>(hasher: &mut H, records: &[crate::UnresolvedPixiRecord]) {
-    records.len().hash(hasher);
-    for record in records {
-        match record {
-            crate::UnresolvedPixiRecord::Binary(binary) => {
-                0u8.hash(hasher);
-                binary.url.as_str().hash(hasher);
+    let mut digests: Vec<u64> = records
+        .iter()
+        .map(|record| {
+            let mut record_hasher = xxhash_rust::xxh3::Xxh3::default();
+            match record {
+                crate::UnresolvedPixiRecord::Binary(binary) => {
+                    0u8.hash(&mut record_hasher);
+                    binary.url.as_str().hash(&mut record_hasher);
+                }
+                crate::UnresolvedPixiRecord::Source(source) => {
+                    1u8.hash(&mut record_hasher);
+                    source.name().as_source().hash(&mut record_hasher);
+                    source.manifest_source.hash(&mut record_hasher);
+                    source.identifier_hash.hash(&mut record_hasher);
+                }
             }
-            crate::UnresolvedPixiRecord::Source(source) => {
-                1u8.hash(hasher);
-                source.name().as_source().hash(hasher);
-                source.manifest_source.hash(hasher);
-                source.identifier_hash.hash(hasher);
-            }
-        }
+            record_hasher.finish()
+        })
+        .collect();
+    digests.sort_unstable();
+    digests.len().hash(hasher);
+    for digest in digests {
+        digest.hash(hasher);
     }
 }
 
@@ -403,11 +418,13 @@ impl<D> SourceRecord<D> {
                 .is_some_and(|bs| bs.pinned().is_mutable())
     }
 
-    /// Compute this record's identifier hash from its current contents.
+    /// Compute this record's identifier hash from its current contents and
+    /// the content hash of the inline package definition that applies to it
+    /// (if any).
     ///
     /// Children referenced via `build_packages` / `host_packages` must already
     /// have their own `identifier_hash` set; see [`compute_identifier_hash`].
-    pub fn compute_identifier_hash(&self) -> String
+    pub fn compute_identifier_hash(&self, inline_content_hash: Option<u64>) -> String
     where
         D: HashIdentifyingData,
     {
@@ -418,7 +435,7 @@ impl<D> SourceRecord<D> {
             &self.data,
             &self.build_packages,
             &self.host_packages,
-            None,
+            inline_content_hash,
         )
     }
 }
@@ -976,12 +993,72 @@ mod tests {
     use super::*;
     use std::{path::Path, str::FromStr};
 
-    use rattler_conda_types::Platform;
+    use rattler_conda_types::{
+        PackageName, PackageRecord, Platform, RepoDataRecord, VersionWithSource,
+        package::DistArchiveIdentifier,
+    };
     use rattler_lock::{
         Channel, CondaPackageData, DEFAULT_ENVIRONMENT_NAME, LockFile, LockFileBuilder,
     };
 
     type SourceRecord = super::SourceRecord<FullSourceRecordData>;
+
+    #[test]
+    fn identifier_hash_ignores_dep_record_order() {
+        // The lock file normalizes the order of build/host package
+        // references, so the identifier hash must not depend on the order
+        // the solver produced them in.
+        let binary_record = |name: &str| {
+            let package_record = PackageRecord::new(
+                PackageName::from_str(name).expect("valid name"),
+                VersionWithSource::from_str("1.0").expect("valid version"),
+                "h0".into(),
+            );
+            let file_name = format!("{name}-1.0-h0.conda");
+            crate::UnresolvedPixiRecord::Binary(std::sync::Arc::new(RepoDataRecord {
+                package_record,
+                identifier: DistArchiveIdentifier::from_str(&file_name).expect("valid identifier"),
+                url: url::Url::parse(&format!("https://example.com/linux-64/{file_name}"))
+                    .expect("valid url"),
+                channel: None,
+            }))
+        };
+
+        let manifest_source = PinnedSourceSpec::Path(PinnedPathSpec {
+            path: "./pkg".into(),
+        });
+        let data = SourceRecordData::Partial(PartialSourceRecordData {
+            name: PackageName::from_str("pkg").expect("valid name"),
+            depends: Vec::new(),
+            constrains: Vec::new(),
+            experimental_extra_depends: Default::default(),
+            flags: Default::default(),
+            purls: None,
+            license: None,
+            run_exports: None,
+            sources: Default::default(),
+        });
+
+        let hash = |host_packages: Vec<crate::UnresolvedPixiRecord>| {
+            compute_identifier_hash(
+                &manifest_source,
+                None,
+                &BTreeMap::new(),
+                &data,
+                &[],
+                &host_packages,
+                None,
+            )
+        };
+        assert_eq!(
+            hash(vec![binary_record("python"), binary_record("setuptools")]),
+            hash(vec![binary_record("setuptools"), binary_record("python")]),
+        );
+        assert_ne!(
+            hash(vec![binary_record("python")]),
+            hash(vec![binary_record("python"), binary_record("setuptools")]),
+        );
+    }
 
     #[test]
     fn roundtrip_conda_source_data() {

--- a/tests/integration_python/pixi_build/test_inline_packages.py
+++ b/tests/integration_python/pixi_build/test_inline_packages.py
@@ -20,7 +20,9 @@ Run it with::
     pixi run test-specific-test-debug inline_overrides  # debug backends
 """
 
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 import tomli_w
@@ -29,6 +31,7 @@ from .common import (
     CONDA_FORGE_CHANNEL,
     CURRENT_PLATFORM,
     ExitCode,
+    git_test_repo,
     verify_cli_command,
 )
 
@@ -213,6 +216,146 @@ def test_inline_definition_inherits_workspace_version(pixi: Path, tmp_pixi_works
         [pixi, "workspace", "environment", "list", "--manifest-path", manifest],
         expected_exit_code=ExitCode.SUCCESS,
         stderr_excludes="does not define a 'version'",
+    )
+
+
+@pytest.mark.parametrize("source_kind", ["path", "git"])
+def test_inline_definition_keeps_host_dependencies(
+    pixi: Path, tmp_pixi_workspace: Path, source_kind: str
+) -> None:
+    """Regression test for https://github.com/prefix-dev/pixi/issues/6527:
+    `host-dependencies` declared in an inline package definition must reach the
+    build backend.
+
+    The consumer declares an inline package with `host-dependencies =
+    { setuptools = "*" }` on a path or git source. `pixi lock` only computes
+    source metadata (no build, no host environment solve), and the debug build
+    of the backend logs the project model it received to `<work dir>/debug/
+    project_model.json`. If the inline definition's host dependencies are
+    dropped anywhere between manifest parsing and backend discovery, the logged
+    project model has no `setuptools` entry.
+    """
+    source = tmp_pixi_workspace / "pkg"
+    source.mkdir(parents=True, exist_ok=True)
+    source.joinpath("pyproject.toml").write_text(
+        tomli_w.dumps(
+            {
+                "project": {"name": "inline-host-deps", "version": "0.1.0"},
+                "build-system": {
+                    "requires": ["setuptools"],
+                    "build-backend": "setuptools.build_meta",
+                },
+            }
+        )
+    )
+    if source_kind == "git":
+        location = {"git": git_test_repo(source, "inline-host-deps-repo", tmp_pixi_workspace)}
+    else:
+        location = {"path": "pkg"}
+    manifest = tmp_pixi_workspace / "pixi.toml"
+    write_consumer_manifest(
+        manifest,
+        {
+            "inline-host-deps": {
+                **location,
+                "package": {
+                    "version": "0.1.0",
+                    "build": {"backend": {"name": "pixi-build-python"}},
+                    "host-dependencies": {"setuptools": "*"},
+                },
+            }
+        },
+    )
+
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest])
+
+    # The backend metadata work directory (and with it the backend's debug
+    # output) lives under the workspace's `.pixi` directory.
+    project_models = list(tmp_pixi_workspace.glob("**/debug/project_model.json"))
+    assert project_models, "the backend should have logged the project model it received"
+    combined = "".join(path.read_text() for path in project_models)
+    assert "setuptools" in combined, (
+        "setuptools from the inline `host-dependencies` never reached the build backend"
+    )
+
+    # The actual build must install setuptools into the host prefix.
+    verify_cli_command([pixi, "install", "--manifest-path", manifest])
+    build_params = list(tmp_pixi_workspace.glob("**/debug/conda_build_v1_params.json"))
+    assert build_params, "the backend should have logged the build parameters it received"
+    host_packages = [
+        package["name"]
+        for path in build_params
+        for package in json.loads(path.read_text()).get("hostPrefix", {}).get("packages", [])
+    ]
+    assert "setuptools" in host_packages, (
+        f"setuptools from the inline `host-dependencies` is missing from the "
+        f"build host environment, got: {host_packages}"
+    )
+
+
+def test_inline_definition_edit_invalidates_lock(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """Regression test for https://github.com/prefix-dev/pixi/issues/6527: editing
+    an inline package definition must invalidate the lock file.
+
+    A git source is content-pinned, so satisfiability normally trusts the
+    locked record without contacting the build backend. The inline package
+    definition lives in the consuming manifest, though: adding
+    `run-dependencies` (or `host-dependencies`) there changes what the
+    dependency resolves to without any lock-file-visible signal. Before the
+    fix, a re-lock after such an edit reported "already up-to-date" and the
+    new dependencies never appeared.
+    """
+    source = tmp_pixi_workspace / "pkg"
+    source.mkdir(parents=True, exist_ok=True)
+    source.joinpath("pyproject.toml").write_text(
+        tomli_w.dumps(
+            {
+                "project": {"name": "inline-edit", "version": "0.1.0"},
+                "build-system": {
+                    "requires": ["setuptools"],
+                    "build-backend": "setuptools.build_meta",
+                },
+            }
+        )
+    )
+    repo_url = git_test_repo(source, "inline-edit-repo", tmp_pixi_workspace)
+    manifest = tmp_pixi_workspace / "pixi.toml"
+
+    def write_manifest(package: dict) -> None:
+        write_consumer_manifest(
+            manifest,
+            {"inline-edit": {"git": repo_url, "package": package}},
+        )
+
+    package: dict[str, Any] = {
+        "version": "0.1.0",
+        "build": {"backend": {"name": "pixi-build-python"}},
+    }
+    write_manifest(package)
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest])
+    lock_file = tmp_pixi_workspace / "pixi.lock"
+    assert "rich" not in lock_file.read_text()
+
+    # Extend the inline definition; the lock file must be re-resolved.
+    package["run-dependencies"] = {"rich": "*"}
+    write_manifest(package)
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest])
+    assert "rich" in lock_file.read_text(), (
+        "editing the inline package definition did not invalidate the lock file"
+    )
+
+    # An unchanged manifest must still satisfy the lock file.
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest],
+        stderr_contains="already up-to-date",
+    )
+
+    # Removing the inline definition's extra dependencies must invalidate again.
+    del package["run-dependencies"]
+    write_manifest(package)
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest])
+    assert "rich" not in lock_file.read_text(), (
+        "reverting the inline package definition did not invalidate the lock file"
     )
 
 


### PR DESCRIPTION
### Description

The satisfiability check trusted locked source records with immutable (git or url pinned) sources without consulting the consuming manifest. An inline package definition lives in that manifest, so adding or editing fields like host-dependencies or run-dependencies there kept reporting the lock file as up-to-date and the new dependencies never resolved.

Recompute the record's identifier hash with the content hash of the inline definition currently in the manifest and force a re-lock on mismatch. This requires hashing the build and host package sets order-insensitively, because the lock file normalizes the order of those references and the solve-time order is not reproducible after a round trip.

Fixes prefix-dev/pixi#6527

### How Has This Been Tested?

Local tests

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.