### PR TITLE
fix: rename `--subdir` to `--subdirectory` for git dependencies

### DIFF
--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -835,6 +835,57 @@ async fn add_dependency_pinning_strategy() {
     assert_eq!(bar_spec, r#"">=1,<2""#);
 }
 
+/// The deprecated `--subdir` alias still resolves to the `subdirectory` field.
+#[tokio::test]
+async fn add_git_deps_deprecated_subdir_alias() {
+    setup_tracing();
+
+    let fixture = GitRepoFixture::new("conda-build-package");
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "test-channel-change"
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["win-64"]
+preview = ['pixi-build']
+"#,
+    )
+    .unwrap()
+    .with_backend_override(backend_override);
+
+    pixi.add("boost-check")
+        .with_git_url(fixture.base_url.clone())
+        .with_git_rev(GitRev::new().with_branch("main".to_string()))
+        .with_deprecated_git_subdir("boost-check".to_string())
+        .await
+        .unwrap();
+
+    let lock = pixi.lock_file().await.unwrap();
+    let p = lock.platform(&Platform::Win64.to_string()).unwrap();
+    let git_package = lock
+        .default_environment()
+        .unwrap()
+        .packages(p)
+        .unwrap()
+        .find(|p| p.as_conda().unwrap().location().as_str().contains("git+"));
+
+    let location = git_package
+        .unwrap()
+        .as_conda()
+        .unwrap()
+        .location()
+        .to_string();
+
+    // The deprecated `--subdir` flag lands in the same `subdirectory=` slot as
+    // the canonical `--subdirectory` flag.
+    assert!(
+        location.contains("subdirectory=boost-check"),
+        "expected the deprecated --subdir alias to resolve to subdirectory=, got: {location}"
+    );
+}
+
 /// Test adding a git dependency with a specific branch (using local fixture)
 #[tokio::test]
 async fn add_git_deps() {
@@ -860,7 +911,7 @@ preview = ['pixi-build']
     pixi.add("boost-check")
         .with_git_url(fixture.base_url.clone())
         .with_git_rev(GitRev::new().with_branch("main".to_string()))
-        .with_git_subdir("boost-check".to_string())
+        .with_git_subdirectory("boost-check".to_string())
         .await
         .unwrap();
 
@@ -922,7 +973,7 @@ preview = ['pixi-build']
             Url::parse("https://user:token123@github.com/wolfv/pixi-build-examples.git").unwrap(),
         )
         .with_git_rev(GitRev::new().with_branch("main".to_string()))
-        .with_git_subdir("boost-check".to_string())
+        .with_git_subdirectory("boost-check".to_string())
         .await
         .unwrap();
 
@@ -981,7 +1032,7 @@ preview = ['pixi-build']"#,
     pixi.add("boost-check")
         .with_git_url(fixture.base_url.clone())
         .with_git_rev(GitRev::new().with_rev(short_commit.to_string()))
-        .with_git_subdir("boost-check".to_string())
+        .with_git_subdirectory("boost-check".to_string())
         .await
         .unwrap();
 
@@ -1038,7 +1089,7 @@ preview = ['pixi-build']"#,
     pixi.add("boost-check")
         .with_git_url(fixture.base_url.clone())
         .with_git_rev(GitRev::new().with_tag("v0.1.0".to_string()))
-        .with_git_subdir("boost-check".to_string())
+        .with_git_subdirectory("boost-check".to_string())
         .await
         .unwrap();
 
@@ -1190,7 +1241,7 @@ platforms = ["linux-64"]
     let result = pixi
         .add("boost-check")
         .with_git_url(Url::parse("https://github.com/wolfv/pixi-build-examples.git").unwrap())
-        .with_git_subdir("boost-check".to_string())
+        .with_git_subdirectory("boost-check".to_string())
         .await;
 
     assert!(result.is_err());
@@ -1225,7 +1276,7 @@ preview = ["pixi-build"]
     let result = pixi
         .add("boost-check")
         .with_git_url(Url::parse("https://github.com/wolfv/pixi-build-examples.git").unwrap())
-        .with_git_subdir("boost-check".to_string())
+        .with_git_subdirectory("boost-check".to_string())
         .with_install(false)
         .with_frozen(true)
         .await;

--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -164,6 +164,7 @@ pub trait HasDependencyConfig: Sized {
             environment: Default::default(),
             git: Default::default(),
             rev: Default::default(),
+            subdirectory: Default::default(),
             subdir: Default::default(),
         }
     }
