### PR TITLE
fix: resolve changelog preview range end to a commit SHA

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -87,9 +87,14 @@ def gh_token() -> str:
 def cliff_preview(tag: str) -> str:
     """Render what git-cliff would add for the commits since `tag`.
 
+    The range ends at the resolved commit SHA because git-cliff forwards the
+    range end verbatim to the GitHub API as the `sha` parameter, which does
+    not know local names like `FETCH_HEAD`.
+
     stderr is left attached to the terminal so git-cliff template or fetch
     errors surface instead of silently collapsing the preview to nothing.
     """
+    head = git_out("rev-parse", "FETCH_HEAD")
     result = subprocess.run(
         [
             "git-cliff",
@@ -97,7 +102,7 @@ def cliff_preview(tag: str) -> str:
             "header",
             "--github-token",
             gh_token(),
-            f"{tag}..FETCH_HEAD",
+            f"{tag}..{head}",
         ],
         cwd=ROOT,
         text=True,


### PR DESCRIPTION
`git-cliff` forwards the range end verbatim to the GitHub API as the `sha` parameter, which does not know local names like `FETCH_HEAD`. Resolve it with `git rev-parse` before building the range.

Similar to prefix-dev/rattler-build#2659.
