### PR TITLE
chore: remove outdated `click` pin

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -144,8 +144,6 @@ description = "Switch to local uv development dependencies"
 #
 [feature.docs.dependencies]
 cairosvg = ">=2.8.2,<3"
-# >=8.3 doesn't work with auto rebuilding on mkdocs serve, see https://github.com/mkdocs/mkdocs/issues/4032
-click = "==8.4.1"
 mdx_truly_sane_lists = ">=1.3,<2"
 mike = ">=2.1.3,<3"
 mkdocs-llmstxt = ">=0.4.0,<0.5"


### PR DESCRIPTION
- looks like renovate has bumped this pin out of sync with the comment
- looks like the intent of the comment is now covered in the metadata of `mkdocs`:
<img width="388" height="172" alt="image" src="https://github.com/user-attachments/assets/0b6ae8fe-2685-416c-a3a3-d5163cd346ba" />

to unblock gh-5801