### PR TITLE
fix(ci): stop docs-dev racing docs-release on tag dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,7 +105,9 @@ jobs:
 
   docs-dev:
     # Don't run on forks
-    if: github.repository == 'prefix-dev/pixi' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && !startsWith(github.event.inputs.tag, 'v'))
+    # Only on a real push to `main`; a `workflow_dispatch` with a version tag targets
+    # `--ref main` too, and letting this job run there races `docs-release` on `gh-pages`.
+    if: github.repository == 'prefix-dev/pixi' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && !startsWith(github.event.inputs.tag, 'v'))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
`release.yml` dispatches `docs.yml` with `--ref main`, so `github.ref` is `refs/heads/main` and the `docs-dev` guard fired even for version tags. Both jobs then pushed `gh-pages` concurrently and whichever lost got a rejected ref - that's why v0.72.2 and v0.73.0 never made it to the docs site.

Scope the `main` branch condition to `push` events so tag dispatches only run `docs-release`.