### PR TITLE
fix(pixi-build-ros): let workspace also consider `pixi.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6134,6 +6134,7 @@ dependencies = [
  "miette 7.6.0",
  "pathdiff",
  "pixi_build_backend",
+ "pixi_build_discovery",
  "pixi_build_types",
  "pixi_glob",
  "rattler_build_jinja",

--- a/crates/pixi_build_discovery/src/discovery.rs
+++ b/crates/pixi_build_discovery/src/discovery.rs
@@ -496,6 +496,25 @@ fn retrieve_channels(
 /// Look for a pixi workspace manifest at or above `start` and return its
 /// containing directory. Returns `None` if no workspace is found or if
 /// discovery fails for any reason; the caller decides on the fallback.
+/// Returns true if [`DiscoveredBackend::discover`] would resolve
+/// `source_dir` as a pixi package, i.e. the directory holds a manifest
+/// (`pixi.toml` or `pyproject.toml`) whose closest package section can be
+/// discovered.
+///
+/// Build backends use this to decide whether to reference a sibling package
+/// by its directory (so the package's own manifest, including
+/// `[package.build.config]`, is honored) or by a backend-specific file like
+/// `package.xml`. Errors during discovery are treated as "not a pixi
+/// package" so callers fall back to their backend-specific reference.
+pub fn is_pixi_package_directory(source_dir: &Path) -> bool {
+    matches!(
+        WorkspaceDiscoverer::new(DiscoveryStart::ExplicitManifest(source_dir.to_path_buf()))
+            .with_closest_package(true)
+            .discover(),
+        Ok(Some(manifests)) if manifests.value.package.is_some()
+    )
+}
+
 fn workspace_root_for(start: &Path) -> Option<PathBuf> {
     let manifests = WorkspaceDiscoverer::new(DiscoveryStart::SearchRoot(start.to_path_buf()))
         .discover()

--- a/crates/pixi_build_discovery/src/lib.rs
+++ b/crates/pixi_build_discovery/src/lib.rs
@@ -36,4 +36,5 @@ pub use backend_spec::{
 };
 pub use discovery::{
     BackendInitializationParams, DiscoveredBackend, DiscoveryError, EnabledProtocols,
+    is_pixi_package_directory,
 };

--- a/crates/pixi_build_discovery/tests/discovery.rs
+++ b/crates/pixi_build_discovery/tests/discovery.rs
@@ -158,3 +158,32 @@ fn test_ros_discovery_priority() {
         }
     }
 }
+
+#[test]
+fn test_is_pixi_package_directory() {
+    let dir = |name: &str| dunce::canonicalize(discovery_directory().join(name)).unwrap();
+
+    // A manifest with a package section.
+    assert!(pixi_build_discovery::is_pixi_package_directory(&dir(
+        "simple"
+    )));
+
+    // Workspace-only manifests, with and without a package.xml next to them.
+    assert!(!pixi_build_discovery::is_pixi_package_directory(&dir(
+        "workspace-only"
+    )));
+    assert!(!pixi_build_discovery::is_pixi_package_directory(&dir(
+        "ros-with-workspace"
+    )));
+    assert!(!pixi_build_discovery::is_pixi_package_directory(&dir(
+        "not-a-package"
+    )));
+
+    // No pixi manifest at all.
+    assert!(!pixi_build_discovery::is_pixi_package_directory(&dir(
+        "ros-package"
+    )));
+    assert!(!pixi_build_discovery::is_pixi_package_directory(Path::new(
+        "/non-existing"
+    )));
+}

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -23,6 +23,7 @@ indexmap = { workspace = true }
 miette = { workspace = true }
 pathdiff = { workspace = true }
 pixi_build_backend = { workspace = true }
+pixi_build_discovery = { workspace = true }
 pixi_build_types = { workspace = true }
 pixi_glob = { workspace = true }
 rattler_build_jinja = { workspace = true }

--- a/crates/pixi_build_ros/src/workspace_discovery.rs
+++ b/crates/pixi_build_ros/src/workspace_discovery.rs
@@ -147,7 +147,15 @@ pub fn discover_ros_packages(
     markers.push(PACKAGE_XML.to_string());
     markers.extend(IGNORE_MARKERS.iter().map(|m| m.to_string()));
     let input_glob_set = InputGlobSet {
-        patterns: vec![format!("**/{PACKAGE_XML}")],
+        // Pixi manifests are included because a sibling that holds a pixi
+        // package manifest is referenced by its directory instead of its
+        // package.xml (see `sibling_source_spec`), so adding or editing
+        // such a manifest changes the emitted metadata.
+        patterns: vec![
+            format!("**/{PACKAGE_XML}"),
+            "**/pixi.toml".to_string(),
+            "**/pyproject.toml".to_string(),
+        ],
         markers,
         exclude_hidden: true,
         // Caller (pixi-build-ros::main) fills in the workspace root
@@ -168,14 +176,23 @@ fn path_to_forward_slashes(path: &Path) -> String {
 /// Build a matchspec string of the form
 /// `ros-<distro>-<name>[url="source://?path=<rel-to-manifest>"]` that, when
 /// parsed via `SerializableMatchSpec::from`, yields a source dependency
-/// pointing at the sibling's `package.xml`.
+/// pointing at the sibling package.
+///
+/// Siblings that hold a pixi package manifest are referenced by their
+/// directory: directory discovery uses that manifest, including its
+/// `[package.build.config]`, which an explicit `package.xml` reference
+/// deliberately ignores. Bare ROS packages are referenced by their
+/// `package.xml`, the only way to select ROS discovery for them.
 pub fn sibling_source_spec(
     conda_name: &str,
     sibling_package_xml: &Path,
     manifest_root: &Path,
 ) -> String {
-    let rel = pathdiff::diff_paths(sibling_package_xml, manifest_root)
-        .unwrap_or_else(|| sibling_package_xml.to_path_buf());
+    let target = match sibling_package_xml.parent() {
+        Some(dir) if pixi_build_discovery::is_pixi_package_directory(dir) => dir,
+        _ => sibling_package_xml,
+    };
+    let rel = pathdiff::diff_paths(target, manifest_root).unwrap_or_else(|| target.to_path_buf());
     let rel = path_to_forward_slashes(&rel);
 
     let mut url = Url::from_str("source://").expect("static URL parses");
@@ -375,7 +392,11 @@ mod tests {
         assert!(result.packages.is_empty());
         assert_eq!(
             result.input_glob_set.patterns,
-            vec!["**/package.xml".to_string()]
+            vec![
+                "**/package.xml".to_string(),
+                "**/pixi.toml".to_string(),
+                "**/pyproject.toml".to_string(),
+            ]
         );
         assert!(
             result
@@ -393,6 +414,73 @@ mod tests {
     fn nonexistent_workspace_root_returns_empty() {
         let result = discover_ros_packages(Path::new("/this/path/does/not/exist")).unwrap();
         assert!(result.packages.is_empty());
+    }
+
+    #[test]
+    fn sibling_with_pixi_package_manifest_is_referenced_by_directory() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        // The workspace the member packages belong to; manifest discovery for
+        // a member walks up to this manifest.
+        fs::write(
+            root.join("pixi.toml"),
+            r#"
+[workspace]
+name = "ws"
+channels = ["conda-forge"]
+platforms = ["linux-64"]
+preview = ["pixi-build"]
+"#,
+        )
+        .unwrap();
+
+        write_package_xml(&root.join("launch_pkg"), "launch_pkg");
+        write_package_xml(&root.join("node_pkg"), "node_pkg");
+        write_package_xml(&root.join("plain_pkg"), "plain_pkg");
+        fs::write(
+            root.join("node_pkg").join("pixi.toml"),
+            r#"
+[package]
+name = "ros-humble-node-pkg"
+version = "0.0.0"
+
+[package.build]
+backend = { name = "pixi-build-ros", version = "*" }
+
+[package.build.config]
+extra-package-mappings = [{ "my-conda-dep" = { conda = ["xtensor"] } }]
+"#,
+        )
+        .unwrap();
+
+        let discovered = discover_ros_packages(root).unwrap().packages;
+        let manifest_root = root.join("launch_pkg");
+        let specs = sibling_source_spec_map(&discovered, "launch_pkg", &manifest_root, "humble");
+
+        let spec_for = |rel: &str| {
+            let mut url = Url::from_str("source://").unwrap();
+            url.query_pairs_mut().append_pair("path", rel);
+            url
+        };
+
+        // node_pkg carries its own pixi package manifest: reference the
+        // directory so pixi discovers that manifest, including its
+        // [package.build.config].
+        assert_eq!(
+            specs.get("ros-humble-node-pkg").unwrap(),
+            &format!("ros-humble-node-pkg[url=\"{}\"]", spec_for("../node_pkg")),
+        );
+
+        // plain_pkg is a bare ROS package: keep pointing at its package.xml,
+        // which is the only way to select ROS discovery for it.
+        assert_eq!(
+            specs.get("ros-humble-plain-pkg").unwrap(),
+            &format!(
+                "ros-humble-plain-pkg[url=\"{}\"]",
+                spec_for("../plain_pkg/package.xml")
+            ),
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Description

The workspace feature currently depends on directly pointing at other `package.xml`. If you add additional configuration to the package that is not what you want, but you want to use the `pixi.toml` instead. This PR fixes that

Fixes #6492

### How Has This Been Tested?

Tested with reproducer in #6492 and made sure it works now

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
