### PR TITLE
fix(build): let explicit source registrations win over implied ones

### DIFF
--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -230,31 +230,50 @@ async fn assemble_source_record_inner(
             output.metadata.subdir,
         );
 
-    let mut sources: HashMap<PackageName, SourceLocationSpec> = HashMap::new();
+    /// A source location in the `sources` bookkeeping, tagged with how it
+    /// was registered. Explicit registrations come from source specs the
+    /// backend declared (run deps, the record's own run-exports, extras)
+    /// and carry the manifest spelling; implied ones are derived from
+    /// pinned build/host env records and may spell the same source
+    /// differently (a pinned commit vs. a branch, or a differently written
+    /// relative path).
+    enum RegisteredSource {
+        Explicit(SourceLocationSpec),
+        Implied(SourceLocationSpec),
+    }
+
+    let mut sources: HashMap<PackageName, RegisteredSource> = HashMap::new();
 
     // Record a source-typed PixiSpec's location into `sources`, erroring
-    // if the same package is registered from two different locations. Only
-    // the location is tracked; the matchspec selectors live on the
+    // if the same package is explicitly registered from two different
+    // locations. An explicit registration replaces an implied one, so the
+    // outcome does not depend on which of the two is encountered first.
+    // Only the location is tracked; the matchspec selectors live on the
     // dependency itself.
     fn track_source(
-        sources: &mut HashMap<PackageName, SourceLocationSpec>,
+        sources: &mut HashMap<PackageName, RegisteredSource>,
         name: &PackageName,
         spec: &PixiSpec,
     ) -> Result<(), SourceRecordError> {
         if let Either::Left(source) = spec.clone().into_source_or_binary() {
             let location = source.location;
             match sources.entry(name.clone()) {
-                std::collections::hash_map::Entry::Occupied(entry) => {
-                    if entry.get() != &location {
-                        return Err(SourceRecordError::DuplicateSourceDependency {
-                            package: name.clone(),
-                            source1: Box::new(entry.get().clone()),
-                            source2: Box::new(location.clone()),
-                        });
+                std::collections::hash_map::Entry::Occupied(mut entry) => match entry.get() {
+                    RegisteredSource::Explicit(existing) => {
+                        if existing != &location {
+                            return Err(SourceRecordError::DuplicateSourceDependency {
+                                package: name.clone(),
+                                source1: Box::new(existing.clone()),
+                                source2: Box::new(location.clone()),
+                            });
+                        }
                     }
-                }
+                    RegisteredSource::Implied(_) => {
+                        entry.insert(RegisteredSource::Explicit(location));
+                    }
+                },
                 std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(location);
+                    entry.insert(RegisteredSource::Explicit(location));
                 }
             }
         }
@@ -264,7 +283,7 @@ async fn assemble_source_record_inner(
     // Stringify a PixiSpec dep map into a `Vec<String>`, threading source
     // locations through `track_source` for the per-source bookkeeping.
     let stringify_pixi_specs = |specs: DependencyMap<PackageName, PixiSpec>,
-                                sources: &mut HashMap<PackageName, SourceLocationSpec>|
+                                sources: &mut HashMap<PackageName, RegisteredSource>|
      -> Result<Vec<String>, SourceRecordError> {
         specs
             .into_specs()
@@ -301,7 +320,9 @@ async fn assemble_source_record_inner(
             }
 
             // Register implied source dependencies leniently (an explicit
-            // source spec registered above wins):
+            // source spec wins, no matter whether it is registered through
+            // the run deps above or through the record's own run-exports or
+            // extras later):
             // - a run-export-introduced source spec carries the pinned
             //   location of the build/host env record it was extracted
             //   from, which can spell the same source differently than an
@@ -328,7 +349,7 @@ async fn assemble_source_record_inner(
                 if let Some(location) =
                     implied_location.and_then(|loc| source_anchor.relativize_location(loc))
                 {
-                    sources.insert(name.clone(), location);
+                    sources.insert(name.clone(), RegisteredSource::Implied(location));
                 }
             }
 
@@ -422,7 +443,11 @@ async fn assemble_source_record_inner(
 
     let sources_by_str: BTreeMap<String, SourceLocationSpec> = sources
         .into_iter()
-        .map(|(name, source)| (name.as_source().to_string(), source))
+        .map(|(name, source)| {
+            let (RegisteredSource::Explicit(location) | RegisteredSource::Implied(location)) =
+                source;
+            (name.as_source().to_string(), location)
+        })
         .collect();
 
     // `SourceRecord::new` derives `identifier_hash` from the contents.

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -21,7 +21,10 @@ use pixi_command_dispatcher::{
     keys::SolvePixiEnvironmentSpec,
 };
 use pixi_record::PinnedSourceSpec;
-use pixi_spec::{GitReference, GitSpec, PathSpec, PixiSpec, ResolvedExcludeNewer, Subdirectory};
+use pixi_spec::{
+    GitReference, GitSpec, PathSpec, PixiSpec, ResolvedExcludeNewer, SourceLocationSpec,
+    Subdirectory,
+};
 use pixi_spec_containers::DependencyMap;
 use pixi_test_utils::format_diagnostic;
 use pixi_utils::variants::VariantConfig;
@@ -739,6 +742,76 @@ pub async fn test_run_export_on_source_host_dependency() {
             "{dep} must be part of the solution as a source record"
         );
     }
+}
+
+/// A package can receive the same source dependency through two channels at
+/// once: implied by a run-export of a build/host env record (carrying the
+/// *pinned* source location) and explicitly through its own run-exports
+/// (carrying the *manifest* spelling of the location). The two can spell the
+/// same source differently - a pinned git commit vs. a branch, or a
+/// differently written relative path - so the explicit registration must win
+/// over the implied one instead of failing with `DuplicateSourceDependency`.
+///
+/// The workspace models this with `package_a` host-depending on source
+/// `package_b` spelled `./../package_b`, while `package_b` run-exports
+/// itself (implying the pinned spelling `../package_b` on `package_a`) and
+/// `package_a`'s own run-exports also name `package_b` as a source spec
+/// with the manifest spelling.
+#[tokio::test]
+pub async fn test_run_export_implied_source_yields_to_explicit_spelling() {
+    use rattler_conda_types::package::RunExportsJson;
+
+    let (tool_platform, tool_virtual_packages) = tool_platform();
+    let root_dir = workspaces_dir().join("run-exports-source-respell");
+    let tempdir = test_tempdir();
+
+    let self_export = RunExportsJson {
+        noarch: vec!["package_b 0.1.0".to_string()],
+        ..Default::default()
+    };
+    let dispatcher = CommandDispatcher::builder()
+        .with_root_dir(to_abs_dir(root_dir.clone()))
+        .with_cache_dirs(default_cache_dirs().with_workspace(to_abs_dir(tempdir.path())))
+        .with_executor(Executor::Serial)
+        .with_tool_platform(tool_platform, tool_virtual_packages)
+        .with_backend_overrides(BackendOverride::from_memory(
+            PassthroughBackend::instantiator()
+                .with_run_exports("package_b", self_export.clone())
+                .with_run_exports("package_a", self_export),
+        ))
+        .finish();
+
+    let records = run_pixi_solve(
+        &dispatcher,
+        SolvePixiEnvironmentSpec {
+            dependencies: DependencyMap::from_iter([(
+                "package_a".parse().unwrap(),
+                PathSpec {
+                    path: "package_a".into(),
+                }
+                .into(),
+            )]),
+            env_ref: env_ref_of(vec![], BuildEnvironment::simple(Platform::Linux64, vec![])),
+            ..empty_pixi_env_spec()
+        },
+    )
+    .await
+    .expect("two spellings of the same source must not fail as duplicate source dependencies");
+
+    let package_a = records
+        .iter()
+        .find_map(|r| {
+            r.as_source()
+                .filter(|s| s.package_record().name.as_normalized() == "package_a")
+        })
+        .expect("package_a source record is in the solution");
+    assert_eq!(
+        package_a.sources().get("package_b"),
+        Some(&SourceLocationSpec::Path(PathSpec {
+            path: "./../package_b".into()
+        })),
+        "the explicit manifest spelling must win over the implied pinned location"
+    );
 }
 
 /// Tests that a stale host dependency triggers a rebuild of both the stale

--- a/tests/data/workspaces/run-exports-source-respell/README.md
+++ b/tests/data/workspaces/run-exports-source-respell/README.md
@@ -1,0 +1,16 @@
+# run-exports-source-respell
+
+Regression workspace for source dependencies that reach a record through two
+channels with different spellings of the same location:
+
+- `package_b` run-exports itself, so `package_a`'s run dependencies receive
+  an *implied* source spec carrying the pinned location (`../package_b`
+  after relativizing against `package_a`'s manifest).
+- `package_a`'s own run-exports also name `package_b`; the backend emits it
+  as a source spec with the *manifest* spelling, which is deliberately
+  written as `./../package_b` here.
+
+The explicit manifest spelling must win over the implied pinned location
+instead of the record assembly failing with a `DuplicateSourceDependency`
+error. The same shape arises with git sources, where the pinned location is
+a commit while the manifest names a branch.

--- a/tests/data/workspaces/run-exports-source-respell/package_a/pixi.toml
+++ b/tests/data/workspaces/run-exports-source-respell/package_a/pixi.toml
@@ -1,0 +1,12 @@
+[package]
+name = "package_a"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+# The redundant "./" prefix is deliberate: the test checks that this
+# spelling coexists with the differently-spelled pinned location that
+# package_b's self run-export introduces.
+[package.host-dependencies]
+package_b = { path = "./../package_b" }

--- a/tests/data/workspaces/run-exports-source-respell/package_b/pixi.toml
+++ b/tests/data/workspaces/run-exports-source-respell/package_b/pixi.toml
@@ -1,0 +1,6 @@
+[package]
+name = "package_b"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }

--- a/tests/data/workspaces/run-exports-source-respell/pixi.toml
+++ b/tests/data/workspaces/run-exports-source-respell/pixi.toml
@@ -1,0 +1,8 @@
+[workspace]
+channels = []
+name = "run-exports-source-respell"
+platforms = []
+preview = ["pixi-build"]
+
+[dependencies]
+package_a = { path = "package_a" }


### PR DESCRIPTION
### Description

Fable came up with this after reviewing https://github.com/prefix-dev/pixi/pull/6519

Since I've already merged the PR at this point, here is the change as a follow-up PR. @baszalmstra please check out the two PRs tomorrow before we make a follow-up PR

## Fable's description 

A package can receive the same source dependency both implied by a run-export of a build/host env record (pinned location) and explicitly through its own run-exports or extras (manifest spelling). The strict duplicate check ran after the lenient insert and errored whenever the two spellings differed, e.g. a pinned git commit vs. a branch. Tag each registered location with its provenance so an explicit registration replaces an implied one regardless of order, while two conflicting explicit registrations still error.

