### PR TITLE
fix: better messaging when adding dependencies to unused features

### DIFF
--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -7,10 +7,12 @@ use pixi_api::{
     workspace::{DependencyOptions, GitOptions},
 };
 use pixi_config::ConfigCli;
+use pixi_consts::consts;
 use pixi_core::{
     DependencyType, WorkspaceLocator,
     workspace::{PypiDeps, SkippedPackage},
 };
+use pixi_manifest::HasFeaturesIter;
 use pixi_pypi_spec::{PixiPypiSource, PixiPypiSpec, PypiPackageName};
 use url::Url;
 
@@ -274,6 +276,47 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             ..args.dependency_config
         };
         display_config.display_success("Added", update_deps.implicit_constraints);
+
+        // A feature that is not part of any environment is never solved, so
+        // the added dependencies could not be resolved or pinned. Point the
+        // user at the missing steps instead of leaving the `*` unexplained.
+        // Re-running the same `pixi add` would hit the "already a dependency"
+        // path, so `pixi upgrade` is the command that replaces the `*`.
+        let added_names = parsed_names
+            .iter()
+            .filter(|name| !skipped_set.contains(name.as_str()))
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let feature_name = display_config.feature_name();
+        if let Some(feature) = feature_name.non_default()
+            && !feature_name.is_environment()
+            && !added_names.is_empty()
+            && !workspace
+                .environments()
+                .iter()
+                .any(|env| env.features().any(|f| f.name == feature_name))
+        {
+            eprintln!(
+                "{}The feature {} is not used in any environment, so the added dependencies were not resolved or pinned",
+                console::style(console::Emoji("⚠️ ", "warning: ")).yellow(),
+                consts::FEATURE_STYLE.apply_to(feature),
+            );
+            eprintln!(
+                "  Add it to an environment with `{}`",
+                console::style(format!(
+                    "pixi workspace environment add <environment> --feature {feature}"
+                ))
+                .green()
+                .bold(),
+            );
+            eprintln!(
+                "  Then run `{}` to resolve and pin the dependencies",
+                console::style(format!("pixi upgrade --feature {feature} {added_names}"))
+                    .green()
+                    .bold(),
+            );
+        }
     }
 
     Ok(())

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -79,6 +79,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
+        // Warning about unused features before the environment they are meant
+        // for even exists would be confusing.
+        .with_ignore_unused_feature_warnings(matches!(args.command, Command::Add(_)))
         .locate()?;
 
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);

