### PR TITLE
fix: Improve error messages on network failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6548,6 +6548,7 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
+ "rattler_redaction",
  "rattler_repodata_gateway",
  "rattler_shell",
  "rattler_solve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6508,6 +6508,7 @@ dependencies = [
  "dunce",
  "fs-err",
  "futures",
+ "human_bytes",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.15.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6501,6 +6501,7 @@ dependencies = [
 name = "pixi_command_dispatcher"
 version = "0.1.0"
 dependencies = [
+ "astral-reqwest-middleware",
  "async-fd-lock",
  "base64 0.22.1",
  "chrono",
@@ -6508,6 +6509,7 @@ dependencies = [
  "dunce",
  "fs-err",
  "futures",
+ "http 1.4.2",
  "human_bytes",
  "indexmap 2.14.0",
  "insta",
@@ -6554,6 +6556,7 @@ dependencies = [
  "rattler_solve",
  "rattler_virtual_packages",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,7 @@ rattler_networking = { version = "0.30", default-features = false, features = [
   "google-cloud-auth",
 ] }
 rattler_package_streaming = { version = "0.26", default-features = false }
+rattler_redaction = { version = "0.2", default-features = false }
 rattler_repodata_gateway = { version = "0.31", default-features = false }
 rattler_s3 = { version = "0.2", default-features = false }
 rattler_shell = { version = "0.27", default-features = false }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -16,6 +16,7 @@ derive_more = { workspace = true, features = ["display", "from", "try_into"] }
 dunce = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
+human_bytes = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -43,6 +43,7 @@ rattler_conda_types = { workspace = true }
 rattler_digest = { workspace = true }
 rattler_networking = { workspace = true }
 rattler_package_streaming = { workspace = true }
+rattler_redaction = { workspace = true }
 rattler_repodata_gateway = { workspace = true }
 rattler_shell = { workspace = true }
 rattler_solve = { workspace = true, features = ["resolvo"] }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -48,6 +48,8 @@ rattler_repodata_gateway = { workspace = true }
 rattler_shell = { workspace = true }
 rattler_solve = { workspace = true, features = ["resolvo"] }
 rattler_virtual_packages = { workspace = true }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 simple_spawn_blocking = { workspace = true, features = ["tokio"] }
 
 pixi_build_discovery = { workspace = true, features = ["serde"] }
@@ -73,6 +75,7 @@ pixi_utils = { workspace = true }
 pixi_variant = { workspace = true }
 
 [dev-dependencies]
+http = { workspace = true }
 indexmap = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 pixi_build_backend_passthrough = { workspace = true }

--- a/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
@@ -24,7 +24,7 @@ use crate::compute_data::{
 use crate::install_pixi::{
     FetchProgressSummary, InstallPixiEnvironmentError, InstallPixiEnvironmentResult,
     InstallPixiEnvironmentSpec, fetch_progress::FetchProgressReporter,
-    reporter::WrappingInstallReporter,
+    reporter::WrappingInstallReporter, sanitized_fetch_error,
 };
 use crate::keys::{ArtifactCache, SourceBuildKey, SourceBuildSpec, WorkspaceCache};
 use crate::reporter::PixiInstallReporter;
@@ -332,7 +332,7 @@ async fn install_inner(
                         package: package.clone(),
                         url: attempt.url.clone(),
                         progress: FetchProgressSummary::from(&attempt),
-                        source: Box::new(err),
+                        source: Box::new(sanitized_fetch_error(err)),
                     },
                     // The fetch failed before the reporter saw it start, so
                     // there is no context to add.

--- a/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
@@ -22,7 +22,8 @@ use crate::compute_data::{
     HasPixiInstallReporter,
 };
 use crate::install_pixi::{
-    InstallPixiEnvironmentError, InstallPixiEnvironmentResult, InstallPixiEnvironmentSpec,
+    FetchProgressSummary, InstallPixiEnvironmentError, InstallPixiEnvironmentResult,
+    InstallPixiEnvironmentSpec, fetch_progress::FetchProgressReporter,
     reporter::WrappingInstallReporter,
 };
 use crate::keys::{ArtifactCache, SourceBuildKey, SourceBuildSpec, WorkspaceCache};
@@ -303,9 +304,14 @@ async fn install_inner(
     if let Some(installed) = spec.installed.take() {
         installer = installer.with_installed_packages(installed);
     }
-    if let Some(reporter) = install_reporter {
-        installer = installer.with_reporter(WrappingInstallReporter(reporter));
-    }
+    // Always wrap: the fetch context is collected whether or not progress is
+    // being displayed, so a failure can be reported with the URL and how far
+    // the transfer got.
+    let (fetch_reporter, fetch_progress) =
+        FetchProgressReporter::new(install_reporter.map(|reporter| {
+            Box::new(WrappingInstallReporter(reporter)) as Box<dyn rattler::install::Reporter>
+        }));
+    installer = installer.with_reporter(fetch_reporter);
 
     let result = installer
         .install(
@@ -316,6 +322,22 @@ async fn install_inner(
         .map_err(|err| match err {
             InstallerError::FailedToDetectInstalledPackages(err) => {
                 InstallPixiEnvironmentError::ReadInstalledPackages(spec.prefix.clone(), err)
+            }
+            // `InstallerError::FailedToFetch` names the package but nothing
+            // else; re-wrap it with what the reporter saw so the URL, transfer
+            // progress and elapsed time reach the user.
+            InstallerError::FailedToFetch(ref package, _) => {
+                match fetch_progress.attempt(package) {
+                    Some(attempt) => InstallPixiEnvironmentError::FailedToFetch {
+                        package: package.clone(),
+                        url: attempt.url.clone(),
+                        progress: FetchProgressSummary::from(&attempt),
+                        source: Box::new(err),
+                    },
+                    // The fetch failed before the reporter saw it start, so
+                    // there is no context to add.
+                    None => InstallPixiEnvironmentError::Installer(err),
+                }
             }
             err => InstallPixiEnvironmentError::Installer(err),
         })

--- a/crates/pixi_command_dispatcher/src/install_pixi/fetch_progress.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/fetch_progress.rs
@@ -1,0 +1,266 @@
+//! Tracks what the prefix installer observed for each package download so a
+//! fetch failure can be reported with request context.
+//!
+//! [`InstallerError::FailedToFetch`](rattler::install::InstallerError) carries
+//! only the package identifier; the URL, the number of bytes that made it
+//! across, and how long the attempt ran are all known to the install reporter
+//! but never reach the error. [`FetchProgressReporter`] sits between rattler
+//! and the (optional) real reporter, records that context per package, and
+//! hands it back through [`FetchProgress`] once the install fails.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+    time::{Duration, Instant},
+};
+
+use rattler::install::{Reporter, Transaction};
+use rattler_conda_types::{PrefixRecord, RepoDataRecord};
+use url::Url;
+
+/// What the installer observed while fetching one package.
+#[derive(Debug, Clone)]
+pub struct FetchAttempt {
+    /// The URL the package was fetched from, with any credentials stripped.
+    pub url: Url,
+    /// Size the repodata advertised, or the total the server reported. `None`
+    /// when neither is known.
+    pub expected: Option<u64>,
+    /// Bytes received before the failure. Zero when the transfer never
+    /// produced a progress report, e.g. because connecting failed.
+    pub transferred: u64,
+    /// How long the fetch ran before it was abandoned.
+    pub elapsed: Duration,
+}
+
+/// Handle onto the state collected by a [`FetchProgressReporter`]. Cloneable
+/// and safe to query after the reporter has been handed to the installer.
+#[derive(Debug, Clone, Default)]
+pub struct FetchProgress {
+    state: Arc<Mutex<State>>,
+}
+
+impl FetchProgress {
+    /// What was observed for `package`, identified the same way
+    /// `InstallerError::FailedToFetch` identifies it. `None` when the package
+    /// never reached the fetch stage.
+    pub fn attempt(&self, package: &str) -> Option<FetchAttempt> {
+        let state = lock(&self.state);
+        let attempt = state.attempts.get(package)?;
+        Some(FetchAttempt {
+            url: redacted(&attempt.url),
+            expected: attempt.expected,
+            transferred: attempt.transferred,
+            elapsed: attempt.started.elapsed(),
+        })
+    }
+}
+
+/// Removes credentials so a URL is safe to put in an error message.
+fn redacted(url: &Url) -> Url {
+    let mut url = url.clone();
+    let _ = url.set_password(None);
+    if !url.username().is_empty() {
+        let _ = url.set_username("");
+    }
+    url
+}
+
+#[derive(Debug, Default)]
+struct State {
+    /// Cache-entry index -> package identifier.
+    entries: HashMap<usize, String>,
+    /// Download index -> package identifier.
+    downloads: HashMap<usize, String>,
+    /// Package identifier -> what we have seen so far.
+    attempts: HashMap<String, Attempt>,
+}
+
+#[derive(Debug)]
+struct Attempt {
+    url: Url,
+    expected: Option<u64>,
+    transferred: u64,
+    started: Instant,
+}
+
+/// A poisoned mutex only means some other thread panicked while holding it;
+/// the collected progress is still readable and is only used for diagnostics.
+fn lock(state: &Mutex<State>) -> MutexGuard<'_, State> {
+    state.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Install reporter that records per-package fetch context and forwards every
+/// call to the wrapped reporter, if there is one.
+pub struct FetchProgressReporter {
+    inner: Option<Box<dyn Reporter>>,
+    state: Arc<Mutex<State>>,
+}
+
+impl FetchProgressReporter {
+    /// Wraps `inner`, which may be absent when progress is not being
+    /// displayed; the fetch context is collected either way.
+    pub fn new(inner: Option<Box<dyn Reporter>>) -> (Self, FetchProgress) {
+        let state = Arc::new(Mutex::new(State::default()));
+        let progress = FetchProgress {
+            state: state.clone(),
+        };
+        (Self { inner, state }, progress)
+    }
+}
+
+impl Reporter for FetchProgressReporter {
+    fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>) {
+        if let Some(inner) = &self.inner {
+            inner.on_transaction_start(transaction);
+        }
+    }
+
+    fn on_transaction_operation_start(&self, operation: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_transaction_operation_start(operation);
+        }
+    }
+
+    fn on_populate_cache_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
+        // Fall back to the operation index when there is no inner reporter to
+        // allocate one; rattler only feeds these values back to us.
+        let cache_entry = self.inner.as_ref().map_or(operation, |inner| {
+            inner.on_populate_cache_start(operation, record)
+        });
+
+        let package = record.identifier.to_string();
+        let mut state = lock(&self.state);
+        state.entries.insert(cache_entry, package.clone());
+        state.attempts.insert(
+            package,
+            Attempt {
+                url: record.url.clone(),
+                expected: record.package_record.size,
+                transferred: 0,
+                started: Instant::now(),
+            },
+        );
+        cache_entry
+    }
+
+    fn on_validate_start(&self, cache_entry: usize) -> usize {
+        self.inner
+            .as_ref()
+            .map_or(cache_entry, |inner| inner.on_validate_start(cache_entry))
+    }
+
+    fn on_validate_complete(&self, validate_idx: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_validate_complete(validate_idx);
+        }
+    }
+
+    fn on_download_start(&self, cache_entry: usize) -> usize {
+        let download_idx = self
+            .inner
+            .as_ref()
+            .map_or(cache_entry, |inner| inner.on_download_start(cache_entry));
+
+        let mut state = lock(&self.state);
+        if let Some(package) = state.entries.get(&cache_entry).cloned() {
+            // Time from here rather than from cache population so the elapsed
+            // time reflects the transfer, not the cache validation before it.
+            if let Some(attempt) = state.attempts.get_mut(&package) {
+                attempt.started = Instant::now();
+            }
+            state.downloads.insert(download_idx, package);
+        }
+        download_idx
+    }
+
+    fn on_download_progress(&self, download_idx: usize, progress: u64, total: Option<u64>) {
+        let mut state = lock(&self.state);
+        if let Some(package) = state.downloads.get(&download_idx).cloned()
+            && let Some(attempt) = state.attempts.get_mut(&package)
+        {
+            attempt.transferred = progress;
+            // The server's content length is more trustworthy than repodata.
+            if total.is_some() {
+                attempt.expected = total;
+            }
+        }
+        drop(state);
+
+        if let Some(inner) = &self.inner {
+            inner.on_download_progress(download_idx, progress, total);
+        }
+    }
+
+    fn on_download_completed(&self, download_idx: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_download_completed(download_idx);
+        }
+    }
+
+    fn on_populate_cache_complete(&self, cache_entry: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_populate_cache_complete(cache_entry);
+        }
+    }
+
+    fn on_unlink_start(&self, operation: usize, record: &PrefixRecord) -> usize {
+        self.inner
+            .as_ref()
+            .map_or(operation, |inner| inner.on_unlink_start(operation, record))
+    }
+
+    fn on_unlink_complete(&self, index: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_unlink_complete(index);
+        }
+    }
+
+    fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
+        self.inner
+            .as_ref()
+            .map_or(operation, |inner| inner.on_link_start(operation, record))
+    }
+
+    fn on_link_complete(&self, index: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_link_complete(index);
+        }
+    }
+
+    fn on_post_link_start(&self, package_name: &str, script_path: &str) -> usize {
+        self.inner.as_ref().map_or(0, |inner| {
+            inner.on_post_link_start(package_name, script_path)
+        })
+    }
+
+    fn on_post_link_complete(&self, index: usize, success: bool) {
+        if let Some(inner) = &self.inner {
+            inner.on_post_link_complete(index, success);
+        }
+    }
+
+    fn on_pre_unlink_start(&self, package_name: &str, script_path: &str) -> usize {
+        self.inner.as_ref().map_or(0, |inner| {
+            inner.on_pre_unlink_start(package_name, script_path)
+        })
+    }
+
+    fn on_pre_unlink_complete(&self, index: usize, success: bool) {
+        if let Some(inner) = &self.inner {
+            inner.on_pre_unlink_complete(index, success);
+        }
+    }
+
+    fn on_transaction_operation_complete(&self, operation: usize) {
+        if let Some(inner) = &self.inner {
+            inner.on_transaction_operation_complete(operation);
+        }
+    }
+
+    fn on_transaction_complete(&self) {
+        if let Some(inner) = &self.inner {
+            inner.on_transaction_complete();
+        }
+    }
+}

