### PR TITLE
fix: satisfiability of conditional dependencies with virtual packages

### DIFF
--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -861,6 +861,15 @@ async fn verify_package_platform_satisfiability(
             Dependency::Input(name, spec, source) => {
                 let (found_package, extras) = match spec.into_source_or_binary() {
                     Either::Left(source_spec) => {
+                        // Skip a conditional dependency whose `when` condition
+                        // the environment does not satisfy; the solver did not
+                        // install it either, so requiring it here would
+                        // spuriously mark the lock file as out of date.
+                        if let Some(condition) = &source_spec.matchspec.condition
+                            && !condition_is_met(condition, locked_pixi_records, &virtual_packages)
+                        {
+                            continue;
+                        }
                         expected_conda_source_dependencies.insert(name.clone());
                         let extras = source_spec.matchspec.extras.clone().unwrap_or_default();
                         let found_package = find_matching_source_package(
@@ -881,6 +890,13 @@ async fn verify_package_platform_satisfiability(
                                     spec_conversion_to_match_spec_error(e),
                                 ))
                             })?;
+                        // Skip a conditional dependency whose `when` condition
+                        // the environment does not satisfy (see above).
+                        if let Some(condition) = &spec.condition
+                            && !condition_is_met(condition, locked_pixi_records, &virtual_packages)
+                        {
+                            continue;
+                        }
                         let extras = spec.extras.clone().unwrap_or_default();
                         match find_matching_package(
                             locked_pixi_records,
@@ -1074,7 +1090,7 @@ async fn verify_package_platform_satisfiability(
                     // fail (e.g. `bat *[when="python>=3.10"]` in an environment
                     // that pins `python <3.10`).
                     if let Some(condition) = &spec.condition
-                        && !condition_is_met(condition, locked_pixi_records)
+                        && !condition_is_met(condition, locked_pixi_records, &virtual_packages)
                     {
                         continue;
                     }
@@ -1329,22 +1345,29 @@ pub struct CondaPackageIdx(usize);
 pub struct PypiPackageIdx(usize);
 
 /// Returns `true` when a matchspec `when=` condition is satisfied by some
-/// locked conda record, mirroring the decision the solver made when it
-/// produced the lock file. `And` / `Or` recurse over their operands.
+/// locked conda record or by a virtual package of the platform (e.g.
+/// `__cuda>=12`), mirroring the decision the solver made when it produced
+/// the lock file. `And` / `Or` recurse over their operands.
 fn condition_is_met(
     condition: &MatchSpecCondition,
     locked_pixi_records: &PixiRecordsByName,
+    virtual_packages: &HashMap<PackageName, GenericVirtualPackage>,
 ) -> bool {
     match condition {
-        MatchSpecCondition::MatchSpec(spec) => locked_pixi_records
-            .records
-            .iter()
-            .any(|record| spec.matches(record)),
+        MatchSpecCondition::MatchSpec(spec) => {
+            locked_pixi_records
+                .records
+                .iter()
+                .any(|record| spec.matches(record))
+                || virtual_packages.values().any(|vpkg| vpkg.matches(spec))
+        }
         MatchSpecCondition::And(lhs, rhs) => {
-            condition_is_met(lhs, locked_pixi_records) && condition_is_met(rhs, locked_pixi_records)
+            condition_is_met(lhs, locked_pixi_records, virtual_packages)
+                && condition_is_met(rhs, locked_pixi_records, virtual_packages)
         }
         MatchSpecCondition::Or(lhs, rhs) => {
-            condition_is_met(lhs, locked_pixi_records) || condition_is_met(rhs, locked_pixi_records)
+            condition_is_met(lhs, locked_pixi_records, virtual_packages)
+                || condition_is_met(rhs, locked_pixi_records, virtual_packages)
         }
     }
 }

--- a/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@conditional-dependency-not-locked.snap
+++ b/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@conditional-dependency-not-locked.snap
@@ -1,0 +1,7 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/tests.rs
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project for platform 'linux-64-cuda'
+    Diagnostic severity: error
+    Caused by: the requirement 'gpu-package *[when="__cuda>=12"]' could not be satisfied (required by '<environment>')

--- a/tests/data/non-satisfiability/conditional-dependency-not-locked/pixi.lock
+++ b/tests/data/non-satisfiability/conditional-dependency-not-locked/pixi.lock
@@ -1,0 +1,17 @@
+version: 7
+platforms:
+- name: linux-64-cuda
+  subdir: linux-64
+  virtual-packages:
+  - __cuda=12
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/cond-test/
+    packages:
+      linux-64-cuda:
+      - conda: https://conda.anaconda.org/cond-test/noarch/base-package-1.0.0-0.conda
+packages:
+- conda: https://conda.anaconda.org/cond-test/noarch/base-package-1.0.0-0.conda
+  sha256: cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe
+  md5: cafebabecafebabecafebabecafebabe

--- a/tests/data/non-satisfiability/conditional-dependency-not-locked/pixi.toml
+++ b/tests/data/non-satisfiability/conditional-dependency-not-locked/pixi.toml
@@ -1,0 +1,10 @@
+[workspace]
+channels = ["https://conda.anaconda.org/cond-test"]
+name = "conditional-dependency-not-locked"
+platforms = [
+  { name = "linux-64-cuda", platform = "linux-64", cuda = "12" },
+]
+
+[dependencies]
+gpu-package = { version = "*", when = "__cuda>=12" }
+base-package = "*"

--- a/tests/data/satisfiability/conditional-dependency-cuda/pixi.lock
+++ b/tests/data/satisfiability/conditional-dependency-cuda/pixi.lock
@@ -1,0 +1,25 @@
+version: 7
+platforms:
+- name: linux-64-cuda
+  subdir: linux-64
+  virtual-packages:
+  - __cuda=12
+- name: linux-64
+  subdir: linux-64
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/cond-test/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/cond-test/noarch/base-package-1.0.0-0.conda
+      linux-64-cuda:
+      - conda: https://conda.anaconda.org/cond-test/noarch/base-package-1.0.0-0.conda
+      - conda: https://conda.anaconda.org/cond-test/noarch/gpu-package-1.0.0-0.conda
+packages:
+- conda: https://conda.anaconda.org/cond-test/noarch/base-package-1.0.0-0.conda
+  sha256: cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe
+  md5: cafebabecafebabecafebabecafebabe
+- conda: https://conda.anaconda.org/cond-test/noarch/gpu-package-1.0.0-0.conda
+  sha256: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+  md5: deadbeefdeadbeefdeadbeefdeadbeef

--- a/tests/data/satisfiability/conditional-dependency-cuda/pixi.toml
+++ b/tests/data/satisfiability/conditional-dependency-cuda/pixi.toml
@@ -1,0 +1,11 @@
+[workspace]
+channels = ["https://conda.anaconda.org/cond-test"]
+name = "conditional-dependency-cuda"
+platforms = [
+  { name = "linux-64-cuda", platform = "linux-64", cuda = "12" },
+  "linux-64",
+]
+
+[dependencies]
+gpu-package = { version = "*", when = "__cuda>=12" }
+base-package = "*"


### PR DESCRIPTION
### Description

The lock-file satisfiability check treated direct manifest dependencies with a `when=` condition as unconditionally required. On platforms that don't meet the condition the solver correctly leaves the package out of the lock file, so the check reported `the requirement 'pytorch-gpu >=2.12.1,<3[when="__cuda>=12"]' could not be satisfied` and marked the environment out of date on every run — re-solving produced the same (correct) lock file, resulting in a permanent re-lock loop.

Two changes in `crates/pixi_core/src/lock_file/satisfiability/platform.rs`:

- Direct manifest dependencies (both binary and source specs) whose `when` condition is not met are now skipped, mirroring the existing behaviour for transitive dependencies.
- `condition_is_met` now also matches conditions against the platform's virtual packages, not just locked records. A condition like `__cuda>=12` can only ever match a virtual package, so without this the dependency would wrongly be skipped on a platform declared with `cuda = "12"` as well (and its locked package flagged as excess).

With a manifest like:

```toml
[workspace]
channels = ["conda-forge"]
platforms = [{ name = "linux-64-cuda", platform = "linux-64", cuda = "12" }, "linux-64", "osx-arm64"]

[dependencies]
pytorch-gpu = { version = ">=2.12.1,<3", when = "__cuda>=12" }
pytorch = ">=2.12.1,<3"
```

`pixi lock` now converges: the conditional dependency is required (and verified) only on `linux-64-cuda`, and the lock file is considered up to date on `linux-64` and `osx-arm64`.

Fixes #6552

### How Has This Been Tested?

Real Ruben: Tested it on the reproducer I used in the issue. 

Two data-driven regression tests modelled on the issue's reproducer:

- `tests/data/satisfiability/conditional-dependency-cuda/`: a workspace with a `cuda = "12"` rich platform plus plain `linux-64`, and a `when = "__cuda>=12"` dependency locked only on the cuda platform. This fails on `main` with exactly the error from the issue and passes with this change.
- `tests/data/non-satisfiability/conditional-dependency-not-locked/`: the inverse guard — the condition is met via the platform's `__cuda=12` virtual package but the package is missing from the lock file, which must still be reported unsatisfiable (snapshot of the diagnostic included).

Ran the full satisfiability test module (`cargo test -p pixi_core --lib satisfiability`, 119 tests) plus `cargo clippy -p pixi_core` and `cargo fmt`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
https://github.com/prefix-dev/pixi/issues/6552

Can you look at this issue and figure out how to fix it and show me that?
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nTbyyUX8SKQfEkZr2y59U

---
_Generated by [Claude Code](https://claude.ai/code/session_017nTbyyUX8SKQfEkZr2y59U)_