### PR TITLE
fix: tone down lockfile format and deprecation warnings on read-only commands

### DIFF
--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -171,6 +171,7 @@ fn map_pypi_requirements_with_index(
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let mut workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -142,6 +142,7 @@ async fn import(args: Args, format: &ImportFileFormat) -> miette::Result<()> {
         (args.file, args.platforms, args.workspace_config);
 
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(source)
         .with_search_start(workspace_config.workspace_locator_start())
         .locate()?

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -44,6 +44,7 @@ pub struct Args {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let mut workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -64,6 +64,7 @@ impl TryFrom<&Args> for DependencyOptions {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -129,6 +129,7 @@ impl UpdateSpecs {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.project_config.workspace_locator_start())
         .locate()?

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -76,6 +76,7 @@ pub struct UpgradeSpecsArgs {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -98,6 +98,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_cli/src/workspace/description.rs
+++ b/crates/pixi_cli/src/workspace/description.rs
@@ -44,6 +44,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -77,6 +77,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         // Warning about unused features before the environment they are meant

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -43,6 +43,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_cli/src/workspace/name.rs
+++ b/crates/pixi_cli/src/workspace/name.rs
@@ -41,6 +41,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -453,6 +453,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
@@ -40,6 +40,7 @@ pub enum Command {
 pub async fn execute(args: Args) -> miette::Result<()> {
     let is_verify = matches!(args.command, Command::Verify);
     let workspace_locator = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .with_ignore_pixi_version_check(!is_verify);

--- a/crates/pixi_cli/src/workspace/version/mod.rs
+++ b/crates/pixi_cli/src/workspace/version/mod.rs
@@ -38,6 +38,7 @@ pub enum Command {
 
 pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace = WorkspaceLocator::for_cli()
+        .with_deprecation_warnings(true)
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -318,7 +318,10 @@ impl Workspace {
         .await;
         if outdated.is_empty() && !(needs_format_upgrade && options.upgrade_lock_file_format) {
             if needs_format_upgrade {
-                tracing::warn!(
+                // An old but up-to-date lock file is perfectly usable, so
+                // don't nag on every command; `pixi lock` performs (and
+                // reports) the actual upgrade.
+                tracing::info!(
                     "the lock file is up-to-date but uses an older format (v{}), \
                      run `pixi lock` to upgrade to v{} for improved reproducibility",
                     derived.lock_file.version(),

--- a/crates/pixi_core/src/workspace/discovery.rs
+++ b/crates/pixi_core/src/workspace/discovery.rs
@@ -71,6 +71,7 @@ pub struct WorkspaceLocator {
     start: DiscoveryStart,
     with_closest_package: bool,
     emit_warnings: bool,
+    emit_deprecation_warnings: bool,
     ignore_unused_feature_warnings: bool,
     consider_environment: bool,
     ignore_pixi_version_check: bool,
@@ -178,6 +179,18 @@ impl WorkspaceLocator {
     pub fn with_emit_warnings(self, emit_warnings: bool) -> Self {
         Self {
             emit_warnings,
+            ..self
+        }
+    }
+
+    /// Set whether to emit deprecation warnings for legacy manifest syntax
+    /// (e.g. the `[system-requirements]` table). These are suppressed by
+    /// default so that everyday commands like `pixi run` stay quiet; commands
+    /// that update the lock file or modify the manifest opt in, as those are
+    /// the natural moments to nudge the user to migrate.
+    pub fn with_deprecation_warnings(self, emit_deprecation_warnings: bool) -> Self {
+        Self {
+            emit_deprecation_warnings,
             ..self
         }
     }
@@ -307,6 +320,9 @@ impl WorkspaceLocator {
         // Emit any warnings that were encountered during the discovery process.
         if self.ignore_unused_feature_warnings {
             warnings.retain(|warning| !warning.error.is_unused_feature());
+        }
+        if !self.emit_deprecation_warnings {
+            warnings.retain(|warning| !warning.error.is_deprecation());
         }
         if self.emit_warnings && !warnings.is_empty() {
             tracing::warn!(

--- a/crates/pixi_manifest/src/warning/mod.rs
+++ b/crates/pixi_manifest/src/warning/mod.rs
@@ -34,6 +34,10 @@ impl Warning {
     pub fn is_unused_feature(&self) -> bool {
         matches!(self, Warning::UnusedFeature(_))
     }
+
+    pub fn is_deprecation(&self) -> bool {
+        matches!(self, Warning::Deprecation(_))
+    }
 }
 
 impl From<GenericError> for Warning {

--- a/docs/workspace/system_requirements.md
+++ b/docs/workspace/system_requirements.md
@@ -5,7 +5,10 @@
     [`pixi workspace platform`](../reference/cli/pixi/workspace/platform.md) CLI.
     Existing `[system-requirements]` tables are still parsed and migrated
     transparently, so older manifests keep working, but new manifests should
-    use the per-platform form.
+    use the per-platform form. The deprecation warning is only shown by
+    commands that update the lock file or modify the manifest (such as
+    `pixi add`, `pixi lock`, or `pixi workspace platform`); everyday commands
+    like `pixi run` stay quiet.
 
 # Migrating from `[system-requirements]`
 


### PR DESCRIPTION
### Description

Everyday commands like `pixi run`, `pixi shell`, and `pixi list` no longer nag about things that don't affect them. Deprecation warnings (such as the legacy `[system-requirements]` table and `[package.target]` tables) are now only shown by commands that update the lock file or modify the manifest, and the old-lockfile-format notice is demoted to `info` on the read path.

> Original request: "My friend was complaining about the lockfile warning in Pixi - maybe we can make that less aggressive? E.g. not on `pixi run` and other operations - because using an old lockfile is totally fine for now. Same / similar for the system requirements -> fancy platforms deprecation - toning it down to only fire when updating? or modifying pixi.toml"

**Key changes:**

1. **Added `emit_deprecation_warnings` flag to `WorkspaceLocator`** (default `false`), following the existing `ignore_unused_feature_warnings` pattern, plus a `Warning::is_deprecation()` helper. Deprecation warnings are filtered out of the manifest-warning report unless the command opts in.

2. **Opt-in via `with_deprecation_warnings(true)`** for the commands where migrating is actually relevant:
   - Lock file updates: `pixi lock`, `pixi update`, `pixi upgrade`
   - Manifest modification: `pixi add`, `pixi remove`, `pixi import`
   - Workspace config: `pixi workspace channel | description | environment | feature | name | platform | requires-pixi | version`

3. **Lock file format notice demoted from `warn` to `info`** on the read path in `update_lock_file()`. An old but up-to-date lock file is perfectly usable; `pixi lock` still performs and reports the actual format upgrade (that path is unchanged).

4. **Documentation**: `docs/workspace/system_requirements.md` now states when the deprecation warning appears.

Note: `pixi install` is deliberately in the quiet group, treated like `pixi run` as an everyday materialization command. Easy to flip if reviewers prefer it noisy.

### How Has This Been Tested?

Verified end-to-end with a built binary on a project containing a `[system-requirements]` table and a v6 lock file:

- `pixi run hello` and `pixi task list`: no warnings, and `run` leaves the v6 lock file untouched.
- `pixi workspace channel list` and `pixi lock`: show the deprecation diagnostic; `pixi lock` upgrades the lock file to v7.

`cargo check`, `cargo clippy`, and the `pixi_manifest`/`pixi_core` unit test suites pass (the two failing `pixi_core` tests are pre-existing env-var races that also fail on a clean tree).

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkisJKP8uDL9tseG1udeST