### PR TITLE
fix: name the failing environment in pixi global error messages

### DIFF
--- a/crates/pixi_cli/src/global/add.rs
+++ b/crates/pixi_cli/src/global/add.rs
@@ -132,7 +132,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 tracing::warn!("Reverting of the operation failed");
                 tracing::info!("Reversion error: {:?}", revert_err);
             }
-            Err(err)
+            Err(err.wrap_err(format!(
+                "Couldn't add packages to environment {}",
+                args.environment
+            )))
         }
     }
 }

--- a/crates/pixi_cli/src/global/install.rs
+++ b/crates/pixi_cli/src/global/install.rs
@@ -3,12 +3,14 @@ use std::{ops::Not, str::FromStr};
 use indexmap::IndexMap;
 
 use clap::Parser;
-use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use miette::Report;
 use rattler_conda_types::{MatchSpec, NamedChannelOrUrl, Platform};
 
-use crate::global::{global_specs::GlobalSpecs, revert_environment_after_error};
+use crate::global::{
+    EnvironmentAction, global_specs::GlobalSpecs, report_failed_environments,
+    revert_environment_after_error,
+};
 use pixi_config::{self, Config, ConfigCli};
 use pixi_global::{
     self, EnvChanges, EnvState, EnvironmentName, Mapping, Project, StateChange, StateChanges,
@@ -165,14 +167,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     )
     .await?;
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        for (env_name, err) in errors {
-            tracing::warn!("Couldn't install {}\n{err:?}", env_name.fancy_display());
-        }
-        Err(miette::miette!("Some environments couldn't be installed."))
-    }
+    report_failed_environments(EnvironmentAction::Install, errors)
 }
 
 async fn setup_environment(

--- a/crates/pixi_cli/src/global/mod.rs
+++ b/crates/pixi_cli/src/global/mod.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
-use miette::IntoDiagnostic;
+use fancy_display::FancyDisplay;
+use miette::{IntoDiagnostic, Report, WrapErr};
 use tokio::fs as tokio_fs;
 
 use pixi_global::EnvironmentName;
@@ -78,6 +79,52 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
     Ok(())
 }
 
+/// The operation that failed for one or more environments; determines the verb
+/// used in the resulting error messages.
+#[derive(Debug, Clone, Copy)]
+enum EnvironmentAction {
+    Sync,
+    Install,
+    Remove,
+}
+
+impl std::fmt::Display for EnvironmentAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let verb = match self {
+            EnvironmentAction::Sync => "sync",
+            EnvironmentAction::Install => "install",
+            EnvironmentAction::Remove => "remove",
+        };
+        write!(f, "{verb}")
+    }
+}
+
+/// Warns about each failed environment with its full error, then returns a
+/// single error naming every environment the operation failed for. Returns
+/// `Ok(())` if there are no errors.
+fn report_failed_environments(
+    action: EnvironmentAction,
+    errors: Vec<(EnvironmentName, Report)>,
+) -> miette::Result<()> {
+    if errors.is_empty() {
+        return Ok(());
+    }
+    for (env_name, err) in &errors {
+        tracing::warn!(
+            "Couldn't {action} environment {}\n{err:?}",
+            env_name.fancy_display()
+        );
+    }
+    let failed_envs = errors
+        .iter()
+        .map(|(env_name, _)| env_name.fancy_display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(miette::miette!(
+        "Couldn't {action} the following environments: {failed_envs}"
+    ))
+}
+
 /// Reverts the changes made to the project for a specific environment after an error occurred.
 async fn revert_environment_after_error(
     env_name: &EnvironmentName,
@@ -87,7 +134,8 @@ async fn revert_environment_after_error(
         // We don't want to report on changes done by the reversion
         let _ = project_to_revert_to
             .sync_environment(env_name, None)
-            .await?;
+            .await
+            .wrap_err_with(|| format!("Couldn't revert environment {env_name}"))?;
     } else {
         // clean up if directory exists for the failed new environment
         let env_dir_path = project_to_revert_to.env_root_path().join(env_name.as_str());

--- a/crates/pixi_cli/src/global/sync.rs
+++ b/crates/pixi_cli/src/global/sync.rs
@@ -1,5 +1,5 @@
+use crate::global::{EnvironmentAction, report_failed_environments};
 use clap::Parser;
-use fancy_display::FancyDisplay;
 use pixi_config::{Config, ConfigCli};
 
 /// Sync global manifest with installed environments
@@ -70,7 +70,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     state_change.report();
                 }
             }
-            Err(err) => errors.push((env_name, err)),
+            Err(err) => errors.push((env_name.clone(), err)),
         }
     }
 
