### PR TITLE
fix: prevent pytest-temp from accumulating stale run directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,15 @@ format-command = "pixi run -e lint ruff format --stdin-filename {filename}"
 test-dir = "tests/integration_python"
 
 [tool.pytest.ini_options]
-# basetemp is set in tests/integration_python/conftest.py to pytest-temp-<pid>
-# so it stays on the same filesystem as the cache (faster than /tmp on a
-# different FS) while still being unique per invocation. A static path
-# would race two concurrent `pixi run test`s on xdist.setup_node's
-# basetemp.mkdir(mode=0o700) call.
+# Temp dirs live in pytest-temp/ (set via PYTEST_DEBUG_TEMPROOT in
+# tests/integration_python/conftest.py) so they stay on the same filesystem
+# as the cache (faster than /tmp on a different FS). Pytest keeps the last
+# tmp_path_retention_count runs and prunes older ones, so failed or
+# interrupted runs can't accumulate unboundedly.
 addopts = "--timeout=600 --durations=0"
 markers = ["slow: marks tests as slow", "extra_slow: marks tests as extra slow"]
 testpaths = ["tests/integration_python"]
+tmp_path_retention_count = 2
 tmp_path_retention_policy = "failed"
 
 [tool.ruff]

--- a/tests/integration_python/conftest.py
+++ b/tests/integration_python/conftest.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 import os
@@ -23,18 +23,22 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    # Keep basetemp inside the workspace so it shares a filesystem with the
-    # pixi cache (cross-FS rename/copy in /tmp is much slower). The PID
-    # subdir makes it unique per invocation so two concurrent `pixi run
-    # test`s don't race on xdist.setup_node's basetemp.mkdir(mode=0o700,
-    # exist_ok=False). The fixed `pytest-temp/` parent matches the literal
-    # path in `workspace.exclude` in Cargo.toml (cargo doesn't glob-expand
-    # exclude entries). xdist workers inherit --basetemp from the
-    # controller, so we only set it once.
+    # Keep temp dirs inside the workspace so they share a filesystem with the
+    # pixi cache (cross-FS rename/copy in /tmp is much slower). The fixed
+    # `pytest-temp/` parent matches the literal path in `workspace.exclude`
+    # in Cargo.toml (cargo doesn't glob-expand exclude entries).
+    #
+    # Rooting pytest's automatic numbered dirs here (instead of passing
+    # --basetemp) keeps pytest's own basetemp management: concurrent runs get
+    # distinct lock-protected `pytest-of-<user>/pytest-<N>` dirs, and dirs
+    # from old runs are pruned down to `tmp_path_retention_count`, so
+    # leftovers from failed or interrupted runs can't accumulate forever.
+    # xdist workers get an explicit --basetemp below the controller's
+    # numbered dir, so both the numbering and the pruning run only once.
     if not config.option.basetemp:
-        parent = Path("pytest-temp")
+        parent = config.rootpath / "pytest-temp"
         parent.mkdir(exist_ok=True)
-        config.option.basetemp = str(parent / str(os.getpid()))
+        os.environ["PYTEST_DEBUG_TEMPROOT"] = str(parent)
 
 
 @pytest.fixture
@@ -91,15 +95,22 @@ def setup_build_backend_override(request: pytest.FixtureRequest) -> None:
 @pytest.fixture(scope="session", autouse=True)
 def isolated_pixi_cache_per_worker(
     tmp_path_factory: pytest.TempPathFactory, worker_id: str
-) -> None:
+) -> Iterator[None]:
     # Parallel xdist workers all share the user's `~/.cache/rattler/` by default,
     # which causes hash mismatches when two workers race to build the same source
     # package into the same `bld/` path. Give each worker its own cache root.
     # Single-process runs (worker_id == "master") keep the user's cache for speed.
     if worker_id == "master":
+        yield
         return
     cache_dir = tmp_path_factory.mktemp("pixi-cache", numbered=False)
     os.environ["PIXI_CACHE_DIR"] = str(cache_dir)
+    yield
+    # The cache can hold hundreds of MB per worker and is not covered by
+    # tmp_path_retention_policy (it's not a tmp_path fixture dir), so a run
+    # with failures would retain it indefinitely. It's regenerable and useless
+    # for debugging retained test workspaces: always remove it.
+    shutil.rmtree(cache_dir, ignore_errors=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description

`pytest-temp/` grows unboundedly, reaching hundreds of GB after a couple of months. Two issues cause that:

- Every run leaks the per-worker pixi caches. `isolated_pixi_cache_per_worker` creates them with `tmp_path_factory.mktemp()`, which `tmp_path_retention_policy` does not cover. Since passing an explicit `--basetemp` also disables pytest's session-end removal of the run directory, the caches stick around even when all tests pass. With `--numprocesses=logical` that is several GB per invocation.
- Nothing ever deletes old run directories. The per-PID `--basetemp` opts out of pytest's keep-last-N pruning, so leftovers from failed and interrupted runs stay around forever.

To fix this:

- Remove the per-worker pixi cache at session end. It is regenerable and not useful for debugging retained test workspaces.
- Root pytest's automatic numbered directories in `pytest-temp/` via `PYTEST_DEBUG_TEMPROOT` instead of passing `--basetemp`. Concurrent runs stay safe through lock-protected numbering, fully passing runs remove their directory at session end, and old runs are pruned down to `tmp_path_retention_count`




### How Has This Been Tested?

`pixi run test-integration-fast -k add` multiple times and make sure it cleans up. Even if I in between cancel some of them.

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
