### PR TITLE
docs: Fix examples to use `requires-pixi` instead of `pixi-minimum`

### DIFF
--- a/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
@@ -29,7 +29,7 @@ pub enum Command {
     /// Set the pixi minimum version requirement.
     ///
     /// Example:
-    /// `pixi workspace pixi-minimum set 0.42`
+    /// `pixi workspace requires-pixi set 0.42`
     Set(set::Args),
     /// Remove the pixi minimum version requirement.
     Unset,

--- a/docs/reference/cli/pixi/workspace/requires-pixi/set.md
+++ b/docs/reference/cli/pixi/workspace/requires-pixi/set.md
@@ -21,7 +21,7 @@ pixi workspace requires-pixi set <VERSION>
 ## Description
 Set the pixi minimum version requirement.
 
-Example: `pixi workspace pixi-minimum set 0.42`
+Example: `pixi workspace requires-pixi set 0.42`
 
 
 --8<-- "docs/reference/cli/pixi/workspace/requires-pixi/set_extender:example"


### PR DESCRIPTION
### Description

Small documentation fix: `pixi-minimum` -> `requires-pixi`

Noticed when following the documentation for setting up the minimum pixi version.

### How Has This Been Tested?

`pixi run test`, `pixi run docs` and checked rendered docs


### AI Disclosure

This PR doesn't contain AI-generated content.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation