### PR TITLE
fix: give inline packages a name and a helpful error for Cargo workspaces

### DIFF
--- a/crates/pixi_build_rust/src/metadata.rs
+++ b/crates/pixi_build_rust/src/metadata.rs
@@ -19,6 +19,13 @@ pub enum MetadataError {
     IoError(#[from] std::io::Error),
     #[error("missing inherited value from workspace {0}")]
     MissingInheritedValue(String),
+    // The suggestion is part of the message rather than a `#[diagnostic(help)]`
+    // because the frontend receives this error as a nested cause, and only the
+    // top-level diagnostic's help survives the JSON-RPC transport.
+    #[error(
+        "the Cargo.toml at `{path}` is a virtual workspace manifest: it has a `[workspace]` table but no `[package]`, so no package name or version could be determined; point the dependency at a member crate with `subdirectory`, e.g. `subdirectory = \"{example}\"`"
+    )]
+    VirtualWorkspace { path: String, example: String },
 }
 
 /// An implementation of [`MetadataProvider`] that reads metadata from a
@@ -50,6 +57,39 @@ impl CargoMetadataProvider {
     /// Ensures that the manifest is loaded and returns the package metadata.
     fn ensure_manifest_package(&self) -> Result<Option<&Package>, MetadataError> {
         Ok(self.ensure_manifest()?.package.as_ref())
+    }
+
+    /// Errors with [`MetadataError::VirtualWorkspace`] when the loaded manifest
+    /// is a virtual workspace (a `[workspace]` table but no `[package]`). Such a
+    /// manifest carries no package name or version, so building it directly is
+    /// impossible; the user has to point at a member crate instead. Any other
+    /// shape passes the check.
+    fn reject_virtual_workspace(&self) -> Result<(), MetadataError> {
+        let manifest = self.ensure_manifest()?;
+        if manifest.package.is_some() {
+            return Ok(());
+        }
+        let Some(workspace) = manifest.workspace.as_ref() else {
+            return Ok(());
+        };
+
+        // Prefer `default-members`, falling back to `members`, to suggest a
+        // concrete crate to point at.
+        let candidates = if !workspace.default_members.is_empty() {
+            &workspace.default_members
+        } else {
+            &workspace.members
+        };
+        let example = candidates
+            .iter()
+            .find(|member| !member.contains('*'))
+            .cloned()
+            .unwrap_or_else(|| String::from("crates/<member>"));
+
+        Err(MetadataError::VirtualWorkspace {
+            path: self.manifest_root.join("Cargo.toml").display().to_string(),
+            example,
+        })
     }
 
     /// Ensures that the manifest is loaded
@@ -152,7 +192,13 @@ impl MetadataProvider for CargoMetadataProvider {
         if self.ignore_cargo_manifest {
             return Ok(None);
         }
-        Ok(self.ensure_manifest_package()?.map(|pkg| pkg.name.clone()))
+        match self.ensure_manifest_package()? {
+            Some(pkg) => Ok(Some(pkg.name.clone())),
+            None => {
+                self.reject_virtual_workspace()?;
+                Ok(None)
+            }
+        }
     }
 
     /// Returns the package version from the Cargo.toml manifest.
@@ -166,6 +212,7 @@ impl MetadataProvider for CargoMetadataProvider {
             return Ok(None);
         }
         let Some(value) = self.ensure_manifest_package()?.map(|pkg| &pkg.version) else {
+            self.reject_virtual_workspace()?;
             return Ok(None);
         };
         let version = match value {
@@ -844,6 +891,39 @@ version = "not.a.valid.version.at.all"
                 // This is the expected error case
             }
             other => panic!("Unexpected result: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_virtual_workspace_reports_helpful_error() {
+        // A virtual workspace manifest (a `[workspace]` table but no `[package]`)
+        // has no name or version to build. Both `name()` and `version()` must
+        // surface a diagnostic that points the user at a member crate rather
+        // than the bare "no name/version defined for the recipe" (see #6633).
+        let cargo_toml_content = r#"
+[workspace]
+resolver = "2"
+members = ["crates/*"]
+default-members = ["crates/app-cli"]
+"#;
+
+        let temp_dir = create_temp_cargo_project(cargo_toml_content);
+        let mut provider = create_metadata_provider(temp_dir.path());
+
+        for result in [provider.name().map(|_| ()), provider.version().map(|_| ())] {
+            match result {
+                Err(err @ MetadataError::VirtualWorkspace { .. }) => {
+                    // The suggestion must be part of the message itself: the
+                    // frontend flattens nested causes to their message, so a
+                    // `help` attached to this error would never reach the user.
+                    let message = err.to_string();
+                    assert!(
+                        message.contains("subdirectory") && message.contains("crates/app-cli"),
+                        "message should suggest a member subdirectory, got: {message}"
+                    );
+                }
+                other => panic!("Expected VirtualWorkspace error, got: {other:?}"),
+            }
         }
     }
 

--- a/crates/pixi_manifest/src/target.rs
+++ b/crates/pixi_manifest/src/target.rs
@@ -111,7 +111,7 @@ impl InlinePackageManifest {
         root_directory: &std::path::Path,
     ) -> Result<crate::WithWarnings<Self>, crate::TomlError> {
         let crate::WithWarnings {
-            value: manifest,
+            value: mut manifest,
             warnings,
         } = package.into_manifest(
             workspace_package_properties,
@@ -119,6 +119,13 @@ impl InlinePackageManifest {
             preview,
             root_directory,
         )?;
+
+        // An inline definition may not set `package.name` (that is rejected
+        // while parsing), so the recipe name comes from the dependency key it
+        // is declared under. This is also the name pixi resolves the source
+        // by, so the built package must carry it; otherwise the backend has no
+        // name to put on the recipe.
+        manifest.package.name = Some(dependency_name.as_normalized().to_string());
 
         let content_hash = {
             let mut hasher = Xxh3::new();

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -1617,6 +1617,45 @@ mod test {
         assert!(inline.build.source.is_none());
     }
 
+    #[test]
+    fn test_inline_package_name_defaults_to_dependency_key() {
+        // An inline package that omits `package.name` takes the dependency key
+        // as its name. This is the name pixi resolves the source by, so the
+        // built package must carry it; without this the backend has no name to
+        // put on the recipe (see #6633).
+        let manifest = <TomlManifest as FromTomlStr>::from_toml_str(
+            r#"
+            [workspace]
+            channels = []
+            platforms = ['linux-64']
+            preview = ["pixi-build"]
+
+            [dependencies]
+            typst = { git = "https://github.com/typst/typst.git", package.build.backend.name = "pixi-build-rust" }
+            "#,
+        )
+        .expect("parse toml");
+        let (ws, _pkg, _warnings) = manifest
+            .into_workspace_manifest(
+                ExternalWorkspaceProperties::default(),
+                PackageDefaults::default(),
+                Path::new(""),
+            )
+            .expect("convert to workspace manifest");
+
+        let name = rattler_conda_types::PackageName::new_unchecked("typst");
+        let inline = ws
+            .default_feature()
+            .targets
+            .default()
+            .inline_packages
+            .get(&name)
+            .expect("inline package stored")
+            .manifest
+            .clone();
+        assert_eq!(inline.package.name.as_deref(), Some("typst"));
+    }
+
     /// Parse a manifest and return the content hash of the named inline package.
     fn inline_content_hash(manifest: &str, package: &str) -> InlineContentHash {
         let manifest = <TomlManifest as FromTomlStr>::from_toml_str(manifest).expect("parse toml");

--- a/pixi.toml
+++ b/pixi.toml
@@ -87,6 +87,7 @@ rich = ">=15,<16"
 "ruamel.yaml" = ">=0.19,<0.20"
 tomlkit = ">=0.15,<0.16"
 
+
 [feature.backends-release.tasks]
 generate-versions = { cmd = "python pixi-build-backends/scripts/generate-versions.py", description = "Generate version env vars for CI" }
 release-backends = { cmd = "python scripts/release_backends.py", description = "Release pixi build backends: bump versions or tag and update feedstocks" }


### PR DESCRIPTION
### Description

Building an inline package from a git repo whose root `Cargo.toml` is a virtual workspace (a `[workspace]` table, no `[package]`) failed with `There was no name defined for the recipe`. That is why `typst` did not build but `xsv` did: `xsv` is a single crate, `typst` is a monorepo whose `typst` binary lives in `crates/typst-cli`.

We already forbid setting `package.name` on an inline definition because "it is taken from the dependency key", but we never actually took it from there. The assembled manifest kept `name = None`, so the backend had nothing to put on the recipe. Now the dependency key is injected as the package name during assembly. That is also the name pixi resolves the source by, so the built package is guaranteed to match it - and pointing at `subdirectory = "crates/typst-cli"` now produces a package named `typst` even though the crate is `typst-cli`.

When `pixi-build-rust` does hit a virtual workspace, it no longer bails with the generic no-name/no-version error. It names the offending `Cargo.toml` and suggests pointing at a member crate with `subdirectory`,

```
Error:   × failed to solve requirements of environment 'default' for platform 'linux-64'
  ├─▶   × An error occurred while querying the version
  │
  ╰─▶   × the Cargo.toml at `/var/home/julian/.cache/rattler/cache/git-v0/checkouts/406cea695b1f67eb/98fec489a/Cargo.toml` is a virtual workspace manifest: it has a `[workspace]` table
        │ but no `[package]`, so no package name or version could be determined; point the dependency at a member crate with `subdirectory`, e.g. `subdirectory = "crates/typst-cli"`
```

Fixes prefix-dev/pixi#6633

### How Has This Been Tested?

* Ran it locally
* Added tests

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added sufficient tests to cover my changes.