--- a/crates/pixi_command_dispatcher/src/install_pixi/fetch_progress.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/fetch_progress.rs
@@ -58,14 +58,15 @@ impl FetchProgress {
     }
 }
 
-/// Removes credentials and signed parameters before displaying a URL.
-fn redacted(url: &Url) -> Url {
+/// Removes userinfo, known path tokens, the entire query, and the fragment.
+pub(super) fn redacted(url: &Url) -> Url {
     let mut url = url.clone().redact();
     let _ = url.set_password(None);
     if !url.username().is_empty() {
         let _ = url.set_username("");
     }
     url.set_query(None);
+    url.set_fragment(None);
     url
 }
 
@@ -298,9 +299,9 @@ mod tests {
     }
 
     #[test]
-    fn removes_signed_query_parameters() {
+    fn removes_query_parameters_and_fragment() {
         let url = Url::parse(
-            "https://dl.cloudsmith.io/signed/org/conda/package.conda?created=1&expires=2&signature=secret",
+            "https://dl.cloudsmith.io/signed/org/conda/package.conda?created=1&expires=2&signature=secret#token",
         )
         .unwrap();
 

--- a/crates/pixi_command_dispatcher/src/install_pixi/fetch_progress.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/fetch_progress.rs
@@ -16,12 +16,13 @@ use std::{
 
 use rattler::install::{Reporter, Transaction};
 use rattler_conda_types::{PrefixRecord, RepoDataRecord};
+use rattler_redaction::Redact;
 use url::Url;
 
 /// What the installer observed while fetching one package.
 #[derive(Debug, Clone)]
 pub struct FetchAttempt {
-    /// The URL the package was fetched from, with any credentials stripped.
+    /// The URL the package was fetched from, with secrets redacted.
     pub url: Url,
     /// Size the repodata advertised, or the total the server reported. `None`
     /// when neither is known.
@@ -47,22 +48,24 @@ impl FetchProgress {
     pub fn attempt(&self, package: &str) -> Option<FetchAttempt> {
         let state = lock(&self.state);
         let attempt = state.attempts.get(package)?;
+        let started = attempt.started?;
         Some(FetchAttempt {
             url: redacted(&attempt.url),
             expected: attempt.expected,
             transferred: attempt.transferred,
-            elapsed: attempt.started.elapsed(),
+            elapsed: started.elapsed(),
         })
     }
 }
 
-/// Removes credentials so a URL is safe to put in an error message.
+/// Removes credentials and signed parameters before displaying a URL.
 fn redacted(url: &Url) -> Url {
-    let mut url = url.clone();
+    let mut url = url.clone().redact();
     let _ = url.set_password(None);
     if !url.username().is_empty() {
         let _ = url.set_username("");
     }
+    url.set_query(None);
     url
 }
 
@@ -79,9 +82,10 @@ struct State {
 #[derive(Debug)]
 struct Attempt {
     url: Url,
+    advertised_size: Option<u64>,
     expected: Option<u64>,
     transferred: u64,
-    started: Instant,
+    started: Option<Instant>,
 }
 
 /// A poisoned mutex only means some other thread panicked while holding it;
@@ -136,9 +140,10 @@ impl Reporter for FetchProgressReporter {
             package,
             Attempt {
                 url: record.url.clone(),
+                advertised_size: record.package_record.size,
                 expected: record.package_record.size,
                 transferred: 0,
-                started: Instant::now(),
+                started: None,
             },
         );
         cache_entry
@@ -167,7 +172,9 @@ impl Reporter for FetchProgressReporter {
             // Time from here rather than from cache population so the elapsed
             // time reflects the transfer, not the cache validation before it.
             if let Some(attempt) = state.attempts.get_mut(&package) {
-                attempt.started = Instant::now();
+                attempt.started = Some(Instant::now());
+                attempt.transferred = 0;
+                attempt.expected = attempt.advertised_size;
             }
             state.downloads.insert(download_idx, package);
         }
@@ -262,5 +269,84 @@ impl Reporter for FetchProgressReporter {
         if let Some(inner) = &self.inner {
             inner.on_transaction_complete();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attempt(url: &str, transferred: u64, started: Option<Instant>) -> Attempt {
+        Attempt {
+            url: Url::parse(url).unwrap(),
+            advertised_size: Some(100),
+            expected: Some(100),
+            transferred,
+            started,
+        }
+    }
+
+    #[test]
+    fn redacts_private_channel_credentials() {
+        let url = Url::parse("https://user:password@conda.anaconda.org/t/token/channel/pkg.conda")
+            .unwrap();
+
+        assert_eq!(
+            redacted(&url).as_str(),
+            "https://conda.anaconda.org/t/********/channel/pkg.conda"
+        );
+    }
+
+    #[test]
+    fn removes_signed_query_parameters() {
+        let url = Url::parse(
+            "https://dl.cloudsmith.io/signed/org/conda/package.conda?created=1&expires=2&signature=secret",
+        )
+        .unwrap();
+
+        assert_eq!(
+            redacted(&url).as_str(),
+            "https://dl.cloudsmith.io/signed/org/conda/package.conda"
+        );
+    }
+
+    #[test]
+    fn ignores_failures_before_download_start() {
+        let state = Arc::new(Mutex::new(State::default()));
+        lock(&state).attempts.insert(
+            "package".to_string(),
+            attempt("https://example.com/package.conda", 0, None),
+        );
+        let progress = FetchProgress { state };
+
+        assert!(progress.attempt("package").is_none());
+    }
+
+    #[test]
+    fn download_retry_resets_transferred_bytes() {
+        let state = Arc::new(Mutex::new(State::default()));
+        {
+            let mut state = lock(&state);
+            state.entries.insert(7, "package".to_string());
+            state.attempts.insert(
+                "package".to_string(),
+                attempt("https://example.com/package.conda", 0, None),
+            );
+        }
+        let reporter = FetchProgressReporter {
+            inner: None,
+            state: Arc::clone(&state),
+        };
+        let progress = FetchProgress {
+            state: Arc::clone(&state),
+        };
+
+        reporter.on_download_start(7);
+        reporter.on_download_progress(7, 42, Some(120));
+        reporter.on_download_start(7);
+
+        let retry = progress.attempt("package").unwrap();
+        assert_eq!(retry.transferred, 0);
+        assert_eq!(retry.expected, Some(100));
     }
 }

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -8,6 +8,7 @@ pub use fetch_progress::FetchAttempt;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
+    error::Error as StdError,
     ffi::OsStr,
     fmt,
     path::PathBuf,
@@ -30,6 +31,7 @@ use rattler_conda_types::{ChannelUrl, PackageName, PrefixRecord, RepoDataRecord,
 use thiserror::Error;
 
 use crate::{BuildEnvironment, SourceBuildError};
+use fetch_progress::redacted;
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -168,6 +170,98 @@ pub enum InstallPixiEnvironmentError {
     AcquireLock(Prefix, #[source] std::io::Error),
 }
 
+#[derive(Debug, Error)]
+#[error("{message}")]
+struct SanitizedHttpError {
+    message: String,
+}
+
+impl SanitizedHttpError {
+    fn new(
+        status: Option<reqwest::StatusCode>,
+        is_timeout: bool,
+        is_body: bool,
+        is_decode: bool,
+        is_request: bool,
+        url: Option<&Url>,
+    ) -> Self {
+        let description = match status {
+            Some(status) if status.is_client_error() => {
+                format!("HTTP status client error ({status})")
+            }
+            Some(status) if status.is_server_error() => {
+                format!("HTTP status server error ({status})")
+            }
+            Some(status) => format!("HTTP status error ({status})"),
+            None if is_timeout => "HTTP request timed out".to_string(),
+            None if is_body => "HTTP response body error".to_string(),
+            None if is_decode => "HTTP response decode error".to_string(),
+            None if is_request => "HTTP request failed".to_string(),
+            None => "HTTP interaction failed".to_string(),
+        };
+        let message = url.map_or(description.clone(), |url| {
+            format!("{description} for url ({})", redacted(url))
+        });
+        Self { message }
+    }
+
+    fn from_middleware(error: &reqwest_middleware::Error) -> Self {
+        Self::new(
+            error.status(),
+            error.is_timeout(),
+            error.is_body(),
+            error.is_decode(),
+            error.is_request(),
+            error.url(),
+        )
+    }
+
+    fn from_reqwest(error: &reqwest::Error) -> Self {
+        Self::new(
+            error.status(),
+            error.is_timeout(),
+            error.is_body(),
+            error.is_decode(),
+            error.is_request(),
+            error.url(),
+        )
+    }
+}
+
+fn sanitized_http_error(mut error: &(dyn StdError + 'static)) -> Option<SanitizedHttpError> {
+    loop {
+        if let Some(rattler::package_cache::PackageCacheLayerError::FetchError(source)) =
+            error.downcast_ref::<rattler::package_cache::PackageCacheLayerError>()
+            && let Some(error) = sanitized_http_error(source.as_ref())
+        {
+            return Some(error);
+        }
+        if let Some(rattler_package_streaming::ExtractError::ReqwestError(error)) =
+            error.downcast_ref::<rattler_package_streaming::ExtractError>()
+        {
+            return Some(SanitizedHttpError::from_middleware(error));
+        }
+        if let Some(error) = error.downcast_ref::<reqwest_middleware::Error>() {
+            return Some(SanitizedHttpError::from_middleware(error));
+        }
+        if let Some(error) = error.downcast_ref::<reqwest::Error>() {
+            return Some(SanitizedHttpError::from_reqwest(error));
+        }
+        error = error.source()?;
+    }
+}
+
+pub(super) fn sanitized_fetch_error(error: InstallerError) -> InstallerError {
+    let sanitized = sanitized_http_error(&error);
+    match (error, sanitized) {
+        (InstallerError::FailedToFetch(package, _), Some(source)) => InstallerError::FailedToFetch(
+            package,
+            rattler::package_cache::PackageCacheError::LayerError(Box::new(source)),
+        ),
+        (error, _) => error,
+    }
+}
+
 /// How far a failed package download got, rendered for an error message.
 #[derive(Debug, Clone, Copy)]
 pub struct FetchProgressSummary {
@@ -222,5 +316,67 @@ fn fetch_help(progress: &FetchProgressSummary) -> String {
             .to_string()
     } else {
         "check that the channel is reachable and that the package still exists in it.".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rattler::package_cache::{PackageCacheError, PackageCacheLayerError};
+    use reqwest::ResponseBuilderExt;
+
+    #[test]
+    fn failed_fetch_diagnostic_does_not_render_query_secrets() {
+        let package = "tzdata-2026c-h151e31d_0.conda";
+        let signed_url = Url::parse(
+            "https://packages.example.test/signed/package.conda?source=source-secret&signature=signature-secret&vendor_token=unknown-secret#fragment-secret",
+        )
+        .unwrap();
+        let response: reqwest::Response = http::Response::builder()
+            .status(reqwest::StatusCode::NOT_FOUND)
+            .url(signed_url)
+            .body(Vec::<u8>::new())
+            .unwrap()
+            .into();
+        let request_error = response.error_for_status().unwrap_err();
+        let extract_error = rattler_package_streaming::ExtractError::ReqwestError(
+            reqwest_middleware::Error::Reqwest(request_error),
+        );
+        let cache_error = PackageCacheError::LayerError(Box::new(
+            PackageCacheLayerError::FetchError(Arc::new(extract_error)),
+        ));
+        let source = sanitized_fetch_error(InstallerError::FailedToFetch(
+            package.to_string(),
+            cache_error,
+        ));
+        let error = InstallPixiEnvironmentError::FailedToFetch {
+            package: package.to_string(),
+            url: Url::parse("https://packages.example.test/package.conda").unwrap(),
+            progress: FetchProgressSummary {
+                transferred: 0,
+                expected: Some(1024),
+                elapsed: Duration::from_secs(2),
+            },
+            source: Box::new(source),
+        };
+
+        let rendered = pixi_test_utils::format_diagnostic(&error);
+        assert!(rendered.contains("404 Not Found"), "{rendered}");
+        assert!(
+            rendered.contains("https://packages.example.test/signed/package.conda"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("package.conda?"), "{rendered}");
+        for secret in [
+            "source-secret",
+            "signature-secret",
+            "unknown-secret",
+            "fragment-secret",
+            "source=",
+            "signature=",
+            "vendor_token=",
+        ] {
+            assert!(!rendered.contains(secret), "leaked {secret}: {rendered}");
+        }
     }
 }

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -129,7 +129,7 @@ pub enum InstallPixiEnvironmentError {
     FailedToFetch {
         /// The package archive identifier, e.g. `tzdata-2025c-hc9c84f9_1.conda`.
         package: String,
-        /// Source URL with credentials stripped.
+        /// Source URL with secrets redacted.
         url: Url,
         progress: FetchProgressSummary,
         #[source]

--- a/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/mod.rs
@@ -1,17 +1,23 @@
 mod ext;
+pub(crate) mod fetch_progress;
 pub(crate) mod reporter;
 
 pub use ext::InstallPixiEnvironmentExt;
+pub use fetch_progress::FetchAttempt;
 
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
     ffi::OsStr,
+    fmt,
     path::PathBuf,
     sync::Arc,
+    time::Duration,
 };
 
+use human_bytes::human_bytes;
 use miette::Diagnostic;
+use url::Url;
 
 use pixi_record::{UnresolvedPixiRecord, VariantValue};
 use pixi_spec::ResolvedExcludeNewer;
@@ -114,6 +120,22 @@ pub enum InstallPixiEnvironmentError {
     #[diagnostic(help("try `pixi clean` to reset the environment and run the command again"))]
     ReadInstalledPackages(Prefix, #[source] std::io::Error),
 
+    /// A package download failed. Split out from [`Self::Installer`] so the
+    /// request context the installer never puts in `InstallerError` — the URL,
+    /// how much of the transfer completed, and how long it ran — is reported
+    /// alongside the cause chain.
+    #[error("failed to fetch {package} from {url} ({progress})")]
+    #[diagnostic(help("{}", fetch_help(.progress)))]
+    FailedToFetch {
+        /// The package archive identifier, e.g. `tzdata-2025c-hc9c84f9_1.conda`.
+        package: String,
+        /// Source URL with credentials stripped.
+        url: Url,
+        progress: FetchProgressSummary,
+        #[source]
+        source: Box<InstallerError>,
+    },
+
     #[error(transparent)]
     Installer(InstallerError),
 
@@ -144,4 +166,61 @@ pub enum InstallPixiEnvironmentError {
 
     #[error("failed to acquire install lock on prefix '{}'", .0.path().display())]
     AcquireLock(Prefix, #[source] std::io::Error),
+}
+
+/// How far a failed package download got, rendered for an error message.
+#[derive(Debug, Clone, Copy)]
+pub struct FetchProgressSummary {
+    /// Bytes received before the failure.
+    pub transferred: u64,
+    /// Total expected, when the server or repodata told us.
+    pub expected: Option<u64>,
+    /// How long the transfer ran before it was abandoned.
+    pub elapsed: Duration,
+}
+
+impl From<&FetchAttempt> for FetchProgressSummary {
+    fn from(attempt: &FetchAttempt) -> Self {
+        Self {
+            transferred: attempt.transferred,
+            expected: attempt.expected,
+            elapsed: attempt.elapsed,
+        }
+    }
+}
+
+impl FetchProgressSummary {
+    /// True when the transfer started but did not finish, which is the
+    /// signature of a stalled or reset connection rather than, say, a 404.
+    fn stalled(&self) -> bool {
+        self.expected
+            .is_some_and(|expected| self.transferred > 0 && self.transferred < expected)
+    }
+}
+
+impl fmt::Display for FetchProgressSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let transferred = human_bytes(self.transferred as f64);
+        match self.expected {
+            Some(expected) => write!(
+                f,
+                "{transferred} of {} transferred after {:.1?}",
+                human_bytes(expected as f64),
+                self.elapsed
+            ),
+            None => write!(f, "{transferred} transferred after {:.1?}", self.elapsed),
+        }
+    }
+}
+
+/// Help text for a failed fetch. A partial transfer points at the network
+/// path, so suggest the knobs that affect it.
+fn fetch_help(progress: &FetchProgressSummary) -> String {
+    if progress.stalled() {
+        "the download did not complete. Check your network connection or proxy configuration, or \
+         reduce `concurrency.downloads`."
+            .to_string()
+    } else {
+        "check that the channel is reachable and that the package still exists in it.".to_string()
+    }
 }

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -111,8 +111,8 @@ pub use injected_config::{
 };
 pub use inline_package::InlinePackage;
 pub use install_pixi::{
-    InstallPixiEnvironmentError, InstallPixiEnvironmentExt, InstallPixiEnvironmentResult,
-    InstallPixiEnvironmentSpec,
+    FetchProgressSummary, InstallPixiEnvironmentError, InstallPixiEnvironmentExt,
+    InstallPixiEnvironmentResult, InstallPixiEnvironmentSpec,
 };
 pub use installed_source_hints::{InstalledSourceHint, InstalledSourceHints};
 pub use instantiate_backend_key::{

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -16,9 +16,10 @@
 //! the parameters needed to create a `BuildContext` uv implementation.
 //! and holds struct that is used to instantiate the conda prefix when its
 //! needed.
+use std::borrow::Borrow;
 use std::cell::Cell;
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, PoisonError};
 use std::{collections::HashMap, path::Path};
 
 use crate::environment::{CondaPrefixUpdated, CondaPrefixUpdater};
@@ -235,7 +236,40 @@ pub struct LazyBuildDispatch<'a> {
 
     /// Shared error holder for storing initialization errors that can be retrieved
     /// after the LazyBuildDispatch is consumed (e.g., in catch_unwind scenarios)
-    pub last_error: Arc<OnceCell<LazyBuildDispatchError>>,
+    pub init_errors: Arc<InitializationErrors>,
+}
+
+/// Collects every build-dispatch initialization failure observed while a
+/// resolve is in flight.
+///
+/// A single resolve fans out over many concurrent uv requests, each of which
+/// may independently trip initialization and then `panic!` out of
+/// [`BuildContext::interpreter`]. A `OnceCell` here would keep only whichever
+/// failure happened to land first and silently drop the rest, so the error
+/// finally reported could belong to a different request than the one that
+/// aborted the resolve. Keeping all of them lets the caller surface the first
+/// failure as the primary cause and attach the remainder as related
+/// diagnostics.
+#[derive(Default, Debug)]
+pub struct InitializationErrors {
+    errors: Mutex<Vec<LazyBuildDispatchError>>,
+}
+
+impl InitializationErrors {
+    /// Records a failure. Ordering is the order in which failures were
+    /// observed, so the first entry is the earliest failure.
+    pub fn push(&self, error: LazyBuildDispatchError) {
+        self.errors
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .push(error);
+    }
+
+    /// Drains every recorded failure, earliest first. Empty when
+    /// initialization never failed.
+    pub fn take_all(&self) -> Vec<LazyBuildDispatchError> {
+        std::mem::take(&mut *self.errors.lock().unwrap_or_else(PoisonError::into_inner))
+    }
 }
 
 /// These are resources for the [`BuildDispatch`] that need to be lazily
@@ -246,7 +280,7 @@ pub struct LazyBuildDispatch<'a> {
 /// 2. **Lifetime requirements**: `BuildDispatch<'a>` needs references with lifetime `'a`,
 ///    so values must be stored in a struct with that lifetime (not borrowed from `&self`)
 ///
-/// The `last_error` field is for panic recovery during build dispatch initialization.
+/// The `init_errors` field is for panic recovery during build dispatch initialization.
 #[derive(Default)]
 pub struct LazyBuildDispatchDependencies {
     /// The initialized python interpreter
@@ -296,6 +330,14 @@ impl IsBuildBackendError for LazyBuildDispatchError {
     }
 }
 
+/// Lets a boxed initialization error be used as a `#[diagnostic_source]`, which
+/// miette's derive resolves through [`Borrow`].
+impl Borrow<dyn miette::Diagnostic> for Box<LazyBuildDispatchError> {
+    fn borrow(&self) -> &(dyn miette::Diagnostic + 'static) {
+        self.as_ref()
+    }
+}
+
 impl<'a> LazyBuildDispatch<'a> {
     /// Create a new `PixiBuildDispatch` instance.
     #[allow(clippy::too_many_arguments)]
@@ -310,7 +352,7 @@ impl<'a> LazyBuildDispatch<'a> {
         ignore_packages: Option<HashSet<rattler_conda_types::PackageName>>,
         macos_deployment_target: Option<String>,
         disallow_install_conda_prefix: bool,
-        last_error: Arc<OnceCell<LazyBuildDispatchError>>,
+        init_errors: Arc<InitializationErrors>,
     ) -> Self {
         Self {
             params,
@@ -326,7 +368,7 @@ impl<'a> LazyBuildDispatch<'a> {
             workspace_cache: WorkspaceCache::default(),
             ignore_packages,
             macos_deployment_target,
-            last_error,
+            init_errors,
         }
     }
 
@@ -472,8 +514,12 @@ impl BuildContext for LazyBuildDispatch<'_> {
         match self.get_or_try_init().await {
             Ok(dispatch) => dispatch.interpreter().await,
             Err(e) => {
-                // Store the error for later retrieval
-                let _ = self.last_error.set(e);
+                // `BuildContext::interpreter` returns `&Interpreter` rather than
+                // a `Result`, so there is no way to propagate this. Stash the
+                // error where the caller can pick it up after `catch_unwind`
+                // and unwind. Concurrent requests each stash their own failure,
+                // so nothing is lost.
+                self.init_errors.push(e);
                 panic!("could not initialize build dispatch correctly")
             }
         }
@@ -629,5 +675,53 @@ impl BuildContext for LazyBuildDispatch<'_> {
             .extra_build_variables
             .get()
             .expect("extra build variables not initialized, this is a programming error")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn error(prefix: &str) -> LazyBuildDispatchError {
+        LazyBuildDispatchError::PythonMissingError {
+            prefix: prefix.to_string(),
+        }
+    }
+
+    /// Every concurrent failure has to survive, in observation order. A
+    /// `OnceCell` used to keep only the first, which made the reported
+    /// environment disagree with the one that actually failed.
+    #[test]
+    fn collects_every_failure_in_order() {
+        let errors = InitializationErrors::default();
+        errors.push(error("first"));
+        errors.push(error("second"));
+        errors.push(error("third"));
+
+        let collected = errors
+            .take_all()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(collected.len(), 3);
+        assert!(collected[0].contains("first"), "{collected:?}");
+        assert!(collected[1].contains("second"), "{collected:?}");
+        assert!(collected[2].contains("third"), "{collected:?}");
+    }
+
+    /// `take_all` drains, so a second resolve attempt does not re-report
+    /// failures from the first.
+    #[test]
+    fn take_all_drains() {
+        let errors = InitializationErrors::default();
+        errors.push(error("only"));
+
+        assert_eq!(errors.take_all().len(), 1);
+        assert!(errors.take_all().is_empty());
+    }
+
+    #[test]
+    fn take_all_is_empty_without_failures() {
+        assert!(InitializationErrors::default().take_all().is_empty());
     }
 }

--- a/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
+++ b/crates/pixi_core/src/lock_file/resolve/build_dispatch.rs
@@ -234,41 +234,32 @@ pub struct LazyBuildDispatch<'a> {
     /// `MACOSX_DEPLOYMENT_TARGET` for PyPI source builds. `None` off macOS.
     macos_deployment_target: Option<String>,
 
-    /// Shared error holder for storing initialization errors that can be retrieved
+    /// Shared error holder for storing an initialization error that can be retrieved
     /// after the LazyBuildDispatch is consumed (e.g., in catch_unwind scenarios)
-    pub init_errors: Arc<InitializationErrors>,
+    pub init_error: Arc<InitializationErrorStore>,
 }
 
-/// Collects every build-dispatch initialization failure observed while a
-/// resolve is in flight.
-///
-/// A single resolve fans out over many concurrent uv requests, each of which
-/// may independently trip initialization and then `panic!` out of
-/// [`BuildContext::interpreter`]. A `OnceCell` here would keep only whichever
-/// failure happened to land first and silently drop the rest, so the error
-/// finally reported could belong to a different request than the one that
-/// aborted the resolve. Keeping all of them lets the caller surface the first
-/// failure as the primary cause and attach the remainder as related
-/// diagnostics.
+/// Stores the first build-dispatch initialization failure for panic recovery.
 #[derive(Default, Debug)]
-pub struct InitializationErrors {
-    errors: Mutex<Vec<LazyBuildDispatchError>>,
+pub struct InitializationErrorStore {
+    error: Mutex<Option<LazyBuildDispatchError>>,
 }
 
-impl InitializationErrors {
-    /// Records a failure. Ordering is the order in which failures were
-    /// observed, so the first entry is the earliest failure.
-    pub fn push(&self, error: LazyBuildDispatchError) {
-        self.errors
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .push(error);
+impl InitializationErrorStore {
+    /// Records the first failure and discards duplicate failures from waiters.
+    pub fn set(&self, error: LazyBuildDispatchError) {
+        let mut stored = self.error.lock().unwrap_or_else(PoisonError::into_inner);
+        if stored.is_none() {
+            *stored = Some(error);
+        }
     }
 
-    /// Drains every recorded failure, earliest first. Empty when
-    /// initialization never failed.
-    pub fn take_all(&self) -> Vec<LazyBuildDispatchError> {
-        std::mem::take(&mut *self.errors.lock().unwrap_or_else(PoisonError::into_inner))
+    /// Takes the recorded failure, leaving the store empty.
+    pub fn take(&self) -> Option<LazyBuildDispatchError> {
+        self.error
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take()
     }
 }
 
@@ -280,7 +271,7 @@ impl InitializationErrors {
 /// 2. **Lifetime requirements**: `BuildDispatch<'a>` needs references with lifetime `'a`,
 ///    so values must be stored in a struct with that lifetime (not borrowed from `&self`)
 ///
-/// The `init_errors` field is for panic recovery during build dispatch initialization.
+/// The `init_error` field is for panic recovery during build dispatch initialization.
 #[derive(Default)]
 pub struct LazyBuildDispatchDependencies {
     /// The initialized python interpreter
@@ -352,7 +343,7 @@ impl<'a> LazyBuildDispatch<'a> {
         ignore_packages: Option<HashSet<rattler_conda_types::PackageName>>,
         macos_deployment_target: Option<String>,
         disallow_install_conda_prefix: bool,
-        init_errors: Arc<InitializationErrors>,
+        init_error: Arc<InitializationErrorStore>,
     ) -> Self {
         Self {
             params,
@@ -368,7 +359,7 @@ impl<'a> LazyBuildDispatch<'a> {
             workspace_cache: WorkspaceCache::default(),
             ignore_packages,
             macos_deployment_target,
-            init_errors,
+            init_error,
         }
     }
 
@@ -517,9 +508,9 @@ impl BuildContext for LazyBuildDispatch<'_> {
                 // `BuildContext::interpreter` returns `&Interpreter` rather than
                 // a `Result`, so there is no way to propagate this. Stash the
                 // error where the caller can pick it up after `catch_unwind`
-                // and unwind. Concurrent requests each stash their own failure,
-                // so nothing is lost.
-                self.init_errors.push(e);
+                // and unwind. Keep the first typed error so its full diagnostic
+                // chain can be recovered after the unwind.
+                self.init_error.set(e);
                 panic!("could not initialize build dispatch correctly")
             }
         }
@@ -688,40 +679,27 @@ mod tests {
         }
     }
 
-    /// Every concurrent failure has to survive, in observation order. A
-    /// `OnceCell` used to keep only the first, which made the reported
-    /// environment disagree with the one that actually failed.
     #[test]
-    fn collects_every_failure_in_order() {
-        let errors = InitializationErrors::default();
-        errors.push(error("first"));
-        errors.push(error("second"));
-        errors.push(error("third"));
+    fn keeps_first_failure() {
+        let error_store = InitializationErrorStore::default();
+        error_store.set(error("first"));
+        error_store.set(error("second"));
 
-        let collected = errors
-            .take_all()
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>();
-        assert_eq!(collected.len(), 3);
-        assert!(collected[0].contains("first"), "{collected:?}");
-        assert!(collected[1].contains("second"), "{collected:?}");
-        assert!(collected[2].contains("third"), "{collected:?}");
-    }
-
-    /// `take_all` drains, so a second resolve attempt does not re-report
-    /// failures from the first.
-    #[test]
-    fn take_all_drains() {
-        let errors = InitializationErrors::default();
-        errors.push(error("only"));
-
-        assert_eq!(errors.take_all().len(), 1);
-        assert!(errors.take_all().is_empty());
+        let stored = error_store.take().unwrap().to_string();
+        assert!(stored.contains("first"), "{stored}");
     }
 
     #[test]
-    fn take_all_is_empty_without_failures() {
-        assert!(InitializationErrors::default().take_all().is_empty());
+    fn take_drains() {
+        let error_store = InitializationErrorStore::default();
+        error_store.set(error("only"));
+
+        assert!(error_store.take().is_some());
+        assert!(error_store.take().is_none());
+    }
+
+    #[test]
+    fn take_is_empty_without_failures() {
+        assert!(InitializationErrorStore::default().take().is_none());
     }
 }

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -73,7 +73,7 @@ use crate::{
         records_by_name::HasNameVersion,
         resolve::{
             build_dispatch::{
-                InitializationErrors, LazyBuildDispatch, LazyBuildDispatchError,
+                InitializationErrorStore, LazyBuildDispatch, LazyBuildDispatchError,
                 UvBuildDispatchParams,
             },
             resolver_provider::CondaResolverProvider,
@@ -163,15 +163,11 @@ pub enum SolveError {
     /// entire cause chain (e.g. package name → cache layer → reqwest error with
     /// the URL) as well as any help it carries.
     ///
-    /// `additional` holds failures from other concurrent requests within the
-    /// same solve; miette renders them as related diagnostics.
     #[error("build dispatch initialization failed")]
     BuildDispatchPanic {
         #[source]
         #[diagnostic_source]
         source: Box<LazyBuildDispatchError>,
-        #[related]
-        additional: Vec<LazyBuildDispatchError>,
     },
     #[error("unexpected panic during PyPI resolution: {message}")]
     GeneralPanic { message: String },
@@ -545,7 +541,7 @@ pub async fn resolve_pypi(
     // Use cached build dispatch dependencies
     let lazy_build_dispatch_deps = &build_cache.lazy_build_dispatch_deps;
 
-    let init_errors = Arc::new(InitializationErrors::default());
+    let init_error = Arc::new(InitializationErrorStore::default());
 
     // Use cached conda_prefix_updater if available, otherwise create new
     let conda_prefix_updater = build_cache
@@ -593,7 +589,7 @@ pub async fn resolve_pypi(
         None,
         deployment_target,
         disallow_install_conda_prefix,
-        Arc::clone(&init_errors),
+        Arc::clone(&init_error),
     );
 
     // Constrain the conda packages to the specific python packages
@@ -826,15 +822,11 @@ pub async fn resolve_pypi(
     let (locked_packages, conda_task) = match resolution_future.catch_unwind().await {
         Ok(result) => result?,
         Err(panic_payload) => {
-            // Recover the initialization errors stashed by the panicking
-            // `BuildContext::interpreter` calls. Many uv requests can fail
-            // concurrently, so report the earliest as the primary cause and
-            // attach the rest as related diagnostics.
-            let mut stored_errors = init_errors.take_all().into_iter();
-            if let Some(primary) = stored_errors.next() {
+            // Recover the typed initialization error stashed by the panicking
+            // `BuildContext::interpreter` call.
+            if let Some(stored_error) = init_error.take() {
                 return Err(SolveError::BuildDispatchPanic {
-                    source: Box::new(primary),
-                    additional: stored_errors.collect(),
+                    source: Box::new(stored_error),
                 }
                 .into());
             } else {
@@ -1296,7 +1288,6 @@ mod tests {
     fn build_dispatch_panic_renders_full_cause_chain() {
         let rendered = pixi_test_utils::format_diagnostic(&SolveError::BuildDispatchPanic {
             source: Box::new(fetch_failed()),
-            additional: Vec::new(),
         });
 
         assert!(
@@ -1317,24 +1308,6 @@ mod tests {
             rendered.contains("check your network connection"),
             "{rendered}"
         );
-    }
-
-    /// Failures from other concurrent requests in the same solve are reported
-    /// too rather than being silently dropped.
-    #[test]
-    fn build_dispatch_panic_reports_concurrent_failures() {
-        let rendered = pixi_test_utils::format_diagnostic(&SolveError::BuildDispatchPanic {
-            source: Box::new(fetch_failed()),
-            additional: vec![LazyBuildDispatchError::PythonMissingError {
-                prefix: "/some/other/prefix".to_string(),
-            }],
-        });
-
-        assert!(
-            rendered.contains("failed to fetch tzdata-2025c-hc9c84f9_1.conda"),
-            "{rendered}"
-        );
-        assert!(rendered.contains("/some/other/prefix"), "{rendered}");
     }
 
     // In this case we want to make the path relative to the project_root or lock

--- a/crates/pixi_core/src/lock_file/resolve/pypi.rs
+++ b/crates/pixi_core/src/lock_file/resolve/pypi.rs
@@ -10,8 +10,6 @@ use std::{
     sync::Arc,
 };
 
-use once_cell::sync::OnceCell;
-
 use futures::FutureExt;
 
 use indexmap::IndexMap;
@@ -74,7 +72,10 @@ use crate::{
         outdated::PypiEnvironmentBuildCache,
         records_by_name::HasNameVersion,
         resolve::{
-            build_dispatch::{LazyBuildDispatch, UvBuildDispatchParams},
+            build_dispatch::{
+                InitializationErrors, LazyBuildDispatch, LazyBuildDispatchError,
+                UvBuildDispatchParams,
+            },
             resolver_provider::CondaResolverProvider,
         },
     },
@@ -155,14 +156,22 @@ pub enum SolveError {
     },
     #[error("failed to resolve pypi dependencies")]
     Other(#[from] ResolveError),
-    #[error("build dispatch initialization failed: {message}")]
+    /// A conda prefix could not be instantiated for the PyPI solve.
+    ///
+    /// The underlying [`LazyBuildDispatchError`] is carried as a
+    /// `#[diagnostic_source]` rather than stringified, so miette renders its
+    /// entire cause chain (e.g. package name → cache layer → reqwest error with
+    /// the URL) as well as any help it carries.
+    ///
+    /// `additional` holds failures from other concurrent requests within the
+    /// same solve; miette renders them as related diagnostics.
+    #[error("build dispatch initialization failed")]
     BuildDispatchPanic {
-        message: String,
-        /// Help carried over from the underlying diagnostic (e.g. the
-        /// `CONDA_OVERRIDE_*` hints for an unsupported platform), kept separate
-        /// so miette renders it as its own help section.
-        #[help]
-        help: Option<String>,
+        #[source]
+        #[diagnostic_source]
+        source: Box<LazyBuildDispatchError>,
+        #[related]
+        additional: Vec<LazyBuildDispatchError>,
     },
     #[error("unexpected panic during PyPI resolution: {message}")]
     GeneralPanic { message: String },
@@ -536,7 +545,7 @@ pub async fn resolve_pypi(
     // Use cached build dispatch dependencies
     let lazy_build_dispatch_deps = &build_cache.lazy_build_dispatch_deps;
 
-    let last_error = Arc::new(OnceCell::new());
+    let init_errors = Arc::new(InitializationErrors::default());
 
     // Use cached conda_prefix_updater if available, otherwise create new
     let conda_prefix_updater = build_cache
@@ -584,7 +593,7 @@ pub async fn resolve_pypi(
         None,
         deployment_target,
         disallow_install_conda_prefix,
-        Arc::clone(&last_error),
+        Arc::clone(&init_errors),
     );
 
     // Constrain the conda packages to the specific python packages
@@ -817,15 +826,15 @@ pub async fn resolve_pypi(
     let (locked_packages, conda_task) = match resolution_future.catch_unwind().await {
         Ok(result) => result?,
         Err(panic_payload) => {
-            // Try to get the stored initialization error from the last_error holder
-            if let Some(stored_error) = last_error.get() {
-                // The panic is re-wrapped as a plain message, so carry the inner
-                // diagnostic's help (e.g. the `CONDA_OVERRIDE_*` hints for an
-                // unsupported platform) across as a separate field rather than
-                // losing it or mashing it into the message.
+            // Recover the initialization errors stashed by the panicking
+            // `BuildContext::interpreter` calls. Many uv requests can fail
+            // concurrently, so report the earliest as the primary cause and
+            // attach the rest as related diagnostics.
+            let mut stored_errors = init_errors.take_all().into_iter();
+            if let Some(primary) = stored_errors.next() {
                 return Err(SolveError::BuildDispatchPanic {
-                    message: format!("{stored_error}"),
-                    help: miette::Diagnostic::help(stored_error).map(|help| help.to_string()),
+                    source: Box::new(primary),
+                    additional: stored_errors.collect(),
                 }
                 .into());
             } else {
@@ -1257,6 +1266,76 @@ mod tests {
     use std::path::PathBuf;
 
     use pixi_uv_conversions::WorkspaceAnchor;
+
+    use super::*;
+
+    /// An initialization failure with a Display-only top level and the useful
+    /// detail one `source()` below it, mirroring how a failed package fetch
+    /// arrives: the package name on top, the URL and IO error underneath.
+    #[derive(Debug, thiserror::Error, miette::Diagnostic)]
+    #[error("failed to fetch tzdata-2025c-hc9c84f9_1.conda")]
+    #[diagnostic(help("check your network connection"))]
+    struct FetchFailed {
+        #[source]
+        source: std::io::Error,
+    }
+
+    fn fetch_failed() -> LazyBuildDispatchError {
+        LazyBuildDispatchError::InitializationError(Box::new(FetchFailed {
+            source: std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "error sending request for url (https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda)",
+            ),
+        }))
+    }
+
+    /// The whole cause chain and the inner help have to reach the rendered
+    /// report. Previously the diagnostic was flattened with `format!`, which
+    /// dropped every `source()` beneath the top-level message.
+    #[test]
+    fn build_dispatch_panic_renders_full_cause_chain() {
+        let rendered = pixi_test_utils::format_diagnostic(&SolveError::BuildDispatchPanic {
+            source: Box::new(fetch_failed()),
+            additional: Vec::new(),
+        });
+
+        assert!(
+            rendered.contains("build dispatch initialization failed"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("failed to fetch tzdata-2025c-hc9c84f9_1.conda"),
+            "{rendered}"
+        );
+        // The URL lives in the innermost error, which stringification lost.
+        assert!(
+            rendered.contains("https://conda.anaconda.org/conda-forge/noarch/"),
+            "{rendered}"
+        );
+        // Help carried by the inner diagnostic still surfaces.
+        assert!(
+            rendered.contains("check your network connection"),
+            "{rendered}"
+        );
+    }
+
+    /// Failures from other concurrent requests in the same solve are reported
+    /// too rather than being silently dropped.
+    #[test]
+    fn build_dispatch_panic_reports_concurrent_failures() {
+        let rendered = pixi_test_utils::format_diagnostic(&SolveError::BuildDispatchPanic {
+            source: Box::new(fetch_failed()),
+            additional: vec![LazyBuildDispatchError::PythonMissingError {
+                prefix: "/some/other/prefix".to_string(),
+            }],
+        });
+
+        assert!(
+            rendered.contains("failed to fetch tzdata-2025c-hc9c84f9_1.conda"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("/some/other/prefix"), "{rendered}");
+    }
 
     // In this case we want to make the path relative to the project_root or lock
     // file path

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -48,7 +48,9 @@ use crate::{
         CondaPrefixUpdater, PixiRecordsByName, PypiRecordsByName,
         outdated::{BuildCacheKey, PypiEnvironmentBuildCache},
         records_by_name::LockedPypiRecordsByName,
-        resolve::build_dispatch::{InitializationErrors, LazyBuildDispatch, UvBuildDispatchParams},
+        resolve::build_dispatch::{
+            InitializationErrorStore, LazyBuildDispatch, UvBuildDispatchParams,
+        },
     },
     workspace::{
         Environment, EnvironmentVars, HasWorkspaceRef, PlatformOverrides, PlatformSource,
@@ -744,7 +746,7 @@ async fn read_local_package_metadata(
         .clone();
 
     // Use cached lazy build dispatch dependencies
-    let init_errors = Arc::new(InitializationErrors::default());
+    let init_error = Arc::new(InitializationErrorStore::default());
     // Use building_pixi_records (host platform) for installing Python and building,
     // since we can only run binaries on the host platform
     let building_records: miette::Result<Vec<PixiRecord>> = ctx
@@ -763,7 +765,7 @@ async fn read_local_package_metadata(
         None,
         deployment_target,
         false,
-        Arc::clone(&init_errors),
+        Arc::clone(&init_error),
     );
 
     // Create distribution database

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -10,7 +10,6 @@ use uv_redacted::DisplaySafeUrl;
 use dashmap::DashMap;
 use futures::TryStreamExt;
 use itertools::Itertools;
-use once_cell::sync::OnceCell;
 use pep440_rs::VersionSpecifiers;
 use pixi_command_dispatcher::{
     CommandDispatcher, CommandDispatcherError, executor::CancellationAwareFutures,
@@ -49,7 +48,7 @@ use crate::{
         CondaPrefixUpdater, PixiRecordsByName, PypiRecordsByName,
         outdated::{BuildCacheKey, PypiEnvironmentBuildCache},
         records_by_name::LockedPypiRecordsByName,
-        resolve::build_dispatch::{LazyBuildDispatch, UvBuildDispatchParams},
+        resolve::build_dispatch::{InitializationErrors, LazyBuildDispatch, UvBuildDispatchParams},
     },
     workspace::{
         Environment, EnvironmentVars, HasWorkspaceRef, PlatformOverrides, PlatformSource,
@@ -745,7 +744,7 @@ async fn read_local_package_metadata(
         .clone();
 
     // Use cached lazy build dispatch dependencies
-    let last_error = Arc::new(OnceCell::new());
+    let init_errors = Arc::new(InitializationErrors::default());
     // Use building_pixi_records (host platform) for installing Python and building,
     // since we can only run binaries on the host platform
     let building_records: miette::Result<Vec<PixiRecord>> = ctx
@@ -764,7 +763,7 @@ async fn read_local_package_metadata(
         None,
         deployment_target,
         false,
-        Arc::clone(&last_error),
+        Arc::clone(&init_errors),
     );
 
     // Create distribution database


### PR DESCRIPTION
### Description

* Preserves typed diagnostics across build-dispatch panic recovery.
* Adds sanitized download URLs, progress, and elapsed time to fetch errors.
* Handles retries and pre-download failures correctly.
* Adds focused tests for redaction, retry tracking, and diagnostic rendering.

Fixes #6679

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude Opus 5, GPT-5.6 Sol

<!-- Add your prompt here, this helps us understand your results.
```plaintext
Please read and understand issue #6679 in the prefix-dev/pixi repository and make the suggested changes 1-3. 
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.

Unfortunately I'm not qualified to comment on the quality of the implementation 😬 

However, I have access to a flaky internal network with which to test it on:

#### BEFORE

```
❯ pixi update
▪ fetching repodata    [━━━━━━━━━━━━━━━━━━━━]
▪ solving              [━━━━━━━━━━━━━━━━━━━━] 18/18
⠒ preparing packages   [━━━━━━━━━━━━━━━━━━━━] 78/85 python-dateutil (+6) @ 4.5 MiB/s
⠉ installing           [━━━━━━━━━━━━━━━━━━━━] 78/85 queued: jmespath (+6)
Error:   × failed to solve the pypi requirements of environment 'docs' for platform 'linux-64'
  ╰─▶ build dispatch initialization failed: failed to fetch python-dateutil-2.9.0.post0-pyhe01879c_2.conda
```

#### AFTER

```
❯ pixi-dev update
▪ fetching repodata    [━━━━━━━━━━━━━━━━━━━━]
⠉ solving              [━━━━━━━━━━━━━━━━━━━─] 17/18 default@linux-64 (linux-64)
⠉ preparing packages   [━━━━━━━━━━━━━━━━━━━─] 33/37 pandas (+3) @ 17.7 MiB/s
⠈ installing           [━━━━━━━━━━━━━━━━━───] 33/37 queued: tzdata (+3)

Error:   × failed to solve the pypi requirements of environment 'test-py312-pandas2' for platform 'linux-64'
  ├─▶ build dispatch initialization failed
  ├─▶ failed to fetch python-dateutil-2.9.0.post0-pyhe01879c_2.conda from https://conda.cloudsmith.io/org/conda/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda (0 B of 227.8 KiB transferred after 2.6s)
  ├─▶ failed to fetch python-dateutil-2.9.0.post0-pyhe01879c_2.conda
  ├─▶ failed to interact with the package cache layer.
  ╰─▶ HTTP status client error (404 Not Found) for url (https://dl.cloudsmith.io/signed/org/conda/upstream/package/conda/python-dateutil-2.9.0.post0-pyhe01879c_2.conda/2.9.0.post0/noarch)
```