@@ -244,7 +245,13 @@ impl AddBuilder {
         self
     }
 
-    pub fn with_git_subdir(mut self, subdir: String) -> Self {
+    pub fn with_git_subdirectory(mut self, subdirectory: String) -> Self {
+        self.args.dependency_config.subdirectory = Some(subdirectory);
+        self
+    }
+
+    /// Sets the deprecated `--subdir` alias rather than `--subdirectory`.
+    pub fn with_deprecated_git_subdir(mut self, subdir: String) -> Self {
         self.args.dependency_config.subdir = Some(subdir);
         self
     }

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -136,7 +136,7 @@ impl From<&Args> for GitOptions {
                 .clone()
                 .unwrap_or_default()
                 .into(),
-            subdir: args.dependency_config.subdir.clone(),
+            subdir: args.dependency_config.subdirectory(),
         }
     }
 }
@@ -170,6 +170,8 @@ fn map_pypi_requirements_with_index(
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
+    args.dependency_config.warn_deprecated_subdir();
+
     let mut workspace = WorkspaceLocator::for_cli()
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
@@ -194,7 +196,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                         .clone()
                         .unwrap_or_default()
                         .into(),
-                    subdir: args.dependency_config.subdir.clone(),
+                    subdir: args.dependency_config.subdirectory(),
                 };
 
                 let specs = args.dependency_config.specs()?;

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -319,8 +319,29 @@ pub struct DependencyConfig {
     pub rev: Option<GitRev>,
 
     /// The subdirectory of the git repository to use
-    #[clap(long, short, requires = "git", help_heading = consts::CLAP_GIT_OPTIONS)]
+    #[clap(long = "subdirectory", short, requires = "git", help_heading = consts::CLAP_GIT_OPTIONS)]
+    pub subdirectory: Option<String>,
+
+    /// Deprecated alias for `--subdirectory`.
+    #[clap(
+        long = "subdir",
+        hide = true,
+        requires = "git",
+        conflicts_with = "subdirectory"
+    )]
     pub subdir: Option<String>,
+}
+
+/// Warns if the deprecated `--subdir` flag was used.
+pub(crate) fn warn_deprecated_subdir(subdir: Option<&str>) {
+    if subdir.is_some() {
+        eprintln!(
+            "{}The '{}' option is deprecated and will be removed in a future release.\nUse '{}' instead.",
+            console::style(console::Emoji("⚠️ ", "")).yellow(),
+            console::style("--subdir").bold().red(),
+            console::style("--subdirectory").bold().green(),
+        );
+    }
 }
 
 /// Resolves the `--feature`/`--environment` flag pair to the feature a
@@ -345,6 +366,17 @@ impl DependencyConfig {
             Some(environment) => FeatureName::environment(environment),
             None => self.feature.clone(),
         }
