### PR TITLE
feat(global): fix build variant information for building

### DIFF
--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -7,7 +7,7 @@ mod has_project_ref;
 pub mod registry;
 mod repodata;
 mod solve_group;
-mod stdlib_variants;
+pub mod stdlib_variants;
 pub mod virtual_packages;
 mod workspace_mut;
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -758,7 +758,11 @@ impl Workspace {
             )
             .filter_map(|channel| channel.clone().into_base_url(&channel_config).ok())
             .collect();
-        for (key, value) in stdlib_variants::derive_stdlib_variants(platform, &channel_urls) {
+        for (key, value) in stdlib_variants::derive_stdlib_variants(
+            platform,
+            &channel_urls,
+            stdlib_variants::StdlibVersionPin::Exact,
+        ) {
             variant_configuration
                 .entry(key)
                 .or_insert_with(|| vec![value]);

--- a/crates/pixi_core/src/workspace/stdlib_variants.rs
+++ b/crates/pixi_core/src/workspace/stdlib_variants.rs
@@ -13,6 +13,23 @@ const C_STDLIB_VERSION: &str = "c_stdlib_version";
 /// the derivation only applies when the workspace builds against this channel.
 const CONDA_FORGE: &str = "conda-forge";
 
+/// How [`derive_stdlib_variants`] turns the declared virtual-package version
+/// into the `c_stdlib_version` build variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StdlibVersionPin {
+    /// Pin to the exact version, truncated to `major.minor` (the providers are
+    /// published at that precision, so a patch-level pin like `15.1.1` would
+    /// resolve to no candidate). Used by the workspace/lock-file flow, where
+    /// this value feeds the build hash and must stay stable.
+    Exact,
+    /// Bound the target with `<=` the full declared version, letting the solve
+    /// pick the highest published provider candidate at or below it. Used by
+    /// `pixi global`: its installs are local to the machine, so tracking the
+    /// device's exact (and often unpublished, e.g. `15.7.1`) version this way
+    /// is both correct and free of the lock-file stability constraint.
+    AtMost,
+}
+
 /// Whether any resolved channel is conda-forge.
 ///
 /// Matched on the final non-empty path segment of the resolved channel URL, so
@@ -44,6 +61,11 @@ fn channels_target_conda_forge<'a>(channels: impl IntoIterator<Item = &'a Channe
 /// | `osx-*`   | `__osx`         | `macosx_deployment_target` | the `__osx` version   |
 /// | `linux-*` | `__glibc`       | `sysroot`                  | the `__glibc` version |
 ///
+/// How the version becomes a variant depends on `pin` (see [`StdlibVersionPin`]):
+/// the workspace flow pins it exactly (keeping build hashes and lock files
+/// stable), while `pixi global` bounds it with `<=` so the solve can pick the
+/// highest published provider candidate the machine can build against.
+///
 /// Because the providers are conda-forge packages, this returns an empty vec
 /// unless one of `channels` is conda-forge. It also returns empty on Windows
 /// (no meaningful stdlib version) and when the platform declares no matching
@@ -53,6 +75,7 @@ fn channels_target_conda_forge<'a>(channels: impl IntoIterator<Item = &'a Channe
 pub fn derive_stdlib_variants<'a>(
     platform: &PixiPlatform,
     channels: impl IntoIterator<Item = &'a ChannelUrl>,
+    pin: StdlibVersionPin,
 ) -> Vec<(String, VariantValue)> {
     if !channels_target_conda_forge(channels) {
         return Vec::new();
@@ -75,13 +98,20 @@ pub fn derive_stdlib_variants<'a>(
         return Vec::new();
     };
 
-    // The providers are only published at `major.minor`, so a patch-level
-    // declared version (e.g. `__osx = 15.1.1`) would pin to a nonexistent
-    // candidate. Truncate to `major.minor`, keeping shorter versions as-is.
-    let stdlib_version = declared
-        .version
-        .with_segments(0..2)
-        .unwrap_or_else(|| declared.version.clone());
+    let stdlib_version = match pin {
+        // The providers are only published at `major.minor`, so a patch-level
+        // declared version (e.g. `__osx = 15.1.1`) would pin to a nonexistent
+        // candidate. Truncate to `major.minor`, keeping shorter versions as-is.
+        StdlibVersionPin::Exact => declared
+            .version
+            .with_segments(0..2)
+            .unwrap_or_else(|| declared.version.clone())
+            .to_string(),
+        // Bound the target instead of pinning it, so the solve selects the
+        // highest published provider candidate at or below the declared
+        // version (see [`StdlibVersionPin::AtMost`]).
+        StdlibVersionPin::AtMost => format!("<={}", declared.version),
+    };
 
     vec![
         (
@@ -90,7 +120,7 @@ pub fn derive_stdlib_variants<'a>(
         ),
         (
             C_STDLIB_VERSION.to_string(),
-            VariantValue::String(stdlib_version.to_string()),
+            VariantValue::String(stdlib_version),
         ),
     ]
 }
