### PR TITLE
docs: fix python version constraint location in pixi-build-python backend

### DIFF
--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -47,8 +47,8 @@ The backend automatically includes the following build tools:
 You can add these to your [`host-dependencies`](https://pixi.sh/latest/build/dependency_types/) if you need specific versions:
 
 ```toml
-[package.build-dependencies]
-python = "3.11"
+[package.host-dependencies]
+python = ">=3.10"
 ```
 
 The backend will be automatically selected by the automatic PyPI dependency mapping feature if you have `pyproject.toml` in your source directory.
@@ -57,6 +57,11 @@ Otherwise, you need to explicitly add it to your package definition in the `[hos
 [package.host-dependencies]
 hatchling = "*"
 ```
+
+!!! note "Where to constrain the Python version"
+    Specify the Python version restriction in `[package.host-dependencies]`, not in `[package.build-dependencies]`. The backend always adds `python` to both the host and run requirements; a spec you provide in `[package.host-dependencies]` intersects with it in the solver, so the constraint is honored and also propagated to the run requirements of the built package.
+
+    The version is also taken from `project.requires-python` in `pyproject.toml` when present. That value is ignored when [`ignore-pyproject-manifest`](#ignore-pyproject-manifest) is set to `true`; in that case set the version in `[package.host-dependencies]` instead.
 
 ## Configuration Options
 

--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -48,7 +48,7 @@ You can add these to your [`host-dependencies`](https://pixi.sh/latest/build/dep
 
 ```toml
 [package.host-dependencies]
-python = ">=3.10"
+python = "3.14.*"
 ```
 
 The backend will be automatically selected by the automatic PyPI dependency mapping feature if you have `pyproject.toml` in your source directory.


### PR DESCRIPTION
The Required Dependencies section told users to set the Python version in host-dependencies but showed the example under [package.build-dependencies]. Correct the example to [package.host-dependencies] and add a note explaining where the constraint belongs, that the backend adds python to both host and run requirements, and that project.requires-python is honored unless ignore-pyproject-manifest is set.

Closes #6530

### How Has This Been Tested?

It's text only, so I just read it :-)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
