### PR TITLE
fix(glob): skip filesystem loops when hashing task inputs/outputs

### DIFF
--- a/crates/pixi_glob/src/glob_set/mod.rs
+++ b/crates/pixi_glob/src/glob_set/mod.rs
@@ -494,6 +494,40 @@ mod tests {
         "#);
     }
 
+    /// A symlink that forms a cycle (a link whose target is one of its own
+    /// ancestors) must not abort the walk. This is the shape pnpm/npm create in
+    /// workspace `node_modules`, where packages link back to the workspace root.
+    /// The looping link is skipped and every other file is still collected,
+    /// rather than the walk failing with `GlobSetError::Walk`.
+    #[cfg(unix)]
+    #[test]
+    fn symlink_loop_is_skipped_not_fatal() {
+        let temp_dir = tempdir().unwrap();
+        let root_path = temp_dir.path().join("workspace");
+        fs::create_dir(&root_path).unwrap();
+
+        File::create(root_path.join("regular.txt")).unwrap();
+
+        // `nested/` holds a real file plus a symlink pointing back to its own
+        // parent (`nested/loop -> ..`), i.e. to an ancestor. With
+        // `follow_links(true)` the walker would otherwise recurse forever; it
+        // instead reports a loop error for this entry.
+        let nested = root_path.join("nested");
+        fs::create_dir(&nested).unwrap();
+        File::create(nested.join("inner.txt")).unwrap();
+        std::os::unix::fs::symlink("..", nested.join("loop")).unwrap();
+
+        let glob_set = GlobSet::create(vec!["**"]);
+        // Before the fix this returned `Err(GlobSetError::Walk(..))`.
+        let entries = glob_set.collect_matching(&root_path).unwrap();
+
+        let paths = sorted_paths(entries, &root_path);
+        assert_yaml_snapshot!(paths, @r#"
+        - nested/inner.txt
+        - regular.txt
+        "#);
+    }
+
     fn workspace_root_for_marker_tests() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()

--- a/crates/pixi_glob/src/glob_set/mod.rs
+++ b/crates/pixi_glob/src/glob_set/mod.rs
@@ -494,11 +494,8 @@ mod tests {
         "#);
     }
 
-    /// A symlink that forms a cycle (a link whose target is one of its own
-    /// ancestors) must not abort the walk. This is the shape pnpm/npm create in
-    /// workspace `node_modules`, where packages link back to the workspace root.
-    /// The looping link is skipped and every other file is still collected,
-    /// rather than the walk failing with `GlobSetError::Walk`.
+    /// A symlink pointing at one of its own ancestors, as pnpm/npm workspace
+    /// `node_modules` create, is skipped instead of failing the whole walk.
     #[cfg(unix)]
     #[test]
     fn symlink_loop_is_skipped_not_fatal() {
@@ -508,17 +505,13 @@ mod tests {
 
         File::create(root_path.join("regular.txt")).unwrap();
 
-        // `nested/` holds a real file plus a symlink pointing back to its own
-        // parent (`nested/loop -> ..`), i.e. to an ancestor. With
-        // `follow_links(true)` the walker would otherwise recurse forever; it
-        // instead reports a loop error for this entry.
+        // A real file next to a symlink pointing back at its own parent
         let nested = root_path.join("nested");
         fs::create_dir(&nested).unwrap();
         File::create(nested.join("inner.txt")).unwrap();
         std::os::unix::fs::symlink("..", nested.join("loop")).unwrap();
 
         let glob_set = GlobSet::create(vec!["**"]);
-        // Before the fix this returned `Err(GlobSetError::Walk(..))`.
         let entries = glob_set.collect_matching(&root_path).unwrap();
 
         let paths = sorted_paths(entries, &root_path);

--- a/crates/pixi_glob/src/glob_set/walk.rs
+++ b/crates/pixi_glob/src/glob_set/walk.rs
@@ -69,7 +69,19 @@ impl ignore::ParallelVisitor for CollectVisitor {
                 self.local.push(Ok(Match::Pattern(dir_entry)));
             }
             Err(e) => {
-                if let Some(ioe) = e.io_error() {
+                if is_loop_error(&e) {
+                    // A symbolic link formed a cycle in the directory tree (its
+                    // target is one of its own ancestors). This is common and
+                    // benign with pnpm/npm workspace `node_modules`, which link
+                    // packages back to the workspace root. `follow_links(true)`
+                    // is required for symlinked directories (see the
+                    // `symlink_to_directory_is_followed` test), so we cannot
+                    // simply stop following links. Instead we skip the offending
+                    // link: every file reachable without looping is still
+                    // collected, and the walk completes rather than aborting the
+                    // whole glob hash.
+                    tracing::debug!("skipping symbolic link loop during glob walk: {e}");
+                } else if let Some(ioe) = e.io_error() {
                     match ioe.kind() {
                         std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied => {}
                         _ => self
@@ -83,6 +95,24 @@ impl ignore::ParallelVisitor for CollectVisitor {
             }
         }
         ignore::WalkState::Continue
+    }
+}
+
+/// Returns `true` if `err` (or any error it wraps) is a filesystem loop that
+/// the walker detected while following symbolic links.
+///
+/// `ignore::Error::Loop` carries no inner `io::Error`, so it is not caught by
+/// the `io_error()` checks in [`CollectVisitor::visit`]; the walker also wraps
+/// errors in `WithPath` / `WithDepth` / `WithLineNumber` / `Partial`, so the
+/// check has to recurse.
+fn is_loop_error(err: &ignore::Error) -> bool {
+    match err {
+        ignore::Error::Loop { .. } => true,
+        ignore::Error::WithPath { err, .. }
+        | ignore::Error::WithDepth { err, .. }
+        | ignore::Error::WithLineNumber { err, .. } => is_loop_error(err),
+        ignore::Error::Partial(errs) => errs.iter().any(is_loop_error),
+        _ => false,
     }
 }
 

--- a/crates/pixi_glob/src/glob_set/walk.rs
+++ b/crates/pixi_glob/src/glob_set/walk.rs
@@ -70,16 +70,10 @@ impl ignore::ParallelVisitor for CollectVisitor {
             }
             Err(e) => {
                 if is_loop_error(&e) {
-                    // A symbolic link formed a cycle in the directory tree (its
-                    // target is one of its own ancestors). This is common and
-                    // benign with pnpm/npm workspace `node_modules`, which link
-                    // packages back to the workspace root. `follow_links(true)`
-                    // is required for symlinked directories (see the
-                    // `symlink_to_directory_is_followed` test), so we cannot
-                    // simply stop following links. Instead we skip the offending
-                    // link: every file reachable without looping is still
-                    // collected, and the walk completes rather than aborting the
-                    // whole glob hash.
+                    // A symlink pointing at one of its own ancestors, as pnpm/npm
+                    // workspace `node_modules` create. Skip the link instead of
+                    // failing the whole walk; we still need `follow_links(true)`
+                    // for the symlinked directories it exists for.
                     tracing::debug!("skipping symbolic link loop during glob walk: {e}");
                 } else if let Some(ioe) = e.io_error() {
                     match ioe.kind() {
@@ -98,13 +92,10 @@ impl ignore::ParallelVisitor for CollectVisitor {
     }
 }
 
-/// Returns `true` if `err` (or any error it wraps) is a filesystem loop that
-/// the walker detected while following symbolic links.
+/// Returns `true` if `err` (or any error it wraps) is a symlink loop.
 ///
-/// `ignore::Error::Loop` carries no inner `io::Error`, so it is not caught by
-/// the `io_error()` checks in [`CollectVisitor::visit`]; the walker also wraps
-/// errors in `WithPath` / `WithDepth` / `WithLineNumber` / `Partial`, so the
-/// check has to recurse.
+/// `ignore::Error::Loop` carries no inner `io::Error`, so `io_error()` misses it,
+/// and the walker wraps errors, so we have to recurse.
 fn is_loop_error(err: &ignore::Error) -> bool {
     match err {
         ignore::Error::Loop { .. } => true,


### PR DESCRIPTION
### Description

Tasks that declare `inputs`/`outputs` abort with a fatal walk error when the
workspace contains a symlink cycle:

```
Error:   × walk error at <repo>
  ╰─▶ File system loop found: .../node_modules/... points to an ancestor ...
```

The input/output cache (`pixi_glob`) walks the workspace with
`follow_links(true)` — which is required so symlinked directories are
discovered (#5417, `symlink_to_directory_is_followed`). When a symbolic link
forms a cycle (its target is one of its own ancestors), the `ignore` walker
yields `ignore::Error::Loop`. In `CollectVisitor::visit` only `NotFound` /
`PermissionDenied` **io** errors were skipped, and `Error::Loop` carries no
inner io error, so it fell through to the fatal `GlobSetError::Walk` and
aborted the entire glob hash.

This is common and benign with **pnpm / npm workspace `node_modules`**, which
symlink packages back to the workspace root (e.g.
`packages/*/node_modules/@scope/foo-build -> ../../..`). Any task with
`inputs`/`outputs` in such a workspace therefore crashes before it can run, and
there is no way to work around it from the manifest (glob negations don't help
— the walk fails before filtering; the walk is workspace-wide regardless of the
glob's root).

This PR treats a filesystem loop as non-fatal: the offending link is skipped
(with a `debug!` log), recursing through the `WithPath` / `WithDepth` /
`WithLineNumber` / `Partial` wrappers to find the `Loop` variant. Every file
reachable without looping is still collected, so the hash is complete and
stable. `git_ignore(false)` is intentionally left unchanged, so gitignored task
outputs continue to be hashed.

### How Has This Been Tested?

- New unit test `symlink_loop_is_skipped_not_fatal` builds a directory with a
  symlink pointing at its own ancestor (`nested/loop -> ..`) and asserts
  `collect_matching` succeeds and returns the real files, where it previously
  returned `Err(GlobSetError::Walk(..))`.
- `cargo test -p pixi_glob --lib` — 36 passed.
- End-to-end against a real pnpm workspace (~40 self-referential
  `node_modules` symlinks): the previously-crashing task now completes, and
  `-vv` shows the walker skipping the cycles (`skipping symbolic link loop
  during glob walk: ...`) instead of aborting on the first one.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.8)

```plaintext
Investigated a `pixi run` "File system loop found" crash in a pnpm workspace,
traced it to pixi_glob's task input/output walker following symlinks and
treating ignore::Error::Loop as fatal, then asked to fix it upstream: make the
walker skip filesystem loops (like it already skips NotFound/PermissionDenied)
without dropping gitignored outputs, add a regression test, and verify against
the real workspace.
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
- JSON schema: not applicable (no manifest/schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