@@ -135,7 +165,11 @@ mod tests {
     #[test]
     fn osx_derives_macosx_deployment_target() {
         let platform = rich("mac", Platform::OsxArm64, vec![vp("__osx", "13.5")]);
-        let variants = into_map(derive_stdlib_variants(&platform, &conda_forge()));
+        let variants = into_map(derive_stdlib_variants(
+            &platform,
+            &conda_forge(),
+            StdlibVersionPin::Exact,
+        ));
 
         assert_eq!(
             variants.get("c_stdlib"),
@@ -152,7 +186,11 @@ mod tests {
     #[test]
     fn linux_derives_sysroot_from_glibc() {
         let platform = rich("lin", Platform::Linux64, vec![vp("__glibc", "2.28")]);
-        let variants = into_map(derive_stdlib_variants(&platform, &conda_forge()));
+        let variants = into_map(derive_stdlib_variants(
+            &platform,
+            &conda_forge(),
+            StdlibVersionPin::Exact,
+        ));
 
         assert_eq!(
             variants.get("c_stdlib"),
@@ -164,10 +202,30 @@ mod tests {
         );
     }
 
+    /// `AtMost` bounds the target with `<=` and keeps the full declared version
+    /// (no `major.minor` truncation), so `pixi global` can track a patch-level
+    /// host version like `15.7.1` that the exact pin could never resolve.
+    #[test]
+    fn atmost_bounds_full_version() {
+        let platform = rich("mac", Platform::OsxArm64, vec![vp("__osx", "15.7.1")]);
+        let variants = into_map(derive_stdlib_variants(
+            &platform,
+            &conda_forge(),
+            StdlibVersionPin::AtMost,
+        ));
+
+        assert_eq!(
+            variants.get("c_stdlib_version"),
+            Some(&VariantValue::String("<=15.7.1".to_string()))
+        );
+    }
+
     #[test]
     fn windows_skips() {
         let platform = rich("windows-rich", Platform::Win64, vec![vp("__win", "10.0")]);
-        assert!(derive_stdlib_variants(&platform, &conda_forge()).is_empty());
+        assert!(
+            derive_stdlib_variants(&platform, &conda_forge(), StdlibVersionPin::Exact).is_empty()
+        );
     }
 
     /// A linux platform that declares no `__glibc` (only an unrelated VP)
@@ -175,7 +233,9 @@ mod tests {
     #[test]
     fn linux_without_glibc_skips() {
         let platform = rich("lin-cuda", Platform::Linux64, vec![vp("__cuda", "12.0")]);
-        assert!(derive_stdlib_variants(&platform, &conda_forge()).is_empty());
+        assert!(
+            derive_stdlib_variants(&platform, &conda_forge(), StdlibVersionPin::Exact).is_empty()
+        );
     }
 
     /// Bare subdir platforms carry pixi's portable defaults (`__glibc=2.28`,
@@ -186,6 +246,7 @@ mod tests {
         let linux = into_map(derive_stdlib_variants(
             &PixiPlatform::from_subdir(Platform::Linux64),
             &conda_forge(),
+            StdlibVersionPin::Exact,
         ));
         assert_eq!(
             linux.get("c_stdlib_version"),
@@ -195,6 +256,7 @@ mod tests {
         let osx = into_map(derive_stdlib_variants(
             &PixiPlatform::from_subdir(Platform::OsxArm64),
             &conda_forge(),
+            StdlibVersionPin::Exact,
         ));
         assert_eq!(
             osx.get("c_stdlib_version"),
@@ -209,6 +271,7 @@ mod tests {
         let variants = into_map(derive_stdlib_variants(
             &platform,
             &channel("https://prefix.dev/conda-forge"),
+            StdlibVersionPin::Exact,
         ));
         assert_eq!(
             variants.get("c_stdlib"),
@@ -224,13 +287,18 @@ mod tests {
     fn non_conda_forge_channel_skips() {
         let platform = rich("mac", Platform::OsxArm64, vec![vp("__osx", "13.5")]);
         assert!(
-            derive_stdlib_variants(&platform, &channel("https://prefix.dev/my-channel")).is_empty()
+            derive_stdlib_variants(
+                &platform,
+                &channel("https://prefix.dev/my-channel"),
+                StdlibVersionPin::Exact,
+            )
+            .is_empty()
         );
     }
 
     #[test]
     fn no_channels_skips() {
         let platform = rich("mac", Platform::OsxArm64, vec![vp("__osx", "13.5")]);
-        assert!(derive_stdlib_variants(&platform, &[]).is_empty());
+        assert!(derive_stdlib_variants(&platform, &[], StdlibVersionPin::Exact).is_empty());
     }
 }

--- a/crates/pixi_core/src/workspace/stdlib_variants.rs
+++ b/crates/pixi_core/src/workspace/stdlib_variants.rs
@@ -50,7 +50,7 @@ fn channels_target_conda_forge<'a>(channels: impl IntoIterator<Item = &'a Channe
 /// virtual package.
 ///
 // TODO(#6175): handle `__musl` (musl libc) and `__cuda` -> `cuda_compiler_version`.
-pub(crate) fn derive_stdlib_variants<'a>(
+pub fn derive_stdlib_variants<'a>(
     platform: &PixiPlatform,
     channels: impl IntoIterator<Item = &'a ChannelUrl>,
 ) -> Vec<(String, VariantValue)> {

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -35,7 +35,8 @@ use pixi_core::environment::{
 };
 use pixi_core::lock_file::virtual_packages::minimal_required_virtual_packages;
 use pixi_core::repodata::Repodata;
-use pixi_manifest::{InlinePackageManifest, PrioritizedChannel, WorkspaceManifest};
+use pixi_core::workspace::stdlib_variants::derive_stdlib_variants;
+use pixi_manifest::{InlinePackageManifest, PixiPlatform, PrioritizedChannel, WorkspaceManifest};
 use pixi_path::AbsPathBuf;
 use pixi_reporters::TopLevelProgress;
 use pixi_spec::{BinarySpec, PathBinarySpec};
@@ -47,8 +48,8 @@ use pixi_utils::{
     rlimit::try_increase_rlimit_to_sensible,
 };
 use rattler_conda_types::{
-    ChannelConfig, GenericVirtualPackage, MatchSpec, NamedChannelOrUrl, PackageName, Platform,
-    PrefixRecord, menuinst::MenuMode, package::CondaArchiveIdentifier,
+    ChannelConfig, ChannelUrl, GenericVirtualPackage, MatchSpec, NamedChannelOrUrl, PackageName,
+    Platform, PrefixRecord, menuinst::MenuMode, package::CondaArchiveIdentifier,
 };
 use rattler_networking::LazyClient;
 use rattler_repodata_gateway::Gateway;
@@ -592,6 +593,28 @@ impl Project {
         }
     }
 
+    /// The build variants to build source packages with for `platform`.
+    ///
+    /// A workspace derives `c_stdlib`/`c_stdlib_version` build variants from
+    /// its system requirements so that `stdlib('c')` recipes pin a stable
+    /// minimum OS/libc target (e.g. `macosx_deployment_target 13.*`).
+    /// `pixi global` has no system-requirements table, so we derive the same
+    /// pair from the subdir's portable defaults (`PixiPlatform::from_subdir`,
+    /// e.g. `__osx = 13.0`) rather than the host's detected virtual packages.
+    /// Deriving from the host (e.g. macOS 26) would pin a deployment target
+    /// newer than most machines can run, which is the bug this avoids.
+    fn build_variants(platform: Platform, channels: &[ChannelUrl]) -> VariantConfig {
+        let variant_configuration =
+            derive_stdlib_variants(&PixiPlatform::from_subdir(platform), channels)
+                .into_iter()
+                .map(|(key, value)| (key, vec![value]))
+                .collect();
+        VariantConfig {
+            variant_configuration,
+            variant_files: Vec::new(),
+        }
+    }
+
     pub async fn install_environment(
         &self,
         env_name: &EnvironmentName,
@@ -680,6 +703,11 @@ impl Project {
 
         let build_environment = BuildEnvironment::simple(platform, solve_virtual_packages.clone());
 
+        // Derive the `c_stdlib` build variants for source builds, mirroring what
+        // a workspace does, so `stdlib('c')` recipes pin a portable deployment
+        // target instead of the host's (see `build_variants`).
+        let variant_config = Self::build_variants(platform, &channels);
+
         // Inline package definitions from the manifest, threaded into the
         // solve and install so backend discovery uses them instead of reading
         // a manifest from the source checkout.
@@ -699,7 +727,7 @@ impl Project {
                 EnvironmentSpec {
                     channels: channels.clone(),
                     build_environment: build_environment.clone(),
-                    variants: VariantConfig::default(),
+                    variants: variant_config.clone(),
                     exclude_newer: None,
                     channel_priority: Default::default(),
                 },
@@ -792,8 +820,8 @@ impl Project {
                 installed: None,
                 ignore_packages: None,
                 force_reinstall: force_reinstall_packages,
-                variant_configuration: None,
-                variant_files: None,
+                variant_configuration: Some(variant_config.variant_configuration),
+                variant_files: Some(variant_config.variant_files),
                 inline_packages: inline_packages.into_iter().collect(),
             })
             .await?;
@@ -1851,6 +1879,7 @@ mod tests {
     use std::{collections::HashMap, io::Write};
 
     use itertools::Itertools;
+    use pixi_utils::variants::VariantValue;
     use rattler_conda_types::{
         NamedChannelOrUrl, PackageRecord, Platform, RepoDataRecord, VersionWithSource,
         package::DistArchiveIdentifier,
@@ -2138,6 +2167,43 @@ mod tests {
                 .into()
         );
         assert_eq!(package, "python".parse().unwrap());
+    }
+
+    /// Source builds derive their `c_stdlib` variant from the subdir's portable
+    /// default (`__osx = 13.0` for osx-arm64), not from the host's detected
+    /// virtual packages -- so a package built on macOS 26 still targets 13.0,
+    /// matching what a workspace produces.
+    #[test]
+    fn test_build_variants_use_subdir_defaults() {
+        let channels = vec![ChannelUrl::from(
+            Url::parse("https://conda.anaconda.org/conda-forge").unwrap(),
+        )];
+        let variants = Project::build_variants(Platform::OsxArm64, &channels).variant_configuration;
+
+        assert_eq!(
+            variants.get("c_stdlib"),
+            Some(&vec![VariantValue::String(
+                "macosx_deployment_target".to_string()
+            )])
+        );
+        assert_eq!(
+            variants.get("c_stdlib_version"),
+            Some(&vec![VariantValue::String("13.0".to_string())])
+        );
+    }
+
+    /// The derived providers are conda-forge packages, so an environment that
+    /// doesn't build against conda-forge contributes no variants.
+    #[test]
+    fn test_build_variants_empty_without_conda_forge() {
+        let channels = vec![ChannelUrl::from(
+            Url::parse("https://prefix.dev/my-channel").unwrap(),
+        )];
+        assert!(
+            Project::build_variants(Platform::OsxArm64, &channels)
+                .variant_configuration
+                .is_empty()
+        );
     }
 
     /// A platform on a different OS than the local machine can't be inspected

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -596,19 +596,24 @@ impl Project {
     /// The build variants to build source packages with for `platform`.
     ///
     /// A workspace derives `c_stdlib`/`c_stdlib_version` build variants from
-    /// its system requirements so that `stdlib('c')` recipes pin a stable
+    /// its system requirements so that `stdlib('c')` recipes pin a
     /// minimum OS/libc target (e.g. `macosx_deployment_target 13.*`).
     /// `pixi global` has no system-requirements table, so we derive the same
-    /// pair from the subdir's portable defaults (`PixiPlatform::from_subdir`,
-    /// e.g. `__osx = 13.0`) rather than the host's detected virtual packages.
-    /// Deriving from the host (e.g. macOS 26) would pin a deployment target
-    /// newer than most machines can run, which is the bug this avoids.
-    fn build_variants(platform: Platform, channels: &[ChannelUrl]) -> VariantConfig {
-        let variant_configuration =
-            derive_stdlib_variants(&PixiPlatform::from_subdir(platform), channels)
-                .into_iter()
-                .map(|(key, value)| (key, vec![value]))
-                .collect();
+    /// pair from the device's detected virtual packages (`virtual_packages`,
+    /// e.g. the host's `__osx`/`__glibc`) rather than the subdir's portable
+    /// defaults. A global install targets the machine it runs on, so the
+    /// `stdlib('c')` target should match that machine's actual OS/libc.
+    fn build_variants(
+        platform: Platform,
+        virtual_packages: &[GenericVirtualPackage],
+        channels: &[ChannelUrl],
+    ) -> VariantConfig {
+        let device_platform =
+            PixiPlatform::from_required_virtual_packages(platform, virtual_packages.to_vec());
+        let variant_configuration = derive_stdlib_variants(&device_platform, channels)
+            .into_iter()
+            .map(|(key, value)| (key, vec![value]))
+            .collect();
         VariantConfig {
             variant_configuration,
             variant_files: Vec::new(),
@@ -704,9 +709,9 @@ impl Project {
         let build_environment = BuildEnvironment::simple(platform, solve_virtual_packages.clone());
 
         // Derive the `c_stdlib` build variants for source builds, mirroring what
-        // a workspace does, so `stdlib('c')` recipes pin a portable deployment
-        // target instead of the host's (see `build_variants`).
-        let variant_config = Self::build_variants(platform, &channels);
+        // a workspace does, so `stdlib('c')` recipes pin a deployment target that
+        // matches the device this install targets (see `build_variants`).
+        let variant_config = Self::build_variants(platform, &solve_virtual_packages, &channels);
 
         // Inline package definitions from the manifest, threaded into the
         // solve and install so backend discovery uses them instead of reading
@@ -2169,16 +2174,26 @@ mod tests {
         assert_eq!(package, "python".parse().unwrap());
     }
 
-    /// Source builds derive their `c_stdlib` variant from the subdir's portable
-    /// default (`__osx = 13.0` for osx-arm64), not from the host's detected
-    /// virtual packages -- so a package built on macOS 26 still targets 13.0,
-    /// matching what a workspace produces.
+    fn gvp(name: &str, version: &str) -> GenericVirtualPackage {
+        GenericVirtualPackage {
+            name: name.parse().unwrap(),
+            version: version.parse().unwrap(),
+            build_string: "0".to_string(),
+        }
+    }
+
+    /// Source builds derive their `c_stdlib` variant from the device's detected
+    /// virtual packages, so a package built on a host reporting `__osx = 15.0`
+    /// targets 15.0 -- the machine the global install runs on -- rather than the
+    /// subdir's portable default.
     #[test]
-    fn test_build_variants_use_subdir_defaults() {
+    fn test_build_variants_use_device_virtual_packages() {
         let channels = vec![ChannelUrl::from(
             Url::parse("https://conda.anaconda.org/conda-forge").unwrap(),
         )];
-        let variants = Project::build_variants(Platform::OsxArm64, &channels).variant_configuration;
+        let device = vec![gvp("__osx", "15.0")];
+        let variants = Project::build_variants(Platform::OsxArm64, &device, &channels)
+            .variant_configuration;
 
         assert_eq!(
             variants.get("c_stdlib"),
@@ -2188,7 +2203,7 @@ mod tests {
         );
         assert_eq!(
             variants.get("c_stdlib_version"),
-            Some(&vec![VariantValue::String("13.0".to_string())])
+            Some(&vec![VariantValue::String("15.0".to_string())])
         );
     }
 
@@ -2199,8 +2214,9 @@ mod tests {
         let channels = vec![ChannelUrl::from(
             Url::parse("https://prefix.dev/my-channel").unwrap(),
         )];
+        let device = vec![gvp("__osx", "15.0")];
         assert!(
-            Project::build_variants(Platform::OsxArm64, &channels)
+            Project::build_variants(Platform::OsxArm64, &device, &channels)
                 .variant_configuration
                 .is_empty()
         );

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -35,7 +35,7 @@ use pixi_core::environment::{
 };
 use pixi_core::lock_file::virtual_packages::minimal_required_virtual_packages;
 use pixi_core::repodata::Repodata;
-use pixi_core::workspace::stdlib_variants::derive_stdlib_variants;
+use pixi_core::workspace::stdlib_variants::{StdlibVersionPin, derive_stdlib_variants};
 use pixi_manifest::{InlinePackageManifest, PixiPlatform, PrioritizedChannel, WorkspaceManifest};
 use pixi_path::AbsPathBuf;
 use pixi_reporters::TopLevelProgress;
@@ -600,9 +600,12 @@ impl Project {
     /// minimum OS/libc target (e.g. `macosx_deployment_target 13.*`).
     /// `pixi global` has no system-requirements table, so we derive the same
     /// pair from the device's detected virtual packages (`virtual_packages`,
-    /// e.g. the host's `__osx`/`__glibc`) rather than the subdir's portable
-    /// defaults. A global install targets the machine it runs on, so the
-    /// `stdlib('c')` target should match that machine's actual OS/libc.
+    /// e.g. the host's `__osx`/`__glibc`). Unlike the workspace flow, we pass
+    /// [`StdlibVersionPin::AtMost`]: a global install is local to this machine,
+    /// so the target is bound with `<=` the device's exact version and the
+    /// solve picks the highest published provider candidate it can build
+    /// against. (The workspace flow keeps an exact pin to preserve build hashes
+    /// and lock-file stability; that constraint doesn't apply here.)
     fn build_variants(
         platform: Platform,
         virtual_packages: &[GenericVirtualPackage],
@@ -610,10 +613,11 @@ impl Project {
     ) -> VariantConfig {
         let device_platform =
             PixiPlatform::from_required_virtual_packages(platform, virtual_packages.to_vec());
-        let variant_configuration = derive_stdlib_variants(&device_platform, channels)
-            .into_iter()
-            .map(|(key, value)| (key, vec![value]))
-            .collect();
+        let variant_configuration =
+            derive_stdlib_variants(&device_platform, channels, StdlibVersionPin::AtMost)
+                .into_iter()
+                .map(|(key, value)| (key, vec![value]))
+                .collect();
         VariantConfig {
             variant_configuration,
             variant_files: Vec::new(),
@@ -2183,17 +2187,18 @@ mod tests {
     }
 
     /// Source builds derive their `c_stdlib` variant from the device's detected
-    /// virtual packages, so a package built on a host reporting `__osx = 15.0`
-    /// targets 15.0 -- the machine the global install runs on -- rather than the
-    /// subdir's portable default.
+    /// virtual packages, emitted as a `<=` bound: a host reporting
+    /// `__osx = 15.7.1` targets `macosx_deployment_target <=15.7.1`, so the
+    /// solve picks the highest published deployment target the device can build
+    /// against rather than pinning the exact -- and unpublished -- host version.
     #[test]
     fn test_build_variants_use_device_virtual_packages() {
         let channels = vec![ChannelUrl::from(
             Url::parse("https://conda.anaconda.org/conda-forge").unwrap(),
         )];
-        let device = vec![gvp("__osx", "15.0")];
-        let variants = Project::build_variants(Platform::OsxArm64, &device, &channels)
-            .variant_configuration;
+        let device = vec![gvp("__osx", "15.7.1")];
+        let variants =
+            Project::build_variants(Platform::OsxArm64, &device, &channels).variant_configuration;
 
         assert_eq!(
             variants.get("c_stdlib"),
@@ -2203,7 +2208,7 @@ mod tests {
         );
         assert_eq!(
             variants.get("c_stdlib_version"),
-            Some(&vec![VariantValue::String("15.0".to_string())])
+            Some(&vec![VariantValue::String("<=15.7.1".to_string())])
         );
     }
 


### PR DESCRIPTION
This fixes the issue that the build variants of the package have the right information about the virtual packages described in this comment:

## [https://github.com/prefix-dev/pixi/pull/6521#issuecomment-5046144158](<https://github.com/prefix-dev/pixi/pull/6521#issuecomment-5046144158>)

I'm trying to figure out whether this is a related issue:

```
pixi g i --git https://github.com/astral-sh/ruff --build-backend pixi-bu
ild-python --package "build.config.ignore-pypi-mapping=false"
```

On osx-arm64 this gives me this error in the maturin install:

```
× Failed to build `ruff @
│ file:///Users/rubenarts/Library/Caches/rattler/cache/bld/git-v0/checkouts/a70e12b41adfc71/1a82d31630`
╰─▶ The built wheel `ruff-0.15.22-py3-none-macosx_26_0_arm64.whl` is not compatible with the current Python 3.14 on macOS aarch64
```

This was a known issue where we wouldn't provide the virtual package in the right way to the build solve. These are related:

* [https://github.com/prefix-dev/pixi/pull/6320](<https://github.com/prefix-dev/pixi/pull/6320>) (I believe we just have to redo this too)
* [https://github.com/prefix-dev/pixi/pull/6396](<https://github.com/prefix-dev/pixi/pull/6396>)
* [https://github.com/prefix-dev/pixi/issues/6392](<https://github.com/prefix-dev/pixi/issues/6392>)

---

### How Has This Been Tested?

I tested it locally with:

```
pixi g i --git https://github.com/astral-sh/ruff --build-backend pixi-build
-python --package "build.config.ignore-pypi-mapping=false"
```

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.