@@ -81,15 +81,5 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         );
     }
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        for (env_name, err) in errors {
-            tracing::warn!(
-                "Couldn't sync environment {}\n{err:?}",
-                env_name.fancy_display(),
-            );
-        }
-        Err(miette::miette!("Some environments couldn't be synced."))
-    }
+    report_failed_environments(EnvironmentAction::Sync, errors)
 }

--- a/crates/pixi_cli/src/global/uninstall.rs
+++ b/crates/pixi_cli/src/global/uninstall.rs
@@ -1,6 +1,7 @@
-use crate::global::revert_environment_after_error;
+use crate::global::{
+    EnvironmentAction, report_failed_environments, revert_environment_after_error,
+};
 use clap::Parser;
-use fancy_display::FancyDisplay;
 use miette::Report;
 use pixi_config::{Config, ConfigCli};
 use pixi_global::StateChanges;
@@ -60,12 +61,5 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
     }
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        for (env_name, err) in errors {
-            tracing::warn!("Couldn't remove {}\n{err:?}", env_name.fancy_display());
-        }
-        Err(miette::miette!("Some environments couldn't be removed."))
-    }
+    report_failed_environments(EnvironmentAction::Remove, errors)
 }

--- a/crates/pixi_cli/src/global/update.rs
+++ b/crates/pixi_cli/src/global/update.rs
@@ -2,6 +2,7 @@ use crate::global::revert_environment_after_error;
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use indexmap::IndexMap;
+use miette::WrapErr;
 use pixi_config::{Config, ConfigCli};
 use pixi_global::common::check_all_exposed;
 use pixi_global::project::ExposedType;
@@ -119,12 +120,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     // Install all environments in parallel, sharing one dispatcher.
-    let install_results: Vec<miette::Result<EnvInstallResult>> = futures::future::join_all(
-        env_names
-            .iter()
-            .map(|env_name| install_and_determine_expose_type(&project_original, env_name)),
-    )
-    .await;
+    let project_ref = &project_original;
+    let install_results: Vec<miette::Result<EnvInstallResult>> =
+        futures::future::join_all(env_names.iter().map(|env_name| async move {
+            install_and_determine_expose_type(project_ref, env_name)
+                .await
+                .wrap_err_with(|| {
+                    format!("Couldn't update environment {}", env_name.fancy_display())
+                })
+        }))
+        .await;
 
     let mut project = project_original;
     project.clear_progress();
@@ -136,7 +141,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     Ok(state_changes) => state_changes.report(),
                     Err(err) => {
                         revert_environment_after_error(&env_name, &project).await?;
-                        return Err(err);
+                        return Err(err.wrap_err(format!(
+                            "Couldn't update environment {}",
+                            env_name.fancy_display()
+                        )));
                     }
                 }
             }

--- a/tests/integration_python/pixi_global/test_global.py
+++ b/tests/integration_python/pixi_global/test_global.py
@@ -1604,7 +1604,7 @@ exposed = {{ dummy-c = "dummy-c" }}
         [pixi, "global", "uninstall", "dummy-a"],
         ExitCode.FAILURE,
         env=env,
-        stderr_contains="Couldn't remove dummy-a",
+        stderr_contains="Couldn't remove environment dummy-a",
     )
 
     # Uninstall multiple packages


### PR DESCRIPTION
## Why

When running `pixi global update` over a bunch of environments, an error in any of them is reported without saying which environment it came from. I ran into this when one of my environments failed to initialize its build backend: after a bunch of lines, pixi printed a solve error and I had no idea which environment to look at.

## Before

```
✔ Environment xz was already up-to-date.
Error:   × failed to solve the environment
  ╰─▶ Cannot solve the request because of: No candidates were found for some-
      package-that-does-not-exist *.
```

## After

```
✔ Environment xz was already up-to-date.
Error:   × Couldn't update environment broken-env
  ├─▶ failed to solve the environment
  ╰─▶ Cannot solve the request because of: No candidates were found for some-
      package-that-does-not-exist *.
```

`pixi global sync` had a related problem: it warned per environment but ended with a generic `Some environments couldn't be synced.`, which is all you see when warnings are suppressed. It now names the envs that error out (same for `install` and `uninstall`):

```
Error:   × Couldn't sync the following environments: broken-env
```

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.


