### PR TITLE
chore: bump version to v0.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.73.0] - 2026-07-15
+#### ✨ Highlights
+
+This release brings two big features:
+- `workspace = true` now also works in environment `[dependency]` tables
+- TOML 1.1 multiline inline tables are now fully supported
+
+As usual we also fixed a couple of bugs.
+
+##### `workspace = true` in environment dependency tables
+
+Until now, `{ workspace = true }` only worked in the package dependency tables and required the `pixi-build` preview.
+With this release, the environment tables can inherit from `[workspace.dependencies]` as well, no preview needed.
+That means a version shared by several features or targets only has to be declared once:
+
+```toml
+[workspace.dependencies]
+numpy = "1.*"
+
+[dependencies]
+numpy = { workspace = true }
+
+[feature.dev.dependencies]
+numpy = { workspace = true }
+```
+
+You can learn more about this feature in the docs: https://pixi.prefix.dev/v0.73.0/build/workspace_dependencies/
+
+##### TOML 1.1
+
+Pixi now fully supports [TOML 1.1](https://toml.io/en/v1.1.0).
+Most notably, inline tables can now span multiple lines and have trailing commas, which used to be a syntax error:
+
+```toml
+[dependencies]
+python = {
+    version = ">=3.12",
+    channel = "conda-forge",
+}
+```
+
+Commands that modify the manifest, like `pixi add`, keep the layout you wrote.
+One word of caution: many other tools only read TOML 1.0 so far, so using the new syntax in `pyproject.toml` can break them even though Pixi accepts it.
+
+
+
+#### Added
+
+- Support `workspace = true` in environment dependency tables by @Hofer-Julian in [#6592](https://github.com/prefix-dev/pixi/pull/6592)
+- Full support for TOML 1.1 by @Hofer-Julian in [#6500](https://github.com/prefix-dev/pixi/pull/6500)
+
+
+#### Changed
+
+- Complete tasks after options in `pixi run` by @hunger in [#6518](https://github.com/prefix-dev/pixi/pull/6518)
+
+
+#### Documentation
+
+- Expand docs for extras, flags, and conditional dependencies by @wolfv in [#6570](https://github.com/prefix-dev/pixi/pull/6570)
+- Document TOML 1.1 support by @Hofer-Julian 
+- Fix python version constraint location in pixi-build-python backend by @hunger in [#6580](https://github.com/prefix-dev/pixi/pull/6580)
+
+
+#### Fixed
+
+- Handle dotted keys, regular tables and name normalization when editing manifests by @Hofer-Julian 
+- Isolate global_specs tests from the user's global manifest by @Hofer-Julian in [#6573](https://github.com/prefix-dev/pixi/pull/6573)
+- Mark slow integration tests with pytest.mark.slow by @Hofer-Julian in [#6574](https://github.com/prefix-dev/pixi/pull/6574)
+- Fail on git subprocess errors so a rev can resolve to a tag by @Hofer-Julian in [#6591](https://github.com/prefix-dev/pixi/pull/6591)
+- Resolve workspace dependencies in inline package definitions by @Hofer-Julian in [#6590](https://github.com/prefix-dev/pixi/pull/6590)
+- Do not chain run-exports when resolving source package run deps by @Hofer-Julian in [#6587](https://github.com/prefix-dev/pixi/pull/6587)
+- Anchor CARGO_TARGET_DIR to the workspace root by @Hofer-Julian in [#6602](https://github.com/prefix-dev/pixi/pull/6602)
+
+
 ### [0.72.2] - 2026-07-09
 #### ✨ Highlights
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,8 @@ authors:
   - given-names: Julian
     family-names: Hofer
     email: julian.hofer@protonmail.com
-repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.72.2'
-url: 'https://pixi.sh/v0.72.2'
+repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.73.0'
+url: 'https://pixi.sh/v0.73.0'
 abstract: >-
   A cross-platform, language agnostic, package/project
   management tool for development in virtual environments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5936,7 +5936,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi"
-version = "0.72.2"
+version = "0.73.0"
 dependencies = [
  "astral-reqwest-middleware",
  "async-trait",

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 name = "pixi"
 readme.workspace = true
 repository.workspace = true
-version = "0.72.2"
+version = "0.73.0"
 
 [features]
 default = ["rustls"]

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -16,7 +16,7 @@ pub const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const PIXI_VERSION: &str = match option_env!("PIXI_VERSION") {
     Some(v) => v,
-    None => "0.72.2",
+    None => "0.73.0",
 };
 pub const PREFIX_FILE_NAME: &str = "pixi_env_prefix";
 pub const ENVIRONMENTS_DIR: &str = "envs";

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -31,7 +31,7 @@ It also makes use of `pixi shell-hook` to not rely on Pixi being installed in th
     For more examples, take a look at [pavelzw/pixi-docker-example](https://github.com/pavelzw/pixi-docker-example).
 
 ```Dockerfile
-FROM ghcr.io/prefix-dev/pixi:0.72.2 AS build
+FROM ghcr.io/prefix-dev/pixi:0.73.0 AS build
 
 # copy source code, pixi.toml and pixi.lock to the container
 WORKDIR /app

--- a/docs/integration/ci/github_actions.md
+++ b/docs/integration/ci/github_actions.md
@@ -10,7 +10,7 @@ We created [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) to 
 ```yaml
 - uses: prefix-dev/setup-pixi@v0.10.0
   with:
-    pixi-version: v0.72.2
+    pixi-version: v0.73.0
     cache: true
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}

--- a/docs/integration/editor/vscode.md
+++ b/docs/integration/editor/vscode.md
@@ -42,7 +42,7 @@ Then, create the following two files in the `.devcontainer` directory:
 ```dockerfile title=".devcontainer/Dockerfile"
 FROM mcr.microsoft.com/devcontainers/base:jammy
 
-ARG PIXI_VERSION=v0.72.2
+ARG PIXI_VERSION=v0.73.0
 
 RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -22,7 +22,7 @@
 .LINK
     https://github.com/prefix-dev/pixi
 .NOTES
-    Version: v0.72.2
+    Version: v0.73.0
 #>
 param (
     [string] $PixiVersion = 'latest',

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-# Version: v0.72.2
+# Version: v0.73.0
 
 __wrap__() {
     # Function to mask username and password in URLs for safe printing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ quote-style = "double"
 github_url = "https://github.com/prefix-dev/pixi"
 
 [tool.tbump.version]
-current = "0.72.2"
+current = "0.73.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -266,7 +266,7 @@
       "description": "The workspace's metadata information"
     }
   },
-  "$comment": "Generated from `pixi` v0.72.2",
+  "$comment": "Generated from `pixi` v0.73.0",
   "$defs": {
     "Activation": {
       "title": "Activation",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.72.2/schema/manifest/pyproject/schema.json",
+  "$id": "https://pixi.sh/v0.73.0/schema/manifest/pyproject/schema.json",
   "title": "`pyproject.toml` manifest file for `pixi`",
   "description": "A `pyproject.toml` with `[tool.pixi]`.",
   "type": "object",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.72.2/schema/manifest/schema.json",
+  "$id": "https://pixi.sh/v0.73.0/schema/manifest/schema.json",
   "title": "`pixi.toml` manifest file",
   "description": "The configuration for a [`pixi`](https://pixi.sh) project.",
   "type": "object",
@@ -10,7 +10,7 @@
       "title": "Schema",
       "description": "The schema identifier for the project's configuration",
       "type": "string",
-      "default": "https://pixi.sh/v0.72.2/schema/manifest/schema.json",
+      "default": "https://pixi.sh/v0.73.0/schema/manifest/schema.json",
       "format": "uri-reference"
     },
     "activation": {

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -15,7 +15,7 @@ from rattler import Platform
 # Regex pattern to match ANSI escape sequences
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 
-PIXI_VERSION = "0.72.2"
+PIXI_VERSION = "0.73.0"
 
 
 ALL_PLATFORMS = '["linux-64", "osx-64", "osx-arm64", "win-64", "linux-ppc64le", "linux-aarch64"]'


### PR DESCRIPTION
### [0.73.0] - 2026-07-15
#### ✨ Highlights

This release brings two big features:
- `workspace = true` now also works in environment `[dependency]` tables
- TOML 1.1 multiline inline tables are now fully supported

As usual we also fixed a couple of bugs.

##### `workspace = true` in environment dependency tables

Until now, `{ workspace = true }` only worked in the package dependency tables and required the `pixi-build` preview.
With this release, the environment tables can inherit from `[workspace.dependencies]` as well, no preview needed.
That means a version shared by several features or targets only has to be declared once:

```toml
[workspace.dependencies]
numpy = "1.*"

[dependencies]
numpy = { workspace = true }

[feature.dev.dependencies]
numpy = { workspace = true }
```

You can learn more about this feature in the docs: https://pixi.prefix.dev/v0.73.0/build/workspace_dependencies/

##### TOML 1.1

Pixi now fully supports [TOML 1.1](https://toml.io/en/v1.1.0).
Most notably, inline tables can now span multiple lines and have trailing commas, which used to be a syntax error:

```toml
[dependencies]
python = {
    version = ">=3.12",
    channel = "conda-forge",
}
```

Commands that modify the manifest, like `pixi add`, keep the layout you wrote.
One word of caution: many other tools only read TOML 1.0 so far, so using the new syntax in `pyproject.toml` can break them even though Pixi accepts it.



#### Added

- Support `workspace = true` in environment dependency tables by @Hofer-Julian in [#6592](https://github.com/prefix-dev/pixi/pull/6592)
- Full support for TOML 1.1 by @Hofer-Julian in [#6500](https://github.com/prefix-dev/pixi/pull/6500)


#### Changed

- Complete tasks after options in `pixi run` by @hunger in [#6518](https://github.com/prefix-dev/pixi/pull/6518)


#### Documentation

- Expand docs for extras, flags, and conditional dependencies by @wolfv in [#6570](https://github.com/prefix-dev/pixi/pull/6570)
- Document TOML 1.1 support by @Hofer-Julian 
- Fix python version constraint location in pixi-build-python backend by @hunger in [#6580](https://github.com/prefix-dev/pixi/pull/6580)


#### Fixed

- Handle dotted keys, regular tables and name normalization when editing manifests by @Hofer-Julian 
- Isolate global_specs tests from the user's global manifest by @Hofer-Julian in [#6573](https://github.com/prefix-dev/pixi/pull/6573)
- Mark slow integration tests with pytest.mark.slow by @Hofer-Julian in [#6574](https://github.com/prefix-dev/pixi/pull/6574)
- Fail on git subprocess errors so a rev can resolve to a tag by @Hofer-Julian in [#6591](https://github.com/prefix-dev/pixi/pull/6591)
- Resolve workspace dependencies in inline package definitions by @Hofer-Julian in [#6590](https://github.com/prefix-dev/pixi/pull/6590)
- Do not chain run-exports when resolving source package run deps by @Hofer-Julian in [#6587](https://github.com/prefix-dev/pixi/pull/6587)
- Anchor CARGO_TARGET_DIR to the workspace root by @Hofer-Julian in [#6602](https://github.com/prefix-dev/pixi/pull/6602)