--- a/crates/pixi_core/src/workspace/discovery.rs
+++ b/crates/pixi_core/src/workspace/discovery.rs
@@ -71,6 +71,7 @@ pub struct WorkspaceLocator {
     start: DiscoveryStart,
     with_closest_package: bool,
     emit_warnings: bool,
+    ignore_unused_feature_warnings: bool,
     consider_environment: bool,
     ignore_pixi_version_check: bool,
     /// Source for the global (system + user-level) config layer.
@@ -177,6 +178,17 @@ impl WorkspaceLocator {
     pub fn with_emit_warnings(self, emit_warnings: bool) -> Self {
         Self {
             emit_warnings,
+            ..self
+        }
+    }
+
+    /// Set whether to skip warnings about features that are not used in any
+    /// environment. Useful for commands that change which features an
+    /// environment consists of, as the warning describes the manifest before
+    /// the command has run.
+    pub fn with_ignore_unused_feature_warnings(self, ignore_unused_feature_warnings: bool) -> Self {
+        Self {
+            ignore_unused_feature_warnings,
             ..self
         }
     }
@@ -293,6 +305,9 @@ impl WorkspaceLocator {
         };
 
         // Emit any warnings that were encountered during the discovery process.
+        if self.ignore_unused_feature_warnings {
+            warnings.retain(|warning| !warning.error.is_unused_feature());
+        }
         if self.emit_warnings && !warnings.is_empty() {
             tracing::warn!(
                 "Encountered {} warning{} while parsing the manifest:\n{}",

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -526,7 +526,7 @@ impl TomlManifest {
                 continue;
             }
 
-            warnings.push(Warning::from(
+            warnings.push(Warning::unused_feature(
                 GenericError::new(format!(
                     "The feature '{feature_name}' is defined but not used in any environment. Dependencies of unused features are not resolved or checked, and use wildcard (*) version specifiers by default, disregarding any set `pinning-strategy`"
                 ))

--- a/crates/pixi_manifest/src/warning/mod.rs
+++ b/crates/pixi_manifest/src/warning/mod.rs
@@ -17,6 +17,23 @@ pub enum Warning {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Generic(#[from] GenericWarning),
+
+    /// A feature is defined in the manifest but not used in any environment.
+    /// Kept as a separate variant so commands that are about to change
+    /// environment membership can filter it out.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnusedFeature(GenericWarning),
+}
+
+impl Warning {
+    pub fn unused_feature(error: GenericError) -> Self {
+        Warning::UnusedFeature(GenericWarning { error })
+    }
+
+    pub fn is_unused_feature(&self) -> bool {
+        matches!(self, Warning::UnusedFeature(_))
+    }
 }
 
 impl From<GenericError> for Warning {

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1584,3 +1584,90 @@ def test_add_url_no_channel(pixi: Path, tmp_pixi_workspace: Path) -> None:
         ],
         stderr_contains="The prefix environment has been installed",
     )
+
+
+def test_add_to_unused_feature_warns(
+    pixi: Path, tmp_pixi_workspace: Path, multiple_versions_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    verify_cli_command([pixi, "init", "--channel", multiple_versions_channel_1, tmp_pixi_workspace])
+
+    # The feature is not part of any environment, so the dependency cannot be
+    # pinned to a solved version and stays `*`.
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest_path, "--feature", "test", "package"],
+        stderr_contains=[
+            "not used in any environment",
+            "pixi workspace environment add <environment> --feature test",
+            "pixi upgrade --feature test package",
+        ],
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["feature"]["test"]["dependencies"]["package"] == "*"
+
+    # Once the feature is part of an environment, the dependency is pinned and
+    # no warning is shown.
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "environment",
+            "add",
+            "--manifest-path",
+            manifest_path,
+            "test-env",
+            "--feature",
+            "test",
+        ],
+    )
+    verify_cli_command(
+        [pixi, "add", "--manifest-path", manifest_path, "--feature", "test", "package2"],
+        stderr_excludes="not used in any environment",
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["feature"]["test"]["dependencies"]["package2"] == ">=0.2.0,<0.3"
+
+    # Following the suggested upgrade command pins the wildcard dependency.
+    verify_cli_command(
+        [pixi, "upgrade", "--manifest-path", manifest_path, "--feature", "test", "package"],
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["feature"]["test"]["dependencies"]["package"] == ">=0.2.0,<0.3"
+
+
+def test_workspace_environment_add_skips_unused_feature_warning(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    manifest_path = tmp_pixi_workspace / "pixi.toml"
+    verify_cli_command([pixi, "init", "--channel", dummy_channel_1, tmp_pixi_workspace])
+    manifest_path.write_text(
+        manifest_path.read_text()
+        + """
+[feature.test.dependencies]
+dummy-a = "*"
+"""
+    )
+
+    # Other commands warn about the unused feature...
+    verify_cli_command(
+        [pixi, "workspace", "environment", "list", "--manifest-path", manifest_path],
+        stderr_contains="not used in any environment",
+    )
+
+    # ...but the command that puts the feature into an environment does not.
+    verify_cli_command(
+        [
+            pixi,
+            "workspace",
+            "environment",
+            "add",
+            "--manifest-path",
+            manifest_path,
+            "test-env",
+            "--feature",
+            "test",
+        ],
+        stderr_excludes="not used in any environment",
+    )
+    parsed_manifest = tomllib.loads(manifest_path.read_text())
+    assert parsed_manifest["environments"]["test-env"] == ["test"]


### PR DESCRIPTION
### Description

A feature that is not part of any environment is never solved, so `pixi add` has no version to pin to and leaves the dependency at `*`. That is expected, but the surrounding UX was confusing:

- `pixi add --feature test pytest` now explains that the dependency was not resolved or pinned, suggests `pixi workspace environment add` followed by `pixi upgrade` to pin it afterward.
- `pixi workspace environment add` no longer warns about an unused feature that it is adding to an environment at that very moment.

Fixes #6620

### How Has This Been Tested?

Added tests and tried it locally

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
