### PR TITLE
fix: only source declarations decide inline package suppression

### DIFF
--- a/crates/pixi_core/src/workspace/grouped_environment.rs
+++ b/crates/pixi_core/src/workspace/grouped_environment.rs
@@ -9,8 +9,8 @@ use itertools::Either;
 use ordermap::OrderSet;
 use pixi_consts::consts;
 use pixi_manifest::{
-    EnvironmentName, Feature, HasFeaturesIter, HasWorkspaceManifest, InlinePackageManifest,
-    PixiPlatform, WorkspaceManifest,
+    EnvironmentName, Feature, FeaturesExt, HasFeaturesIter, HasWorkspaceManifest,
+    InlinePackageManifest, PixiPlatform, WorkspaceManifest,
 };
 use pixi_spec::SourceLocationSpec;
 use pixi_utils::prefix::Prefix;
@@ -151,17 +151,24 @@ impl<'p> GroupedEnvironment<'p> {
         let mut merged: IndexMap<PackageName, &InlinePackageManifest> = IndexMap::new();
         let mut decided: HashSet<PackageName> = HashSet::new();
         // `features` yields features from highest to lowest priority. The
-        // highest priority feature that declares a package as a dependency
-        // decides whether it carries an inline definition; a plain (non-inline)
-        // declaration in a higher priority feature suppresses an inline
-        // definition from a lower priority one.
-        for feature in self.features() {
+        // highest priority feature that declares a package as a *source*
+        // dependency decides whether it carries an inline definition; a plain
+        // source declaration in a higher priority feature suppresses an inline
+        // definition from a lower priority one. Binary declarations don't
+        // decide anything: the dependency merge combines specs across
+        // features, so a binary constraint in one feature still resolves to
+        // the source location (and inline definition) of another.
+        for feature in self
+            .features()
+            .filter(|f| self.feature_supports_platform(f, platform))
+        {
             let feature_inline = feature.inline_packages(platform);
             let Some(dependencies) = feature.combined_dependencies(platform) else {
                 continue;
             };
-            for name in dependencies.names() {
-                if decided.insert(name.clone())
+            for (name, spec) in dependencies.iter_specs() {
+                if spec.is_source()
+                    && decided.insert(name.clone())
                     && let Some(manifest) = feature_inline.get(name)
                 {
                     merged.insert(name.clone(), *manifest);


### PR DESCRIPTION
### Description

When merging features, a plain binary constraint like `gmpy2 = "*"` in a higher priority feature suppressed an **inline package definition** from a lower priority feature. The dependency merge combines specs across features, so the solve still used the git source location, but backend discovery lost the inline manifest and fell back to reading a manifest from the checkout, which doesn't have one. In scipy's `asan` environment this made `pixi lock` fail with "the source directory ... does not contain a supported manifest" (and hung on older versions).

- Only source declarations decide in `combined_inline_packages` whether a package carries an inline definition; a binary constraint merely constrains the version
- A plain *source* declaration in a higher priority feature still suppresses an inline definition from a lower priority one

Fixes #6561

### How Has This Been Tested?

- Lucas reproducer doesn't hang anymore
- Tests

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
