### PR TITLE
fix(ci): keep PR docs builds out of the deploy concurrency group

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,10 +29,12 @@ on:
         required: true
         default: "v0.0.0"
 
-# Allow one concurrent deployment
+# Allow one concurrent deployment. PRs only run `build-docs`, which never touches
+# `gh-pages`, so they get their own per-ref group; deploys queue instead of
+# cancelling, since a cancelled `mike` push leaves `gh-pages` stale.
 concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.ref) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
A PR only runs `build-docs`, which never touches `gh-pages`, but it shared the `pages` group with `cancel-in-progress`. A renovate PR run killed the v0.73.0 deploy 19s in, which is why those docs never appeared.

Give PRs their own per-ref group and let deploys queue instead of cancelling - a cancelled `mike` push just leaves `gh-pages` stale.