### PR TITLE
fix: truncate stdlib variant version to major.minor

### DIFF
--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -1632,6 +1632,72 @@ mod tests {
         );
     }
 
+    /// Reproduces #6566: a custom platform with a patch-level macOS version
+    /// (`macos = "15.1.1"` -> `__osx = 15.1.1`) must derive a `major.minor`
+    /// `c_stdlib_version`. `macosx_deployment_target_<subdir>` is only published
+    /// at `major.minor`, so a `15.1.1` pin resolves to no candidate and the build
+    /// solve fails.
+    #[test]
+    fn osx_patch_version_truncated_to_major_minor() {
+        let file_contents = r#"
+            [workspace]
+            name = "foo"
+            channels = ["conda-forge"]
+            platforms = ["osx-arm64"]
+            "#;
+        let workspace = Workspace::from_str(Path::new("pixi.toml"), file_contents).unwrap();
+
+        let platform = pixi_manifest::PixiPlatform::new(
+            pixi_manifest::PixiPlatformName::from_str("my-mac").unwrap(),
+            Platform::OsxArm64,
+            vec![GenericVirtualPackage {
+                name: "__osx".parse().unwrap(),
+                version: Version::from_str("15.1.1").unwrap(),
+                build_string: "0".to_string(),
+            }],
+        )
+        .unwrap();
+
+        let variants = workspace.variants(&platform).unwrap().variant_configuration;
+
+        assert_eq!(
+            variants.get("c_stdlib_version"),
+            Some(&vec![VariantValue::String("15.1".to_string())])
+        );
+    }
+
+    /// Same as [`osx_patch_version_truncated_to_major_minor`] for the linux
+    /// `sysroot` provider: `glibc` is likewise only published at `major.minor`,
+    /// so a patch-level `__glibc` must be truncated before it becomes a pin.
+    #[test]
+    fn glibc_patch_version_truncated_to_major_minor() {
+        let file_contents = r#"
+            [workspace]
+            name = "foo"
+            channels = ["conda-forge"]
+            platforms = ["linux-64"]
+            "#;
+        let workspace = Workspace::from_str(Path::new("pixi.toml"), file_contents).unwrap();
+
+        let platform = pixi_manifest::PixiPlatform::new(
+            pixi_manifest::PixiPlatformName::from_str("my-linux").unwrap(),
+            Platform::Linux64,
+            vec![GenericVirtualPackage {
+                name: "__glibc".parse().unwrap(),
+                version: Version::from_str("2.28.1").unwrap(),
+                build_string: "0".to_string(),
+            }],
+        )
+        .unwrap();
+
+        let variants = workspace.variants(&platform).unwrap().variant_configuration;
+
+        assert_eq!(
+            variants.get("c_stdlib_version"),
+            Some(&vec![VariantValue::String("2.28".to_string())])
+        );
+    }
+
     #[test]
     fn test_mapping_location() {
         let file_contents = r#"

--- a/crates/pixi_core/src/workspace/stdlib_variants.rs
+++ b/crates/pixi_core/src/workspace/stdlib_variants.rs
@@ -75,6 +75,14 @@ pub(crate) fn derive_stdlib_variants<'a>(
         return Vec::new();
     };
 
+    // The providers are only published at `major.minor`, so a patch-level
+    // declared version (e.g. `__osx = 15.1.1`) would pin to a nonexistent
+    // candidate. Truncate to `major.minor`, keeping shorter versions as-is.
+    let stdlib_version = declared
+        .version
+        .with_segments(0..2)
+        .unwrap_or_else(|| declared.version.clone());
+
     vec![
         (
             C_STDLIB.to_string(),
@@ -82,7 +90,7 @@ pub(crate) fn derive_stdlib_variants<'a>(
         ),
         (
             C_STDLIB_VERSION.to_string(),
-            VariantValue::String(declared.version.to_string()),
+            VariantValue::String(stdlib_version.to_string()),
         ),
     ]
 }


### PR DESCRIPTION
### Description
derive_stdlib_variants passed the declared __osx/__glibc version through
verbatim as c_stdlib_version, which becomes the pin for the
macosx_deployment_target and sysroot conda-forge providers. Those are
only published at major.minor, so a patch-level version such as
macos = "15.1.1" pinned to a nonexistent candidate and failed the build
solve.

Truncate the version to its first two segments before emitting the
variant, keeping already-short versions untouched.

Fixes: #6566

### How Has This Been Tested?

New unit tests

### AI Disclosure

- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
