### PR TITLE
feat: support `workspace = true` in environment dependency tables

### DIFF
--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use indexmap::{IndexMap, IndexSet};
 use miette::IntoDiagnostic;
 use pixi_core::workspace::{
-    Environment, PypiDeps, UpdateDeps, WorkspaceMut, virtual_packages::EnvironmentRunnability,
+    Environment, PypiDeps, SkippedPackage, UpdateDeps, WorkspaceMut,
+    virtual_packages::EnvironmentRunnability,
 };
 use pixi_core::{Workspace, environment::LockFileUsage};
 use pixi_manifest::{
@@ -347,7 +348,7 @@ impl<I: Interface> WorkspaceContext<I> {
         spec_type: SpecType,
         dep_options: DependencyOptions,
         git_options: GitOptions,
-    ) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
+    ) -> miette::Result<(Option<UpdateDeps>, Vec<SkippedPackage>)> {
         Box::pin(crate::workspace::add::add_conda_dep(
             self.workspace_mut()?,
             specs,
@@ -363,7 +364,7 @@ impl<I: Interface> WorkspaceContext<I> {
         pypi_deps: PypiDeps,
         editable: bool,
         options: DependencyOptions,
-    ) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
+    ) -> miette::Result<(Option<UpdateDeps>, Vec<SkippedPackage>)> {
         Box::pin(crate::workspace::add::add_pypi_dep(
             self.workspace_mut()?,
             pypi_deps,

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -2,7 +2,7 @@ use indexmap::IndexMap;
 use miette::IntoDiagnostic;
 use pixi_core::{
     environment::sanity_check_workspace,
-    workspace::{PypiDeps, UpdateDeps, WorkspaceMut},
+    workspace::{PypiDeps, SkippedPackage, UpdateDeps, WorkspaceMut},
 };
 use pixi_manifest::{
     DependencyOverwriteBehavior, FeatureName, HasWorkspaceManifest, KnownPreviewFeature, SpecType,
@@ -22,7 +22,7 @@ pub async fn add_conda_dep(
     spec_type: SpecType,
     dep_options: DependencyOptions,
     git_options: GitOptions,
-) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
+) -> miette::Result<(Option<UpdateDeps>, Vec<SkippedPackage>)> {
     sanity_check_workspace(workspace.workspace()).await?;
 
     // Resolve the requested platforms, accepting bare subdirs as subdir
@@ -123,7 +123,7 @@ pub async fn add_pypi_dep(
     pypi_deps: PypiDeps,
     editable: bool,
     options: DependencyOptions,
-) -> miette::Result<(Option<UpdateDeps>, Vec<String>)> {
+) -> miette::Result<(Option<UpdateDeps>, Vec<SkippedPackage>)> {
     sanity_check_workspace(workspace.workspace()).await?;
 
     // Resolve the requested platforms, accepting bare subdirs as subdir

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -7,7 +7,10 @@ use pixi_api::{
     workspace::{DependencyOptions, GitOptions},
 };
 use pixi_config::ConfigCli;
-use pixi_core::{DependencyType, WorkspaceLocator, workspace::PypiDeps};
+use pixi_core::{
+    DependencyType, WorkspaceLocator,
+    workspace::{PypiDeps, SkippedPackage},
+};
 use pixi_pypi_spec::{PixiPypiSource, PixiPypiSpec, PypiPackageName};
 use url::Url;
 
@@ -178,7 +181,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
 
-    let (update_deps, skipped, parsed_names): (_, Vec<String>, Vec<String>) =
+    let (update_deps, skipped, parsed_names): (_, Vec<SkippedPackage>, Vec<String>) =
         match args.dependency_config.dependency_type() {
             DependencyType::CondaDependency(spec_type) => {
                 let git_options = GitOptions {
@@ -226,20 +229,35 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             }
         };
 
-    let skipped_set: HashSet<&str> = skipped.iter().map(|s| s.as_str()).collect();
+    let skipped_set: HashSet<&str> = skipped.iter().map(|s| s.name.as_str()).collect();
 
     for package in &skipped {
-        eprintln!(
-            "{}{} is already a dependency",
-            console::style(console::Emoji("✔ ", "")).green(),
-            console::style(package).bold(),
-        );
-        eprintln!(
-            "  Run `{}` to get the newest compatible version",
-            console::style(format!("pixi upgrade {package}"))
-                .green()
-                .bold(),
-        );
+        let name = &package.name;
+        if package.inherits_workspace {
+            eprintln!(
+                "{}{} inherits from `[workspace.dependencies]` and was left unchanged",
+                console::style(console::Emoji("✔ ", "")).green(),
+                console::style(name).bold(),
+            );
+            eprintln!(
+                "  Update the `[workspace.dependencies]` entry, or pass an explicit spec like `{}` to replace the inheritance",
+                console::style(format!("pixi add \"{name}==1.0\""))
+                    .green()
+                    .bold(),
+            );
+        } else {
+            eprintln!(
+                "{}{} is already a dependency",
+                console::style(console::Emoji("✔ ", "")).green(),
+                console::style(name).bold(),
+            );
+            eprintln!(
+                "  Run `{}` to get the newest compatible version",
+                console::style(format!("pixi upgrade {name}"))
+                    .green()
+                    .bold(),
+            );
+        }
     }
 
     if let Some(update_deps) = update_deps {

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -145,6 +145,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .into_lock_file_or_empty_with_warning();
 
     let mut printed_any = false;
+    let mut inherited_packages = IndexSet::new();
 
     for (feature_name, specs) in specs_by_feature {
         let SpecsByTarget {
@@ -153,8 +154,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             per_target,
         } = specs;
 
-        if (!default_match_specs.is_empty() || !default_pypi_deps.is_empty())
-            && let (Some(update), _) = workspace
+        if !default_match_specs.is_empty() || !default_pypi_deps.is_empty() {
+            let (update, skipped) = workspace
                 .update_dependencies(
                     default_match_specs,
                     default_pypi_deps,
@@ -167,15 +168,22 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     args.dry_run,
                     DependencyOverwriteBehavior::Overwrite,
                 )
-                .await?
-        {
-            let diff = update.lock_file_diff;
-            if !args.json {
-                diff.print()
-                    .into_diagnostic()
-                    .context("failed to print lock file diff")?;
+                .await?;
+            inherited_packages.extend(
+                skipped
+                    .into_iter()
+                    .filter(|package| package.inherits_workspace)
+                    .map(|package| package.name),
+            );
+            if let Some(update) = update {
+                let diff = update.lock_file_diff;
+                if !args.json {
+                    diff.print()
+                        .into_diagnostic()
+                        .context("failed to print lock file diff")?;
+                }
+                printed_any = true;
             }
-            printed_any = true;
         }
 
         for (target, (target_match_specs, target_pypi_deps)) in per_target {
@@ -183,7 +191,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 continue;
             }
 
-            if let (Some(update), _) = workspace
+            let (update, skipped) = workspace
                 .update_dependencies(
                     target_match_specs,
                     target_pypi_deps,
@@ -196,8 +204,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     args.dry_run,
                     DependencyOverwriteBehavior::Overwrite,
                 )
-                .await?
-            {
+                .await?;
+            inherited_packages.extend(
+                skipped
+                    .into_iter()
+                    .filter(|package| package.inherits_workspace)
+                    .map(|package| package.name),
+            );
+            if let Some(update) = update {
                 let diff = update.lock_file_diff;
                 if !args.json {
                     if printed_any {
@@ -210,6 +224,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 printed_any = true;
             }
         }
+    }
+
+    if !inherited_packages.is_empty() && !args.json {
+        eprintln!(
+            "{}Dependencies inheriting from `[workspace.dependencies]` were left unchanged: {}",
+            console::style(console::Emoji("i ", "i ")).blue(),
+            inherited_packages
+                .iter()
+                .map(|name| console::style(name).bold().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        eprintln!("  Update the corresponding `[workspace.dependencies]` entries to upgrade them");
     }
 
     // If JSON is requested, emit a single combined diff once.

--- a/crates/pixi_core/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@mismatch-exclude-newer.snap.new
+++ b/crates/pixi_core/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@mismatch-exclude-newer.snap.new
@@ -1,0 +1,8 @@
+---
+source: crates/pixi_core/src/lock_file/satisfiability/tests.rs
+assertion_line: 263
+expression: s
+---
+environment 'default' does not satisfy the requirements of the project
+    Diagnostic severity: error
+    Caused by: the locked package 'foobar' has timestamp 2025-11-05T00:00:00Z, which is newer than the environment's exclude-newer cutoff 2025-11-04T00:00:00Z

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -988,6 +988,16 @@ pub struct UpdateDeps {
     pub lock_file_diff: LockFileDiff,
 }
 
+/// A package that `update_dependencies` left untouched in the manifest.
+#[derive(Debug, Clone)]
+pub struct SkippedPackage {
+    /// The normalized package name.
+    pub name: String,
+    /// True when the manifest entry inherits from `[workspace.dependencies]`
+    /// via `{ workspace = true }`.
+    pub inherits_workspace: bool,
+}
+
 impl<'source> HasWorkspaceManifest<'source> for &'source Workspace {
     fn workspace_manifest(&self) -> &'source WorkspaceManifest {
         &self.workspace.value

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -16,10 +16,10 @@ use pixi_command_dispatcher::{MissingChannelError, SolvePixiEnvironmentError::Mi
 use pixi_config::PinningStrategy;
 use pixi_diff::LockFileDiff;
 use pixi_manifest::{
-    DependencyOverwriteBehavior, FeatureName, FeaturesExt, HasFeaturesIter, LoadManifestsError,
-    ManifestDocument, ManifestKind, PixiPlatformName, PypiDependencyLocation, SpecType,
-    TargetSelector, TomlError, WorkspaceManifest, WorkspaceManifestMut, toml::TomlDocument,
-    utils::WithSourceCode,
+    AddDependencyOutcome, DependencyOverwriteBehavior, FeatureName, FeaturesExt, HasFeaturesIter,
+    LoadManifestsError, ManifestDocument, ManifestKind, PixiPlatformName, PypiDependencyLocation,
+    SpecType, TargetSelector, TomlError, WorkspaceManifest, WorkspaceManifestMut,
+    toml::TomlDocument, utils::WithSourceCode,
 };
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 use pixi_spec::PixiSpec;
@@ -32,7 +32,7 @@ use crate::{
     environment::LockFileUsage,
     lock_file::{LockFileDerivedData, ReinstallPackages, UpdateContext, UpdateMode},
     workspace::{
-        MatchSpecs, NON_SEMVER_PACKAGES, PypiDeps, SourceSpecs, UpdateDeps,
+        MatchSpecs, NON_SEMVER_PACKAGES, PypiDeps, SkippedPackage, SourceSpecs, UpdateDeps,
         grouped_environment::GroupedEnvironment,
     },
 };
@@ -266,7 +266,7 @@ impl WorkspaceMut {
         editable: bool,
         dry_run: bool,
         overwrite_behavior: DependencyOverwriteBehavior,
-    ) -> Result<(Option<UpdateDeps>, Vec<String>), miette::Error> {
+    ) -> Result<(Option<UpdateDeps>, Vec<SkippedPackage>), miette::Error> {
         let mut conda_specs_to_add_constraints_for = IndexMap::new();
         let mut pypi_specs_to_add_constraints_for = IndexMap::new();
         let mut conda_packages = HashSet::new();
@@ -278,7 +278,7 @@ impl WorkspaceMut {
             let pixi_spec =
                 PixiSpec::from_nameless_matchspec(nameless_spec.clone(), &channel_config);
 
-            let added = self.manifest().add_dependency(
+            let outcome = self.manifest().add_dependency(
                 &name,
                 &pixi_spec,
                 spec_type,
@@ -286,14 +286,20 @@ impl WorkspaceMut {
                 feature_name,
                 overwrite_behavior,
             )?;
-            if added {
-                if nameless_spec.version.is_none() {
-                    conda_specs_to_add_constraints_for
-                        .insert(name.clone(), (spec_type, nameless_spec));
+            match outcome {
+                AddDependencyOutcome::Added => {
+                    if nameless_spec.version.is_none() {
+                        conda_specs_to_add_constraints_for
+                            .insert(name.clone(), (spec_type, nameless_spec));
+                    }
+                    conda_packages.insert(name);
                 }
-                conda_packages.insert(name);
-            } else {
-                skipped_packages.push(name.as_normalized().to_string());
+                AddDependencyOutcome::AlreadyExists | AddDependencyOutcome::InheritsWorkspace => {
+                    skipped_packages.push(SkippedPackage {
+                        name: name.as_normalized().to_string(),
+                        inherits_workspace: outcome == AddDependencyOutcome::InheritsWorkspace,
+                    });
+                }
             }
         }
 
@@ -326,7 +332,10 @@ impl WorkspaceMut {
                 }
                 pypi_packages.insert(name.as_normalized().clone());
             } else {
-                skipped_packages.push(name.as_normalized().to_string());
+                skipped_packages.push(SkippedPackage {
+                    name: name.as_normalized().to_string(),
+                    inherits_workspace: false,
+                });
             }
         }
 

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -105,6 +105,22 @@ pub enum DependencyOverwriteBehavior {
     Error,
 }
 
+/// Outcome of adding a conda dependency to the manifest.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AddDependencyOutcome {
+    /// At least one of the requested target tables was modified.
+    Added,
+
+    /// Nothing was modified; every requested target already declares the
+    /// dependency and the overwrite behavior kept it.
+    AlreadyExists,
+
+    /// Nothing was modified; the entry inherits from
+    /// `[workspace.dependencies]` via `{ workspace = true }` and the new spec
+    /// carried no explicit constraint that would justify replacing the marker.
+    InheritsWorkspace,
+}
+
 /// Internal behavior for handling duplicate dependencies.
 ///
 /// This enum is used internally by `WorkspaceTarget` and `PackageTarget` for

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -319,6 +319,44 @@ impl ManifestDocument {
         Ok(())
     }
 
+    /// Returns true when the dependency entry in the TOML document inherits
+    /// from `[workspace.dependencies]` via `{ workspace = true }`.
+    pub fn dependency_inherits_workspace(
+        &self,
+        name: &PackageName,
+        spec_type: SpecType,
+        target: Option<&TargetSelector>,
+        feature_name: &FeatureName,
+    ) -> bool {
+        let dependency_table = TableName::new()
+            .with_prefix(self.table_prefix())
+            .with_target(target.cloned())
+            .with_feature_name(Some(feature_name))
+            .with_table(Some(spec_type.name()));
+
+        let mut keys = dependency_table.as_keys().into_iter();
+        let Some(first) = keys.next() else {
+            return false;
+        };
+        let Some(mut item) = self.manifest().as_table().get(first) else {
+            return false;
+        };
+        for key in keys {
+            match item.get(key) {
+                Some(next) => item = next,
+                None => return false,
+            }
+        }
+
+        let Some(key) = existing_conda_key(item, name) else {
+            return false;
+        };
+        item.get(&key)
+            .and_then(|entry| entry.get("workspace"))
+            .and_then(|marker| marker.as_bool())
+            .unwrap_or(false)
+    }
+
     /// Adds a conda dependency to the TOML manifest
     ///
     /// If a dependency with the same name already exists, it will be replaced.

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -17,9 +17,10 @@ use rattler_conda_types::{
 use toml_edit::Value;
 
 use crate::{
-    DependencyOverwriteBehavior, GetFeatureError, PixiPlatform, PixiPlatformName, PlatformEdit,
-    PlatformMove, Preview, PrioritizedChannel, PypiDependencyLocation, SpecType, TargetSelector,
-    Task, TaskName, TomlError, WorkspaceTarget, consts,
+    AddDependencyOutcome, DependencyOverwriteBehavior, GetFeatureError, PixiPlatform,
+    PixiPlatformName, PlatformEdit, PlatformMove, Preview, PrioritizedChannel,
+    PypiDependencyLocation, SpecType, TargetSelector, Task, TaskName, TomlError, WorkspaceTarget,
+    consts,
     environment::{Environment, EnvironmentName},
     environments::Environments,
     error::{DependencyError, UnknownFeature},
@@ -1044,9 +1045,28 @@ impl WorkspaceManifestMut<'_> {
         targets: &[TargetSelector],
         feature_name: &FeatureName,
         overwrite_behavior: DependencyOverwriteBehavior,
-    ) -> miette::Result<bool> {
+    ) -> miette::Result<AddDependencyOutcome> {
         let mut any_added = false;
+        let mut any_inherited = false;
         for target in to_target_options(targets) {
+            // An entry that inherits from `[workspace.dependencies]` stays as
+            // it is unless the new spec pins something down explicitly:
+            // rewriting the marker with a concrete spec would silently
+            // disconnect the entry from the workspace pool. This keeps
+            // `pixi upgrade` and bare `pixi add` from clobbering inherited
+            // entries.
+            if !spec.has_version_spec()
+                && !spec.is_source()
+                && self.document.dependency_inherits_workspace(
+                    name,
+                    spec_type,
+                    target.as_ref(),
+                    feature_name,
+                )
+            {
+                any_inherited = true;
+                continue;
+            }
             match self
                 .workspace
                 .get_or_insert_target_mut(target.as_ref(), Some(feature_name))
@@ -1066,7 +1086,13 @@ impl WorkspaceManifestMut<'_> {
                 Err(e) => return Err(e.into()),
             };
         }
-        Ok(any_added)
+        Ok(if any_added {
+            AddDependencyOutcome::Added
+        } else if any_inherited {
+            AddDependencyOutcome::InheritsWorkspace
+        } else {
+            AddDependencyOutcome::AlreadyExists
+        })
     }
 
     /// Convert a (possibly absent) workspace platform name into the
@@ -4470,6 +4496,84 @@ bar = "*"
         );
 
         assert_snapshot!(manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_add_dependency_preserves_workspace_inherited_entry() {
+        let file_contents = r#"
+[workspace]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[workspace.dependencies]
+numpy = "1.*"
+boltons = ">=24"
+
+[dependencies]
+numpy = { workspace = true }
+boltons = { workspace = true }
+"#;
+        let channel_config = default_channel_config();
+        let mut manifest = parse_pixi_toml(file_contents);
+        let mut manifest = manifest.editable();
+
+        // An unconstrained spec, as written by `pixi upgrade` and a bare
+        // `pixi add`, leaves the inherited entry untouched.
+        let (name, nameless) = MatchSpec::from_str("numpy", Strict)
+            .unwrap()
+            .into_nameless();
+        let spec = PixiSpec::from_nameless_matchspec(nameless, &channel_config);
+        let outcome = manifest
+            .add_dependency(
+                name.as_exact().unwrap(),
+                &spec,
+                SpecType::Run,
+                &[],
+                &FeatureName::DEFAULT,
+                DependencyOverwriteBehavior::Overwrite,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            AddDependencyOutcome::InheritsWorkspace,
+            "inherited entry must be skipped"
+        );
+        assert!(
+            manifest
+                .document
+                .to_string()
+                .contains("numpy = { workspace = true }"),
+            "the workspace marker must remain in the document"
+        );
+
+        // An explicit version constraint replaces the marker.
+        let (name, nameless) = MatchSpec::from_str("boltons ==25.0", Strict)
+            .unwrap()
+            .into_nameless();
+        let spec = PixiSpec::from_nameless_matchspec(nameless, &channel_config);
+        let outcome = manifest
+            .add_dependency(
+                name.as_exact().unwrap(),
+                &spec,
+                SpecType::Run,
+                &[],
+                &FeatureName::DEFAULT,
+                DependencyOverwriteBehavior::Overwrite,
+            )
+            .unwrap();
+        assert_eq!(
+            outcome,
+            AddDependencyOutcome::Added,
+            "an explicit spec must overwrite the marker"
+        );
+        assert!(
+            manifest
+                .document
+                .to_string()
+                .contains(r#"boltons = "==25.0""#),
+            "the marker must be replaced by the concrete spec"
+        );
     }
 
     #[test]

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -1082,8 +1082,8 @@ mod tests {
             DependencyOverwriteBehavior::IgnoreDuplicate,
         );
 
-        // Should return Ok(false) indicating nothing was added
-        assert!(!result.unwrap());
+        // Nothing was added; the existing entry was kept.
+        assert_eq!(result.unwrap(), crate::AddDependencyOutcome::AlreadyExists);
 
         // Verify TOML still has original version
         assert_snapshot!(manifest_mut.document.to_string(), @r###"

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -201,10 +201,25 @@ impl<'de> toml_span::Deserialize<'de> for TomlBuildBackend {
         let spec = match workspace_marker {
             None => BackendSpec::Direct(toml_spec),
             Some(Spanned { value: true, span }) => {
-                if toml_spec.version.is_some() {
+                // The version and the source location stay owned by the
+                // workspace entry; an inherited backend cannot be repointed.
+                let location = toml_spec.location.as_ref();
+                let owned_field = if toml_spec.version.is_some() {
+                    Some("version")
+                } else if location.is_some_and(|loc| loc.path.is_some()) {
+                    Some("path")
+                } else if location.is_some_and(|loc| loc.git.is_some()) {
+                    Some("git")
+                } else if location.is_some_and(|loc| loc.url.is_some()) {
+                    Some("url")
+                } else {
+                    None
+                };
+                if let Some(owned_field) = owned_field {
                     return Err(DeserError::from(toml_span::Error {
                         kind: toml_span::ErrorKind::Custom(
-                            "`version` is mutual exclusive with `workspace`".into(),
+                            format!("`{owned_field}` is mutually exclusive with `workspace`")
+                                .into(),
                         ),
                         span,
                         line_info: None,
@@ -378,6 +393,25 @@ mod test {
             .expect_err("parsing should fail");
 
         format_parse_error(pixi_toml, parse_error)
+    }
+
+    #[test]
+    fn test_inherited_backend_rejects_owned_field_overrides() {
+        // The version and the source location of an inherited backend are
+        // owned by the workspace entry.
+        for (field, spec) in [
+            ("version", r#"version = "1.0""#),
+            ("path", r#"path = "./backend""#),
+            ("git", r#"git = "https://github.com/user/repo.git""#),
+            ("url", r#"url = "https://example.com/backend.conda""#),
+        ] {
+            let toml = format!(r#"backend = {{ name = "foobar", workspace = true, {spec} }}"#);
+            let error = expect_parse_failure(&toml);
+            assert!(
+                error.contains(&format!("`{field}` is mutually exclusive with `workspace`")),
+                "unexpected error for `{field}`: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -14,8 +14,7 @@ use crate::{
         task::TomlTask,
     },
     utils::{
-        PixiSpanned,
-        package_map::{DependencyTable, UniquePackageMap},
+        PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
     },
     warning::Deprecation,
     workspace::{ChannelPriority, SolveStrategy},
@@ -38,7 +37,7 @@ pub struct TomlFeature {
 
     /// Version constraints - limit versions of packages that can be installed
     /// without explicitly requiring them.
-    pub constraints: Option<PixiSpanned<UniquePackageMap>>,
+    pub constraints: Option<PixiSpanned<InheritablePackageMap>>,
 
     /// Additional information to activate an environment.
     pub activation: Option<Activation>,
@@ -66,6 +65,10 @@ impl TomlFeature {
         workspace_package_properties: &WorkspacePackageProperties,
         root_directory: &Path,
     ) -> Result<WithWarnings<(Feature, SystemRequirements)>, TomlError> {
+        // The `[workspace.dependencies]` pool that `{ workspace = true }`
+        // entries in this feature's dependency tables resolve against.
+        let workspace_dependencies = workspace.dependency_pool();
+
         let WithWarnings {
             value: default_target,
             mut warnings,
@@ -84,6 +87,7 @@ impl TomlFeature {
             None,
             preview,
             workspace_package_properties,
+            workspace_dependencies,
             root_directory,
         )?;
 
@@ -144,6 +148,7 @@ impl TomlFeature {
                 Some(selector.value.clone()),
                 preview,
                 workspace_package_properties,
+                workspace_dependencies,
                 root_directory,
             )?;
             targets.insert(selector, target);

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -32,8 +32,7 @@ use crate::{
         environment::TomlEnvironmentList, task::TomlTask,
     },
     utils::{
-        PixiSpanned,
-        package_map::{DependencyTable, UniquePackageMap},
+        PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
     },
     warning::Deprecation,
 };
@@ -53,7 +52,7 @@ pub struct TomlManifest {
 
     /// Version constraints - limit versions of packages that can be installed
     /// without explicitly requiring them.
-    pub constraints: Option<PixiSpanned<UniquePackageMap>>,
+    pub constraints: Option<PixiSpanned<InheritablePackageMap>>,
     pub exclude_newer: Option<PixiSpanned<IndexMap<PackageName, ExcludeNewer>>>,
 
     pub pypi_dependencies: Option<PixiSpanned<IndexMap<PypiPackageName, PixiPypiSpec>>>,
@@ -175,20 +174,14 @@ impl TomlManifest {
         // made absolute here.
         let inline_dependency_pool = workspace
             .value
-            .dependencies
-            .as_ref()
-            .map(|deps| {
-                deps.value
-                    .specs
-                    .iter()
-                    .map(|(name, spec)| {
-                        let mut spec = spec.clone();
-                        spec.absolutize_path(root_directory);
-                        (name.clone(), spec)
-                    })
-                    .collect()
+            .dependency_pool()
+            .iter()
+            .map(|(name, spec)| {
+                let mut spec = spec.clone();
+                spec.absolutize_path(root_directory);
+                (name.clone(), spec)
             })
-            .unwrap_or_default();
+            .collect();
         let inline_workspace_properties = WorkspacePackageProperties {
             name: external.name.clone(),
             version: external.version.clone(),
@@ -203,6 +196,10 @@ impl TomlManifest {
             dependencies: inline_dependency_pool,
             workspace_root: Some(root_directory.to_path_buf()),
         };
+
+        // The `[workspace.dependencies]` pool that `{ workspace = true }`
+        // entries in the root-level dependency tables resolve against.
+        let workspace_dependencies = workspace.value.dependency_pool();
 
         let WithWarnings {
             value: default_workspace_target,
@@ -222,6 +219,7 @@ impl TomlManifest {
             None,
             preview,
             &inline_workspace_properties,
+            workspace_dependencies,
             root_directory,
         )?;
 
@@ -252,6 +250,7 @@ impl TomlManifest {
                 Some(selector.value.clone()),
                 preview,
                 &inline_workspace_properties,
+                workspace_dependencies,
                 root_directory,
             )?;
             workspace_targets.insert(selector, workspace_target);
@@ -2081,6 +2080,373 @@ mod test {
         numpy = { workspace = false }
         "#,
         ));
+    }
+
+    /// Parses a workspace-only manifest and returns the workspace manifest.
+    fn parse_workspace(source: &str) -> WorkspaceManifest {
+        let manifest = <TomlManifest as FromTomlStr>::from_toml_str(source).expect("parse toml");
+        let (ws, _pkg, _warnings) = manifest
+            .into_workspace_manifest(
+                ExternalWorkspaceProperties::default(),
+                PackageDefaults::default(),
+                Path::new(""),
+            )
+            .expect("convert to workspace manifest");
+        ws
+    }
+
+    /// Returns the single run-dependency spec `dependency` of `feature` for
+    /// `platform`.
+    fn feature_run_dependency(
+        ws: &WorkspaceManifest,
+        feature: &FeatureName,
+        platform: Platform,
+        dependency: &str,
+    ) -> pixi_spec::PixiSpec {
+        let platform = PixiPlatform::from_subdir(platform);
+        ws.feature(feature)
+            .expect("feature exists")
+            .dependencies(crate::SpecType::Run, Some(&platform))
+            .expect("dependencies exist")
+            .get(&rattler_conda_types::PackageName::new_unchecked(dependency))
+            .expect("dependency exists")
+            .iter()
+            .next()
+            .expect("spec exists")
+            .clone()
+    }
+
+    #[test]
+    fn test_dependencies_inherit_workspace_dependency() {
+        // `{ workspace = true }` in `[dependencies]` resolves against the
+        // `[workspace.dependencies]` pool without any preview feature.
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [dependencies]
+            numpy = { workspace = true }
+            "#,
+        );
+        let spec = feature_run_dependency(&ws, &FeatureName::default(), Platform::Linux64, "numpy");
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_feature_dependencies_inherit_workspace_dependency() {
+        // The dotted-key shorthand works in feature dependency tables too.
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [feature.dev.dependencies]
+            numpy.workspace = true
+
+            [environments]
+            dev = ["dev"]
+            "#,
+        );
+        let spec =
+            feature_run_dependency(&ws, &FeatureName::from("dev"), Platform::Linux64, "numpy");
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_target_dependencies_inherit_workspace_dependency() {
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [target.linux-64.dependencies]
+            numpy = { workspace = true }
+            "#,
+        );
+        let spec = feature_run_dependency(&ws, &FeatureName::default(), Platform::Linux64, "numpy");
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_dependencies_inherit_with_override() {
+        // Non-version fields layer on top of the inherited workspace entry.
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [dependencies]
+            numpy = { workspace = true, build = "py311*" }
+            "#,
+        );
+        let spec = feature_run_dependency(&ws, &FeatureName::default(), Platform::Linux64, "numpy");
+        match spec {
+            pixi_spec::PixiSpec::DetailedVersion(detailed) => {
+                assert_eq!(detailed.version.as_ref().unwrap().to_string(), "1.*");
+                assert!(detailed.build.is_some(), "build override applied");
+            }
+            other => panic!("expected DetailedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_constraints_inherit_workspace_dependency() {
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [constraints]
+            numpy = { workspace = true }
+            "#,
+        );
+        let spec = ws
+            .default_feature()
+            .targets
+            .default()
+            .constraints
+            .as_ref()
+            .expect("constraints exist")
+            .get(&rattler_conda_types::PackageName::new_unchecked("numpy"))
+            .expect("constraint exists")
+            .iter()
+            .next()
+            .expect("spec exists")
+            .clone();
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_legacy_host_dependencies_inherit_workspace_dependency() {
+        // The legacy workspace-level [host-dependencies] table (only valid
+        // without pixi-build) participates in inheritance as well.
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+
+            [workspace.dependencies]
+            numpy = "1.*"
+
+            [host-dependencies]
+            numpy = { workspace = true }
+            "#,
+        );
+        let spec = ws
+            .default_feature()
+            .targets
+            .default()
+            .dependencies
+            .get(&crate::SpecType::Host)
+            .expect("host bucket")
+            .get(&rattler_conda_types::PackageName::new_unchecked("numpy"))
+            .expect("dependency exists")
+            .iter()
+            .next()
+            .expect("spec exists")
+            .clone();
+        assert_eq!(spec.as_version_spec().unwrap().to_string(), "1.*");
+    }
+
+    #[test]
+    fn test_dependencies_inherited_entry_missing_pool_errors() {
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+        [workspace]
+        channels = []
+        platforms = ['linux-64']
+
+        [dependencies]
+        ghost = { workspace = true }
+        "#,
+            ),
+            @"
+         × the workspace does not define `ghost` in `[workspace.dependencies]`
+          ╭─[pixi.toml:7:31]
+        6 │         [dependencies]
+        7 │         ghost = { workspace = true }
+          ·                               ────
+        8 │
+          ╰────
+         help: Add the package to `[workspace.dependencies]` in the workspace `pixi.toml`.
+        "
+        );
+    }
+
+    #[test]
+    fn test_dependencies_workspace_false_errors() {
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+        [workspace]
+        channels = []
+        platforms = ['linux-64']
+
+        [dependencies]
+        numpy = { workspace = false }
+        "#,
+            ),
+            @"
+         × `workspace` cannot be false
+          ╭─[pixi.toml:7:31]
+        6 │         [dependencies]
+        7 │         numpy = { workspace = false }
+          ·                               ─────
+        8 │
+          ╰────
+         help: Remove the `workspace = false` entry; inheritance from the workspace is opt-in.
+        "
+        );
+    }
+
+    #[test]
+    fn test_dependencies_inherited_entry_cannot_restate_version() {
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+        [workspace]
+        channels = []
+        platforms = ['linux-64']
+
+        [workspace.dependencies]
+        numpy = "1.*"
+
+        [dependencies]
+        numpy = { workspace = true, version = "2.*" }
+        "#,
+            ),
+            @r#"
+         × `version` is mutually exclusive with `workspace`
+           ╭─[pixi.toml:10:37]
+         9 │         [dependencies]
+        10 │         numpy = { workspace = true, version = "2.*" }
+           ·                                     ───────
+        11 │
+           ╰────
+        "#
+        );
+    }
+
+    #[test]
+    fn test_dependencies_inherit_source_with_inline_package() {
+        // The pool provides the source location while the consumer attaches an
+        // inline package definition to the inherited entry.
+        let ws = parse_workspace(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [workspace.dependencies]
+            rust-package = { git = "https://github.com/user/repo.git" }
+
+            [dependencies]
+            rust-package = { workspace = true, package.build.backend = { name = "pixi-build-rust", version = "*" } }
+            "#,
+        );
+        let default_target = ws.default_feature().targets.default();
+        let name = rattler_conda_types::PackageName::new_unchecked("rust-package");
+
+        let spec = default_target
+            .run_dependencies()
+            .and_then(|deps| deps.get(&name))
+            .expect("source spec retained");
+        assert!(spec.iter().all(|s| s.is_source()));
+
+        let inline = default_target
+            .inline_packages
+            .get(&name)
+            .expect("inline package stored")
+            .manifest
+            .clone();
+        assert_eq!(inline.build.backend.name.as_normalized(), "pixi-build-rust");
+    }
+
+    #[test]
+    fn test_inline_package_on_inherited_binary_spec_errors() {
+        // An inline package definition needs a source location; a pool entry
+        // that resolves to a binary spec cannot carry one.
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+        [workspace]
+        channels = []
+        platforms = ['linux-64']
+        preview = ["pixi-build"]
+
+        [workspace.dependencies]
+        numpy = "1.*"
+
+        [dependencies]
+        numpy = { workspace = true, package.build.backend = { name = "pixi-build-rust", version = "*" } }
+        "#,
+            ),
+            @r#"
+         × an inline package definition requires a `git`, `path` or `url` source location
+           ╭─[pixi.toml:11:17]
+        10 │         [dependencies]
+        11 │         numpy = { workspace = true, package.build.backend = { name = "pixi-build-rust", version = "*" } }
+           ·                 ─────────────────────────────────────────────────────────────────────────────────────────
+        12 │
+           ╰────
+        "#
+        );
+    }
+
+    #[test]
+    fn test_dependencies_inherited_source_requires_pixi_build() {
+        // A source entry in the pool requires the pixi-build preview, so it
+        // cannot be smuggled into `[dependencies]` through inheritance.
+        assert_snapshot!(
+            expect_parse_failure(
+                r#"
+        [workspace]
+        channels = []
+        platforms = ['linux-64']
+
+        [workspace.dependencies]
+        mylib = { path = "libs/mylib" }
+
+        [dependencies]
+        mylib = { workspace = true }
+        "#,
+            ),
+            @r#"
+         × conda source dependencies are not allowed without enabling the 'pixi-build' preview feature
+           ╭─[pixi.toml:10:17]
+         9 │         [dependencies]
+        10 │         mylib = { workspace = true }
+           ·                 ──────────┬─────────
+           ·                           ╰── source dependency specified here
+        11 │
+           ╰────
+         help: Add `preview = ["pixi-build"]` to the `workspace` or `project` table of your manifest
+        "#
+        );
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__inherited_entry_cannot_restate_version.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__inherited_entry_cannot_restate_version.snap
@@ -3,7 +3,7 @@ source: crates/pixi_manifest/src/toml/manifest.rs
 assertion_line: 1003
 expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"monorepo\"\n        channels = []\n        platforms = ['linux-64']\n        preview = [\"pixi-build\"]\n\n        [workspace.dependencies]\n        numpy = \"1.*\"\n\n        [package]\n        name = \"lib\"\n        version = \"0.1.0\"\n\n        [package.build]\n        backend = { name = \"foobar\", version = \"*\" }\n\n        [package.host-dependencies]\n        numpy = { workspace = true, version = \"2.0\" }\n        \"#,)"
 ---
-  × `version` is mutual exclusive with `workspace`
+  × `version` is mutually exclusive with `workspace`
     ╭─[pixi.toml:19:37]
  18 │         [package.host-dependencies]
  19 │         numpy = { workspace = true, version = "2.0" }

--- a/crates/pixi_manifest/src/toml/target.rs
+++ b/crates/pixi_manifest/src/toml/target.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use indexmap::IndexMap;
-use pixi_spec::{PixiSpec, TomlLocationSpec};
+use pixi_spec::{PixiSpec, TomlLocationSpec, TomlSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_toml::{TomlHashMap, TomlIndexMap};
 use toml_span::{DeserError, Value, de_helpers::TableHelper};
@@ -20,8 +20,8 @@ use crate::{
         task::TomlTask,
     },
     utils::{
-        PixiSpanned,
-        package_map::{DependencyTable, UniquePackageMap},
+        PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
+        package_map::UniquePackageMap,
     },
 };
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
@@ -37,7 +37,7 @@ pub struct TomlTarget {
 
     /// Version constraints - limit versions of packages that can be installed
     /// without explicitly requiring them.
-    pub constraints: Option<PixiSpanned<UniquePackageMap>>,
+    pub constraints: Option<PixiSpanned<InheritablePackageMap>>,
 
     /// Additional information to activate an environment.
     pub activation: Option<Activation>,
@@ -56,12 +56,15 @@ impl TomlTarget {
     /// target; it is used to resolve and convert any inline package
     /// definitions. `workspace_package_properties` are the consuming workspace's
     /// values that inline package definitions inherit from when they use
-    /// `{ workspace = true }`.
+    /// `{ workspace = true }`. `workspace_dependencies` is the
+    /// `[workspace.dependencies]` pool that `{ workspace = true }` dependency
+    /// entries resolve against.
     pub fn into_workspace_target(
         self,
         target: Option<TargetSelector>,
         preview: &TomlPreview,
         workspace_package_properties: &WorkspacePackageProperties,
+        workspace_dependencies: &IndexMap<PackageName, TomlSpec>,
         root_directory: &Path,
     ) -> Result<WithWarnings<WorkspaceTarget>, TomlError> {
         let pixi_build_enabled = preview.is_enabled(KnownPreviewFeature::PixiBuild);
@@ -105,12 +108,28 @@ impl TomlTarget {
             }
         }
 
-        // Peel inline package definitions off each consumer dependency table,
-        // leaving the source specs to flow into the regular dependency map.
+        // Peel inline package definitions off each consumer dependency table
+        // and resolve `{ workspace = true }` entries against the workspace
+        // pool, leaving plain specs to flow into the regular dependency map.
         let mut inline_toml: IndexMap<PackageName, PixiSpanned<TomlPackage>> = IndexMap::new();
-        let dependencies = split_inline_packages(dependencies, &mut inline_toml)?;
-        let host_dependencies = split_inline_packages(host_dependencies, &mut inline_toml)?;
-        let build_dependencies = split_inline_packages(build_dependencies, &mut inline_toml)?;
+        let dependencies = resolve_dependency_table(
+            dependencies,
+            &mut inline_toml,
+            workspace_dependencies,
+            pixi_build_enabled,
+        )?;
+        let host_dependencies = resolve_dependency_table(
+            host_dependencies,
+            &mut inline_toml,
+            workspace_dependencies,
+            pixi_build_enabled,
+        )?;
+        let build_dependencies = resolve_dependency_table(
+            build_dependencies,
+            &mut inline_toml,
+            workspace_dependencies,
+            pixi_build_enabled,
+        )?;
 
         // Convert the inline package definitions into full package manifests.
         // Their build source is taken from the surrounding dependency spec, so
@@ -173,24 +192,27 @@ impl TomlTarget {
                 )))
             })?;
 
-        // Convert constraints from UniquePackageMap to DependencyMap.
-        // Source specs are never valid in [constraints], regardless of pixi-build mode.
+        // Resolve constraints against the workspace pool and convert them to a
+        // DependencyMap. Source specs are never valid in [constraints],
+        // regardless of pixi-build mode, so resolution skips the preview gate
+        // and the constraint-specific check below rejects them instead.
         let constraints = constraints
             .map(|c| {
-                if let Some((name, _)) = c.value.specs.iter().find(|(_, spec)| spec.is_source()) {
+                let resolved = c.value.resolve(workspace_dependencies, true)?;
+                if let Some((name, _)) = resolved.specs.iter().find(|(_, spec)| spec.is_source()) {
                     return Err(TomlError::Generic(
                         GenericError::new(format!(
                             "source specifications are not supported in `[constraints]`, but '{}' is a source specification",
                             name.as_source()
                         ))
-                        .with_opt_span(c.value.value_spans.get(name).cloned())
+                        .with_opt_span(resolved.value_spans.get(name).cloned())
                         .with_span_label("source specification specified here")
                         .with_help(
                             "constraints only apply to packages resolved from channels, not source packages",
                         ),
                     ));
                 }
-                c.value
+                resolved
                     .into_inner(pixi_build_enabled)
                     .map(|index_map| index_map.into_iter().collect())
             })
@@ -224,12 +246,16 @@ impl TomlTarget {
     }
 }
 
-/// Splits a consumer dependency table into its source specs and inline package
-/// definitions, draining the latter into `inline`. Errors if a package name
-/// already has an inline definition in another table.
-fn split_inline_packages(
+/// Resolves a consumer dependency table against the workspace pool and drains
+/// its inline package definitions into `inline`. Errors if a package name
+/// already has an inline definition in another table, or if an inline
+/// definition is attached to an inherited entry that resolves to a binary
+/// spec.
+fn resolve_dependency_table(
     table: Option<PixiSpanned<DependencyTable>>,
     inline: &mut IndexMap<PackageName, PixiSpanned<TomlPackage>>,
+    workspace_dependencies: &IndexMap<PackageName, TomlSpec>,
+    pixi_build_enabled: bool,
 ) -> Result<Option<PixiSpanned<UniquePackageMap>>, TomlError> {
     let Some(PixiSpanned { span, value }) = table else {
         return Ok(None);
@@ -238,7 +264,22 @@ fn split_inline_packages(
         specs,
         inline_packages,
     } = value;
+    let resolved = specs.resolve(workspace_dependencies, pixi_build_enabled)?;
     for (name, package) in inline_packages {
+        // Direct specs were already validated at parse time; this catches
+        // inherited entries whose pool spec is not a source location.
+        if resolved
+            .specs
+            .get(&name)
+            .is_some_and(|spec| !spec.is_source())
+        {
+            return Err(TomlError::Generic(
+                GenericError::new(
+                    "an inline package definition requires a `git`, `path` or `url` source location",
+                )
+                .with_opt_span(resolved.value_spans.get(&name).cloned()),
+            ));
+        }
         if inline.insert(name.clone(), package).is_some() {
             return Err(TomlError::Generic(GenericError::new(format!(
                 "the package '{}' has more than one inline definition",
@@ -246,7 +287,10 @@ fn split_inline_packages(
             ))));
         }
     }
-    Ok(Some(PixiSpanned { span, value: specs }))
+    Ok(Some(PixiSpanned {
+        span,
+        value: resolved,
+    }))
 }
 
 /// Combines different target dependencies into a single map.

--- a/crates/pixi_manifest/src/toml/workspace.rs
+++ b/crates/pixi_manifest/src/toml/workspace.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::LazyLock,
 };
 
 use indexmap::{IndexMap, IndexSet};
@@ -127,6 +128,15 @@ pub struct TomlWorkspace {
 }
 
 impl TomlWorkspace {
+    /// The `[workspace.dependencies]` pool that `{ workspace = true }`
+    /// entries resolve against. An absent table acts as an empty pool.
+    pub fn dependency_pool(&self) -> &IndexMap<PackageName, TomlSpec> {
+        static EMPTY: LazyLock<IndexMap<PackageName, TomlSpec>> = LazyLock::new(IndexMap::new);
+        self.dependencies
+            .as_ref()
+            .map_or(&EMPTY, |deps| &deps.value.specs)
+    }
+
     /// Converts the TOML representation of the workspace section to the actual
     /// workspace.
     ///

--- a/crates/pixi_manifest/src/utils/inheritable_package_map.rs
+++ b/crates/pixi_manifest/src/utils/inheritable_package_map.rs
@@ -18,12 +18,14 @@ use crate::{
     utils::package_map::UniquePackageMap,
 };
 
-/// Entry in a `[package.*-dependencies]` table that may inherit from
+/// Entry in a dependency table that may inherit from
 /// `[workspace.dependencies]`.
 #[derive(Debug)]
 pub enum InheritableSpec {
     Direct(PixiSpec),
-    /// Inherited from the workspace pool. `overrides.version` is always `None`.
+    /// Inherited from the workspace pool. The overrides never carry a
+    /// `version` or a source location (`path`, `git`, `url`); those fields
+    /// are owned by the workspace entry.
     Inherited {
         marker_span: Range<usize>,
         overrides: Box<TomlSpec>,
@@ -46,6 +48,40 @@ pub struct InheritablePackageMap {
 impl InheritablePackageMap {
     pub fn is_empty(&self) -> bool {
         self.specs.is_empty()
+    }
+
+    /// Convert into a plain [`UniquePackageMap`], rejecting any entry that
+    /// declares workspace inheritance. Used by tables that never resolve
+    /// against a `[workspace.dependencies]` pool.
+    pub fn into_direct(self) -> Result<UniquePackageMap, DeserError> {
+        let mut out = UniquePackageMap::default();
+        for (name, spec) in self.specs {
+            let spec = match spec {
+                InheritableSpec::Direct(spec) => spec,
+                InheritableSpec::Inherited { marker_span, .. }
+                | InheritableSpec::NotWorkspace { marker_span } => {
+                    return Err(toml_span::Error {
+                        kind: toml_span::ErrorKind::Custom(
+                            "`workspace` inheritance is not supported in this table".into(),
+                        ),
+                        span: Span {
+                            start: marker_span.start,
+                            end: marker_span.end,
+                        },
+                        line_info: None,
+                    }
+                    .into());
+                }
+            };
+            if let Some(span) = self.name_spans.get(&name) {
+                out.name_spans.insert(name.clone(), span.clone());
+            }
+            if let Some(span) = self.value_spans.get(&name) {
+                out.value_spans.insert(name.clone(), span.clone());
+            }
+            out.specs.insert(name, spec);
+        }
+        Ok(out)
     }
 
     /// Resolve every entry against the pool. Source specs require the
@@ -317,7 +353,9 @@ impl<'de> toml_span::Deserialize<'de> for ConditionalInheritablePackageMap {
     }
 }
 
-fn parse_inheritable_entry(value: &mut Value<'_>) -> Result<InheritableSpec, DeserError> {
+pub(crate) fn parse_inheritable_entry(
+    value: &mut Value<'_>,
+) -> Result<InheritableSpec, DeserError> {
     let outer_span = value.span;
     match value.take() {
         ValueInner::String(s) => {
@@ -365,30 +403,29 @@ fn parse_workspace_marker<'de>(
         });
     }
 
-    // workspace = true: remaining keys are TomlSpec overrides; `version` is rejected.
-    let version_key_span = remaining
-        .iter()
-        .find(|(k, _)| k.name == "version")
-        .map(|(k, _)| k.span);
+    // workspace = true: remaining keys are TomlSpec overrides. The fields
+    // that identify the dependency stay owned by the workspace entry: the
+    // version and the source location. Rejecting them keeps an inherited
+    // entry from being silently repointed at a different version or source.
+    for owned_field in ["version", "path", "git", "url"] {
+        if let Some((key, _)) = remaining.iter().find(|(k, _)| k.name == owned_field) {
+            return Err(toml_span::Error {
+                kind: toml_span::ErrorKind::Custom(
+                    format!("`{owned_field}` is mutually exclusive with `workspace`").into(),
+                ),
+                span: key.span,
+                line_info: None,
+            }
+            .into());
+        }
+    }
 
-    let mut overrides = if remaining.is_empty() {
+    let overrides = if remaining.is_empty() {
         TomlSpec::empty()
     } else {
         let mut tmp = Value::with_span(ValueInner::Table(remaining), outer_span);
         <TomlSpec as toml_span::Deserialize>::deserialize(&mut tmp)?
     };
-
-    if overrides.version.is_some() {
-        return Err(toml_span::Error {
-            kind: toml_span::ErrorKind::Custom(
-                "`version` is mutual exclusive with `workspace`".into(),
-            ),
-            span: version_key_span.unwrap_or(marker_span),
-            line_info: None,
-        }
-        .into());
-    }
-    overrides.version = None;
 
     Ok(InheritableSpec::Inherited {
         marker_span: marker_span.start..marker_span.end,
@@ -483,6 +520,30 @@ mod test {
             msg.contains("version") && msg.contains("workspace"),
             "unexpected error: {msg}",
         );
+    }
+
+    #[test]
+    fn rejects_source_location_overrides_on_inherited_entry() {
+        // The source location is owned by the workspace entry; an inherited
+        // entry cannot be repointed at a different path, git repo or url.
+        for (field, input) in [
+            ("path", r#"mylib = { workspace = true, path = "./lib" }"#),
+            (
+                "git",
+                r#"mylib = { workspace = true, git = "https://github.com/user/repo.git" }"#,
+            ),
+            (
+                "url",
+                r#"mylib = { workspace = true, url = "https://example.com/pkg.conda" }"#,
+            ),
+        ] {
+            let err = InheritablePackageMap::from_toml_str(input).expect_err("must reject");
+            let msg = format!("{:?}", err);
+            assert!(
+                msg.contains(field) && msg.contains("workspace"),
+                "unexpected error for `{field}`: {msg}",
+            );
+        }
     }
 
     #[test]

--- a/crates/pixi_manifest/src/utils/package_map.rs
+++ b/crates/pixi_manifest/src/utils/package_map.rs
@@ -14,7 +14,17 @@ use toml_span::{
     value::ValueInner,
 };
 
-use crate::{TomlError, error::GenericError, toml::TomlPackage, utils::PixiSpanned};
+use crate::{
+    TomlError,
+    error::GenericError,
+    toml::TomlPackage,
+    utils::{
+        PixiSpanned,
+        inheritable_package_map::{
+            InheritablePackageMap, InheritableSpec, parse_inheritable_entry,
+        },
+    },
+};
 
 #[derive(Clone, Default, Debug, Serialize)]
 pub struct UniquePackageMap {
@@ -168,7 +178,9 @@ impl<'de> DeserializeSeed<'de> for PackageMap<'_> {
 
 impl<'de> toml_span::Deserialize<'de> for UniquePackageMap {
     fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
-        Ok(deserialize_dependency_table(value, InlinePackages::Deny)?.specs)
+        deserialize_dependency_table(value, InlinePackages::Deny)?
+            .specs
+            .into_direct()
     }
 }
 
@@ -181,19 +193,20 @@ enum InlinePackages {
     Deny,
 }
 
-/// A dependency table that may carry inline package definitions.
+/// A dependency table that may carry inline package definitions and
+/// `{ workspace = true }` inheritance markers.
 ///
-/// Behaves like a [`UniquePackageMap`] but additionally captures any inline
-/// package definitions (`package = { ... }`) attached to individual dependency
-/// specs. An inline definition describes a conda source dependency's package,
-/// so it is only accepted next to a `git`, `path` or `url` source. The conda
-/// dependency tables (`[dependencies]`, `[host-dependencies]`,
-/// `[build-dependencies]`) use this type because that is where source
-/// dependencies may appear.
+/// Behaves like an [`InheritablePackageMap`] but additionally captures any
+/// inline package definitions (`package = { ... }`) attached to individual
+/// dependency specs. An inline definition describes a conda source
+/// dependency's package, so it is only accepted next to a `git`, `path` or
+/// `url` source. The conda dependency tables (`[dependencies]`,
+/// `[host-dependencies]`, `[build-dependencies]`) use this type because that
+/// is where source dependencies may appear.
 #[derive(Default, Debug)]
 pub struct DependencyTable {
     /// The dependency specs with any inline `package` keys peeled off.
-    pub specs: UniquePackageMap,
+    pub specs: InheritablePackageMap,
 
     /// Inline `package` tables keyed by dependency name. Each is the parsed
     /// `package = { ... }` sub-table of the matching source spec.
@@ -210,8 +223,8 @@ impl<'de> toml_span::Deserialize<'de> for DependencyTable {
 /// optionally peeling inline package definitions off each value.
 ///
 /// When `inline` is [`InlinePackages::Allow`], a `package` sub-table is removed
-/// from each value before the remaining keys are parsed as a [`PixiSpec`], and
-/// the parsed [`TomlPackage`] is collected into
+/// from each value before the remaining keys are parsed as an
+/// [`InheritableSpec`], and the parsed [`TomlPackage`] is collected into
 /// [`DependencyTable::inline_packages`] keyed by the same dependency name. When
 /// it is [`InlinePackages::Deny`] the value is parsed verbatim, leaving any
 /// `package` key to be rejected by the spec parser, and the returned
@@ -226,7 +239,7 @@ fn deserialize_dependency_table<'de>(
     };
 
     let mut errors = DeserError { errors: vec![] };
-    let mut result = UniquePackageMap::default();
+    let mut result = InheritablePackageMap::default();
     let mut inline_packages = IndexMap::new();
     for (key, mut value) in table.into_iter().sorted_by_key(|(k, _)| k.span.start) {
         let name = match PackageName::from_str(&key.name) {
@@ -272,7 +285,7 @@ fn deserialize_dependency_table<'de>(
             InlinePackages::Deny => None,
         };
 
-        let spec: Option<PixiSpec> = match toml_span::Deserialize::deserialize(&mut value) {
+        let spec: Option<InheritableSpec> = match parse_inheritable_entry(&mut value) {
             Ok(spec) => Some(spec),
             Err(e) => {
                 errors.merge(e);
@@ -281,9 +294,11 @@ fn deserialize_dependency_table<'de>(
         };
 
         // An inline package definition describes how to build source code, so
-        // the surrounding spec must point at a git, path or url source.
+        // the surrounding spec must point at a git, path or url source. For an
+        // inherited entry the spec is only known after resolving against the
+        // workspace pool, so the check happens at resolve time instead.
         if inline_package.is_some()
-            && let Some(spec) = spec.as_ref()
+            && let Some(InheritableSpec::Direct(spec)) = spec.as_ref()
             && !spec.is_source()
         {
             errors.errors.push(toml_span::Error {
@@ -409,7 +424,10 @@ mod test {
 
         let name = PackageName::from_str("rust-package").unwrap();
         let spec = table.specs.specs.get(&name).expect("spec retained");
-        assert!(spec.is_source(), "the spec should remain a source spec");
+        assert!(
+            matches!(spec, InheritableSpec::Direct(spec) if spec.is_source()),
+            "the spec should remain a source spec"
+        );
 
         let inline = table
             .inline_packages

--- a/docs/build/workspace_dependencies.md
+++ b/docs/build/workspace_dependencies.md
@@ -3,19 +3,14 @@ the build backend, the language runtime, common libraries, sibling packages
 referenced by relative path.
 Bumping such a version requires editing every package's `pixi.toml`, and the
 files drift out of sync when someone forgets one.
+The same applies within a single workspace manifest, where several features and targets often pin the same package.
 
-`[workspace.dependencies]` solves this by letting the workspace declare a pool
-of dependency specs that packages opt into per entry.
+`[workspace.dependencies]` solves this by letting the workspace declare a pool of dependency specs that dependency tables opt into per entry.
 
-!!! warning
-    `[workspace.dependencies]` is part of the `pixi-build` preview and applies
-    **only to package dependencies** (`[package.*-dependencies]`,
-    `[package.run-constraints]` and `[package.build.backend]`, including their
-    `"if(<expression>)"` conditional sub-tables).
-    The workspace-level environment tables (`[dependencies]`,
-    `[host-dependencies]`, `[build-dependencies]`, `[pypi-dependencies]`,
-    `[constraints]`) do **not** participate; entries there continue to be
-    declared directly.
+!!! note
+    `{ workspace = true }` works out of the box in the workspace's environment tables (`[dependencies]`, `[constraints]`, their `[feature.*]` and `[target.*]` variants, and the legacy `[host-dependencies]` and `[build-dependencies]` tables).
+    The package tables (`[package.*-dependencies]`, `[package.run-constraints]` and `[package.build.backend]`, including their `"if(<expression>)"` conditional sub-tables) require the `pixi-build` preview, as do source (`path`/`git`) entries in the pool itself.
+    `[pypi-dependencies]` does **not** participate; entries there continue to be declared directly.
 
 ## Defining common dependencies
 
@@ -35,6 +30,24 @@ pixi-build-cmake = "0.3.*"
 boltons = { version = ">=24", channel = "conda-forge" }
 shared-lib = { path = "packages/shared-lib" }
 ```
+
+## Using a workspace dependency in an environment
+
+Any environment dependency table can opt in per entry, so a version shared by several features or targets is declared once:
+
+```toml title="pixi.toml (workspace root)"
+[dependencies]
+numpy = { workspace = true }
+
+[feature.dev.dependencies]
+numpy = { workspace = true }
+
+[target.linux-64.constraints]
+boltons = { workspace = true }
+```
+
+`pixi upgrade` leaves inherited entries unchanged and points at the `[workspace.dependencies]` entry instead.
+`pixi add` only replaces the marker when an explicit spec is given (e.g. `pixi add "numpy==2.1"`).
 
 Relative `path` specs are resolved against the workspace manifest's directory
 and re-anchored automatically when handed to a package in a different
@@ -74,18 +87,21 @@ The inheritance marker is recognized in every package dependency table:
 - `"if(<expression>)"` conditional sub-tables of the above
 - `[package.build.backend]` (the lookup key is the backend's `name`)
 
-## Layering package overrides
+## Layering overrides
 
-A package can add fields alongside `workspace = true` to override or extend
-the workspace entry. Any field on a
-[conda spec table](../reference/pixi_manifest.md#dependencies) may be
-overridden, **except `version`**, which is mutually exclusive with
-`workspace`; if the package needs a different version, drop the inheritance
-marker and write a direct spec. When both sides set the same field, the
-package's value wins.
+A consuming table can add fields alongside `workspace = true` to override or extend the workspace entry.
+Any field on a [conda spec table](../reference/pixi_manifest.md#dependencies) may be overridden, **except `version` and the source location fields `path`, `git` and `url`**, which are mutually exclusive with `workspace`; if the consumer needs a different version or source, drop the inheritance marker and write a direct spec.
+When both sides set the same field, the consumer's value wins.
 
 ```toml
 [package.host-dependencies]
 # Use the workspace's numpy version, but pin a specific build string here.
+numpy = { workspace = true, build = "py311*" }
+```
+
+The same layering applies in the environment tables:
+
+```toml
+[feature.py311.dependencies]
 numpy = { workspace = true, build = "py311*" }
 ```

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -526,17 +526,10 @@ Otherwise, it will use `rattler-build`'s syntax as outlined in the [rattler-buil
 
 ### `dependencies` (optional)
 
-!!! warning "Preview Feature"
-    `[workspace.dependencies]` requires the `pixi-build` preview feature to be
-    enabled and only applies to **package** dependencies (see
-    [Workspace Dependencies](../build/workspace_dependencies.md) for the
-    semantics, override rules and error cases).
-
-A pool of conda dependency specs that members of the workspace can inherit
-per entry by writing `{ workspace = true }` in any of their
-`[package.*-dependencies]` tables or `[package.build.backend]`.
-Relative `path` specs are resolved against the workspace manifest's
-directory and re-anchored per consuming member.
+A pool of conda dependency specs that dependency tables can inherit from per entry by writing `{ workspace = true }`.
+The environment tables (`[dependencies]`, `[feature.*.dependencies]`, `[target.*.dependencies]`, `[constraints]`) can inherit out of the box.
+The package tables (`[package.*-dependencies]`, `[package.run-constraints]`, `[package.build.backend]`) require the `pixi-build` preview feature, as do source (`path`/`git`) entries in the pool itself (see [Workspace Dependencies](../build/workspace_dependencies.md) for the semantics, override rules and error cases).
+Relative `path` specs are resolved against the workspace manifest's directory and re-anchored per consuming member.
 
 ```toml
 [workspace.dependencies]
@@ -835,6 +828,18 @@ Dependencies can also be defined as a mapping where it is using a matchspec
 package0 = { version = ">=1.2.3", channel="conda-forge" }
 package1 = { version = ">=1.2.3", build="py34_0" }
 ```
+
+An entry can also inherit its spec from the [`[workspace.dependencies]`](#dependencies-optional) pool by writing `{ workspace = true }` instead of a direct spec:
+
+```toml
+[workspace.dependencies]
+numpy = "1.*"
+
+[dependencies]
+numpy = { workspace = true }
+```
+
+See [Workspace Dependencies](../build/workspace_dependencies.md) for the override layering and error rules.
 
 !!! tip
     The dependencies can be easily added using the `pixi add` command line.

--- a/schema/model.py
+++ b/schema/model.py
@@ -527,17 +527,17 @@ class InheritableMatchspecTable(MatchspecTable):
     """A spec that may inherit from `[workspace.dependencies]`.
 
     Setting `workspace = true` pulls the version (and any other unset fields)
-    from the matching `[workspace.dependencies]` entry. Members may layer any
-    non-version attribute on top; restating `version` alongside `workspace =
-    true` is an error.
+    from the matching `[workspace.dependencies]` entry. Members may layer
+    further attributes on top; restating `version` or the source location
+    (`path`, `git`, `url`) alongside `workspace = true` is an error.
     """
 
     workspace: Literal[True] | None = Field(
         None,
         description=(
             "Inherit this spec from `[workspace.dependencies]`. Other fields on "
-            "this table layer on top of the workspace base; `version` is "
-            "mutually exclusive with `workspace`."
+            "this table layer on top of the workspace base; `version`, `path`, "
+            "`git` and `url` are mutually exclusive with `workspace`."
         ),
     )
 
@@ -859,10 +859,10 @@ class WorkspaceTarget(StrictBaseModel):
 class Target(StrictBaseModel):
     """A machine-specific configuration of dependencies and tasks"""
 
-    dependencies: Dependencies = DependenciesField
-    host_dependencies: Dependencies = HostDependenciesField
-    build_dependencies: Dependencies = BuildDependenciesField
-    constraints: Dependencies = ConstraintsField
+    dependencies: InheritableDependencies = DependenciesField
+    host_dependencies: InheritableDependencies = HostDependenciesField
+    build_dependencies: InheritableDependencies = BuildDependenciesField
+    constraints: InheritableDependencies = ConstraintsField
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
         None, description="The PyPI dependencies for this target"
     )
@@ -907,10 +907,10 @@ class Feature(StrictBaseModel):
         None,
         description="The platforms that the feature supports: a union of all features combined in one environment is used for the environment. Each entry is either a conda subdir or the name of a workspace platform.",
     )
-    dependencies: Dependencies = DependenciesField
-    host_dependencies: Dependencies = HostDependenciesField
-    build_dependencies: Dependencies = BuildDependenciesField
-    constraints: Dependencies = ConstraintsField
+    dependencies: InheritableDependencies = DependenciesField
+    host_dependencies: InheritableDependencies = HostDependenciesField
+    build_dependencies: InheritableDependencies = BuildDependenciesField
+    constraints: InheritableDependencies = ConstraintsField
     pypi_dependencies: dict[PyPIPackageName, PyPIRequirement] | None = Field(
         None, description="The PyPI dependencies of this feature"
     )
@@ -1192,8 +1192,8 @@ class BuildBackend(BinaryMatchspecTable):
         None,
         description=(
             "Inherit the backend version from `[workspace.dependencies]` using "
-            "`name` as the lookup key. `version` is mutually exclusive with "
-            "`workspace`."
+            "`name` as the lookup key. `version`, `path`, `git` and `url` are "
+            "mutually exclusive with `workspace`."
         ),
     )
 
@@ -1207,10 +1207,10 @@ class BaseManifest(BaseModel):
     workspace: Workspace | None = Field(None, description="The workspace's metadata information")
     project: Workspace | None = Field(None, description="The project's metadata information")
     package: Package | None = Field(None, description="The package's metadata information")
-    dependencies: Dependencies = DependenciesField
-    host_dependencies: Dependencies = HostDependenciesField
-    build_dependencies: Dependencies = BuildDependenciesField
-    constraints: Dependencies = ConstraintsField
+    dependencies: InheritableDependencies = DependenciesField
+    host_dependencies: InheritableDependencies = HostDependenciesField
+    build_dependencies: InheritableDependencies = BuildDependenciesField
+    constraints: InheritableDependencies = ConstraintsField
     exclude_newer: dict[CondaPackageName, ExcludeNewer] | None = Field(
         None,
         description="Workspace-wide per-package `exclude-newer` overrides for conda packages",

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -20,7 +20,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -39,7 +39,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -58,7 +58,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -132,7 +132,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -591,7 +591,7 @@
         },
         "workspace": {
           "title": "Workspace",
-          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version` is mutually exclusive with `workspace`.",
+          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version`, `path`, `git` and `url` are mutually exclusive with `workspace`.",
           "type": "boolean",
           "const": true
         }
@@ -849,7 +849,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -897,7 +897,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -916,7 +916,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -946,7 +946,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1113,7 +1113,7 @@
     },
     "InheritableMatchspecTable": {
       "title": "InheritableMatchspecTable",
-      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer any\nnon-version attribute on top; restating `version` alongside `workspace =\ntrue` is an error.",
+      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer\nfurther attributes on top; restating `version` or the source location\n(`path`, `git`, `url`) alongside `workspace = true` is an error.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -1285,7 +1285,7 @@
         },
         "workspace": {
           "title": "Workspace",
-          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version` is mutually exclusive with `workspace`.",
+          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version`, `path`, `git` and `url` are mutually exclusive with `workspace`.",
           "type": "boolean",
           "const": true
         }
@@ -2547,7 +2547,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2566,7 +2566,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2585,7 +2585,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2615,7 +2615,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -334,7 +334,7 @@
         },
         "workspace": {
           "title": "Workspace",
-          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version` is mutually exclusive with `workspace`.",
+          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version`, `path`, `git` and `url` are mutually exclusive with `workspace`.",
           "type": "boolean",
           "const": true
         }
@@ -592,7 +592,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -640,7 +640,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -659,7 +659,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -689,7 +689,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -856,7 +856,7 @@
     },
     "InheritableMatchspecTable": {
       "title": "InheritableMatchspecTable",
-      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer any\nnon-version attribute on top; restating `version` alongside `workspace =\ntrue` is an error.",
+      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer\nfurther attributes on top; restating `version` or the source location\n(`path`, `git`, `url`) alongside `workspace = true` is an error.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -1028,7 +1028,7 @@
         },
         "workspace": {
           "title": "Workspace",
-          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version` is mutually exclusive with `workspace`.",
+          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version`, `path`, `git` and `url` are mutually exclusive with `workspace`.",
           "type": "boolean",
           "const": true
         }
@@ -2050,7 +2050,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2069,7 +2069,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2088,7 +2088,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2162,7 +2162,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2585,7 +2585,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2604,7 +2604,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2623,7 +2623,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2653,7 +2653,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -28,7 +28,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -47,7 +47,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -66,7 +66,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -140,7 +140,7 @@
             "minLength": 1
           },
           {
-            "$ref": "#/$defs/MatchspecTable"
+            "$ref": "#/$defs/InheritableMatchspecTable"
           }
         ]
       },
@@ -615,7 +615,7 @@
         },
         "workspace": {
           "title": "Workspace",
-          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version` is mutually exclusive with `workspace`.",
+          "description": "Inherit the backend version from `[workspace.dependencies]` using `name` as the lookup key. `version`, `path`, `git` and `url` are mutually exclusive with `workspace`.",
           "type": "boolean",
           "const": true
         }
@@ -873,7 +873,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -921,7 +921,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -940,7 +940,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -970,7 +970,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -1137,7 +1137,7 @@
     },
     "InheritableMatchspecTable": {
       "title": "InheritableMatchspecTable",
-      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer any\nnon-version attribute on top; restating `version` alongside `workspace =\ntrue` is an error.",
+      "description": "A spec that may inherit from `[workspace.dependencies]`.\n\nSetting `workspace = true` pulls the version (and any other unset fields)\nfrom the matching `[workspace.dependencies]` entry. Members may layer\nfurther attributes on top; restating `version` or the source location\n(`path`, `git`, `url`) alongside `workspace = true` is an error.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -1309,7 +1309,7 @@
         },
         "workspace": {
           "title": "Workspace",
-          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version` is mutually exclusive with `workspace`.",
+          "description": "Inherit this spec from `[workspace.dependencies]`. Other fields on this table layer on top of the workspace base; `version`, `path`, `git` and `url` are mutually exclusive with `workspace`.",
           "type": "boolean",
           "const": true
         }
@@ -2571,7 +2571,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2590,7 +2590,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2609,7 +2609,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },
@@ -2639,7 +2639,7 @@
                 "minLength": 1
               },
               {
-                "$ref": "#/$defs/MatchspecTable"
+                "$ref": "#/$defs/InheritableMatchspecTable"
               }
             ]
           },

--- a/tests/integration_python/test_upgrade.py
+++ b/tests/integration_python/test_upgrade.py
@@ -79,6 +79,36 @@ def test_upgrade_conda_package(
     assert "build-number" not in package
 
 
+def test_upgrade_keeps_workspace_inherited_dependency(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        f"""
+[workspace]
+name = "test-upgrade"
+channels = ["{multiple_versions_channel_1}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[workspace.dependencies]
+package = "==0.1.0"
+
+[dependencies]
+package = {{ workspace = true }}
+"""
+    )
+
+    # The inherited entry is skipped and reported instead of being replaced
+    # with a concrete spec.
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest_path],
+        stderr_contains=["[workspace.dependencies]", "package"],
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["dependencies"]["package"] == {"workspace": True}
+    assert parsed_manifest["workspace"]["dependencies"]["package"] == "==0.1.0"
+
+
 @pytest.mark.slow
 def test_upgrade_exclude(
     pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str

--- a/tests/integration_python/test_workspace_dependencies.py
+++ b/tests/integration_python/test_workspace_dependencies.py
@@ -1,0 +1,504 @@
+"""Edge-case tests for `{ workspace = true }` in environment dependency tables."""
+
+import json
+import tomllib
+from pathlib import Path
+
+from .common import (
+    CURRENT_PLATFORM,
+    ExitCode,
+    verify_cli_command,
+)
+
+
+def build_manifest(
+    channel: str,
+    workspace_dependencies: str,
+    body: str,
+) -> str:
+    return f"""
+[workspace]
+name = "test-workspace-deps"
+channels = ["{channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[workspace.dependencies]
+{workspace_dependencies}
+
+{body}
+"""
+
+
+def test_lock_resolves_inherited_entries_across_tables(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """Markers in every environment table resolve against the pool."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"\npackage2 = "==0.1.0"',
+            f"""
+[dependencies]
+package = {{ workspace = true }}
+
+[constraints]
+package2 = {{ workspace = true }}
+
+[feature.dev.dependencies]
+package2 = {{ workspace = true }}
+
+[target.{CURRENT_PLATFORM}.dependencies]
+package4 = "==0.1.0"
+
+[environments]
+dev = ["dev"]
+""",
+        )
+    )
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest_path])
+    lock_file = (tmp_pixi_workspace / "pixi.lock").read_text()
+    assert "package-0.1.0-" in lock_file
+    assert "package2-0.1.0-" in lock_file
+
+
+def test_lock_resolves_inherited_entry_in_feature_target_table(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            f"""
+[feature.dev.target.{CURRENT_PLATFORM}.dependencies]
+package = {{ workspace = true }}
+
+[environments]
+dev = ["dev"]
+""",
+        )
+    )
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest_path])
+    assert "package-0.1.0-" in (tmp_pixi_workspace / "pixi.lock").read_text()
+
+
+def test_lock_resolves_inherited_entries_in_legacy_host_and_build_tables(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """The legacy workspace-level host/build tables participate without pixi-build."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"\npackage2 = "==0.1.0"',
+            """
+[host-dependencies]
+package = { workspace = true }
+
+[build-dependencies]
+package2 = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest_path])
+
+
+def test_pool_lookup_is_case_insensitive(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'PACKAGE = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest_path])
+
+
+def test_override_layers_on_inherited_entry(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """A build override next to the marker narrows the inherited spec."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    # package3 has the build string "abc" on every platform.
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package3 = "==0.1.0"',
+            """
+[dependencies]
+package3 = { workspace = true, build = "ab*" }
+""",
+        )
+    )
+    verify_cli_command([pixi, "lock", "--manifest-path", manifest_path])
+
+    # A build override that matches nothing must fail the solve.
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package3 = "==0.1.0"',
+            """
+[dependencies]
+package3 = { workspace = true, build = "nonexistent*" }
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest_path],
+        ExitCode.FAILURE,
+    )
+
+
+def test_missing_pool_entry_fails(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+ghost = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest_path],
+        ExitCode.FAILURE,
+        stderr_contains="does not define `ghost` in `[workspace.dependencies]`",
+    )
+
+
+def test_workspace_false_fails(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = false }
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest_path],
+        ExitCode.FAILURE,
+        stderr_contains="`workspace` cannot be false",
+    )
+
+
+def test_version_override_on_marker_fails(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true, version = "==0.2.0" }
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest_path],
+        ExitCode.FAILURE,
+        stderr_contains="`version` is mutually exclusive with `workspace`",
+    )
+
+
+def test_source_location_override_on_marker_fails(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """The workspace entry owns the source location; it cannot be overridden."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    for field, spec in [
+        ("path", 'path = "./lib"'),
+        ("git", 'git = "https://github.com/user/repo.git"'),
+        ("url", 'url = "https://example.com/pkg.conda"'),
+    ]:
+        manifest_path.write_text(
+            build_manifest(
+                multiple_versions_channel_1,
+                'package = "==0.1.0"',
+                f"""
+[dependencies]
+package = {{ workspace = true, {spec} }}
+""",
+            )
+        )
+        verify_cli_command(
+            [pixi, "lock", "--manifest-path", manifest_path],
+            ExitCode.FAILURE,
+            stderr_contains=f"`{field}` is mutually exclusive with `workspace`",
+        )
+
+
+def test_source_pool_entry_requires_pixi_build(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'mylib = { path = "libs/mylib" }',
+            """
+[dependencies]
+mylib = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "lock", "--manifest-path", manifest_path],
+        ExitCode.FAILURE,
+        stderr_contains="pixi-build",
+    )
+
+
+def test_add_bare_keeps_marker_and_hints_at_workspace(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest_path, "package"],
+        stderr_contains="inherits from `[workspace.dependencies]`",
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["dependencies"]["package"] == {"workspace": True}
+
+
+def test_add_explicit_spec_replaces_marker(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command([pixi, "add", "--manifest-path", manifest_path, "package==0.2.0"])
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["dependencies"]["package"] == "==0.2.0"
+    # The pool entry itself stays untouched.
+    assert parsed_manifest["workspace"]["dependencies"]["package"] == "==0.1.0"
+
+
+def test_add_bare_keeps_marker_in_feature_table(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[feature.dev.dependencies]
+package = { workspace = true }
+
+[environments]
+dev = ["dev"]
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest_path, "--feature", "dev", "package"],
+        stderr_contains="inherits from `[workspace.dependencies]`",
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["feature"]["dev"]["dependencies"]["package"] == {"workspace": True}
+
+
+def test_upgrade_keeps_markers_in_feature_and_target_tables(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"\npackage2 = "==0.1.0"',
+            f"""
+[feature.dev.dependencies]
+package = {{ workspace = true }}
+
+[target.{CURRENT_PLATFORM}.dependencies]
+package2 = {{ workspace = true }}
+
+[environments]
+dev = ["dev"]
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest_path],
+        stderr_contains="[workspace.dependencies]",
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["feature"]["dev"]["dependencies"]["package"] == {"workspace": True}
+    assert parsed_manifest["target"][CURRENT_PLATFORM]["dependencies"]["package2"] == {
+        "workspace": True
+    }
+    assert parsed_manifest["workspace"]["dependencies"]["package"] == "==0.1.0"
+    assert parsed_manifest["workspace"]["dependencies"]["package2"] == "==0.1.0"
+
+
+def test_upgrade_keeps_dotted_marker(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """The dotted `package.workspace = true` form is recognized as well."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package.workspace = true
+""",
+        )
+    )
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest_path],
+        stderr_contains="[workspace.dependencies]",
+    )
+    assert "package.workspace = true" in manifest_path.read_text()
+
+
+def test_upgrade_json_suppresses_inherited_note(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """The inherited-entries note is quiet in JSON mode like all other output."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true }
+""",
+        )
+    )
+    output = verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest_path, "--json"],
+        stderr_excludes="[workspace.dependencies]",
+    )
+    json.loads(output.stdout)
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["dependencies"]["package"] == {"workspace": True}
+
+
+def test_remove_inherited_entry(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command([pixi, "remove", "--manifest-path", manifest_path, "package"])
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert "package" not in parsed_manifest.get("dependencies", {})
+    # The pool entry itself stays untouched.
+    assert parsed_manifest["workspace"]["dependencies"]["package"] == "==0.1.0"
+
+
+def test_pyproject_add_and_upgrade_keep_marker(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """The marker also works in the `[tool.pixi.*]` tables of a pyproject.toml."""
+    manifest_path = tmp_pixi_workspace / "pyproject.toml"
+    manifest_path.write_text(
+        f"""
+[project]
+name = "test-workspace-deps"
+version = "0.1.0"
+
+[tool.pixi.workspace]
+channels = ["{multiple_versions_channel_1}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[tool.pixi.workspace.dependencies]
+package = "==0.1.0"
+
+[tool.pixi.dependencies]
+package = {{ workspace = true }}
+"""
+    )
+    # `--frozen` skips the solve; a pyproject manifest implicitly requires
+    # python, which the test channel does not provide.
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest_path, "--frozen", "package"],
+        stderr_contains="inherits from `[workspace.dependencies]`",
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["tool"]["pixi"]["dependencies"]["package"] == {"workspace": True}
+
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest_path, "--frozen", "package==0.2.0"],
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["tool"]["pixi"]["dependencies"]["package"] == "==0.2.0"
+
+
+def test_add_platform_specific_does_not_touch_root_marker(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    """A platform-scoped add writes to the target table and leaves the root marker alone."""
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    manifest_path.write_text(
+        build_manifest(
+            multiple_versions_channel_1,
+            'package = "==0.1.0"',
+            """
+[dependencies]
+package = { workspace = true }
+""",
+        )
+    )
+    verify_cli_command(
+        [
+            pixi,
+            "add",
+            "--manifest-path",
+            manifest_path,
+            "--platform",
+            CURRENT_PLATFORM,
+            "package==0.2.0",
+        ]
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["dependencies"]["package"] == {"workspace": True}
+    assert parsed_manifest["target"][CURRENT_PLATFORM]["dependencies"]["package"] == "==0.2.0"


### PR DESCRIPTION
`{ workspace = true }` entries were only resolved in the package dependency tables. With this PR the following tables are allowed to use workspace dependencies as well: `[dependencies]`, `[host-dependencies]`, `[build-dependencies]` and `[constraints]`, including their `[feature.*]` and `[target.*]` variants. No preview feature is required; source entries in `[workspace.dependencies]` still need `pixi-build`.

An inline `package = { ... }` definition may sit next to the marker, so the pool can provide the source location. `pixi upgrade` leaves inherited entries unchanged and points at `[workspace.dependencies]` instead; `pixi add` only replaces the marker when given an explicit spec.

@ruben-arts 

