### PR TITLE
fix: add build variant prep to the global install

### DIFF
--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -7,7 +7,7 @@ mod has_project_ref;
 pub mod registry;
 mod repodata;
 mod solve_group;
-mod stdlib_variants;
+pub mod stdlib_variants;
 pub mod virtual_packages;
 mod workspace_mut;
 

--- a/crates/pixi_core/src/workspace/stdlib_variants.rs
+++ b/crates/pixi_core/src/workspace/stdlib_variants.rs
@@ -50,7 +50,7 @@ fn channels_target_conda_forge<'a>(channels: impl IntoIterator<Item = &'a Channe
 /// virtual package.
 ///
 // TODO(#6175): handle `__musl` (musl libc) and `__cuda` -> `cuda_compiler_version`.
-pub(crate) fn derive_stdlib_variants<'a>(
+pub fn derive_stdlib_variants<'a>(
     platform: &PixiPlatform,
     channels: impl IntoIterator<Item = &'a ChannelUrl>,
 ) -> Vec<(String, VariantValue)> {

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -35,7 +35,8 @@ use pixi_core::environment::{
 };
 use pixi_core::lock_file::virtual_packages::minimal_required_virtual_packages;
 use pixi_core::repodata::Repodata;
-use pixi_manifest::{InlinePackageManifest, PrioritizedChannel, WorkspaceManifest};
+use pixi_core::workspace::stdlib_variants::derive_stdlib_variants;
+use pixi_manifest::{InlinePackageManifest, PixiPlatform, PrioritizedChannel, WorkspaceManifest};
 use pixi_path::AbsPathBuf;
 use pixi_reporters::TopLevelProgress;
 use pixi_spec::{BinarySpec, PathBinarySpec};
@@ -47,8 +48,8 @@ use pixi_utils::{
     rlimit::try_increase_rlimit_to_sensible,
 };
 use rattler_conda_types::{
-    ChannelConfig, GenericVirtualPackage, MatchSpec, NamedChannelOrUrl, PackageName, Platform,
-    PrefixRecord, menuinst::MenuMode, package::CondaArchiveIdentifier,
+    ChannelConfig, ChannelUrl, GenericVirtualPackage, MatchSpec, NamedChannelOrUrl, PackageName,
+    Platform, PrefixRecord, menuinst::MenuMode, package::CondaArchiveIdentifier,
 };
 use rattler_networking::LazyClient;
 use rattler_repodata_gateway::Gateway;
@@ -592,6 +593,28 @@ impl Project {
         }
     }
 
