### PR TITLE
fix: do not chain run-exports when resolving source package run deps

### DIFF
--- a/crates/pixi_command_dispatcher/src/build/dependencies.rs
+++ b/crates/pixi_command_dispatcher/src/build/dependencies.rs
@@ -276,6 +276,16 @@ impl Dependencies {
         self
     }
 
+    /// Whether `name` was declared as a dependency directly, rather than
+    /// only merged in from another package's run-exports.
+    fn is_declared_dependency(&self, name: &PackageName) -> bool {
+        self.dependencies.get(name).is_some_and(|specs| {
+            specs
+                .iter()
+                .any(|spec| !matches!(spec.source, Some(DependencySource::RunExport { .. })))
+        })
+    }
+
     /// Extract run exports from the solved environments.
     pub async fn extract_run_exports(
         &self,
@@ -306,7 +316,10 @@ impl Dependencies {
         let mut relevant_records = records
             .iter_mut()
             // Only record run exports for packages that are direct dependencies.
-            .filter(|r| self.dependencies.contains_key(&r.package_record().name))
+            // Entries that were merged in from another package's run-exports do
+            // not count as direct: per conda-build semantics (and rattler-build's
+            // implementation) they don't contribute their own run-exports.
+            .filter(|r| self.is_declared_dependency(&r.package_record().name))
             // Filter based on whether we want to ignore run exports for a particular
             // package.
             .filter(|r| !ignore.from_package.contains(&r.package_record().name))
@@ -326,10 +339,7 @@ impl Dependencies {
 
         for record in relevant_records {
             // Only record run exports for packages that are direct dependencies.
-            if !self
-                .dependencies
-                .contains_key(&record.package_record().name)
-            {
+            if !self.is_declared_dependency(&record.package_record().name) {
                 continue;
             }
 
@@ -594,12 +604,93 @@ impl PixiRunExports {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::{
+        collections::{BTreeMap, HashMap},
+        str::FromStr,
+        sync::Arc,
+    };
 
-    use pixi_build_types::{ExtraGroupName, NamedSpec, PackageSpec, PathSpec, SourcePackageName};
-    use rattler_conda_types::PackageName;
+    use pixi_build_types::{
+        ExtraGroupName, NamedSpec, PackageSpec, PathSpec, SourcePackageName,
+        procedures::conda_outputs::CondaOutputIgnoreRunExports,
+    };
+    use rattler_conda_types::{
+        PackageName, PackageRecord, RepoDataRecord, VersionWithSource,
+        package::{DistArchiveIdentifier, RunExportsJson},
+    };
+    use rattler_repodata_gateway::Gateway;
+    use url::Url;
 
-    use super::convert_extra_dependencies;
+    use super::{Dependencies, PixiRunExports, convert_extra_dependencies, filter_match_specs};
+    use pixi_record::PixiRecord;
+
+    fn binary_record(name: &str, version: &str, run_exports: RunExportsJson) -> PixiRecord {
+        let mut pr = PackageRecord::new(
+            PackageName::from_str(name).unwrap(),
+            VersionWithSource::from_str(version).unwrap(),
+            "h0".into(),
+        );
+        pr.subdir = "linux-64".into();
+        pr.run_exports = Some(run_exports);
+        let file_name = format!("{name}-{version}-h0.conda");
+        PixiRecord::Binary(Arc::new(RepoDataRecord {
+            package_record: pr,
+            identifier: DistArchiveIdentifier::from_str(&file_name).unwrap(),
+            url: Url::parse(&format!(
+                "https://example.com/conda-forge/linux-64/{file_name}"
+            ))
+            .unwrap(),
+            channel: None,
+        }))
+    }
+
+    /// A package that is only in the environment because another package's
+    /// run-export injected it must not contribute its own run-exports.
+    /// rattler-build treats run-export entries as not direct, so a chain
+    /// like gxx -> libstdcxx-ng -> libstdcxx stops after the first hop.
+    #[tokio::test]
+    async fn run_export_injected_dependencies_do_not_contribute_run_exports() {
+        let ignore = CondaOutputIgnoreRunExports::default();
+        let build_run_exports = vec![(
+            PackageName::from_str("gxx_linux-64").unwrap(),
+            PixiRunExports {
+                strong: filter_match_specs(&["libstdcxx-ng >=12".to_string()], &ignore),
+                ..Default::default()
+            },
+        )];
+        // Host env without backend-declared deps; libstdcxx-ng only enters
+        // through the build dep's strong run-export.
+        let host_dependencies =
+            Dependencies::default().extend_with_run_exports_from_build(&build_run_exports);
+
+        let mut host_records = vec![binary_record(
+            "libstdcxx-ng",
+            "15.2.0",
+            RunExportsJson {
+                strong: vec!["libstdcxx".to_string()],
+                ..Default::default()
+            },
+        )];
+
+        let host_run_exports = host_dependencies
+            .extract_run_exports(
+                &mut host_records,
+                &ignore,
+                &Gateway::builder().finish(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            host_run_exports.is_empty(),
+            "run-export-injected libstdcxx-ng must not contribute run-exports, got: {:?}",
+            host_run_exports
+                .iter()
+                .map(|(name, _)| name.as_normalized())
+                .collect::<Vec<_>>()
+        );
+    }
 
     /// A source dependency inside an extra group must be resolved as a source
     /// spec rather than stringified into a meaningless binary match spec, so

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -373,8 +373,9 @@ async fn compute_inner(
         .transpose()
         .map_err(SourceBuildError::from)?
         .unwrap_or_default()
-        // Apply strong build run-exports to host so the host env's
-        // run-export extraction sees them as direct dependencies.
+        // Apply strong build run-exports to host so they are part of the
+        // host env solve. They stay marked as run-export-sourced, so the
+        // extraction below does not treat them as direct dependencies.
         .extend_with_run_exports_from_build(&build_run_exports);
 
     let host_run_exports = host_dependencies

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -912,7 +912,8 @@ mod tests {
     use pixi_spec::{SourceAnchor, SourceSpec};
     use rattler_conda_types::{
         ChannelConfig, NoArchType, PackageName, PackageRecord, Platform, RepoDataRecord,
-        VersionSpec, VersionWithSource, package::DistArchiveIdentifier,
+        VersionSpec, VersionWithSource,
+        package::{DistArchiveIdentifier, RunExportsJson},
     };
     use std::{
         collections::BTreeMap,
@@ -1608,6 +1609,101 @@ mod tests {
                 assert_eq!(removed, vec!["bar <2".to_string()]);
             }
             other => panic!("expected RunConstrains drift, got: {other}"),
+        }
+    }
+
+    /// Build a binary record carrying run-exports, for the run-export
+    /// chain tests below.
+    fn make_binary_record_with_run_exports(
+        name: &str,
+        version: &str,
+        run_exports: RunExportsJson,
+    ) -> RepoDataRecord {
+        let mut record = make_binary_record(name, version);
+        record.package_record.run_exports = Some(run_exports);
+        record
+    }
+
+    /// The run-dep reconstruction only collects run-exports from
+    /// backend-declared dependencies. A package that reached the host env
+    /// through a build dep's strong run-export (gxx -> libstdcxx-ng) does
+    /// not contribute its own run-exports, matching the solve path and
+    /// rattler-build. A lock produced by that solve must verify clean.
+    #[test]
+    fn verify_locked_run_deps_ignores_run_export_injected_host_packages() {
+        let mut record =
+            make_full_source_record("pkg", vec!["libstdcxx-ng >=12".to_string()], Vec::new());
+        record.build_packages = vec![UnresolvedPixiRecord::Binary(Arc::new(
+            make_binary_record_with_run_exports(
+                "gxx_linux-64",
+                "11.4.0",
+                RunExportsJson {
+                    strong: vec!["libstdcxx-ng >=12".to_string()],
+                    ..Default::default()
+                },
+            ),
+        ))];
+        record.host_packages = vec![UnresolvedPixiRecord::Binary(Arc::new(
+            make_binary_record_with_run_exports(
+                "libstdcxx-ng",
+                "15.2.0",
+                RunExportsJson {
+                    strong: vec!["libstdcxx".to_string()],
+                    ..Default::default()
+                },
+            ),
+        ))];
+        let output = make_conda_output("pkg", vec![binary_dep("gxx_linux-64", "")]);
+
+        let result = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG);
+        assert!(result.is_ok(), "expected no drift: {result:?}");
+    }
+
+    /// A lock written by pixi versions that chained run-exports carries the
+    /// injected package's exports (`libstdcxx *`) in `depends`. Those must
+    /// surface as drift so the lock is regenerated once (#6584).
+    #[test]
+    fn verify_locked_run_deps_rejects_chained_run_exports() {
+        let mut record = make_full_source_record(
+            "pkg",
+            vec!["libstdcxx-ng >=12".to_string(), "libstdcxx *".to_string()],
+            Vec::new(),
+        );
+        record.build_packages = vec![UnresolvedPixiRecord::Binary(Arc::new(
+            make_binary_record_with_run_exports(
+                "gxx_linux-64",
+                "11.4.0",
+                RunExportsJson {
+                    strong: vec!["libstdcxx-ng >=12".to_string()],
+                    ..Default::default()
+                },
+            ),
+        ))];
+        record.host_packages = vec![UnresolvedPixiRecord::Binary(Arc::new(
+            make_binary_record_with_run_exports(
+                "libstdcxx-ng",
+                "15.2.0",
+                RunExportsJson {
+                    strong: vec!["libstdcxx".to_string()],
+                    ..Default::default()
+                },
+            ),
+        ))];
+        let output = make_conda_output("pkg", vec![binary_dep("gxx_linux-64", "")]);
+
+        let err = verify_locked_run_deps_against_backend(&record, &output, &CHANNEL_CONFIG)
+            .expect_err("a chained run-export in the lock must surface as drift");
+        match *err {
+            super::super::PlatformUnsat::SourceRunDependenciesChanged {
+                kind: SourceRunDepKind::RunDepends,
+                added,
+                removed,
+                ..
+            } => {
+                assert!(added.is_empty());
+                assert_eq!(removed, vec!["libstdcxx *".to_string()]);
+            }
+            other => panic!("expected RunDepends drift, got: {other}"),
         }
     }
 


### PR DESCRIPTION
### Description

Strong run-exports of direct build dependencies are added to the host environment, and the injected packages' own run-exports leaked into the run dependencies (gxx -> libstdcxx-ng -> libstdcxx). rattler-build also does not treat run-export entries as direct dependencies, so we should skip them during run-export extraction as well.

Fixes prefix-dev/pixi#6584

### How Has This Been Tested?

`pixi run test`

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added sufficient tests to cover my changes.