+    }
+
+    /// The subdirectory of the git repository to use, resolving the deprecated
+    /// `--subdir` alias when `--subdirectory` is not given.
+    pub(crate) fn subdirectory(&self) -> Option<String> {
+        self.subdirectory.clone().or_else(|| self.subdir.clone())
+    }
+
+    /// Warns once if the deprecated `--subdir` flag was used.
+    pub(crate) fn warn_deprecated_subdir(&self) {
+        warn_deprecated_subdir(self.subdir.as_deref());
     }
 
     pub(crate) fn dependency_type(&self) -> DependencyType {
@@ -428,7 +460,7 @@ impl DependencyConfig {
                             package_name,
                             git,
                             self.rev.as_ref(),
-                            self.subdir.clone(),
+                            self.subdirectory(),
                         );
 
                         let dep = Requirement::parse(&vcs_req, project.root()).into_diagnostic()?;
@@ -489,10 +521,56 @@ fn build_vcs_requirement(
 mod tests {
     use url::Url;
 
+    use clap::Parser;
+
     use crate::cli_config::{
-        GitRev, LockAndInstallConfig, LockFileUpdateConfig, NoInstallConfig, build_vcs_requirement,
+        DependencyConfig, GitRev, LockAndInstallConfig, LockFileUpdateConfig, NoInstallConfig,
+        build_vcs_requirement,
     };
     use pixi_core::environment::LockFileUsage;
+
+    #[test]
+    fn test_subdirectory_flag_parses() {
+        let config = DependencyConfig::try_parse_from([
+            "add",
+            "pkg",
+            "--git",
+            "https://github.com/org/repo",
+            "--subdirectory",
+            "src/pkg",
+        ])
+        .unwrap();
+        assert_eq!(config.subdirectory(), Some("src/pkg".to_string()));
+    }
+
+    #[test]
+    fn test_deprecated_subdir_alias_resolves() {
+        let config = DependencyConfig::try_parse_from([
+            "add",
+            "pkg",
+            "--git",
+            "https://github.com/org/repo",
+            "--subdir",
+            "src/pkg",
+        ])
+        .unwrap();
+        assert_eq!(config.subdirectory(), Some("src/pkg".to_string()));
+    }
+
+    #[test]
+    fn test_subdir_and_subdirectory_conflict() {
+        let result = DependencyConfig::try_parse_from([
+            "add",
+            "pkg",
+            "--git",
+            "https://github.com/org/repo",
+            "--subdirectory",
+            "a",
+            "--subdir",
+            "b",
+        ]);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_build_vcs_requirement_with_all_fields() {

--- a/crates/pixi_cli/src/global/global_specs.rs
+++ b/crates/pixi_cli/src/global/global_specs.rs
@@ -15,6 +15,7 @@ use rattler_conda_types::{
 };
 use typed_path::Utf8NativePathBuf;
 
+use crate::cli_config::warn_deprecated_subdir;
 use crate::has_specs::HasSpecs;
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -32,7 +33,16 @@ pub struct GlobalSpecs {
     pub rev: Option<crate::cli_config::GitRev>,
 
     /// The subdirectory within the git repository
-    #[clap(long, requires = "git", help_heading = consts::CLAP_GIT_OPTIONS)]
+    #[clap(long = "subdirectory", requires = "git", help_heading = consts::CLAP_GIT_OPTIONS)]
+    pub subdirectory: Option<String>,
+
+    /// Deprecated alias for `--subdirectory`.
+    #[clap(
+        long = "subdir",
+        hide = true,
+        requires = "git",
+        conflicts_with = "subdirectory"
+    )]
     pub subdir: Option<String>,
 
     /// The path to the local package
@@ -259,12 +269,15 @@ impl GlobalSpecs {
         project: &pixi_global::Project,
         channels: &[NamedChannelOrUrl],
     ) -> Result<Vec<pixi_global::project::GlobalSpec>, GlobalSpecsConversionError> {
+        warn_deprecated_subdir(self.subdir.as_deref());
+
         let git_or_path_spec = if let Some(git_url) = &self.git {
             let git_spec = pixi_spec::GitSpec::new(
                 git_url.clone(),
                 self.rev.clone().map(Into::into),
-                self.subdir
+                self.subdirectory
                     .clone()
+                    .or_else(|| self.subdir.clone())
                     .map(Subdirectory::try_from)
                     .transpose()?
                     .unwrap_or_default(),
@@ -411,12 +424,68 @@ impl GlobalSpecs {
 mod tests {
     use std::path::PathBuf;
 
+    use clap::Parser;
     use fs_err as fs;
     use rattler_conda_types::ChannelConfig;
     use temp_env;
     use tempfile::tempdir;
 
     use super::*;
+
+    #[derive(Parser)]
+    struct GlobalSpecsWrapper {
+        #[clap(flatten)]
+        specs: GlobalSpecs,
+    }
+
+    fn parse_specs(args: &[&str]) -> Result<GlobalSpecs, clap::Error> {
+        GlobalSpecsWrapper::try_parse_from(args).map(|w| w.specs)
+    }
+
+    #[test]
+    fn test_subdirectory_flag_parses() {
+        let specs = parse_specs(&[
+            "add",
+            "pkg",
+            "--git",
+            "https://github.com/org/repo",
+            "--subdirectory",
+            "src/pkg",
+        ])
+        .unwrap();
+        assert_eq!(specs.subdirectory.as_deref(), Some("src/pkg"));
+        assert_eq!(specs.subdir, None);
+    }
+
+    #[test]
+    fn test_deprecated_subdir_alias_parses() {
+        let specs = parse_specs(&[
+            "add",
+            "pkg",
+            "--git",
+            "https://github.com/org/repo",
+            "--subdir",
+            "src/pkg",
+        ])
+        .unwrap();
+        assert_eq!(specs.subdir.as_deref(), Some("src/pkg"));
+        assert_eq!(specs.subdirectory, None);
+    }
+
+    #[test]
+    fn test_subdir_and_subdirectory_conflict() {
+        let result = parse_specs(&[
+            "add",
+            "pkg",
+            "--git",
+            "https://github.com/org/repo",
+            "--subdirectory",
+            "a",
+            "--subdir",
+            "b",
+        ]);
+        assert!(result.is_err());
+    }
 
     /// Create a project in an isolated `PIXI_HOME` so tests never read the
     /// global manifest of the machine they run on.

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -63,6 +63,8 @@ impl TryFrom<&Args> for DependencyOptions {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
+    args.dependency_config.warn_deprecated_subdir();
+
     let workspace = WorkspaceLocator::for_cli()
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -87,7 +87,7 @@ pixi add [OPTIONS] <SPEC>...
 :  The git tag
 - <a id="arg---rev" href="#arg---rev">`--rev <REV>`</a>
 :  The git revision
-- <a id="arg---subdir" href="#arg---subdir">`--subdir (-s) <SUBDIR>`</a>
+- <a id="arg---subdirectory" href="#arg---subdirectory">`--subdirectory (-s) <SUBDIRECTORY>`</a>
 :  The subdirectory of the git repository to use
 
 ## Update Options

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -17,7 +17,7 @@ pixi add --feature featurex numpy # (10)!
 pixi add --environment dev numpy # (28)!
 pixi add /absolute/path/to/package-1.0-hb0f4dca_0.conda # (11)!
 pixi add --git https://github.com/wolfv/pixi-build-examples boost-check # (12)!
-pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdir boost-check boost-check # (13)!
+pixi add --git https://github.com/wolfv/pixi-build-examples --branch main --subdirectory boost-check boost-check # (13)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --tag v0.1.0 boost-check # (14)!
 pixi add --git https://github.com/wolfv/pixi-build-examples --rev e50d4a1 boost-check # (15)!
 
@@ -33,7 +33,7 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --pypi # (23)!
 pixi add --git https://github.com/mahmoud/boltons.git boltons --branch main --pypi # (24)!
 pixi add --git https://github.com/mahmoud/boltons.git boltons --rev e50d4a1 --pypi # (25)!
 pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi # (26)!
-pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdir boltons # (27)!
+pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdirectory boltons # (27)!
 ```
 
 1. This will add the `numpy` package to the project with the latest available for the solved environment.

--- a/docs/reference/cli/pixi/global/add.md
+++ b/docs/reference/cli/pixi/global/add.md
@@ -78,7 +78,7 @@ pixi global add [OPTIONS] --environment <ENVIRONMENT> [PACKAGE]...
 :  The git tag
 - <a id="arg---rev" href="#arg---rev">`--rev <REV>`</a>
 :  The git revision
-- <a id="arg---subdir" href="#arg---subdir">`--subdir <SUBDIR>`</a>
+- <a id="arg---subdirectory" href="#arg---subdirectory">`--subdirectory <SUBDIRECTORY>`</a>
 :  The subdirectory within the git repository
 
 ## Description

--- a/docs/reference/cli/pixi/global/install.md
+++ b/docs/reference/cli/pixi/global/install.md
@@ -89,7 +89,7 @@ pixi global install [OPTIONS] [PACKAGE]...
 :  The git tag
 - <a id="arg---rev" href="#arg---rev">`--rev <REV>`</a>
 :  The git revision
-- <a id="arg---subdir" href="#arg---subdir">`--subdir <SUBDIR>`</a>
+- <a id="arg---subdirectory" href="#arg---subdirectory">`--subdirectory <SUBDIRECTORY>`</a>
 :  The subdirectory within the git repository
 
 ## Description

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -83,7 +83,7 @@ pixi remove [OPTIONS] <SPEC>...
 :  The git tag
 - <a id="arg---rev" href="#arg---rev">`--rev <REV>`</a>
 :  The git revision
-- <a id="arg---subdir" href="#arg---subdir">`--subdir (-s) <SUBDIR>`</a>
+- <a id="arg---subdirectory" href="#arg---subdirectory">`--subdirectory (-s) <SUBDIRECTORY>`</a>
 :  The subdirectory of the git repository to use
 
 ## Update Options


### PR DESCRIPTION
Closes prefix-dev/pixi#6646

The CLI flag for a git dependency's subdirectory was `--subdir`, but the manifest key it writes is `subdirectory`. This standardizes the flag on `--subdirectory` across all four commands that accept it:

* `pixi add`
* `pixi remove`
* `pixi global add`
* `pixi global install`

`--subdir` stays as a hidden, deprecated alias so existing scripts keep working. Using it prints a deprecation warning and resolves to the same value. It is slated for removal in a future release.