### PR TITLE
fix(config): top-level 'concurrency' key incorrectly overwrote pypi-c…

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -3302,7 +3302,10 @@ UNUSED = "unused"
         );
 
         config.set("concurrency", None).unwrap();
-        assert_eq!(config.concurrency.solves, ConcurrencyConfig::default().solves);
+        assert_eq!(
+            config.concurrency.solves,
+            ConcurrencyConfig::default().solves
+        );
         assert_eq!(
             config.concurrency.downloads,
             ConcurrencyConfig::default().downloads

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -2293,9 +2293,9 @@ impl Config {
             key if key.starts_with("concurrency") => {
                 if key == "concurrency" {
                     if let Some(value) = value {
-                        self.pypi_config = serde_json::de::from_str(&value).into_diagnostic()?;
+                        self.concurrency = serde_json::de::from_str(&value).into_diagnostic()?;
                     } else {
-                        self.pypi_config = PyPIConfig::default();
+                        self.concurrency = ConcurrencyConfig::default();
                     }
                     return Ok(());
                 } else if !key.starts_with("concurrency.") {
@@ -3277,6 +3277,41 @@ UNUSED = "unused"
             .unwrap();
 
         assert_eq!(config.max_concurrent_downloads(), 1);
+
+        // Regression test: setting the top-level "concurrency" key must update
+        // `self.concurrency`, not `self.pypi_config` (see #issue: copy-paste bug
+        // where the "concurrency" branch mistakenly wrote to `pypi_config`).
+        config
+            .set(
+                "pypi-config.keyring-provider",
+                Some("subprocess".to_string()),
+            )
+            .unwrap();
+        config
+            .set(
+                "concurrency",
+                Some(r#"{"solves": 7, "downloads": 42}"#.to_string()),
+            )
+            .unwrap();
+        assert_eq!(config.concurrency.solves, 7);
+        assert_eq!(config.concurrency.downloads, 42);
+        // pypi_config must be untouched by the "concurrency" set above.
+        assert_eq!(
+            config.pypi_config().keyring_provider,
+            Some(KeyringProvider::Subprocess)
+        );
+
+        config.set("concurrency", None).unwrap();
+        assert_eq!(config.concurrency.solves, ConcurrencyConfig::default().solves);
+        assert_eq!(
+            config.concurrency.downloads,
+            ConcurrencyConfig::default().downloads
+        );
+        // Unsetting "concurrency" must not reset pypi_config either.
+        assert_eq!(
+            config.pypi_config().keyring_provider,
+            Some(KeyringProvider::Subprocess)
+        );
 
         config.set("s3-options.my-bucket", Some(r#"{"endpoint-url": "http://localhost:9000", "force-path-style": true, "region": "auto"}"#.to_string())).unwrap();
         let s3_options = config.s3_options.0.get("my-bucket").unwrap();


### PR DESCRIPTION
…onfig

The 'concurrency' branch in Config::set was copy-pasted from the 'pypi-config' branch without updating the target field. Setting pixi config set concurrency ... silently overwrote pypi_config instead of concurrency settings, causing data loss of PyPI index URL, keyring provider, and other PyPI configuration.

Added regression test to verify that setting/unsetting the top-level 'concurrency' key correctly updates concurrency fields and leaves pypi_config untouched.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
