### PR TITLE
chore: bump version to v0.72.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.72.1] - 2026-07-07
+#### ✨ Highlights
+
+This release contains important bugfixes for rich platforms, v3 repodata handling, pixi-build-r and more.
+
+#### Changed
+
+- Do not fail when running tasks in an environment by @hunger in [#6507](https://github.com/prefix-dev/pixi/pull/6507)
+- Provide R packages under their r-prefixed conda name by @roaldarbol in [#6515](https://github.com/prefix-dev/pixi/pull/6515)
+- Suggest `pixi self-update --version` for requires-pixi errors by @hunger in [#6516](https://github.com/prefix-dev/pixi/pull/6516)
+- Register run-export-introduced source deps on the assembled record by @wolfv in [#6519](https://github.com/prefix-dev/pixi/pull/6519)
+- Let explicit source registrations win over implied ones by @Hofer-Julian in [#6532](https://github.com/prefix-dev/pixi/pull/6532)
+
+
+#### Documentation
+
+- Document all override variables by @Hofer-Julian in [#6486](https://github.com/prefix-dev/pixi/pull/6486)
+- Fix `requires-python` field by @mwtoews in [#6512](https://github.com/prefix-dev/pixi/pull/6512)
+
+
+#### Fixed
+
+- Don't drag rich platform variants into bare-subdir environments by @hunger in [#6517](https://github.com/prefix-dev/pixi/pull/6517)
+- Invalidate lock file when an inline package definition changes by @Hofer-Julian in [#6529](https://github.com/prefix-dev/pixi/pull/6529)
+
+
+#### Refactor
+
+- Use shared config types from rattler_config by @wolfv in [#6528](https://github.com/prefix-dev/pixi/pull/6528)
+
+
+#### New Contributors
+* @mwtoews made their first contribution in [#6512](https://github.com/prefix-dev/pixi/pull/6512)
+* @roaldarbol made their first contribution in [#6515](https://github.com/prefix-dev/pixi/pull/6515)
+
 ### [0.72.0] - 2026-07-01
 #### ✨ Highlights
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,8 @@ authors:
   - given-names: Julian
     family-names: Hofer
     email: julian.hofer@protonmail.com
-repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.72.0'
-url: 'https://pixi.sh/v0.72.0'
+repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.72.1'
+url: 'https://pixi.sh/v0.72.1'
 abstract: >-
   A cross-platform, language agnostic, package/project
   management tool for development in virtual environments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5937,7 +5937,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "astral-reqwest-middleware",
  "async-trait",

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 name = "pixi"
 readme.workspace = true
 repository.workspace = true
-version = "0.72.0"
+version = "0.72.1"
 
 [features]
 default = ["rustls"]

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -16,7 +16,7 @@ pub const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const PIXI_VERSION: &str = match option_env!("PIXI_VERSION") {
     Some(v) => v,
-    None => "0.72.0",
+    None => "0.72.1",
 };
 pub const PREFIX_FILE_NAME: &str = "pixi_env_prefix";
 pub const ENVIRONMENTS_DIR: &str = "envs";

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -31,7 +31,7 @@ It also makes use of `pixi shell-hook` to not rely on Pixi being installed in th
     For more examples, take a look at [pavelzw/pixi-docker-example](https://github.com/pavelzw/pixi-docker-example).
 
 ```Dockerfile
-FROM ghcr.io/prefix-dev/pixi:0.72.0 AS build
+FROM ghcr.io/prefix-dev/pixi:0.72.1 AS build
 
 # copy source code, pixi.toml and pixi.lock to the container
 WORKDIR /app

--- a/docs/integration/ci/github_actions.md
+++ b/docs/integration/ci/github_actions.md
@@ -10,7 +10,7 @@ We created [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) to 
 ```yaml
 - uses: prefix-dev/setup-pixi@v0.10.0
   with:
-    pixi-version: v0.72.0
+    pixi-version: v0.72.1
     cache: true
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}

--- a/docs/integration/editor/vscode.md
+++ b/docs/integration/editor/vscode.md
@@ -42,7 +42,7 @@ Then, create the following two files in the `.devcontainer` directory:
 ```dockerfile title=".devcontainer/Dockerfile"
 FROM mcr.microsoft.com/devcontainers/base:jammy
 
-ARG PIXI_VERSION=v0.72.0
+ARG PIXI_VERSION=v0.72.1
 
 RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -22,7 +22,7 @@
 .LINK
     https://github.com/prefix-dev/pixi
 .NOTES
-    Version: v0.72.0
+    Version: v0.72.1
 #>
 param (
     [string] $PixiVersion = 'latest',

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-# Version: v0.72.0
+# Version: v0.72.1
 
 __wrap__() {
     # Function to mask username and password in URLs for safe printing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ quote-style = "double"
 github_url = "https://github.com/prefix-dev/pixi"
 
 [tool.tbump.version]
-current = "0.72.0"
+current = "0.72.1"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -266,7 +266,7 @@
       "description": "The workspace's metadata information"
     }
   },
-  "$comment": "Generated from `pixi` v0.72.0",
+  "$comment": "Generated from `pixi` v0.72.1",
   "$defs": {
     "Activation": {
       "title": "Activation",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.72.0/schema/manifest/pyproject/schema.json",
+  "$id": "https://pixi.sh/v0.72.1/schema/manifest/pyproject/schema.json",
   "title": "`pyproject.toml` manifest file for `pixi`",
   "description": "A `pyproject.toml` with `[tool.pixi]`.",
   "type": "object",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.72.0/schema/manifest/schema.json",
+  "$id": "https://pixi.sh/v0.72.1/schema/manifest/schema.json",
   "title": "`pixi.toml` manifest file",
   "description": "The configuration for a [`pixi`](https://pixi.sh) project.",
   "type": "object",
@@ -10,7 +10,7 @@
       "title": "Schema",
       "description": "The schema identifier for the project's configuration",
       "type": "string",
-      "default": "https://pixi.sh/v0.72.0/schema/manifest/schema.json",
+      "default": "https://pixi.sh/v0.72.1/schema/manifest/schema.json",
       "format": "uri-reference"
     },
     "activation": {

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -15,7 +15,7 @@ from rattler import Platform
 # Regex pattern to match ANSI escape sequences
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 
-PIXI_VERSION = "0.72.0"
+PIXI_VERSION = "0.72.1"
 
 
 ALL_PLATFORMS = '["linux-64", "osx-64", "osx-arm64", "win-64", "linux-ppc64le", "linux-aarch64"]'


### PR DESCRIPTION
### [0.72.1] - 2026-07-07
#### ✨ Highlights

This release contains important bugfixes for rich platforms, v3 repodata handling, pixi-build-r and more.

#### Changed

- Do not fail when running tasks in an environment by @hunger in [#6507](https://github.com/prefix-dev/pixi/pull/6507)
- Provide R packages under their r-prefixed conda name by @roaldarbol in [#6515](https://github.com/prefix-dev/pixi/pull/6515)
- Suggest `pixi self-update --version` for requires-pixi errors by @hunger in [#6516](https://github.com/prefix-dev/pixi/pull/6516)
- Register run-export-introduced source deps on the assembled record by @wolfv in [#6519](https://github.com/prefix-dev/pixi/pull/6519)
- Let explicit source registrations win over implied ones by @Hofer-Julian in [#6532](https://github.com/prefix-dev/pixi/pull/6532)


#### Documentation

- Document all override variables by @Hofer-Julian in [#6486](https://github.com/prefix-dev/pixi/pull/6486)
- Fix `requires-python` field by @mwtoews in [#6512](https://github.com/prefix-dev/pixi/pull/6512)


#### Fixed

- Don't drag rich platform variants into bare-subdir environments by @hunger in [#6517](https://github.com/prefix-dev/pixi/pull/6517)
- Invalidate lock file when an inline package definition changes by @Hofer-Julian in [#6529](https://github.com/prefix-dev/pixi/pull/6529)


#### Refactor

- Use shared config types from rattler_config by @wolfv in [#6528](https://github.com/prefix-dev/pixi/pull/6528)


#### New Contributors
* @mwtoews made their first contribution in [#6512](https://github.com/prefix-dev/pixi/pull/6512)
* @roaldarbol made their first contribution in [#6515](https://github.com/prefix-dev/pixi/pull/6515)