### PR TITLE
feat: add progress spinner to pixi global sync

### DIFF
--- a/crates/pixi_cli/src/global/sync.rs
+++ b/crates/pixi_cli/src/global/sync.rs
@@ -1,5 +1,6 @@
 use crate::global::{EnvironmentAction, report_failed_environments};
 use clap::Parser;
+use fancy_display::FancyDisplay;
 use pixi_config::{Config, ConfigCli};
 
 /// Sync global manifest with installed environments
@@ -38,8 +39,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         tracing::warn!("Couldn't remove broken files\n{err:?}")
     }
 
-    let mut errors = Vec::new();
-
     // Phase 1: install all environments in parallel, sharing one dispatcher.
     let env_names: Vec<_> = project.environments().keys().cloned().collect();
     let install_results = futures::future::join_all(
@@ -51,28 +50,43 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     project.clear_progress();
 
     // Phase 2: expose executables, shortcuts and completions sequentially, since
-    // they write into directories shared across all environments.
-    for (env_name, install_result) in env_names.iter().zip(install_results) {
-        let result = match install_result {
-            Ok(mut state_changes) => match project.sync_environment_expose(env_name).await {
-                Ok(expose_changes) => {
-                    state_changes |= expose_changes;
-                    Ok(state_changes)
-                }
-                Err(err) => Err(err),
-            },
-            Err(err) => Err(err),
-        };
-        match result {
-            Ok(state_change) => {
-                if state_change.has_changed() {
-                    has_changed = true;
-                    state_change.report();
+    // they write into directories shared across all environments. Drive a spinner
+    // over the loop so a sync that installs nothing still shows progress instead of
+    // appearing frozen while executables are (re)exposed and trampolines rebuilt
+    // (#6658). Reports use `pixi_progress::println!`, which suspends the spinner, so
+    // change output stays readable above it.
+    let (expose_changed, errors) =
+        pixi_progress::await_in_progress("Syncing global environments", |pb| async move {
+            let mut changed = false;
+            let mut errors = Vec::new();
+            for (env_name, install_result) in env_names.iter().zip(install_results) {
+                pb.set_message(format!("Syncing environment {}", env_name.fancy_display()));
+                let result = match install_result {
+                    Ok(mut state_changes) => {
+                        match project.sync_environment_expose(env_name).await {
+                            Ok(expose_changes) => {
+                                state_changes |= expose_changes;
+                                Ok(state_changes)
+                            }
+                            Err(err) => Err(err),
+                        }
+                    }
+                    Err(err) => Err(err),
+                };
+                match result {
+                    Ok(state_change) => {
+                        if state_change.has_changed() {
+                            changed = true;
+                            state_change.report();
+                        }
+                    }
+                    Err(err) => errors.push((env_name.clone(), err)),
                 }
             }
-            Err(err) => errors.push((env_name.clone(), err)),
-        }
-    }
+            (changed, errors)
+        })
+        .await;
+    has_changed |= expose_changed;
 
     if !has_changed {
         eprintln!(


### PR DESCRIPTION
### Description

`pixi global sync` does visible work after resolving what to install: pruning, exposing executables, and (re)creating trampolines. That phase currently shows no progress. When there is nothing to install, the install phase is a no-op, so the command can appear frozen for several seconds before finally printing "Nothing to do", as reported in #6658.

This drives a spinner over the expose phase using the existing `pixi_progress::await_in_progress` helper, updating the message per environment (for example `Syncing environment jq`). The install phase keeps its own progress reporting untouched, and change output still prints above the spinner because `StateChanges::report()` uses `pixi_progress::println!`, which suspends the spinner while printing.

Before: several silent seconds, then `✔ Nothing to do. ...`
After: `⠙ Syncing environment <name>` while it works, then `✔ Nothing to do. ...`

Fixes #6658

### How Has This Been Tested?

- `cargo build -p pixi`, `cargo fmt --check`, and `cargo clippy -p pixi_cli` all pass with no warnings.
- Ran the built binary against an isolated `PIXI_HOME`: with no environments it prints `Nothing to do`; after `pixi global install jq`, a later `pixi global sync` (nothing to install) shows the spinner during the expose phase and then the up-to-date message.
- Captured under a pseudo-terminal to confirm the spinner renders during the previously-silent phase:
  ```
  ⠁ Syncing environment jq
  ⠙ Syncing environment jq
  ✔ Nothing to do. The pixi global installation is already up-to-date.
  ```
- No automated test added: the spinner is an `indicatif` progress bar gated to interactive terminals (suppressed in non-interactive output by design), so it is not meaningfully unit-testable here. Verified manually as above.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.8). Task: add a progress spinner over the expose phase of `pixi global sync` using the existing `pixi_progress` helpers, keeping the change scoped to `crates/pixi_cli/src/global/sync.rs`.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
