### PR TITLE
test: mark slow integration tests with pytest.mark.slow

### DIFF
--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -19,6 +19,7 @@ from .common import (
 BUILD_RUNNING_STRING = "Running build for recipe:"
 
 
+@pytest.mark.slow
 def test_build_conda_package(
     pixi: Path,
     simple_workspace: Workspace,
@@ -294,6 +295,7 @@ def test_incremental_builds(
     )
 
 
+@pytest.mark.slow
 def test_error_manifest_deps(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     test_data = build_data.joinpath("rattler-build-backend")
     # copy the whole smokey project to the tmp_pixi_workspace
@@ -313,6 +315,7 @@ def test_error_manifest_deps(pixi: Path, build_data: Path, tmp_pixi_workspace: P
     )
 
 
+@pytest.mark.slow
 def test_error_manifest_deps_no_default(
     pixi: Path, build_data: Path, tmp_pixi_workspace: Path
 ) -> None:
@@ -334,6 +337,7 @@ def test_error_manifest_deps_no_default(
     )
 
 
+@pytest.mark.slow
 def test_rattler_build_source_dependency(
     pixi: Path, build_data: Path, tmp_pixi_workspace: Path
 ) -> None:
@@ -357,6 +361,7 @@ def test_rattler_build_source_dependency(
     )
 
 
+@pytest.mark.slow
 def test_rattler_build_point_to_recipe(
     pixi: Path, build_data: Path, tmp_pixi_workspace: Path
 ) -> None:
@@ -379,6 +384,7 @@ def test_rattler_build_point_to_recipe(
     assert built_packages, "no package artifacts produced"
 
 
+@pytest.mark.slow
 def test_rattler_build_autodiscovery(
     pixi: Path, build_data: Path, tmp_pixi_workspace: Path
 ) -> None:

--- a/tests/integration_python/pixi_build/test_conditional_dependencies.py
+++ b/tests/integration_python/pixi_build/test_conditional_dependencies.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 import tomli_w
 from rattler.lock import LockFile
 
@@ -64,6 +65,7 @@ def locked_package_names(workspace_dir: Path) -> dict[str, set[str]]:
     }
 
 
+@pytest.mark.slow
 def test_simple_conditional_dependency(
     pixi: Path, tmp_pixi_workspace: Path, target_specific_channel_1: str
 ) -> None:
@@ -87,6 +89,7 @@ def test_simple_conditional_dependency(
     assert "package-unix" not in packages["win-64"]
 
 
+@pytest.mark.slow
 def test_complex_conditional_expression(
     pixi: Path, tmp_pixi_workspace: Path, target_specific_channel_1: str
 ) -> None:
@@ -106,6 +109,7 @@ def test_complex_conditional_expression(
     assert "package-unix" not in packages["win-64"]
 
 
+@pytest.mark.slow
 def test_variant_conditional_expression(
     pixi: Path, tmp_pixi_workspace: Path, target_specific_channel_1: str
 ) -> None:
@@ -130,6 +134,7 @@ def test_variant_conditional_expression(
     assert "package-windows" not in packages["linux-64"]
 
 
+@pytest.mark.slow
 def test_invalid_conditional_expression(
     pixi: Path, tmp_pixi_workspace: Path, target_specific_channel_1: str
 ) -> None:

--- a/tests/integration_python/pixi_build/test_global.py
+++ b/tests/integration_python/pixi_build/test_global.py
@@ -14,6 +14,7 @@ from .common import (
 )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "package_name",
     ["simple-package", None],
@@ -56,6 +57,7 @@ def test_install_path_dependency(
     verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "relative",
     [True, False],
@@ -96,6 +98,7 @@ def test_sync(pixi: Path, tmp_path: Path, build_data: Path, relative: bool) -> N
     verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "package_name",
     ["simple-package", None],
@@ -129,6 +132,7 @@ def test_install_git_repository(
     verify_cli_command([simple_package], env=env, stdout_contains="hello from simple-package")
 
 
+@pytest.mark.slow
 def test_add_git_repository_to_existing_environment(
     pixi: Path, tmp_path: Path, build_data: Path, dummy_channel_1: Path
 ) -> None:
@@ -227,6 +231,7 @@ def test_update(pixi: Path, tmp_path: Path, build_data: Path) -> None:
     verify_cli_command([simple_package], env=env, stdout_contains="goodbye from simple-package")
 
 
+@pytest.mark.slow
 def test_install_multi_output_failing(
     pixi: Path,
     tmp_path: Path,
@@ -249,6 +254,7 @@ def test_install_multi_output_failing(
     )
 
 
+@pytest.mark.slow
 @pytest.mark.xfail(
     reason="multi output recipes where one package depends on another doesn't work yet with pixi global"
 )
@@ -276,6 +282,7 @@ def test_install_multi_output_single(
     verify_cli_command([foobar_desktop], env=env, stdout_contains="Hello from foobar-desktop")
 
 
+@pytest.mark.slow
 def test_install_multi_output_multiple(
     pixi: Path,
     tmp_path: Path,
@@ -325,6 +332,7 @@ def test_install_recursive_source_run_dependencies(
     assert not package_b.is_file()
 
 
+@pytest.mark.slow
 def test_install_recursive_source_build_dependencies(
     pixi: Path,
     tmp_path: Path,

--- a/tests/integration_python/pixi_build/test_inline_packages.py
+++ b/tests/integration_python/pixi_build/test_inline_packages.py
@@ -219,6 +219,7 @@ def test_inline_definition_inherits_workspace_version(pixi: Path, tmp_pixi_works
     )
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("source_kind", ["path", "git"])
 def test_inline_definition_keeps_host_dependencies(
     pixi: Path, tmp_pixi_workspace: Path, source_kind: str
@@ -293,6 +294,7 @@ def test_inline_definition_keeps_host_dependencies(
     )
 
 
+@pytest.mark.slow
 def test_inline_definition_edit_invalidates_lock(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """Regression test for https://github.com/prefix-dev/pixi/issues/6527: editing
     an inline package definition must invalidate the lock file.

--- a/tests/integration_python/pixi_build/test_log.py
+++ b/tests/integration_python/pixi_build/test_log.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from .common import ExitCode, copytree_with_local_backend, verify_cli_command
 
 
@@ -36,6 +38,7 @@ def test_log_working_default(pixi: Path, build_data: Path, tmp_pixi_workspace: P
     )
 
 
+@pytest.mark.slow
 def test_log_failing(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     test_data = build_data.joinpath("log-example", "failing")
 

--- a/tests/integration_python/pixi_build/test_multi_output.py
+++ b/tests/integration_python/pixi_build/test_multi_output.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
+import pytest
+
 from .common import CURRENT_PLATFORM, copytree_with_local_backend, verify_cli_command, ExitCode
 
 
+@pytest.mark.slow
 def test_build(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     project = "multi-output"
     test_data = build_data.joinpath(project)
@@ -23,6 +26,7 @@ def test_build(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     assert len(built_packages) == 3
 
 
+@pytest.mark.slow
 def test_install(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     project = "multi-output"
     test_data = build_data.joinpath(project)
@@ -36,6 +40,7 @@ def test_install(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None
     verify_cli_command([pixi, "install", "-v", "--locked", "--manifest-path", tmp_pixi_workspace])
 
 
+@pytest.mark.slow
 def test_available_packages(pixi: Path, build_data: Path, tmp_pixi_workspace: Path) -> None:
     project = "multi-output"
     test_data = build_data.joinpath(project)

--- a/tests/integration_python/pixi_global/test_global.py
+++ b/tests/integration_python/pixi_global/test_global.py
@@ -2394,6 +2394,7 @@ class TestCondaFile:
         relative_conda_file = conda_file.relative_to(cwd, walk_up=True)
         check_install(relative_conda_file, cwd)
 
+    @pytest.mark.slow
     def test_update_sync_conda_file(
         self, pixi: Path, tmp_path: Path, shortcuts_channel_1: str
     ) -> None:

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -561,6 +561,7 @@ def test_dont_add_broken_dep(pixi: Path, tmp_pixi_workspace: Path, dummy_channel
     assert manifest_content == tmp_pixi_workspace.joinpath("pixi.toml").read_text()
 
 
+@pytest.mark.slow
 def test_list_exits_unsuccessful_on_unknown_pkg(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:

--- a/tests/integration_python/test_run_cli.py
+++ b/tests/integration_python/test_run_cli.py
@@ -355,6 +355,7 @@ def test_detached_environments_run(pixi: Path, tmp_path: Path, dummy_channel_1: 
     )
 
 
+@pytest.mark.slow
 def test_run_help(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     manifest.write_text(EMPTY_BOILERPLATE_PROJECT)
@@ -1533,6 +1534,7 @@ multiple-depends = {{ cmd = "echo hello from depends", depends-on = [{{ task = "
     )
 
 
+@pytest.mark.slow
 def test_caching_multiple_tasks_with_depends_on_args(pixi: Path, tmp_pixi_workspace: Path) -> None:
     """Test ``depends-on`` with the same inputs, outputs, but different args, are cached independently.
 


### PR DESCRIPTION
When running `pixi run test-integration-fast`, some tests ran over 2 seconds. I marked all of them as slow

