### PR TITLE
fix: backends-v0 cache misses when using exclude-newer 

### DIFF
--- a/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
@@ -543,12 +543,9 @@ async fn read_pointer(pointer_path: &std::path::Path) -> Option<EphemeralEnvPoin
     Some(pointer)
 }
 
-/// Write the spec → fingerprint pointer atomically (write-temp +
-/// rename). Failures are swallowed: skipping the write only costs the
-/// next caller one extra solve, never correctness. Unlike the records
-/// marker this is also written outside the env lock, so the temp name
-/// carries the process id to keep concurrent writers off each other's
-/// half-written file.
+/// Write the spec → fingerprint pointer atomically. Failures are
+/// swallowed: skipping the write only costs the next caller one extra
+/// solve, never correctness.
 async fn write_pointer(
     pointer_path: &std::path::Path,
     spec: &EphemeralEnvSpec,
@@ -562,14 +559,7 @@ async fn write_pointer(
     let Ok(bytes) = serde_json::to_vec(&pointer) else {
         return;
     };
-    let Some(name) = pointer_path.file_name().and_then(|n| n.to_str()) else {
-        return;
-    };
-    let tmp = pointer_path.with_file_name(format!("{name}.{}.tmp", std::process::id()));
-    if tokio::fs::write(&tmp, &bytes).await.is_err() {
-        return;
-    }
-    let _ = tokio::fs::rename(&tmp, pointer_path).await;
+    let _ = pixi_utils::atomic_write::atomic_write(pointer_path, &bytes).await;
 }
 
 /// Fetch binary repodata for the spec's dependencies + constraints.

--- a/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
@@ -1,9 +1,18 @@
 //! Content-addressed compute-engine Key for disposable, binary-only conda
-//! environments. Source specs are rejected up-front. The prefix path is
-//! derived from a fingerprint of the *resolved* records — so a relative
-//! `exclude-newer`, whose cutoff moves every invocation, reuses one prefix
-//! instead of leaking a fresh one per solve — and locked with
-//! [`EnvironmentLock`] for cross-process safety.
+//! environments. Source specs are rejected up-front.
+//!
+//! The on-disk cache under the backends dir is two-level:
+//!
+//! - The heavy prefix is addressed by a fingerprint of the *resolved*
+//!   records, so a relative `exclude-newer`, whose cutoff moves every
+//!   invocation, reuses one prefix instead of leaking a fresh one per
+//!   solve.
+//! - A tiny spec-keyed pointer file ([`EphemeralEnvPointer`]) records
+//!   which fingerprint a spec (including its cutoff) last resolved to,
+//!   so a later process can reuse the prefix without a repodata fetch
+//!   or solve.
+//!
+//! Prefixes are locked with [`EnvironmentLock`] for cross-process safety.
 //!
 //! This key has no per-key reporter trait of its own. The ephemeral
 //! prefix is populated as part of backend instantiation, so it reads
@@ -28,7 +37,7 @@ use pixi_compute_engine::{ComputeCtx, DataStore, Key};
 use pixi_record::PixiRecord;
 use pixi_spec::{BinarySpec, PixiSpec, ResolvedExcludeNewer};
 use pixi_spec_containers::DependencyMap;
-use pixi_utils::EnvironmentLock;
+use pixi_utils::{EnvironmentFingerprint, EnvironmentLock};
 use rattler::install::InstallerError;
 use rattler_conda_types::{ChannelUrl, PackageName, RepoDataRecord, prefix::Prefix};
 use rattler_repodata_gateway::{GatewayError, RepoData};
@@ -55,7 +64,9 @@ const EPHEMERAL_LOCK_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
 ///
 /// The spec's hash keys the compute-engine dedup (via [`EphemeralEnvKey`]);
 /// the on-disk prefix is content-addressed on the *resolved* records (see
-/// [`EphemeralEnvSpec::prefix_cache_key`]). Source `PixiSpec`s in
+/// [`EphemeralEnvSpec::prefix_cache_key`]), fronted by a spec-keyed pointer
+/// file as a pre-solve fast path (see
+/// [`EphemeralEnvSpec::pointer_file_name`]). Source `PixiSpec`s in
 /// `dependencies` cause the Key to fail at compute time.
 #[derive(Clone, Debug)]
 pub struct EphemeralEnvSpec {
@@ -80,23 +91,8 @@ pub struct EphemeralEnvSpec {
 
 impl Hash for EphemeralEnvSpec {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let Self {
-            dependencies,
-            constraints,
-            channels,
-            exclude_newer,
-            strategy,
-            channel_priority,
-        } = self;
-        dependencies.hash(state);
-        constraints.hash(state);
-        channels.hash(state);
-        exclude_newer.hash(state);
-        // Neither SolveStrategy nor ChannelPriority implement Hash;
-        // use the enum discriminant (both are C-like enums, so the
-        // discriminant fully captures identity).
-        mem::discriminant(strategy).hash(state);
-        mem::discriminant(channel_priority).hash(state);
+        self.hash_without_exclude_newer(state);
+        self.exclude_newer.hash(state);
     }
 }
 
@@ -115,6 +111,28 @@ impl PartialEq for EphemeralEnvSpec {
 impl Eq for EphemeralEnvSpec {}
 
 impl EphemeralEnvSpec {
+    /// Hash every field except `exclude_newer`. Factored out of [`Hash`]
+    /// so the pointer file name can be keyed on the cutoff-independent
+    /// spec identity (see [`Self::pointer_file_name`]).
+    fn hash_without_exclude_newer<H: Hasher>(&self, state: &mut H) {
+        let Self {
+            dependencies,
+            constraints,
+            channels,
+            exclude_newer: _,
+            strategy,
+            channel_priority,
+        } = self;
+        dependencies.hash(state);
+        constraints.hash(state);
+        channels.hash(state);
+        // Neither SolveStrategy nor ChannelPriority implement Hash;
+        // use the enum discriminant (both are C-like enums, so the
+        // discriminant fully captures identity).
+        mem::discriminant(strategy).hash(state);
+        mem::discriminant(channel_priority).hash(state);
+    }
+
     /// Human-readable hint for the ephemeral env: the alphabetically-first
     /// dependency package name, or `env` when there are no dependencies.
     fn dependency_hint(&self) -> String {
@@ -135,8 +153,25 @@ impl EphemeralEnvSpec {
     /// every invocation but resolves to the same packages — so `backends-v0`
     /// no longer accumulates a duplicate prefix per solve. `exclude_newer`
     /// influences only the solve, never the cache identity.
-    fn prefix_cache_key(&self, fingerprint: &pixi_utils::EnvironmentFingerprint) -> String {
+    fn prefix_cache_key(&self, fingerprint: &EnvironmentFingerprint) -> String {
         format!("{}-{}", self.dependency_hint(), fingerprint.as_str())
+    }
+
+    /// File name of this spec's [`EphemeralEnvPointer`], next to the
+    /// prefixes in the backends cache dir:
+    /// `<hint>-<hash of the spec sans cutoff>.pointer.json`.
+    ///
+    /// The cutoff is deliberately left out of the name and stored *inside*
+    /// the pointer instead, so a moving (relative) `exclude-newer`
+    /// overwrites one pointer per spec rather than accreting one file per
+    /// resolved cutoff. The `.pointer.json` suffix cannot collide with a
+    /// prefix directory: the hash segment of a prefix name is base64/hex
+    /// and never contains a dot.
+    fn pointer_file_name(&self) -> String {
+        let mut hasher = Xxh3::new();
+        self.hash_without_exclude_newer(&mut hasher);
+        let encoded = URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes());
+        format!("{}-{}.pointer.json", self.dependency_hint(), encoded)
     }
 
     /// Stable per-spec label for logging/telemetry only. The compute engine
@@ -231,6 +266,26 @@ impl Key for EphemeralEnvKey {
     async fn compute(&self, ctx: &mut ComputeCtx) -> Self::Value {
         let spec: &EphemeralEnvSpec = &self.0;
 
+        // Cross-process fast path: the spec-keyed pointer file records
+        // the fingerprint this spec last resolved to. When its stored
+        // cutoff equals the spec's and the fingerprint-addressed prefix
+        // carries a marker, the env is fully reusable with no repodata
+        // fetch or solve — ~250 ms on Windows for pixi-build-cmake /
+        // pixi-build-python. A relative `exclude-newer` resolves to a
+        // fresh cutoff every invocation, so it never matches here and
+        // always re-solves, landing on the shared fingerprint-addressed
+        // prefix below.
+        let backends_dir = ctx.cache_dir::<BuildBackendsDir>().await;
+        let pointer_path = backends_dir.join(spec.pointer_file_name());
+        if let Some(pointer) = read_pointer(pointer_path.as_std_path()).await
+            && pointer.exclude_newer == spec.exclude_newer
+        {
+            let prefix_path = backends_dir.join(spec.prefix_cache_key(&pointer.fingerprint));
+            if let Some(cached) = read_cached_marker(prefix_path.as_std_path()).await {
+                return Ok(Arc::new(cached));
+            }
+        }
+
         // 1. Reject source specs, get a binary-only dep map.
         let binary_specs = match split_into_binary(&spec.dependencies) {
             Ok(b) => b,
@@ -288,16 +343,18 @@ impl Key for EphemeralEnvKey {
                 PixiRecord::Source(_) => None,
             })
             .collect::<Vec<_>>();
-        let expected_fingerprint =
-            pixi_utils::EnvironmentFingerprint::compute(binary_records.iter());
+        let expected_fingerprint = EnvironmentFingerprint::compute(binary_records.iter());
 
         let cache_key = spec.prefix_cache_key(&expected_fingerprint);
-        let prefix_path = ctx.cache_dir::<BuildBackendsDir>().await.join(&cache_key);
+        let prefix_path = backends_dir.join(&cache_key);
 
-        // Cross-process fast path: a prefix already provisioned for this
-        // resolved record set (marker present) is fully reusable, so a later
-        // process skips the install entirely.
+        // A prefix already provisioned for this resolved record set
+        // (marker present) is fully reusable — e.g. a moving cutoff that
+        // re-solved to the same packages, or a pointer that was missing
+        // or stale. Refresh the pointer so the next process with this
+        // spec can skip the solve entirely.
         if let Some(cached) = read_cached_marker(prefix_path.as_std_path()).await {
+            write_pointer(pointer_path.as_std_path(), spec, &expected_fingerprint).await;
             return Ok(Arc::new(cached));
         }
 
@@ -311,7 +368,6 @@ impl Key for EphemeralEnvKey {
         })?;
 
         // 6. Cross-process install lock + recheck + install.
-
         let prefix_display = prefix.path().display().to_string();
         let mut env_lock = EnvironmentLock::acquire_with_progress(
             prefix.path(),
@@ -334,6 +390,7 @@ impl Key for EphemeralEnvKey {
         if env_lock.matches(&expected_fingerprint)
             && let Some(cached) = read_cached_marker(prefix.path()).await
         {
+            write_pointer(pointer_path.as_std_path(), spec, &expected_fingerprint).await;
             return Ok(Arc::new(cached));
         }
 
@@ -368,8 +425,10 @@ impl Key for EphemeralEnvKey {
         })?;
 
         // Write the records marker before releasing the lock so peers
-        // see it on the lock-free fast path.
+        // see it on the lock-free fast path, then the spec → fingerprint
+        // pointer so the next process with this spec skips the solve.
         write_cached_marker(prefix.path(), &binary_records).await;
+        write_pointer(pointer_path.as_std_path(), spec, &expected_fingerprint).await;
 
         env_lock.finish(&expected_fingerprint).await.map_err(|e| {
             Arc::new(EphemeralEnvError::UpdateLock(
@@ -447,6 +506,72 @@ async fn write_cached_marker(prefix_path: &std::path::Path, records: &[RepoDataR
     let _ = tokio::fs::rename(&tmp, &dest).await;
 }
 
+/// Spec → fingerprint pointer, the first level of the two-level cache
+/// (see the module docs). Stored at
+/// [`EphemeralEnvSpec::pointer_file_name`] in the backends cache dir.
+///
+/// Purely advisory: the records are always read from the pointed-to
+/// prefix's own marker, so a missing, stale, or corrupt pointer costs
+/// one solve, never correctness. The stored `exclude_newer` must equal
+/// the spec's before the pointer is followed; it lives *inside* the
+/// pointer rather than in the file name so a moving (relative) cutoff
+/// rewrites one pointer per spec instead of accreting one per resolved
+/// cutoff.
+#[derive(Serialize, Deserialize)]
+struct EphemeralEnvPointer {
+    version: u32,
+    exclude_newer: Option<ResolvedExcludeNewer>,
+    fingerprint: EnvironmentFingerprint,
+}
+
+const EPHEMERAL_ENV_POINTER_VERSION: u32 = 1;
+
+/// Read and validate a spec → fingerprint pointer. Returns `None` (the
+/// caller falls through to the solve) on a missing / unparsable /
+/// wrong-version pointer, or when the fingerprint is not a plain hex
+/// digest — it becomes a path segment, so nothing else may pass.
+async fn read_pointer(pointer_path: &std::path::Path) -> Option<EphemeralEnvPointer> {
+    let bytes = tokio::fs::read(pointer_path).await.ok()?;
+    let pointer: EphemeralEnvPointer = serde_json::from_slice(&bytes).ok()?;
+    if pointer.version != EPHEMERAL_ENV_POINTER_VERSION {
+        return None;
+    }
+    let fingerprint = pointer.fingerprint.as_str();
+    if fingerprint.is_empty() || !fingerprint.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(pointer)
+}
+
+/// Write the spec → fingerprint pointer atomically (write-temp +
+/// rename). Failures are swallowed: skipping the write only costs the
+/// next caller one extra solve, never correctness. Unlike the records
+/// marker this is also written outside the env lock, so the temp name
+/// carries the process id to keep concurrent writers off each other's
+/// half-written file.
+async fn write_pointer(
+    pointer_path: &std::path::Path,
+    spec: &EphemeralEnvSpec,
+    fingerprint: &EnvironmentFingerprint,
+) {
+    let pointer = EphemeralEnvPointer {
+        version: EPHEMERAL_ENV_POINTER_VERSION,
+        exclude_newer: spec.exclude_newer.clone(),
+        fingerprint: fingerprint.clone(),
+    };
+    let Ok(bytes) = serde_json::to_vec(&pointer) else {
+        return;
+    };
+    let Some(name) = pointer_path.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+    let tmp = pointer_path.with_file_name(format!("{name}.{}.tmp", std::process::id()));
+    if tokio::fs::write(&tmp, &bytes).await.is_err() {
+        return;
+    }
+    let _ = tokio::fs::rename(&tmp, pointer_path).await;
+}
+
 /// Fetch binary repodata for the spec's dependencies + constraints.
 async fn fetch_binary_repodata(
     ctx: &mut ComputeCtx,
@@ -520,7 +645,6 @@ fn split_into_binary(
 mod tests {
     use super::*;
     use chrono::{DateTime, Utc};
-    use pixi_utils::EnvironmentFingerprint;
 
     fn spec_with_exclude_newer(exclude_newer: Option<ResolvedExcludeNewer>) -> EphemeralEnvSpec {
         EphemeralEnvSpec {
@@ -577,5 +701,69 @@ mod tests {
         let b = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
         assert_ne!(a, b);
         assert_ne!(a.label(), b.label());
+    }
+
+    /// The pointer round-trips through disk and carries the cutoff it
+    /// was written under.
+    #[tokio::test]
+    async fn pointer_round_trip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let spec = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
+        let path = dir.path().join(spec.pointer_file_name());
+        let fingerprint = EnvironmentFingerprint::from_string("0123456789abcdef".to_string());
+
+        assert!(read_pointer(&path).await.is_none());
+        write_pointer(&path, &spec, &fingerprint).await;
+        let pointer = read_pointer(&path).await.unwrap();
+        assert_eq!(pointer.fingerprint, fingerprint);
+        assert_eq!(pointer.exclude_newer, spec.exclude_newer);
+    }
+
+    /// Specs that differ only in their cutoff share one pointer *file*
+    /// (bounded growth: a moving cutoff overwrites rather than accretes),
+    /// but the stored cutoff distinguishes them, so a pointer written
+    /// under one cutoff is never followed for another.
+    #[tokio::test]
+    async fn pointer_is_shared_per_spec_but_keyed_on_cutoff() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let a = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
+        let b = spec_with_exclude_newer(Some(resolved("2026-07-16T09:00:00Z")));
+        assert_eq!(a.pointer_file_name(), b.pointer_file_name());
+
+        let path = dir.path().join(a.pointer_file_name());
+        let fingerprint = EnvironmentFingerprint::from_string("0123456789abcdef".to_string());
+        write_pointer(&path, &a, &fingerprint).await;
+
+        let pointer = read_pointer(&path).await.unwrap();
+        assert_eq!(pointer.exclude_newer, a.exclude_newer);
+        assert_ne!(pointer.exclude_newer, b.exclude_newer);
+    }
+
+    /// Corrupt or incompatible pointers fall through to the solve. A
+    /// fingerprint that is not a plain hex digest is rejected because it
+    /// becomes a path segment.
+    #[tokio::test]
+    async fn read_pointer_rejects_invalid_contents() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("env-abc.pointer.json");
+
+        tokio::fs::write(&path, b"not json").await.unwrap();
+        assert!(read_pointer(&path).await.is_none());
+
+        tokio::fs::write(
+            &path,
+            br#"{"version":999,"exclude_newer":null,"fingerprint":"0123456789abcdef"}"#,
+        )
+        .await
+        .unwrap();
+        assert!(read_pointer(&path).await.is_none());
+
+        tokio::fs::write(
+            &path,
+            br#"{"version":1,"exclude_newer":null,"fingerprint":"../escape"}"#,
+        )
+        .await
+        .unwrap();
+        assert!(read_pointer(&path).await.is_none());
     }
 }

--- a/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
@@ -1,7 +1,9 @@
 //! Content-addressed compute-engine Key for disposable, binary-only conda
 //! environments. Source specs are rejected up-front. The prefix path is
-//! derived from the spec hash and locked with [`EnvironmentLock`] for
-//! cross-process safety.
+//! derived from a fingerprint of the *resolved* records — so a relative
+//! `exclude-newer`, whose cutoff moves every invocation, reuses one prefix
+//! instead of leaking a fresh one per solve — and locked with
+//! [`EnvironmentLock`] for cross-process safety.
 //!
 //! This key has no per-key reporter trait of its own. The ephemeral
 //! prefix is populated as part of backend instantiation, so it reads
@@ -51,8 +53,9 @@ const EPHEMERAL_LOCK_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Specification for an ephemeral, binary-only conda environment.
 ///
-/// The spec's hash is used as the prefix cache key; callers with an
-/// equal spec share the same installed prefix. Source `PixiSpec`s in
+/// The spec's hash keys the compute-engine dedup (via [`EphemeralEnvKey`]);
+/// the on-disk prefix is content-addressed on the *resolved* records (see
+/// [`EphemeralEnvSpec::prefix_cache_key`]). Source `PixiSpec`s in
 /// `dependencies` cause the Key to fail at compute time.
 #[derive(Clone, Debug)]
 pub struct EphemeralEnvSpec {
@@ -112,21 +115,38 @@ impl PartialEq for EphemeralEnvSpec {
 impl Eq for EphemeralEnvSpec {}
 
 impl EphemeralEnvSpec {
-    /// Returns a stable cache key derived from the spec hash. The first
-    /// segment is the alphabetically-first dependency package name (as
-    /// a human-readable hint); the second is a URL-safe encoding of the
-    /// spec hash.
-    pub fn cache_key(&self) -> String {
-        let hint: String = self
-            .dependencies
+    /// Human-readable hint for the ephemeral env: the alphabetically-first
+    /// dependency package name, or `env` when there are no dependencies.
+    fn dependency_hint(&self) -> String {
+        self.dependencies
             .iter_specs()
             .map(|(name, _)| name.as_normalized().to_string())
             .min()
-            .unwrap_or_else(|| "env".to_string());
+            .unwrap_or_else(|| "env".to_string())
+    }
+
+    /// Content-addressed cache key for the *resolved* environment.
+    ///
+    /// The key is `<hint>-<fingerprint>`, where `<fingerprint>` is a content
+    /// hash of the resolved binary records (`name + sha256`, via
+    /// [`pixi_utils::EnvironmentFingerprint`]). Deriving the key from the
+    /// solve's *output* rather than from the input spec keeps the prefix
+    /// path stable across a relative `exclude-newer` whose cutoff moves on
+    /// every invocation but resolves to the same packages — so `backends-v0`
+    /// no longer accumulates a duplicate prefix per solve. `exclude_newer`
+    /// influences only the solve, never the cache identity.
+    fn prefix_cache_key(&self, fingerprint: &pixi_utils::EnvironmentFingerprint) -> String {
+        format!("{}-{}", self.dependency_hint(), fingerprint.as_str())
+    }
+
+    /// Stable per-spec label for logging/telemetry only. The compute engine
+    /// dedups on the spec's `Hash`/`Eq` (which include `exclude_newer`), not
+    /// on this string, so genuinely different specs remain distinct keys.
+    fn label(&self) -> String {
         let mut hasher = Xxh3::new();
         self.hash(&mut hasher);
         let encoded = URL_SAFE_NO_PAD.encode(hasher.finish().to_ne_bytes());
-        format!("{hint}-{encoded}")
+        format!("{}-{}", self.dependency_hint(), encoded)
     }
 }
 
@@ -159,7 +179,7 @@ impl Eq for EphemeralEnvKey {}
 
 impl fmt::Display for EphemeralEnvKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.cache_key())
+        write!(f, "{}", self.0.label())
     }
 }
 
@@ -211,22 +231,6 @@ impl Key for EphemeralEnvKey {
     async fn compute(&self, ctx: &mut ComputeCtx) -> Self::Value {
         let spec: &EphemeralEnvSpec = &self.0;
 
-        // Cross-process fast path: ephemeral env prefixes are
-        // content-addressed by `spec.cache_key()`, so an existing
-        // prefix at the derived path with a marker file recording
-        // the install records is fully reusable. The compute-engine
-        // cache only dedups within a single process, so without this
-        // marker every `pixi run` re-fetches repodata and re-solves
-        // the backend's binary deps — ~250 ms on Windows for
-        // pixi-build-cmake / pixi-build-python — even when the
-        // prefix on disk was already provisioned by a previous run.
-        //
-        let cache_key = spec.cache_key();
-        let prefix_path = ctx.cache_dir::<BuildBackendsDir>().await.join(&cache_key);
-        if let Some(cached) = read_cached_marker(prefix_path.as_std_path()).await {
-            return Ok(Arc::new(cached));
-        }
-
         // 1. Reject source specs, get a binary-only dep map.
         let binary_specs = match split_into_binary(&spec.dependencies) {
             Ok(b) => b,
@@ -263,18 +267,20 @@ impl Key for EphemeralEnvKey {
             .await
             .map_err(|e| Arc::new(EphemeralEnvError::Solve(Arc::new(e))))?;
 
-        // 5. Compute prefix path and create it. (`cache_key` and
-        //    `prefix_path` were already derived above for the
-        //    fast-path lookup.)
-        let prefix_std = prefix_path.as_std_path().to_path_buf();
-        let prefix = Prefix::create(prefix_std.clone()).map_err(|e| {
-            Arc::new(EphemeralEnvError::CreatePrefix(
-                prefix_std.clone(),
-                Arc::new(e),
-            ))
-        })?;
-
-        // 6. Cross-process install lock + recheck + install.
+        // 5. Content-address the prefix on the *resolved* records.
+        //
+        //    The prefix is keyed by a fingerprint of the solved binary
+        //    records (`name + sha256`), so callers that resolve to the same
+        //    packages share one prefix. This makes a *relative*
+        //    `exclude-newer` reusable: its cutoff is `now - duration`, which
+        //    changes on every invocation, yet as long as the resolved
+        //    package set is unchanged the fingerprint — and therefore the
+        //    prefix path — is stable. `exclude_newer` influences only the
+        //    solve above, never the cache identity, exactly as if a plain
+        //    solve had been cached at that point in the past. The spec
+        //    (including `exclude_newer`) still keys the in-process
+        //    compute-engine dedup via `EphemeralEnvKey`, so two genuinely
+        //    different cutoffs that resolve differently never collide here.
         let binary_records = records
             .iter()
             .filter_map(|r| match r {
@@ -284,6 +290,27 @@ impl Key for EphemeralEnvKey {
             .collect::<Vec<_>>();
         let expected_fingerprint =
             pixi_utils::EnvironmentFingerprint::compute(binary_records.iter());
+
+        let cache_key = spec.prefix_cache_key(&expected_fingerprint);
+        let prefix_path = ctx.cache_dir::<BuildBackendsDir>().await.join(&cache_key);
+
+        // Cross-process fast path: a prefix already provisioned for this
+        // resolved record set (marker present) is fully reusable, so a later
+        // process skips the install entirely.
+        if let Some(cached) = read_cached_marker(prefix_path.as_std_path()).await {
+            return Ok(Arc::new(cached));
+        }
+
+        // Create the prefix directory.
+        let prefix_std = prefix_path.as_std_path().to_path_buf();
+        let prefix = Prefix::create(prefix_std.clone()).map_err(|e| {
+            Arc::new(EphemeralEnvError::CreatePrefix(
+                prefix_std.clone(),
+                Arc::new(e),
+            ))
+        })?;
+
+        // 6. Cross-process install lock + recheck + install.
 
         let prefix_display = prefix.path().display().to_string();
         let mut env_lock = EnvironmentLock::acquire_with_progress(
@@ -487,4 +514,68 @@ fn split_into_binary(
         }
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use pixi_utils::EnvironmentFingerprint;
+
+    fn spec_with_exclude_newer(exclude_newer: Option<ResolvedExcludeNewer>) -> EphemeralEnvSpec {
+        EphemeralEnvSpec {
+            dependencies: DependencyMap::default(),
+            constraints: DependencyMap::default(),
+            channels: Vec::new(),
+            exclude_newer,
+            strategy: SolveStrategy::default(),
+            channel_priority: ChannelPriority::default(),
+        }
+    }
+
+    fn resolved(cutoff: &str) -> ResolvedExcludeNewer {
+        ResolvedExcludeNewer::from_datetime(cutoff.parse::<DateTime<Utc>>().unwrap())
+    }
+
+    /// Acceptance criteria 1 & 3: the prefix path is a pure function of the
+    /// resolved records, so two solves that resolve to the same packages
+    /// under *different* `exclude-newer` cutoffs (as a relative cutoff
+    /// produces on every invocation) share one prefix — `backends-v0` does
+    /// not grow per solve.
+    #[test]
+    fn prefix_cache_key_ignores_exclude_newer() {
+        let fingerprint = EnvironmentFingerprint::from_string("0123456789abcdef".to_string());
+        let none = spec_with_exclude_newer(None);
+        let a = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
+        let b = spec_with_exclude_newer(Some(resolved("2026-07-16T09:00:00Z")));
+
+        let key = none.prefix_cache_key(&fingerprint);
+        assert_eq!(key, a.prefix_cache_key(&fingerprint));
+        assert_eq!(key, b.prefix_cache_key(&fingerprint));
+    }
+
+    /// Acceptance criterion 2: a different resolved record set yields a
+    /// different prefix, so genuinely different resolutions never collide on
+    /// one prefix.
+    #[test]
+    fn prefix_cache_key_changes_with_resolved_records() {
+        let spec = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
+        let fp1 = EnvironmentFingerprint::from_string("0123456789abcdef".to_string());
+        let fp2 = EnvironmentFingerprint::from_string("fedcba9876543210".to_string());
+        assert_ne!(spec.prefix_cache_key(&fp1), spec.prefix_cache_key(&fp2));
+    }
+
+    /// Acceptance criterion 4 (correctness guard): the compute-engine key
+    /// still distinguishes specs that differ only in `exclude_newer`, so two
+    /// genuinely different cutoffs are solved independently — their resolved
+    /// records then decide whether they end up sharing a prefix. The cache
+    /// key never inspects timestamps, so untimestamped-package handling stays
+    /// entirely in the solve, unchanged.
+    #[test]
+    fn spec_identity_still_distinguishes_exclude_newer() {
+        let a = spec_with_exclude_newer(Some(resolved("2024-01-01T00:00:00Z")));
+        let b = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
+        assert_ne!(a, b);
+        assert_ne!(a.label(), b.label());
+    }
 }

--- a/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
@@ -1,16 +1,10 @@
 //! Content-addressed compute-engine Key for disposable, binary-only conda
 //! environments. Source specs are rejected up-front.
 //!
-//! The on-disk cache under the backends dir is two-level:
-//!
-//! - The heavy prefix is addressed by a fingerprint of the *resolved*
-//!   records, so a relative `exclude-newer`, whose cutoff moves every
-//!   invocation, reuses one prefix instead of leaking a fresh one per
-//!   solve.
-//! - A tiny spec-keyed pointer file ([`EphemeralEnvPointer`]) records
-//!   which fingerprint a spec (including its cutoff) last resolved to,
-//!   so a later process can reuse the prefix without a repodata fetch
-//!   or solve.
+//! The on-disk cache is two-level: prefixes are addressed by a
+//! fingerprint of the *resolved* records, and a spec-keyed pointer file
+//! ([`EphemeralEnvPointer`]) maps a spec to the fingerprint it last
+//! resolved to so a later process can skip the solve.
 //!
 //! Prefixes are locked with [`EnvironmentLock`] for cross-process safety.
 //!
@@ -62,11 +56,9 @@ const EPHEMERAL_LOCK_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Specification for an ephemeral, binary-only conda environment.
 ///
-/// The spec's hash keys the compute-engine dedup (via [`EphemeralEnvKey`]);
-/// the on-disk prefix is content-addressed on the *resolved* records (see
-/// [`EphemeralEnvSpec::prefix_cache_key`]), fronted by a spec-keyed pointer
-/// file as a pre-solve fast path (see
-/// [`EphemeralEnvSpec::pointer_file_name`]). Source `PixiSpec`s in
+/// The spec's hash keys the compute-engine dedup; the on-disk prefix is
+/// content-addressed on the *resolved* records (see
+/// [`EphemeralEnvSpec::prefix_cache_key`]). Source `PixiSpec`s in
 /// `dependencies` cause the Key to fail at compute time.
 #[derive(Clone, Debug)]
 pub struct EphemeralEnvSpec {
@@ -111,9 +103,8 @@ impl PartialEq for EphemeralEnvSpec {
 impl Eq for EphemeralEnvSpec {}
 
 impl EphemeralEnvSpec {
-    /// Hash every field except `exclude_newer`. Factored out of [`Hash`]
-    /// so the pointer file name can be keyed on the cutoff-independent
-    /// spec identity (see [`Self::pointer_file_name`]).
+    /// Hash every field except `exclude_newer`, so the pointer file name
+    /// can be keyed on the cutoff-independent spec identity.
     fn hash_without_exclude_newer<H: Hasher>(&self, state: &mut H) {
         let Self {
             dependencies,
@@ -143,30 +134,19 @@ impl EphemeralEnvSpec {
             .unwrap_or_else(|| "env".to_string())
     }
 
-    /// Content-addressed cache key for the *resolved* environment.
-    ///
-    /// The key is `<hint>-<fingerprint>`, where `<fingerprint>` is a content
-    /// hash of the resolved binary records (`name + sha256`, via
-    /// [`pixi_utils::EnvironmentFingerprint`]). Deriving the key from the
-    /// solve's *output* rather than from the input spec keeps the prefix
-    /// path stable across a relative `exclude-newer` whose cutoff moves on
-    /// every invocation but resolves to the same packages — so `backends-v0`
-    /// no longer accumulates a duplicate prefix per solve. `exclude_newer`
-    /// influences only the solve, never the cache identity.
+    /// Content-addressed cache key for the *resolved* environment:
+    /// `<hint>-<fingerprint of the resolved records>`. Keying on the
+    /// solve's output keeps the prefix path stable across a moving
+    /// (relative) `exclude-newer` cutoff.
     fn prefix_cache_key(&self, fingerprint: &EnvironmentFingerprint) -> String {
         format!("{}-{}", self.dependency_hint(), fingerprint.as_str())
     }
 
-    /// File name of this spec's [`EphemeralEnvPointer`], next to the
-    /// prefixes in the backends cache dir:
-    /// `<hint>-<hash of the spec sans cutoff>.pointer.json`.
-    ///
-    /// The cutoff is deliberately left out of the name and stored *inside*
-    /// the pointer instead, so a moving (relative) `exclude-newer`
-    /// overwrites one pointer per spec rather than accreting one file per
-    /// resolved cutoff. The `.pointer.json` suffix cannot collide with a
-    /// prefix directory: the hash segment of a prefix name is base64/hex
-    /// and never contains a dot.
+    /// File name of this spec's [`EphemeralEnvPointer`]:
+    /// `<hint>-<hash of the spec sans cutoff>.pointer.json`. The cutoff is
+    /// stored *inside* the pointer rather than in the name so a moving
+    /// cutoff overwrites one file per spec instead of accreting one per
+    /// resolved cutoff.
     fn pointer_file_name(&self) -> String {
         let mut hasher = Xxh3::new();
         self.hash_without_exclude_newer(&mut hasher);
@@ -174,9 +154,7 @@ impl EphemeralEnvSpec {
         format!("{}-{}.pointer.json", self.dependency_hint(), encoded)
     }
 
-    /// Stable per-spec label for logging/telemetry only. The compute engine
-    /// dedups on the spec's `Hash`/`Eq` (which include `exclude_newer`), not
-    /// on this string, so genuinely different specs remain distinct keys.
+    /// Stable per-spec label, for display purposes only.
     fn label(&self) -> String {
         let mut hasher = Xxh3::new();
         self.hash(&mut hasher);
@@ -266,15 +244,11 @@ impl Key for EphemeralEnvKey {
     async fn compute(&self, ctx: &mut ComputeCtx) -> Self::Value {
         let spec: &EphemeralEnvSpec = &self.0;
 
-        // Cross-process fast path: the spec-keyed pointer file records
-        // the fingerprint this spec last resolved to. When its stored
-        // cutoff equals the spec's and the fingerprint-addressed prefix
-        // carries a marker, the env is fully reusable with no repodata
-        // fetch or solve — ~250 ms on Windows for pixi-build-cmake /
-        // pixi-build-python. A relative `exclude-newer` resolves to a
-        // fresh cutoff every invocation, so it never matches here and
-        // always re-solves, landing on the shared fingerprint-addressed
-        // prefix below.
+        // Cross-process fast path: if the pointer matches the spec's
+        // cutoff and the prefix it points at carries a marker, the env is
+        // reusable without a repodata fetch or solve. A relative
+        // `exclude-newer` yields a fresh cutoff every invocation and never
+        // matches here.
         let backends_dir = ctx.cache_dir::<BuildBackendsDir>().await;
         let pointer_path = backends_dir.join(spec.pointer_file_name());
         if let Some(pointer) = read_pointer(pointer_path.as_std_path()).await
@@ -322,20 +296,9 @@ impl Key for EphemeralEnvKey {
             .await
             .map_err(|e| Arc::new(EphemeralEnvError::Solve(Arc::new(e))))?;
 
-        // 5. Content-address the prefix on the *resolved* records.
-        //
-        //    The prefix is keyed by a fingerprint of the solved binary
-        //    records (`name + sha256`), so callers that resolve to the same
-        //    packages share one prefix. This makes a *relative*
-        //    `exclude-newer` reusable: its cutoff is `now - duration`, which
-        //    changes on every invocation, yet as long as the resolved
-        //    package set is unchanged the fingerprint — and therefore the
-        //    prefix path — is stable. `exclude_newer` influences only the
-        //    solve above, never the cache identity, exactly as if a plain
-        //    solve had been cached at that point in the past. The spec
-        //    (including `exclude_newer`) still keys the in-process
-        //    compute-engine dedup via `EphemeralEnvKey`, so two genuinely
-        //    different cutoffs that resolve differently never collide here.
+        // 5. Content-address the prefix on the *resolved* records: solves
+        //    that resolve to the same packages share one prefix even when
+        //    a relative `exclude-newer` cutoff moves between invocations.
         let binary_records = records
             .iter()
             .filter_map(|r| match r {
@@ -348,11 +311,8 @@ impl Key for EphemeralEnvKey {
         let cache_key = spec.prefix_cache_key(&expected_fingerprint);
         let prefix_path = backends_dir.join(&cache_key);
 
-        // A prefix already provisioned for this resolved record set
-        // (marker present) is fully reusable — e.g. a moving cutoff that
-        // re-solved to the same packages, or a pointer that was missing
-        // or stale. Refresh the pointer so the next process with this
-        // spec can skip the solve entirely.
+        // A prefix already provisioned for these records is reusable;
+        // refresh the pointer so the next process can skip the solve.
         if let Some(cached) = read_cached_marker(prefix_path.as_std_path()).await {
             write_pointer(pointer_path.as_std_path(), spec, &expected_fingerprint).await;
             return Ok(Arc::new(cached));
@@ -425,8 +385,7 @@ impl Key for EphemeralEnvKey {
         })?;
 
         // Write the records marker before releasing the lock so peers
-        // see it on the lock-free fast path, then the spec → fingerprint
-        // pointer so the next process with this spec skips the solve.
+        // see it on the lock-free fast path, then refresh the pointer.
         write_cached_marker(prefix.path(), &binary_records).await;
         write_pointer(pointer_path.as_std_path(), spec, &expected_fingerprint).await;
 
@@ -506,17 +465,12 @@ async fn write_cached_marker(prefix_path: &std::path::Path, records: &[RepoDataR
     let _ = tokio::fs::rename(&tmp, &dest).await;
 }
 
-/// Spec → fingerprint pointer, the first level of the two-level cache
-/// (see the module docs). Stored at
+/// Spec → fingerprint pointer, stored at
 /// [`EphemeralEnvSpec::pointer_file_name`] in the backends cache dir.
 ///
-/// Purely advisory: the records are always read from the pointed-to
-/// prefix's own marker, so a missing, stale, or corrupt pointer costs
-/// one solve, never correctness. The stored `exclude_newer` must equal
-/// the spec's before the pointer is followed; it lives *inside* the
-/// pointer rather than in the file name so a moving (relative) cutoff
-/// rewrites one pointer per spec instead of accreting one per resolved
-/// cutoff.
+/// Purely advisory: a missing, stale, or corrupt pointer costs one
+/// solve, never correctness. The stored `exclude_newer` must equal the
+/// spec's before the pointer is followed.
 #[derive(Serialize, Deserialize)]
 struct EphemeralEnvPointer {
     version: u32,
@@ -526,10 +480,9 @@ struct EphemeralEnvPointer {
 
 const EPHEMERAL_ENV_POINTER_VERSION: u32 = 1;
 
-/// Read and validate a spec → fingerprint pointer. Returns `None` (the
-/// caller falls through to the solve) on a missing / unparsable /
-/// wrong-version pointer, or when the fingerprint is not a plain hex
-/// digest — it becomes a path segment, so nothing else may pass.
+/// Read and validate a spec → fingerprint pointer. Returns `None` on a
+/// missing, unparsable, or wrong-version pointer, or when the
+/// fingerprint is not plain hex (it becomes a path segment).
 async fn read_pointer(pointer_path: &std::path::Path) -> Option<EphemeralEnvPointer> {
     let bytes = tokio::fs::read(pointer_path).await.ok()?;
     let pointer: EphemeralEnvPointer = serde_json::from_slice(&bytes).ok()?;
@@ -651,11 +604,8 @@ mod tests {
         ResolvedExcludeNewer::from_datetime(cutoff.parse::<DateTime<Utc>>().unwrap())
     }
 
-    /// Acceptance criteria 1 & 3: the prefix path is a pure function of the
-    /// resolved records, so two solves that resolve to the same packages
-    /// under *different* `exclude-newer` cutoffs (as a relative cutoff
-    /// produces on every invocation) share one prefix — `backends-v0` does
-    /// not grow per solve.
+    /// Solves that resolve to the same records share one prefix
+    /// regardless of the `exclude-newer` cutoff.
     #[test]
     fn prefix_cache_key_ignores_exclude_newer() {
         let fingerprint = EnvironmentFingerprint::from_string("0123456789abcdef".to_string());
@@ -668,9 +618,7 @@ mod tests {
         assert_eq!(key, b.prefix_cache_key(&fingerprint));
     }
 
-    /// Acceptance criterion 2: a different resolved record set yields a
-    /// different prefix, so genuinely different resolutions never collide on
-    /// one prefix.
+    /// Different resolved records yield different prefixes.
     #[test]
     fn prefix_cache_key_changes_with_resolved_records() {
         let spec = spec_with_exclude_newer(Some(resolved("2026-01-01T00:00:00Z")));
@@ -679,12 +627,8 @@ mod tests {
         assert_ne!(spec.prefix_cache_key(&fp1), spec.prefix_cache_key(&fp2));
     }
 
-    /// Acceptance criterion 4 (correctness guard): the compute-engine key
-    /// still distinguishes specs that differ only in `exclude_newer`, so two
-    /// genuinely different cutoffs are solved independently — their resolved
-    /// records then decide whether they end up sharing a prefix. The cache
-    /// key never inspects timestamps, so untimestamped-package handling stays
-    /// entirely in the solve, unchanged.
+    /// The compute-engine key still distinguishes specs that differ only
+    /// in `exclude_newer`, so different cutoffs are solved independently.
     #[test]
     fn spec_identity_still_distinguishes_exclude_newer() {
         let a = spec_with_exclude_newer(Some(resolved("2024-01-01T00:00:00Z")));
@@ -709,10 +653,8 @@ mod tests {
         assert_eq!(pointer.exclude_newer, spec.exclude_newer);
     }
 
-    /// Specs that differ only in their cutoff share one pointer *file*
-    /// (bounded growth: a moving cutoff overwrites rather than accretes),
-    /// but the stored cutoff distinguishes them, so a pointer written
-    /// under one cutoff is never followed for another.
+    /// Specs that differ only in their cutoff share one pointer file, but
+    /// the stored cutoff keeps them distinct.
     #[tokio::test]
     async fn pointer_is_shared_per_spec_but_keyed_on_cutoff() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -729,9 +671,7 @@ mod tests {
         assert_ne!(pointer.exclude_newer, b.exclude_newer);
     }
 
-    /// Corrupt or incompatible pointers fall through to the solve. A
-    /// fingerprint that is not a plain hex digest is rejected because it
-    /// becomes a path segment.
+    /// Corrupt or incompatible pointers are rejected.
     #[tokio::test]
     async fn read_pointer_rejects_invalid_contents() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
+++ b/crates/pixi_command_dispatcher/src/ephemeral_env/mod.rs
@@ -57,9 +57,9 @@ const EPHEMERAL_LOCK_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
 /// Specification for an ephemeral, binary-only conda environment.
 ///
 /// The spec's hash keys the compute-engine dedup; the on-disk prefix is
-/// content-addressed on the *resolved* records (see
-/// [`EphemeralEnvSpec::prefix_cache_key`]). Source `PixiSpec`s in
-/// `dependencies` cause the Key to fail at compute time.
+/// content-addressed on the *resolved* records (see `prefix_cache_key`).
+/// Source `PixiSpec`s in `dependencies` cause the Key to fail at compute
+/// time.
 #[derive(Clone, Debug)]
 pub struct EphemeralEnvSpec {
     /// Package requirements. Must be binary-only at compute time.

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -494,13 +494,16 @@ pub async fn dropping_future_cancels_background_task() {
     let root_dir = cargo_workspace_dir();
     let channel_dir = root_dir.join("tests/data/channels/channels/backend_channel_1");
 
-    // Use an isolated cache dir so this test's backend prefix can't
-    // collide with another run's. The ephemeral-env key derives the
-    // prefix path from the *resolved* records, so its
-    // `.pixi-ephemeral-cache.json` marker is only consulted after the
-    // conda solve — a `CondaSolveStarted` event always fires — but a
-    // fresh tempdir still keeps the prefix clean and the abort
-    // deterministic.
+    // Use an isolated cache dir. The ephemeral-env compute key takes a
+    // fast path when a spec-keyed `.pointer.json` file and the
+    // fingerprint-addressed prefix's `.pixi-ephemeral-cache.json`
+    // marker are both present, returning the cached records before any
+    // `CondaSolveStarted` event fires. With a shared cache those can
+    // already be present from a previous run of this test (or a stray
+    // `pixi run` reusing the same backend), so the test would wait for
+    // a solve that never happens. A fresh tempdir guarantees a clean
+    // prefix and forces the slow path the test actually wants to
+    // observe.
     let cache_tempdir = tempfile::TempDir::new().unwrap();
     let cache_dirs = CacheDirs::new(to_abs_dir(cache_tempdir.path().to_path_buf()));
 

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -494,16 +494,10 @@ pub async fn dropping_future_cancels_background_task() {
     let root_dir = cargo_workspace_dir();
     let channel_dir = root_dir.join("tests/data/channels/channels/backend_channel_1");
 
-    // Use an isolated cache dir. The ephemeral-env compute key takes a
-    // fast path when a spec-keyed `.pointer.json` file and the
-    // fingerprint-addressed prefix's `.pixi-ephemeral-cache.json`
-    // marker are both present, returning the cached records before any
-    // `CondaSolveStarted` event fires. With a shared cache those can
-    // already be present from a previous run of this test (or a stray
-    // `pixi run` reusing the same backend), so the test would wait for
-    // a solve that never happens. A fresh tempdir guarantees a clean
-    // prefix and forces the slow path the test actually wants to
-    // observe.
+    // Use an isolated cache dir: with a shared cache the ephemeral-env
+    // fast path can return cached records before any `CondaSolveStarted`
+    // event fires, and the test would wait for a solve that never
+    // happens.
     let cache_tempdir = tempfile::TempDir::new().unwrap();
     let cache_dirs = CacheDirs::new(to_abs_dir(cache_tempdir.path().to_path_buf()));
 

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -494,15 +494,13 @@ pub async fn dropping_future_cancels_background_task() {
     let root_dir = cargo_workspace_dir();
     let channel_dir = root_dir.join("tests/data/channels/channels/backend_channel_1");
 
-    // Use an isolated cache dir. The ephemeral-env compute key takes a
-    // fast path when it finds a `.pixi-ephemeral-cache.json` marker in
-    // the target prefix, returning the cached records before any
-    // `CondaSolveStarted` event fires. With a shared cache that marker
-    // can already be present from a previous run of this test (or a
-    // stray `pixi run` reusing the same backend), so the test waits for
-    // a solve that never happens. A fresh tempdir guarantees a clean
-    // prefix and forces the slow path the test actually wants to
-    // observe.
+    // Use an isolated cache dir so this test's backend prefix can't
+    // collide with another run's. The ephemeral-env key derives the
+    // prefix path from the *resolved* records, so its
+    // `.pixi-ephemeral-cache.json` marker is only consulted after the
+    // conda solve — a `CondaSolveStarted` event always fires — but a
+    // fresh tempdir still keeps the prefix clean and the abort
+    // deterministic.
     let cache_tempdir = tempfile::TempDir::new().unwrap();
     let cache_dirs = CacheDirs::new(to_abs_dir(cache_tempdir.path().to_path_buf()));
 


### PR DESCRIPTION
### Description

This PR contains a fix and an optional enhancement:

* The first commit is a solution by itself by using the resolved records to build the cache key. The downside of this is that it removes the fast-path from the code which can currently avoid running the solver. This is similar to #5607.

* The second commit restores the fast path for non-relative values of `exclude-newer` by adding a spec keyed pointer file to track the cut off used without including it in the hash. Unfortunately this doesn't allow the fast path to work with a relative `exclude-newer` but that seems to be a non-trivial thing to fix as the information is already lost by this point.

Feel free to close this PR if you want to go a different direction.

Fixes https://github.com/prefix-dev/pixi/issues/6617

### How Has This Been Tested?

Tests inside the PR plus building pixi manually and ensuring it behaves as I expect.

### AI Disclosure

Tools: Claude

I lost track of the prompt as I took things in a different direction than Claude's original suggestions.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

