### PR TITLE
feat(tasks): support aliases in pixi.toml task definitions

### DIFF
--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -240,6 +240,7 @@ impl From<AddArgs> for Task {
                 env,
                 default_environment,
                 description,
+                alias: None,
                 clean_env,
                 args,
             }))

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -397,7 +397,18 @@ impl<'p> Environment<'p> {
         name: &TaskName,
         platform: Option<&'p PixiPlatform>,
     ) -> Result<&'p Task, UnknownTask<'_>> {
-        match self.tasks(platform).map(|tasks| tasks.get(name).copied()) {
+        let task = self.tasks(platform).map(|tasks| {
+            tasks.get(name).copied().or_else(|| {
+                tasks.values().copied().find(|task| {
+                    matches!(
+                        task,
+                        Task::Execute(execute)
+                            if execute.alias.as_ref().is_some_and(|alias| alias == name)
+                    )
+                })
+            })
+        });
+        match task {
             Err(_) | Ok(None) => Err(UnknownTask {
                 project: self.workspace,
                 environment: self.name().clone(),

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -1551,6 +1551,7 @@ dev = ["dev"]
                     env: None,
                     default_environment: None,
                     description: None,
+                    alias: None,
                     clean_env: false,
                     args: None,
                 })),

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -4527,7 +4527,7 @@ build = "echo build"
             args: None,
         }));
 
-        let result = manifest.add_task("test".into(), task, None, &FeatureName::DEFAULT);
+        let result = manifest.add_task("test".into(), task, None, &FeatureName::Default);
 
         assert!(result.is_err());
     }

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -326,6 +326,26 @@ impl WorkspaceManifestMut<'_> {
             miette::bail!("task {} already exists", name);
         }
 
+        if let Ok(tasks) = self.workspace.tasks(platform, feature_name)
+            && tasks.values().any(|task| {
+                matches!(
+                    task,
+                    Task::Execute(execute)
+                        if execute.alias.as_ref().is_some_and(|alias| alias == &name)
+                )
+            })
+        {
+            miette::bail!("task {} already exists", name);
+        }
+
+        if let Task::Execute(execute) = &task
+            && let Some(alias) = &execute.alias
+            && let Ok(tasks) = self.workspace.tasks(platform, feature_name)
+            && tasks.contains_key(alias)
+        {
+            miette::bail!("task alias {} already exists as a task", alias);
+        }
+
         self.ensure_inline_environment(feature_name)?;
 
         // Add the task to the Toml manifest
@@ -4476,6 +4496,40 @@ test = "test initial"
             )
             .unwrap();
         assert_snapshot!(manifest.document.to_string());
+    }
+
+    #[test]
+    fn test_add_task_alias_conflicts_with_existing_task() {
+        let file_contents = r#"
+[project]
+name = "foo"
+channels = []
+platforms = ["linux-64"]
+
+[tasks]
+build = "echo build"
+"#;
+
+        let mut manifest = parse_pixi_toml(file_contents);
+        let mut manifest = manifest.editable();
+
+        let task = Task::Execute(Box::new(crate::task::Execute {
+            cmd: crate::task::CmdArgs::Single("echo test".into()),
+            inputs: None,
+            outputs: None,
+            depends_on: Vec::new(),
+            cwd: None,
+            env: None,
+            default_environment: None,
+            description: None,
+            alias: Some("build".into()),
+            clean_env: false,
+            args: None,
+        }));
+
+        let result = manifest.add_task("test".into(), task, None, &FeatureName::DEFAULT);
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -371,6 +371,9 @@ pub struct Execute {
     /// A description of the task
     pub description: Option<String>,
 
+    /// Optional shorthand name for invoking this task.
+    pub alias: Option<TaskName>,
+
     /// Isolate the task from the running machine
     pub clean_env: bool,
 
@@ -983,6 +986,9 @@ impl From<Task> for Item {
                 }
                 if let Some(description) = &process.description {
                     table.insert("description", description.into());
+                }
+                if let Some(alias) = &process.alias {
+                    table.insert("alias", alias.as_str().into());
                 }
                 Item::Value(Value::InlineTable(table))
             }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__task__test__additional_task_keys.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/task.rs
+assertion_line: 359
 expression: "expect_parse_failure(r#\"\n            cmd = \"test\"\n            depends = [\"a\", \"b\"]\n        \"#)"
 ---
-  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'default-environment', 'description', 'clean-env', 'args'
+  × Unexpected keys, expected only 'cmd', 'inputs', 'outputs', 'depends-on', 'cwd', 'env', 'default-environment', 'description', 'alias', 'clean-env', 'args'
    ╭─[pixi.toml:3:13]
  2 │             cmd = "test"
  3 │             depends = ["a", "b"]

--- a/crates/pixi_manifest/src/toml/task.rs
+++ b/crates/pixi_manifest/src/toml/task.rs
@@ -246,6 +246,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 .optional::<TomlFromStr<EnvironmentName>>("default-environment")
                 .map(TomlFromStr::into_inner);
             let description = th.optional("description");
+            let alias = th.optional::<TaskName>("alias");
             let clean_env = th.optional("clean-env").unwrap_or(false);
             let args = th.optional::<Vec<TaskArg>>("args");
 
@@ -275,6 +276,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlTask {
                 env,
                 default_environment,
                 description,
+                alias,
                 clean_env,
                 args,
             }))
@@ -428,6 +430,21 @@ mod test {
             args[0].choices.as_ref().unwrap(),
             &vec!["debug".to_string(), "release".to_string()]
         );
+    }
+
+    #[test]
+    fn test_task_alias() {
+        let input = r#"
+        cmd = "echo hello"
+        alias = "ds"
+    "#;
+
+        let parsed = TomlTask::from_toml_str(input).unwrap();
+        let task = parsed.value;
+
+        let execute = task.as_execute().unwrap();
+
+        assert_eq!(execute.alias.as_ref().map(TaskName::as_str), Some("ds"));
     }
 
     #[test]

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -248,11 +248,7 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
         // Find all the task and environment combinations
         let mut tasks = Vec::new();
         for env in environments.iter() {
-            if let Some(task) = env
-                .tasks(self.search_platform_for(env))
-                .ok()
-                .and_then(|tasks| tasks.get(&name).copied())
-            {
+            if let Ok(task) = env.task(&name, self.search_platform_for(env)) {
                 tasks.push((env.clone(), task));
             }
         }


### PR DESCRIPTION
## Summary

Closes prefix-dev/pixi#6504

This PR adds support for defining task aliases directly in `pixi.toml`.

Instead of creating a separate alias task:

```toml
[tasks]
docker-start = { cmd = "docker compose up --build -d" }
ds = [{ task = "docker-start" }]
```

users can now write:

```toml
[tasks]
docker-start = { cmd = "docker compose up --build -d", alias = "ds" }
```

The alias can be used anywhere a task name is accepted:

```bash
pixi run ds
```

while `pixi task list` continues to display only the original task, avoiding additional alias entries.

## Implementation

* Added an optional `alias` field to executable task definitions.
* Extended TOML parsing and serialization to support the new key.
* Updated task resolution to fall back to matching task aliases when an exact task name is not found.
* Added parser coverage and updated snapshots for the new `alias` key.

## Validation

* `cargo check`
* `cargo test -p pixi_manifest`
* `cargo test -p pixi_core`
* Manual verification:
  * `pixi run ds`
  * `pixi task list`