### PR TITLE
fix: fail on git subprocess errors so a rev can resolve to a tag

### DIFF
--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -81,6 +81,26 @@ impl GitLfs {
     }
 }
 
+/// Runs a prepared `git` command and returns its output, failing when git
+/// exits with a non-zero status. Reading the output of a failed command is
+/// never safe: `git rev-parse` for example echoes unresolvable refnames back
+/// to stdout.
+fn git_output(cmd: &mut Command) -> Result<std::process::Output, GitError> {
+    let output = cmd.output()?;
+    if !output.status.success() {
+        let args = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        return Err(GitError::Command(
+            args,
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    Ok(output)
+}
+
 /// Value for `GIT_LFS_SKIP_SMUDGE`, or `None` to leave the var unset.
 /// `Some(true)` → "0" (run smudge), `Some(false)` → "1" (skip smudge).
 fn lfs_skip_smudge_env(lfs: Option<bool>) -> Option<&'static str> {
@@ -298,7 +318,16 @@ impl GitRemote {
         fetch(&mut repo, self.url.as_str(), reference, client)?;
         let rev = match locked_rev {
             Some(rev) => rev,
-            None => reference.resolve(&repo)?,
+            None => reference.resolve(&repo).map_err(|err| {
+                let mut repository = self.url.clone();
+                let _ = repository.set_password(None);
+                let _ = repository.set_username("");
+                GitError::ReferenceNotFound {
+                    reference: reference.as_rev().to_string(),
+                    repository: repository.to_string(),
+                    source: Box::new(err),
+                }
+            })?,
         };
 
         let ready = (lfs == Some(true))
@@ -384,12 +413,13 @@ impl GitDatabase {
 
     /// Get a short OID for a `revision`, usually 7 chars or more if ambiguous.
     pub(crate) fn to_short_id(&self, revision: GitOid) -> Result<String, GitError> {
-        let output = Command::new(GIT.as_ref().map_err(|e| e.clone())?)
-            .arg("rev-parse")
-            .arg("--short")
-            .arg(revision.as_str())
-            .current_dir(&self.repo.path)
-            .output()?;
+        let output = git_output(
+            Command::new(GIT.as_ref().map_err(|e| e.clone())?)
+                .arg("rev-parse")
+                .arg("--short")
+                .arg(revision.as_str())
+                .current_dir(&self.repo.path),
+        )?;
 
         let mut result = String::from_utf8(output.stdout)?;
 
@@ -414,10 +444,11 @@ impl GitRepository {
     /// Opens an existing Git repository at `path`.
     pub(crate) fn open(path: &Path) -> Result<GitRepository, GitError> {
         // Make sure there is a Git repository at the specified path.
-        Command::new(GIT.as_ref().map_err(|e| e.clone())?)
-            .arg("rev-parse")
-            .current_dir(path)
-            .output()?;
+        git_output(
+            Command::new(GIT.as_ref().map_err(|e| e.clone())?)
+                .arg("rev-parse")
+                .current_dir(path),
+        )?;
 
         Ok(GitRepository {
             path: path.to_path_buf(),
@@ -427,10 +458,11 @@ impl GitRepository {
     /// Initializes a Git repository at `path`.
     fn init(path: &Path) -> Result<GitRepository, GitError> {
         // Initialize the repository.
-        Command::new(GIT.as_ref().map_err(|e| e.clone())?)
-            .arg("init")
-            .current_dir(path)
-            .output()?;
+        git_output(
+            Command::new(GIT.as_ref().map_err(|e| e.clone())?)
+                .arg("init")
+                .current_dir(path),
+        )?;
 
         Ok(GitRepository {
             path: path.to_path_buf(),
@@ -439,11 +471,12 @@ impl GitRepository {
 
     /// Parses the object ID of the given `refname`.
     fn rev_parse(&self, refname: &str) -> Result<GitOid, GitError> {
-        let result = Command::new(GIT.as_ref().map_err(|e| e.clone())?)
-            .arg("rev-parse")
-            .arg(refname)
-            .current_dir(&self.path)
-            .output()?;
+        let result = git_output(
+            Command::new(GIT.as_ref().map_err(|e| e.clone())?)
+                .arg("rev-parse")
+                .arg(refname)
+                .current_dir(&self.path),
+        )?;
 
         let mut result = String::from_utf8(result.stdout)?;
 
@@ -522,15 +555,16 @@ impl GitCheckout {
         // Perform a local clone of the repository, which will attempt to use
         // hardlinks to set up the repository. This should speed up the clone operation
         // quite a bit if it works.
-        let output = Command::new(GIT.as_ref().map_err(|e| e.clone())?)
-            .arg("clone")
-            .arg("--local")
-            // Make sure to pass the local file path and not a file://... url. If given a url,
-            // Git treats the repository as a remote origin and gets confused because we don't
-            // have a HEAD checked out.
-            .arg(dunce::simplified(&database.repo.path).display().to_string())
-            .arg(dunce::simplified(into).display().to_string())
-            .output()?;
+        let output = git_output(
+            Command::new(GIT.as_ref().map_err(|e| e.clone())?)
+                .arg("clone")
+                .arg("--local")
+                // Make sure to pass the local file path and not a file://... url. If given a url,
+                // Git treats the repository as a remote origin and gets confused because we don't
+                // have a HEAD checked out.
+                .arg(dunce::simplified(&database.repo.path).display().to_string())
+                .arg(dunce::simplified(into).display().to_string()),
+        )?;
 
         tracing::debug!("output after cloning {:?}", output);
 
@@ -582,7 +616,7 @@ impl GitCheckout {
         if let Some(value) = skip_smudge {
             reset_cmd.env(GIT_LFS_SKIP_SMUDGE, value);
         }
-        reset_cmd.output()?;
+        git_output(&mut reset_cmd)?;
 
         // Update submodules (`git submodule update --recursive`).
         let mut submodule_cmd = Command::new(GIT.as_ref().map_err(|e| e.clone())?);
@@ -595,7 +629,7 @@ impl GitCheckout {
         if let Some(value) = skip_smudge {
             submodule_cmd.env(GIT_LFS_SKIP_SMUDGE, value);
         }
-        submodule_cmd.output().map(drop)?;
+        git_output(&mut submodule_cmd)?;
 
         fs_err::File::create(ok_file)?;
         Ok(())

--- a/crates/pixi_git/src/lib.rs
+++ b/crates/pixi_git/src/lib.rs
@@ -193,6 +193,17 @@ pub enum GitError {
     #[error("failed to fetch {0}: {1}")]
     Fetch(String, String),
 
+    #[error("`git {0}` failed: {1}")]
+    Command(String, String),
+
+    #[error("could not find a branch, tag, or commit named `{reference}` in `{repository}`")]
+    ReferenceNotFound {
+        reference: String,
+        repository: String,
+        #[source]
+        source: Box<GitError>,
+    },
+
     #[error("failed to fetch LFS objects for {0}: {1}")]
     LfsFetch(String, String),
 

--- a/crates/pixi_git/src/sha.rs
+++ b/crates/pixi_git/src/sha.rs
@@ -12,8 +12,6 @@ use std::{
 use thiserror::Error;
 
 /// Unique identity of any Git object (commit, tree, blob, tag).
-///
-/// Note this type does not validate whether the input is a valid hash.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GitOid {
     len: usize,
@@ -33,6 +31,8 @@ pub enum OidParseError {
     TooLong,
     #[error("Object ID cannot be parsed from empty string")]
     Empty,
+    #[error("Object ID can only contain hex characters")]
+    NotHex,
     #[error("Not a valid URL: `{0}`")]
     UrlParse(String),
 }
@@ -47,6 +47,10 @@ impl FromStr for GitOid {
 
         if s.len() > 40 {
             return Err(OidParseError::TooLong);
+        }
+
+        if !s.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(OidParseError::NotHex);
         }
 
         let mut out = [0; 40];
@@ -144,5 +148,10 @@ mod tests {
             GitOid::from_str(&str::repeat("a", 41)),
             Err(OidParseError::TooLong)
         );
+        assert_eq!(
+            GitOid::from_str("origin/v1.0.0^0"),
+            Err(OidParseError::NotHex)
+        );
+        assert_eq!(GitOid::from_str("v1.0.0"), Err(OidParseError::NotHex));
     }
 }

--- a/crates/pixi_git/tests/checkout.rs
+++ b/crates/pixi_git/tests/checkout.rs
@@ -1,0 +1,65 @@
+//! Integration tests for reference resolution in `GitSource::fetch`.
+//! Uses the `minimal-pypi-package` fixture (two commits, tags `v0.1.0`
+//! and `v0.2.0`).
+
+use std::path::Path;
+
+use pixi_git::{
+    GitError, GitUrl,
+    git::GitReference,
+    source::{Fetch, GitSource},
+};
+use pixi_test_utils::GitRepoFixture;
+use rattler_networking::LazyClient;
+use reqwest_middleware::ClientWithMiddleware;
+
+/// LazyClient that panics if HTTP is touched. file:// URLs never trigger it.
+fn panic_client() -> LazyClient {
+    LazyClient::new(|| -> ClientWithMiddleware {
+        panic!("network should not be used in checkout tests")
+    })
+}
+
+/// Fetch the fixture repository at the given `rev` string, as a manifest
+/// `rev = "..."` entry would.
+fn fetch_rev(repo: &GitRepoFixture, cache: &Path, rev: &str) -> Result<Fetch, GitError> {
+    let git_url = GitUrl::try_from(repo.base_url.clone())
+        .unwrap()
+        .with_reference(GitReference::from_rev(rev.to_string()));
+    GitSource::new(git_url, panic_client(), cache).fetch()
+}
+
+/// A `rev` that names a tag resolves to the tag's commit and produces a
+/// populated checkout (#6589). `rev` maps to `BranchOrTag`, so the branch
+/// candidate fails and resolution must fall through to the tag.
+#[test]
+fn rev_naming_a_tag_resolves_to_the_tag_commit() {
+    let repo = GitRepoFixture::new("minimal-pypi-package");
+    let cache = tempfile::tempdir().unwrap();
+
+    let fetch = fetch_rev(&repo, cache.path(), "v0.1.0").expect("fetch should succeed");
+
+    assert_eq!(fetch.commit().to_string(), repo.tag_commit("v0.1.0"));
+    assert!(
+        fetch.path().join("pyproject.toml").is_file(),
+        "checkout at {} should contain the fixture files",
+        fetch.path().display()
+    );
+}
+
+/// A hash-looking `rev` that exists nowhere in the repository fails with an
+/// error naming the rev, instead of returning a broken empty checkout.
+#[test]
+fn rev_that_does_not_exist_errors() {
+    let repo = GitRepoFixture::new("minimal-pypi-package");
+    let cache = tempfile::tempdir().unwrap();
+
+    // Hash-like, so the fetch itself succeeds (all branches and tags) and
+    // only the resolution step can report the failure.
+    let err = fetch_rev(&repo, cache.path(), "deadbeef").expect_err("fetch should fail");
+
+    assert!(
+        err.to_string().contains("deadbeef"),
+        "error should name the unresolved rev, got: {err}"
+    );
+}


### PR DESCRIPTION
`git rev-parse` echoes unresolvable refnames back to stdout, and pixi_git ignored subprocess exit codes, so resolving `rev = "<tag>"` succeeded with the literal string `origin/<tag>^0` instead of falling through to the tag candidate. The bogus object ID then produced an empty short id and a checkout directory without the commit component, which surfaced as "failed to discover a valid project manifest" during solves.

Run every git subprocess through a helper that fails on non-zero exit with stderr in the message, reject non-hex object IDs when parsing, and report an unresolvable rev with a dedicated error naming the reference and the repository.

Fixes #6589 