### PR TITLE
test: isolate global_specs tests from the user's global manifest

### DIFF
--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -225,6 +225,18 @@ mod tests {
 
     use super::*;
 
+    /// Create a project in an isolated `PIXI_HOME` so tests never read the
+    /// global manifest of the machine they run on.
+    async fn isolated_project(temp_dir: &Path) -> pixi_global::Project {
+        let pixi_home_dir = temp_dir.join("pixi-home");
+        temp_env::async_with_vars(
+            [("PIXI_HOME", Some(pixi_home_dir.to_str().unwrap()))],
+            pixi_global::Project::discover_or_create(),
+        )
+        .await
+        .unwrap()
+    }
+
     #[tokio::test]
     async fn test_to_global_specs_named() {
         let specs = GlobalSpecs {
@@ -240,7 +252,8 @@ mod tests {
 
         // Create a dummy project - this test doesn't use path/git specs so project
         // won't be called
-        let project = pixi_global::Project::discover_or_create().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let project = isolated_project(temp_dir.path()).await;
 
         let global_specs = specs
             .to_global_specs(&channel_config, &manifest_root, &project)
@@ -265,7 +278,8 @@ mod tests {
 
         // Create a dummy project - this test specifies a package name so inference
         // won't be needed
-        let project = pixi_global::Project::discover_or_create().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let project = isolated_project(temp_dir.path()).await;
 
         let global_specs = specs
             .to_global_specs(&channel_config, &manifest_root, &project)
@@ -353,7 +367,8 @@ mod tests {
         let manifest_root = PathBuf::from(".");
 
         // Create a dummy project
-        let project = pixi_global::Project::discover_or_create().await.unwrap();
+        let temp_dir = tempdir().unwrap();
+        let project = isolated_project(temp_dir.path()).await;
 
         let global_specs = specs
             .to_global_specs(&channel_config, &manifest_root, &project)


### PR DESCRIPTION
### Description

I've noticed that tests where failing locally for me because my `pixi-global.toml` had syntax that is not yet supported by main. That of course should not happen. This fixes it.

### How Has This Been Tested?

`pixi run test-fast`

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code