### PR TITLE
Add blake3 content-hash fallback to artifact cache freshness checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1234,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.4",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1843,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "content_inspector"
@@ -2483,7 +2509,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2517,7 +2543,7 @@ checksum = "ad5208a115eaba24916f7456929832e310a81518c641f93fee4f89aa93aa3675"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2773,7 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4124,7 +4150,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4550,7 +4576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4560,7 +4586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "160f2eade097f30263b548aae5deb12ad349c909baa710fa24b92c9090b2e006"
 dependencies = [
  "scopeguard",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4578,7 +4604,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5164,7 +5190,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6479,9 +6505,11 @@ version = "0.1.0"
 dependencies = [
  "async-fd-lock",
  "base64 0.22.1",
+ "blake3",
  "chrono",
  "derive_more",
  "dunce",
+ "filetime",
  "fs-err",
  "futures",
  "indexmap 2.14.0",
@@ -9428,7 +9456,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9508,7 +9536,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10847,7 +10875,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10857,7 +10885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13228,7 +13256,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ async-trait = "0.1.86"
 axum = "0.8"
 barrier_cell = { path = "crates/barrier_cell" }
 base64 = "0.22.1"
+blake3 = "1.5.5"
 cargo_toml = "0.22.3"
 chrono = "0.4.40"
 clap = { version = "4.6.1", default-features = false }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 [dependencies]
 async-fd-lock = { workspace = true }
 base64 = { workspace = true }
+blake3 = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true, features = ["display", "from", "try_into"] }
 dunce = { workspace = true }
@@ -70,6 +71,7 @@ pixi_utils = { workspace = true }
 pixi_variant = { workspace = true }
 
 [dev-dependencies]
+filetime = { workspace = true }
 indexmap = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 pixi_build_backend_passthrough = { workspace = true }

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -11,8 +11,8 @@
 //!
 //! The cache key is structural (identity of the build inputs plus content
 //! addresses of its dependencies). Freshness of the source files themselves
-//! is tracked in the sidecar via per-file mtimes, plus a re-glob pass that
-//! detects added files.
+//! is tracked in the sidecar via per-file whole-second mtimes with a blake3
+//! content-hash fallback, plus a re-glob pass that detects added files.
 //!
 //! On a hit, the cached `.conda` is returned along with its sha256; no
 //! backend work happens. On a miss (or stale sidecar), the caller rebuilds
@@ -71,8 +71,9 @@ impl std::fmt::Display for ArtifactCacheKey {
 ///   string and number, so different overrides must not share a cache
 ///   entry
 ///
-/// Source *files* are not hashed here: the sidecar captures their mtimes
-/// separately so a content change still invalidates the entry on lookup.
+/// Source *files* are not hashed here: the sidecar captures their whole-second
+/// mtimes and blake3 content hashes separately so a content change still
+/// invalidates the entry on lookup.
 ///
 /// The caller provides source-dep sha256s split into build / host buckets
 /// to preserve the same bucket separation applied to binary deps.
@@ -152,11 +153,12 @@ pub struct ArtifactSidecar {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub input_glob_sets: Vec<InputGlobSet>,
 
-    /// Files that matched the input globs, paired with their mtime at build
-    /// time. Keyed by absolute path (the walk roots are absolute), so the keys
-    /// round-trip directly against the engine walk at lookup time.
+    /// Files that matched the input globs, paired with the freshness
+    /// fingerprint captured at build time. Keyed by absolute path (the walk
+    /// roots are absolute), so the keys round-trip directly against the engine
+    /// walk at lookup time.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub input_files: BTreeMap<AbsPathBuf, DateTime<Utc>>,
+    pub input_files: BTreeMap<AbsPathBuf, InputFileFingerprint>,
 
     /// sha256 of the cached `.conda`. Callers rely on this for transitive
     /// invalidation of dependents.
@@ -169,6 +171,44 @@ pub struct ArtifactSidecar {
     /// Fully-assembled `RepoDataRecord` for the artifact. Stored so cache
     /// hits can return it without re-reading index.json from the `.conda`.
     pub record: RepoDataRecord,
+}
+
+/// Freshness fingerprint for a single input file, captured at build time.
+///
+/// `mtime` is truncated to whole-second precision because that is the coarsest
+/// resolution that survives common transports: tar and Docker layer extraction,
+/// zip archives, and FAT/exFAT all drop sub-second precision. Comparing at full
+/// precision caused spurious rebuilds whenever a source tree round-tripped
+/// through one of those (notably a Docker build sharing `PIXI_CACHE_DIR` via
+/// `--mount=type=cache`, where `COPY` truncates mtimes to whole seconds).
+///
+/// `content` is a blake3 digest of the file bytes, used as the authoritative
+/// fallback when the truncated mtime differs: an mtime that shifted without the
+/// contents changing (again, routine after a Docker `COPY`) then still hits the
+/// cache instead of forcing a rebuild.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputFileFingerprint {
+    /// mtime of the file, truncated to whole-second precision.
+    pub mtime: DateTime<Utc>,
+
+    /// blake3 hash of the file contents, hex-encoded.
+    pub content: String,
+}
+
+/// Truncate a timestamp to whole-second precision.
+///
+/// Sub-second precision does not survive tar/Docker/zip/FAT, so freshness
+/// comparisons are done at the granularity that does.
+fn truncate_to_secs(dt: DateTime<Utc>) -> DateTime<Utc> {
+    DateTime::from_timestamp(dt.timestamp(), 0).unwrap_or(dt)
+}
+
+/// Compute the blake3 digest of a file's contents, hex-encoded.
+fn blake3_file(path: &Path) -> std::io::Result<String> {
+    let mut file = fs_err::File::open(path)?;
+    let mut hasher = blake3::Hasher::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(hasher.finalize().to_hex().to_string())
 }
 
 /// Result of a successful cache lookup.
@@ -301,13 +341,29 @@ impl ArtifactCache {
         };
         drop(_guard);
 
-        // Check every recorded file still matches its mtime.
-        for (path, expected_mtime) in &sidecar.input_files {
+        // Check every recorded file is still fresh. The whole-second mtime is a
+        // fast path; when it drifts we fall back to the content hash so an mtime
+        // that merely round-tripped through a tar/Docker layer doesn't force a
+        // rebuild.
+        for (path, fingerprint) in &sidecar.input_files {
             let modified = match fs_err::metadata(path).and_then(|m| m.modified()) {
-                Ok(m) => DateTime::<Utc>::from(m),
+                Ok(m) => truncate_to_secs(DateTime::<Utc>::from(m)),
                 Err(_) => return Ok(None),
             };
-            if modified != *expected_mtime {
+            // Fast path: the whole-second mtime is unchanged, trust it and skip
+            // hashing the file.
+            if modified == fingerprint.mtime {
+                continue;
+            }
+            // The mtime drifted. That happens routinely when a source tree is
+            // copied through a Docker layer (or any tar/zip) without the
+            // contents changing, so compare the content hash before declaring
+            // the entry stale.
+            let content = match blake3_file(path.as_std_path()) {
+                Ok(content) => content,
+                Err(_) => return Ok(None),
+            };
+            if content != fingerprint.content {
                 return Ok(None);
             }
         }
@@ -396,19 +452,28 @@ impl ArtifactCache {
             .map_err(|err| ArtifactCacheError::io("hashing artifact", dest.clone(), err))?
         };
 
-        let mut input_files_mtimes = BTreeMap::new();
+        let mut input_fingerprints = BTreeMap::new();
         for path in input_files {
             let modified = fs_err::metadata(&path)
                 .and_then(|m| m.modified())
                 .map_err(|err| {
                     ArtifactCacheError::io("stat input file", path.clone().into(), err)
                 })?;
-            input_files_mtimes.insert(path, DateTime::<Utc>::from(modified));
+            let content = blake3_file(path.as_std_path()).map_err(|err| {
+                ArtifactCacheError::io("hashing input file", path.clone().into(), err)
+            })?;
+            input_fingerprints.insert(
+                path,
+                InputFileFingerprint {
+                    mtime: truncate_to_secs(DateTime::<Utc>::from(modified)),
+                    content,
+                },
+            );
         }
 
         let sidecar = ArtifactSidecar {
             input_glob_sets,
-            input_files: input_files_mtimes,
+            input_files: input_fingerprints,
             artifact_sha256: sha256,
             artifact_filename: filename,
             record: record.clone(),
@@ -464,6 +529,7 @@ impl From<pixi_glob::GlobSetError> for ArtifactCacheError {
 mod tests {
     use std::str::FromStr;
 
+    use filetime::FileTime;
     use pixi_compute_engine::ComputeEngine;
     use rattler_conda_types::{PackageName, PackageRecord};
     use tempfile::TempDir;
@@ -614,14 +680,64 @@ mod tests {
             .await
             .unwrap();
 
-        // Modify the source file's mtime by rewriting it after a sleep.
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Change the contents, and push the mtime to a clearly different
+        // whole second so the fast-path mtime check registers the change
+        // deterministically (a sub-second rewrite could land in the same
+        // truncated second).
         fs_err::write(&input, b"new").unwrap();
+        filetime::set_file_mtime(&input, FileTime::from_unix_time(2_000_000_000, 0)).unwrap();
 
         let got = lookup(&engine, &cache, &pkg("foo"), &key, &source)
             .await
             .unwrap();
-        assert!(got.is_none(), "mtime change should invalidate the entry");
+        assert!(got.is_none(), "content change should invalidate the entry");
+    }
+
+    /// Regression for the Docker `--mount=type=cache` scenario: copying a
+    /// source tree through an image layer rewrites mtimes (Docker truncates to
+    /// whole seconds and may shift them) without changing file contents. The
+    /// blake3 content-hash fallback must keep the entry valid instead of
+    /// rebuilding the pixi-build package on every `pixi run`/`pixi install`.
+    #[tokio::test]
+    async fn lookup_hits_when_only_mtime_shifts() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
+
+        let source = tmp.path().join("src");
+        fs_err::create_dir_all(&source).unwrap();
+        let input = source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+
+        let scratch = tmp.path().join("scratch");
+        fs_err::create_dir_all(&scratch).unwrap();
+        let artifact = scratch.join("foo-1.0.0-h0.conda");
+        fs_err::write(&artifact, b"artifact").unwrap();
+
+        let key = key("linux-64-abc");
+        cache
+            .store(
+                &pkg("foo"),
+                &key,
+                &artifact,
+                Vec::new(),
+                vec![abs(input.clone())],
+                dummy_record("foo"),
+            )
+            .await
+            .unwrap();
+
+        // Rewrite the mtime to a different whole second but leave the bytes
+        // untouched, mimicking a source tree copied through a Docker layer.
+        filetime::set_file_mtime(&input, FileTime::from_unix_time(2_000_000_000, 0)).unwrap();
+
+        let got = lookup(&engine, &cache, &pkg("foo"), &key, &source)
+            .await
+            .unwrap();
+        assert!(
+            got.is_some(),
+            "an mtime shift with unchanged contents must still hit the cache"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description

This change improves the artifact cache's freshness validation to handle a common scenario where file modification times shift without content changing. This occurs routinely when source trees are copied through Docker layers, tar archives, or other transports that truncate sub-second precision.

**Problem:** The cache previously relied solely on file modification times (mtimes) to detect changes. When a source tree was copied through a Docker layer (e.g., via `COPY` in a Dockerfile or `--mount=type=cache`), Docker would truncate mtimes to whole-second precision and potentially shift them, causing spurious cache invalidations even though file contents were unchanged.

**Solution:** 
- Store both whole-second truncated mtimes and blake3 content hashes for each input file
- Use the mtime as a fast-path check (most common case)
- Fall back to content-hash comparison when mtimes differ, avoiding unnecessary rebuilds when only the mtime shifted

The implementation:
1. Introduces `InputFileFingerprint` struct to store both mtime and content hash
2. Replaces `BTreeMap<AbsPathBuf, DateTime<Utc>>` with `BTreeMap<AbsPathBuf, InputFileFingerprint>` in `ArtifactSidecar`
3. Adds helper functions `truncate_to_secs()` and `blake3_file()` for consistent fingerprinting
4. Updates cache lookup logic to check content hash when mtime drifts
5. Updates cache storage to compute and store both values

### How Has This Been Tested?

- Added regression test `lookup_hits_when_only_mtime_shifts()` that verifies cache hits when file mtimes change but contents remain identical
- Updated existing test `lookup_misses_on_input_file_change()` to use explicit mtime manipulation for deterministic testing
- Both tests use `filetime` crate to set precise mtime values, ensuring the fast-path and fallback paths are properly exercised

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes

https://claude.ai/code/session_01S2w89Ws26vMAaMedQUs4Ri