+    /// The build variants to build source packages with for `platform`.
+    ///
+    /// A workspace derives `c_stdlib`/`c_stdlib_version` build variants from
+    /// its system requirements so that `stdlib('c')` recipes pin a stable
+    /// minimum OS/libc target (e.g. `macosx_deployment_target 13.*`).
+    /// `pixi global` has no system-requirements table, so we derive the same
+    /// pair from the subdir's portable defaults (`PixiPlatform::from_subdir`,
+    /// e.g. `__osx = 13.0`) rather than the host's detected virtual packages.
+    /// Deriving from the host (e.g. macOS 26) would pin a deployment target
+    /// newer than most machines can run, which is the bug this avoids.
+    fn build_variants(platform: Platform, channels: &[ChannelUrl]) -> VariantConfig {
+        let variant_configuration =
+            derive_stdlib_variants(&PixiPlatform::from_subdir(platform), channels)
+                .into_iter()
+                .map(|(key, value)| (key, vec![value]))
+                .collect();
+        VariantConfig {
+            variant_configuration,
+            variant_files: Vec::new(),
+        }
+    }
+
     pub async fn install_environment(
         &self,
         env_name: &EnvironmentName,
@@ -680,6 +703,11 @@ impl Project {
 
         let build_environment = BuildEnvironment::simple(platform, solve_virtual_packages.clone());
 
+        // Derive the `c_stdlib` build variants for source builds, mirroring what
+        // a workspace does, so `stdlib('c')` recipes pin a portable deployment
+        // target instead of the host's (see `build_variants`).
+        let variant_config = Self::build_variants(platform, &channels);
+
         // Inline package definitions from the manifest, threaded into the
         // solve and install so backend discovery uses them instead of reading
         // a manifest from the source checkout.
@@ -699,7 +727,7 @@ impl Project {
                 EnvironmentSpec {
                     channels: channels.clone(),
                     build_environment: build_environment.clone(),
-                    variants: VariantConfig::default(),
+                    variants: variant_config.clone(),
                     exclude_newer: None,
                     channel_priority: Default::default(),
                 },
@@ -792,8 +820,8 @@ impl Project {
                 installed: None,
                 ignore_packages: None,
                 force_reinstall: force_reinstall_packages,
-                variant_configuration: None,
-                variant_files: None,
+                variant_configuration: Some(variant_config.variant_configuration),
+                variant_files: Some(variant_config.variant_files),
                 inline_packages: inline_packages.into_iter().collect(),
             })
             .await?;
@@ -1851,6 +1879,7 @@ mod tests {
     use std::{collections::HashMap, io::Write};
 
     use itertools::Itertools;
+    use pixi_utils::variants::VariantValue;
     use rattler_conda_types::{
         NamedChannelOrUrl, PackageRecord, Platform, RepoDataRecord, VersionWithSource,
         package::DistArchiveIdentifier,
@@ -2138,6 +2167,43 @@ mod tests {
                 .into()
         );
         assert_eq!(package, "python".parse().unwrap());
+    }
+
+    /// Source builds derive their `c_stdlib` variant from the subdir's portable
+    /// default (`__osx = 13.0` for osx-arm64), not from the host's detected
+    /// virtual packages -- so a package built on macOS 26 still targets 13.0,
+    /// matching what a workspace produces.
+    #[test]
+    fn test_build_variants_use_subdir_defaults() {
+        let channels = vec![ChannelUrl::from(
+            Url::parse("https://conda.anaconda.org/conda-forge").unwrap(),
+        )];
+        let variants = Project::build_variants(Platform::OsxArm64, &channels).variant_configuration;
+
+        assert_eq!(
+            variants.get("c_stdlib"),
+            Some(&vec![VariantValue::String(
+                "macosx_deployment_target".to_string()
+            )])
+        );
+        assert_eq!(
+            variants.get("c_stdlib_version"),
+            Some(&vec![VariantValue::String("13.0".to_string())])
+        );
+    }
+
+    /// The derived providers are conda-forge packages, so an environment that
+    /// doesn't build against conda-forge contributes no variants.
+    #[test]
+    fn test_build_variants_empty_without_conda_forge() {
+        let channels = vec![ChannelUrl::from(
+            Url::parse("https://prefix.dev/my-channel").unwrap(),
+        )];
+        assert!(
+            Project::build_variants(Platform::OsxArm64, &channels)
+                .variant_configuration
+                .is_empty()
+        );
     }
 
     /// A platform on a different OS than the local machine can't be inspected

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -596,19 +596,24 @@ impl Project {
     /// The build variants to build source packages with for `platform`.
     ///
     /// A workspace derives `c_stdlib`/`c_stdlib_version` build variants from
-    /// its system requirements so that `stdlib('c')` recipes pin a stable
+    /// its system requirements so that `stdlib('c')` recipes pin a
     /// minimum OS/libc target (e.g. `macosx_deployment_target 13.*`).
     /// `pixi global` has no system-requirements table, so we derive the same
-    /// pair from the subdir's portable defaults (`PixiPlatform::from_subdir`,
-    /// e.g. `__osx = 13.0`) rather than the host's detected virtual packages.
-    /// Deriving from the host (e.g. macOS 26) would pin a deployment target
-    /// newer than most machines can run, which is the bug this avoids.
-    fn build_variants(platform: Platform, channels: &[ChannelUrl]) -> VariantConfig {
-        let variant_configuration =
-            derive_stdlib_variants(&PixiPlatform::from_subdir(platform), channels)
-                .into_iter()
-                .map(|(key, value)| (key, vec![value]))
-                .collect();
+    /// pair from the device's detected virtual packages (`virtual_packages`,
+    /// e.g. the host's `__osx`/`__glibc`) rather than the subdir's portable
+    /// defaults. A global install targets the machine it runs on, so the
+    /// `stdlib('c')` target should match that machine's actual OS/libc.
+    fn build_variants(
+        platform: Platform,
+        virtual_packages: &[GenericVirtualPackage],
+        channels: &[ChannelUrl],
+    ) -> VariantConfig {
+        let device_platform =
+            PixiPlatform::from_required_virtual_packages(platform, virtual_packages.to_vec());
+        let variant_configuration = derive_stdlib_variants(&device_platform, channels)
+            .into_iter()
+            .map(|(key, value)| (key, vec![value]))
+            .collect();
         VariantConfig {
             variant_configuration,
             variant_files: Vec::new(),
@@ -704,9 +709,9 @@ impl Project {
         let build_environment = BuildEnvironment::simple(platform, solve_virtual_packages.clone());
 
         // Derive the `c_stdlib` build variants for source builds, mirroring what
-        // a workspace does, so `stdlib('c')` recipes pin a portable deployment
-        // target instead of the host's (see `build_variants`).
-        let variant_config = Self::build_variants(platform, &channels);
+        // a workspace does, so `stdlib('c')` recipes pin a deployment target that
+        // matches the device this install targets (see `build_variants`).
+        let variant_config = Self::build_variants(platform, &solve_virtual_packages, &channels);
 
         // Inline package definitions from the manifest, threaded into the
         // solve and install so backend discovery uses them instead of reading
@@ -2169,16 +2174,26 @@ mod tests {
         assert_eq!(package, "python".parse().unwrap());
     }
 
-    /// Source builds derive their `c_stdlib` variant from the subdir's portable
-    /// default (`__osx = 13.0` for osx-arm64), not from the host's detected
-    /// virtual packages -- so a package built on macOS 26 still targets 13.0,
-    /// matching what a workspace produces.
+    fn gvp(name: &str, version: &str) -> GenericVirtualPackage {
+        GenericVirtualPackage {
+            name: name.parse().unwrap(),
+            version: version.parse().unwrap(),
+            build_string: "0".to_string(),
+        }
+    }
+
+    /// Source builds derive their `c_stdlib` variant from the device's detected
+    /// virtual packages, so a package built on a host reporting `__osx = 15.0`
+    /// targets 15.0 -- the machine the global install runs on -- rather than the
+    /// subdir's portable default.
     #[test]
-    fn test_build_variants_use_subdir_defaults() {
+    fn test_build_variants_use_device_virtual_packages() {
         let channels = vec![ChannelUrl::from(
             Url::parse("https://conda.anaconda.org/conda-forge").unwrap(),
         )];
-        let variants = Project::build_variants(Platform::OsxArm64, &channels).variant_configuration;
+        let device = vec![gvp("__osx", "15.0")];
+        let variants = Project::build_variants(Platform::OsxArm64, &device, &channels)
+            .variant_configuration;
 
         assert_eq!(
             variants.get("c_stdlib"),
@@ -2188,7 +2203,7 @@ mod tests {
         );
         assert_eq!(
             variants.get("c_stdlib_version"),
-            Some(&vec![VariantValue::String("13.0".to_string())])
+            Some(&vec![VariantValue::String("15.0".to_string())])
         );
     }
 
@@ -2199,8 +2214,9 @@ mod tests {
         let channels = vec![ChannelUrl::from(
             Url::parse("https://prefix.dev/my-channel").unwrap(),
         )];
+        let device = vec![gvp("__osx", "15.0")];
         assert!(
-            Project::build_variants(Platform::OsxArm64, &channels)
+            Project::build_variants(Platform::OsxArm64, &device, &channels)
                 .variant_configuration
                 .is_empty()
         );


### PR DESCRIPTION
This fixes the issue that the build variants of the package have the right information about the virtual packages described in this comment:

https://github.com/prefix-dev/pixi/pull/6521#issuecomment-5046144158
---
I'm trying to figure out wheter this is a related issue:

```
pixi g i --git https://github.com/astral-sh/ruff --build-backend pixi-bu
ild-python --package "build.config.ignore-pypi-mapping=false"
```
On osx-arm64 this gives me this error in the maturin install:
```
× Failed to build `ruff @
│ file:///Users/rubenarts/Library/Caches/rattler/cache/bld/git-v0/checkouts/a70e12b41adfc71/1a82d31630`
╰─▶ The built wheel `ruff-0.15.22-py3-none-macosx_26_0_arm64.whl` is not compatible with the current Python 3.14 on macOS aarch64
```

This was a known issue where we wouldn't provide the virtual package in the right way to the build solve. These are related: 
- https://github.com/prefix-dev/pixi/pull/6320 (I believe we just have to redo this too)
- https://github.com/prefix-dev/pixi/pull/6396
- https://github.com/prefix-dev/pixi/issues/6392
---


### How Has This Been Tested?
I tested it locally with:

```
pixi g i --git https://github.com/astral-sh/ruff --build-backend pixi-build
-python --package "build.config.ignore-pypi-mapping=false"
```
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.