### PR TITLE
feat: add --from-url option for self-update

### DIFF
--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -55,7 +55,7 @@ pub struct Args {
     #[clap(long, default_value_t = false)]
     no_release_note: bool,
 
-    /// Accept the specified url prefix
+    /// Accept the specified url prefix.
     #[clap(long)]
     from_url: Option<String>,
 }
@@ -364,11 +364,7 @@ pub async fn execute(args: Args, global_options: &GlobalOptions) -> miette::Resu
     };
 
     let download_url = if let Some(ref target_version) = target_version {
-        format!(
-            "{}/download/v{}/{}", 
-            pre_fix, 
-            target_version, 
-            archive_name)
+        format!("{}/download/v{}/{}", pre_fix, target_version, archive_name)
     } else {
         format!("{}/latest/download/{}", pre_fix, archive_name)
     };

--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -222,10 +222,10 @@ pub async fn execute(args: Args, global_options: &GlobalOptions) -> miette::Resu
     }
 
     // Exam the validity of provided url
-    if let Some(ref url) = args.from_url {
-        if let Err(err) = Url::parse(url) {
-            miette::bail!("URL: {}. Url validation failed: {}", url, err)
-        }
+    if let Some(ref url) = args.from_url
+        && let Err(err) = Url::parse(url)
+    {
+        miette::bail!("URL: {}. Url validation failed: {}", url, err)
     }
 
     let is_quiet = global_options.quiet > 0;

--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -54,6 +54,10 @@ pub struct Args {
     /// Skip printing the release notes.
     #[clap(long, default_value_t = false)]
     no_release_note: bool,
+
+    /// Accept the specified url prefix
+    #[clap(long)]
+    from_url: Option<String>,
 }
 
 /// Response from the Github API when fetching a release by tag.
@@ -217,6 +221,13 @@ pub async fn execute(args: Args, global_options: &GlobalOptions) -> miette::Resu
         .into());
     }
 
+    // Exam the validity of provided url
+    if let Some(ref url) = args.from_url {
+        if let Err(err) = Url::parse(url) {
+            miette::bail!("URL: {}. Url validation failed: {}", url, err)
+        }
+    }
+
     let is_quiet = global_options.quiet > 0;
     // Get the target version, without 'v' prefix, None for force latest version
     let target_version = match &args.version {
@@ -346,15 +357,20 @@ pub async fn execute(args: Args, global_options: &GlobalOptions) -> miette::Resu
     let archive_name = default_archive_name()
         .expect("Could not find the default archive name for the current platform");
 
+    let pre_fix = if let Some(ref from_url) = args.from_url {
+        from_url
+    } else {
+        consts::RELEASES_URL
+    };
+
     let download_url = if let Some(ref target_version) = target_version {
         format!(
-            "{}/download/v{}/{}",
-            consts::RELEASES_URL,
-            target_version,
-            archive_name
-        )
+            "{}/download/v{}/{}", 
+            pre_fix, 
+            target_version, 
+            archive_name)
     } else {
-        format!("{}/latest/download/{}", consts::RELEASES_URL, archive_name)
+        format!("{}/latest/download/{}", pre_fix, archive_name)
     };
 
     // Create a temp file to download the archive

--- a/crates/pixi_cli/src/self_update.rs
+++ b/crates/pixi_cli/src/self_update.rs
@@ -55,7 +55,7 @@ pub struct Args {
     #[clap(long, default_value_t = false)]
     no_release_note: bool,
 
-    /// Accept the specified url prefix.
+    /// The github releases URL, useful when behind a proxy, or using custom Pixi release
     #[clap(long)]
     from_url: Option<String>,
 }

--- a/docs/reference/cli/pixi/self-update.md
+++ b/docs/reference/cli/pixi/self-update.md
@@ -28,6 +28,8 @@ pixi self-update [OPTIONS]
 - <a id="arg---no-release-note" href="#arg---no-release-note">`--no-release-note`</a>
 :  Skip printing the release notes
 <br>**default**: `false`
+- <a id="arg---from-url" href="#arg---from-url">`--from-url <FROM_URL>`</a>
+:  Accept the specified url prefix
 
 ## Config Options
 - <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>

--- a/docs/reference/cli/pixi/self-update.md
+++ b/docs/reference/cli/pixi/self-update.md
@@ -29,7 +29,7 @@ pixi self-update [OPTIONS]
 :  Skip printing the release notes
 <br>**default**: `false`
 - <a id="arg---from-url" href="#arg---from-url">`--from-url <FROM_URL>`</a>
-:  Accept the specified url prefix
+:  The github releases URL, useful when behind a proxy, or using custom Pixi release
 
 ## Config Options
 - <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Allow users to specify a custom base URL for downloading Pixi updates. This is useful for internal mirrors, air-gapped environments, and proxy setups.

The URL is validated to ensure it starts with http:// or https:// and is a valid URL via the `url` crate. The existing `--version`, `--force`, and `--dry-run` flags continue to work as expected.

<img width="1617" height="556" alt="image" src="https://github.com/user-attachments/assets/19703642-c2c1-4124-aa41-199de5e9d624" />


MOTIVATION: I'm from China, so it's a bit tough for me to use `pixi self-update`.Everytime I try to run this command ,it will take about 5 min or even more.I've also tried `pixi config edit` to add proxy settings, but it didn't work at all, which is hard to reproduce for other developers.So this is what I exactly want, and others will benefits from it. 

Relates to #6299.

I'm new in rust and not familiar with contribution process ( but I've read the CONTRIBUTION.md and relevant documents ), so if there is anything inproper, just point it out derectly.I will be glad to learn from it.

### How Has This Been Tested?
- Run `pixi run test` and the result is `Summary [ 143.227s] 2590 tests run: 2590 passed, 67 skipped`
- Verified that the `--from-url` option appears in `--help`.
- Tested with an invalid URL (e.g., `--from-url "not-a-url"`) to confirm the validation error is shown.
- Tested with a working mirror URL (e.g., `https://gh-proxy.com/https://github.com/prefix-dev/pixi/releases/`) to confirm the download and update process works.
- Confirmed that `--version`, `--force`, and `--dry-run` still work correctly when used together with `--from-url`.

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools:  DeepSeek

<!-- Add your prompt here, this helps us understand your results.
```plaintext
I do ask AI to translate and polish some text, that is.
```
-->
Prompt: I used AI to translate and polish some text in this PR description, and to help with code explanation and documentation formatting.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
