### PR TITLE
fix: name the package when solving build environments fails

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -1112,7 +1112,7 @@ foo = "{override_cutoff}"
         .expect_err("host dependency should still be excluded until it is overridden too");
     let rendered = format_diagnostic(err.as_ref());
     assert!(
-        rendered.contains("while trying to solve the host environment"),
+        rendered.contains("failed to solve the host environment for package 'my-package'"),
         "{rendered}"
     );
     assert!(rendered.contains("bar"), "{rendered}");

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -145,19 +145,21 @@ pub enum SourceRecordError {
     #[error("failed to amend run exports for {0} environment")]
     RunExportsExtraction(String, #[source] Arc<RunExportExtractorError>),
 
-    #[error("while trying to solve the build environment for the package")]
-    SolveBuildEnvironment(
+    #[error("failed to solve the build environment for package '{}'", package.as_source())]
+    SolveBuildEnvironment {
+        package: PackageName,
         #[diagnostic_source]
         #[source]
-        Box<SolvePixiEnvironmentError>,
-    ),
+        error: Box<SolvePixiEnvironmentError>,
+    },
 
-    #[error("while trying to solve the host environment for the package")]
-    SolveHostEnvironment(
+    #[error("failed to solve the host environment for package '{}'", package.as_source())]
+    SolveHostEnvironment {
+        package: PackageName,
         #[diagnostic_source]
         #[source]
-        Box<SolvePixiEnvironmentError>,
-    ),
+        error: Box<SolvePixiEnvironmentError>,
+    },
 
     #[error(transparent)]
     SpecConversionError(Arc<SpecConversionError>),
@@ -258,6 +260,19 @@ pub enum SolvePixiEnvironmentError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     SourceMetadata(SourceMetadataError),
+
+    /// Resolving a source package that is part of the environment failed.
+    /// Names the package and its source location so failures deep inside
+    /// nested build/host environments can be traced back to the package
+    /// they belong to.
+    #[error("failed to resolve source package '{}' (at '{source}')", name.as_source())]
+    ResolveSourcePackage {
+        name: PackageName,
+        source: Box<SourceLocationSpec>,
+        #[diagnostic_source]
+        #[source]
+        error: Box<SourceRecordError>,
+    },
 }
 
 impl SolvePixiEnvironmentError {
@@ -268,6 +283,9 @@ impl SolvePixiEnvironmentError {
         match self {
             SolvePixiEnvironmentError::SourceMetadata(err) => err.discovery_error(),
             SolvePixiEnvironmentError::DevSourceMetadataError(err) => err.discovery_error(),
+            SolvePixiEnvironmentError::ResolveSourcePackage { error, .. } => {
+                error.discovery_error()
+            }
             _ => None,
         }
     }
@@ -291,8 +309,8 @@ impl SourceRecordError {
     pub fn discovery_error(&self) -> Option<&pixi_build_discovery::DiscoveryError> {
         match self {
             SourceRecordError::BuildBackendMetadata(err) => err.discovery_error(),
-            SourceRecordError::SolveBuildEnvironment(err)
-            | SourceRecordError::SolveHostEnvironment(err) => err.discovery_error(),
+            SourceRecordError::SolveBuildEnvironment { error, .. }
+            | SourceRecordError::SolveHostEnvironment { error, .. } => error.discovery_error(),
             _ => None,
         }
     }
@@ -348,6 +366,12 @@ pub struct MissingChannelError {
 }
 
 impl Borrow<dyn Diagnostic> for Box<SolvePixiEnvironmentError> {
+    fn borrow(&self) -> &(dyn Diagnostic + 'static) {
+        self.as_ref()
+    }
+}
+
+impl Borrow<dyn Diagnostic> for Box<SourceRecordError> {
     fn borrow(&self) -> &(dyn Diagnostic + 'static) {
         self.as_ref()
     }
@@ -418,7 +442,10 @@ mod tests {
             SourceMetadataError::BuildBackendMetadata(metadata_error()),
         );
         let err = SolvePixiEnvironmentError::SourceMetadata(SourceMetadataError::SourceRecord(
-            SourceRecordError::SolveBuildEnvironment(Box::new(inner)),
+            SourceRecordError::SolveBuildEnvironment {
+                package: PackageName::new_unchecked("some-package"),
+                error: Box::new(inner),
+            },
         ));
         assert!(err.discovery_error().is_some());
     }

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -577,9 +577,15 @@ async fn nested_solve(
         // not a wrapping "solve the build/host environment" error.
         crate::SolvePixiEnvironmentError::Cycle(cycle) => SourceRecordError::Cycle(cycle),
         other => match cycle_env {
-            CycleEnvironment::Build => SourceRecordError::SolveBuildEnvironment(Box::new(other)),
+            CycleEnvironment::Build => SourceRecordError::SolveBuildEnvironment {
+                package: pkg_name.clone(),
+                error: Box::new(other),
+            },
             CycleEnvironment::Host | CycleEnvironment::Run => {
-                SourceRecordError::SolveHostEnvironment(Box::new(other))
+                SourceRecordError::SolveHostEnvironment {
+                    package: pkg_name.clone(),
+                    error: Box::new(other),
+                }
             }
         },
     })?;

--- a/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
+++ b/crates/pixi_command_dispatcher/src/keys/solve_pixi_environment.rs
@@ -513,6 +513,7 @@ async fn walk_and_resolve(
         if !seen.insert((name.clone(), location.clone())) {
             return;
         }
+        let source_location = location.clone();
         let key = ResolveSourcePackageKey::new(ResolveSourcePackageSpec {
             package: name.clone(),
             source_location: location,
@@ -534,9 +535,19 @@ async fn walk_and_resolve(
                 .await;
             match guarded {
                 Ok(Ok(records)) => Ok((name, parent, records)),
-                Ok(Err(e)) => Err(SolvePixiEnvironmentError::from(
-                    crate::SourceMetadataError::SourceRecord(e),
-                )),
+                // Wrap resolution failures with the package name and source
+                // location so errors surfacing from deep inside nested
+                // build/host environments name the package they belong to.
+                // Cycle errors keep their identity so callers still see
+                // `SolvePixiEnvironmentError::Cycle(..)`.
+                Ok(Err(crate::SourceRecordError::Cycle(cycle))) => {
+                    Err(SolvePixiEnvironmentError::Cycle(cycle))
+                }
+                Ok(Err(e)) => Err(SolvePixiEnvironmentError::ResolveSourcePackage {
+                    name,
+                    source: Box::new(source_location),
+                    error: Box::new(e),
+                }),
                 Err(cycle) => {
                     let fallback_env = match env_ref {
                         EnvironmentRef::Derived { kind, .. } => match kind {

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -668,6 +668,98 @@ pub async fn test_cycle_three_packages() {
     ));
 }
 
+/// Regression test for <https://github.com/prefix-dev/pixi/issues/6642>.
+///
+/// When the build environment of a source package cannot be solved, the
+/// error names the package the environment belongs to.
+#[tokio::test]
+pub async fn test_unsolvable_build_environment_names_package() {
+    let (tool_platform, tool_virtual_packages) = tool_platform();
+    let root_dir = workspaces_dir().join("unsolvable-build-env");
+    let tempdir = test_tempdir();
+    let dispatcher = CommandDispatcher::builder()
+        .with_root_dir(to_abs_dir(root_dir.clone()))
+        .with_cache_dirs(default_cache_dirs().with_workspace(to_abs_dir(tempdir.path())))
+        .with_executor(Executor::Serial)
+        .with_tool_platform(tool_platform, tool_virtual_packages)
+        .with_backend_overrides(BackendOverride::from_memory(
+            PassthroughBackend::instantiator(),
+        ))
+        .finish();
+
+    let error = run_pixi_solve(
+        &dispatcher,
+        SolvePixiEnvironmentSpec {
+            dependencies: DependencyMap::from_iter([(
+                "package_a".parse().unwrap(),
+                PathSpec {
+                    path: "package_a".into(),
+                }
+                .into(),
+            )]),
+            env_ref: env_ref_of(vec![], BuildEnvironment::simple(Platform::Linux64, vec![])),
+            ..empty_pixi_env_spec()
+        },
+    )
+    .await
+    .expect_err("expected the build environment solve to fail");
+
+    insta::assert_snapshot!(format_diagnostic(&error), @"
+    × failed to resolve source package 'package_a' (at 'package_a')
+    ├─▶   × failed to solve the build environment for package 'package_a'
+
+    ├─▶   × failed to solve the environment
+
+    ╰─▶ Cannot solve the request because of: No candidates were found for missing-build-dep *.
+    ");
+}
+
+/// Regression test for <https://github.com/prefix-dev/pixi/issues/6642>.
+///
+/// When the build backend of a source package cannot be instantiated, the
+/// error names the package the backend belongs to.
+#[tokio::test]
+pub async fn test_unsolvable_backend_names_package() {
+    let (tool_platform, tool_virtual_packages) = tool_platform();
+    let root_dir = workspaces_dir().join("unsolvable-backend");
+    let tempdir = test_tempdir();
+    // No backend overrides: the backend `missing-backend` requested by
+    // `package_a` is instantiated for real, which fails because the
+    // workspace has no channels to solve the backend's environment from.
+    let dispatcher = CommandDispatcher::builder()
+        .with_root_dir(to_abs_dir(root_dir.clone()))
+        .with_cache_dirs(default_cache_dirs().with_workspace(to_abs_dir(tempdir.path())))
+        .with_executor(Executor::Serial)
+        .with_tool_platform(tool_platform, tool_virtual_packages)
+        .finish();
+
+    let error = run_pixi_solve(
+        &dispatcher,
+        SolvePixiEnvironmentSpec {
+            dependencies: DependencyMap::from_iter([(
+                "package_a".parse().unwrap(),
+                PathSpec {
+                    path: "package_a".into(),
+                }
+                .into(),
+            )]),
+            env_ref: env_ref_of(vec![], BuildEnvironment::simple(Platform::Linux64, vec![])),
+            ..empty_pixi_env_spec()
+        },
+    )
+    .await
+    .expect_err("expected the backend instantiation to fail");
+
+    insta::assert_snapshot!(format_diagnostic(&error), @"
+    × failed to resolve source package 'package_a' (at 'package_a')
+    ├─▶   × could not initialize the build-backend
+
+    ├─▶   × failed to solve the environment
+
+    ╰─▶ Cannot solve the request because of: No candidates were found for missing-backend *.
+    ");
+}
+
 /// Regression test for <https://github.com/prefix-dev/pixi/issues/6482>.
 ///
 /// `package_a` (a source dependency of the top-level env) host-depends on

--- a/tests/data/workspaces/unsolvable-backend/README.md
+++ b/tests/data/workspaces/unsolvable-backend/README.md
@@ -1,0 +1,3 @@
+This workspace contains a source package whose build backend cannot be
+instantiated: `package_a` requests the backend `missing-backend`, which does
+not exist in any channel (the workspace has no channels at all).

--- a/tests/data/workspaces/unsolvable-backend/package_a/pixi.toml
+++ b/tests/data/workspaces/unsolvable-backend/package_a/pixi.toml
@@ -1,0 +1,6 @@
+[package]
+name = "package_a"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "missing-backend", version = "*" }

--- a/tests/data/workspaces/unsolvable-backend/pixi.toml
+++ b/tests/data/workspaces/unsolvable-backend/pixi.toml
@@ -1,0 +1,8 @@
+[workspace]
+channels = []
+name = "unsolvable-backend"
+platforms = []
+preview = ["pixi-build"]
+
+[dependencies]
+package_a = { path = "package_a" }

--- a/tests/data/workspaces/unsolvable-build-env/README.md
+++ b/tests/data/workspaces/unsolvable-build-env/README.md
@@ -1,0 +1,3 @@
+This workspace contains a source package whose build environment cannot be
+solved: `package_a` build-depends on `missing-build-dep`, which does not exist
+in any channel (the workspace has no channels at all).

--- a/tests/data/workspaces/unsolvable-build-env/package_a/pixi.toml
+++ b/tests/data/workspaces/unsolvable-build-env/package_a/pixi.toml
@@ -1,0 +1,9 @@
+[package]
+name = "package_a"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+[package.build-dependencies]
+missing-build-dep = "*"

--- a/tests/data/workspaces/unsolvable-build-env/pixi.toml
+++ b/tests/data/workspaces/unsolvable-build-env/pixi.toml
@@ -1,0 +1,8 @@
+[workspace]
+channels = []
+name = "unsolvable-build-env"
+platforms = []
+preview = ["pixi-build"]
+
+[dependencies]
+package_a = { path = "package_a" }


### PR DESCRIPTION
Solver failures for build and host environments of source packages now name the package they belong to.
The first error chain from the issue, before:

```
× could not initialize the build-backend
├─▶ × failed to solve the environment
╰─▶ Cannot solve the request because of: No candidates were found for missing-backend *.
```

and after:

```
× failed to resolve source package 'package_a' (at 'package_a')
├─▶ × could not initialize the build-backend
├─▶ × failed to solve the environment
╰─▶ Cannot solve the request because of: No candidates were found for missing-backend *.
```

Fixes #6642
