### PR TITLE
chore: remove stray insta snapshot artifact

### DIFF
--- a/crates/pixi_core/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@mismatch-exclude-newer.snap.new
+++ b/crates/pixi_core/crates/pixi_core/src/lock_file/satisfiability/snapshots/pixi_core__lock_file__satisfiability__tests__failing_satisfiability@mismatch-exclude-newer.snap.new
@@ -1,8 +1,0 @@
----
-source: crates/pixi_core/src/lock_file/satisfiability/tests.rs
-assertion_line: 263
-expression: s
----
-environment 'default' does not satisfy the requirements of the project
-    Diagnostic severity: error
-    Caused by: the locked package 'foobar' has timestamp 2025-11-05T00:00:00Z, which is newer than the environment's exclude-newer cutoff 2025-11-04T00:00:00Z


### PR DESCRIPTION
`cargo-insta` writes `.snap.new` next to the snapshot it could not match, for `insta review` to accept or reject. This one was committed instead, and under a doubled `crates/pixi_core/crates/pixi_core/` prefix that no test reads from, so nothing has referenced it since.