### PR TITLE
fix: release workspace gateway before indexing on publish

### DIFF
--- a/crates/pixi_cli/src/publish.rs
+++ b/crates/pixi_cli/src/publish.rs
@@ -783,10 +783,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         built_packages.push((package_path, variants));
     }
 
-    // Drop the dispatcher (and its repodata gateway) before indexing. The
-    // gateway memory-maps the target channel's `repodata.json`; on Windows that
-    // mapping blocks the indexer from overwriting it (os error 1224). See #6362.
+    // Release the repodata gateway before indexing. It memory-maps the target
+    // channel's `repodata.json` when that channel is also a source channel; on
+    // Windows an open mapping blocks the indexer from replacing the file (os
+    // error 1224 truncating in place, os error 5 renaming over it). The
+    // `Gateway` is `Arc`-shared, so the dispatcher's clone and the workspace's
+    // own copy must both be dropped to unmap. See #6362.
     drop(command_dispatcher);
+    drop(workspace);
 
     if built_packages.is_empty() {
         miette::bail!("No packages were built. Nothing to publish.");


### PR DESCRIPTION
The repodata gateway memory-maps a local/network channel's repodata.json when that channel is also a source channel. On Windows the open mapping blocks rattler-index from replacing the file: os error 1224 when it truncated in place, and os error 5 now that it renames over the target.

Dropping the command dispatcher only released its Arc clone of the gateway; the workspace held another copy in its OnceCell, keeping the mapping alive. Drop the workspace as well so the file is unmapped before indexing runs.

Fixes prefix-dev/pixi#6362

### How Has This Been Tested?

Not at all: It needs windows and a SMB share. I have neither of these.

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.