### PR TITLE
fix: account for Cargo build target in install-as

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -32,9 +32,11 @@ def main() -> None:
 
     rel_or_deb = "release" if not args.debug else "debug"
 
-    built_executable_path = Path(os.environ["CARGO_TARGET_DIR"]).joinpath(
-        rel_or_deb, executable_extension("pixi")
-    )
+    cargo_target_dir = Path(os.environ["CARGO_TARGET_DIR"])
+    if cargo_build_target := os.getenv("CARGO_BUILD_TARGET"):
+        cargo_target_dir /= cargo_build_target
+
+    built_executable_path = cargo_target_dir.joinpath(rel_or_deb, executable_extension("pixi"))
     destination_path = args.dest.joinpath(executable_extension(args.name))
 
     print(f"Copying ({rel_or_deb}) the executable to {destination_path}")


### PR DESCRIPTION
### Description

`pixi install-as` assumes Cargo writes the executable directly to `$CARGO_TARGET_DIR/{release,debug}`. On Windows, the conda Rust compiler sets `CARGO_BUILD_TARGET`, so Cargo writes it to `$CARGO_TARGET_DIR/<target-triple>/{release,debug}` instead and the install fails to find the binary.

Take the optional Cargo build target into account when locating the executable.

### How Has This Been Tested?

- `pixi run -e rust-build install-as pixi-test --dest target/install-as-pr-test`
- `target/install-as-pr-test/pixi-test.exe --version` (`pixi 0.73.0`)
- `ruff format --check scripts/install.py`
- `ruff check scripts/install.py`
- `ty check scripts/install.py`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist:

- [x] I have performed a self-review of my own code
