### PR TITLE
fix(run): drop unrunnable environments from task disambiguation

### DIFF
--- a/crates/pixi_api/src/workspace/task/mod.rs
+++ b/crates/pixi_api/src/workspace/task/mod.rs
@@ -6,7 +6,10 @@ use pixi_core::{
     Workspace,
     workspace::{
         Environment, WorkspaceMut,
-        virtual_packages::{EnvironmentRunnability, classify_environment_runnability},
+        virtual_packages::{
+            EnvironmentRunnability, classify_environment_runnability,
+            minimum_compatible_declared_platform,
+        },
     },
 };
 use pixi_manifest::{
@@ -102,11 +105,15 @@ pub async fn list_tasks(
         .into_iter()
         .map(|(env, (runnability, task_names))| {
             let env_name = env.name().clone();
-            let best_declared_platform = env.best_declared_platform();
+            let task_platform = env.best_declared_platform().or_else(|| {
+                lock_file.as_ref().and_then(|lock_file| {
+                    minimum_compatible_declared_platform(&env, lock_file).ok()
+                })
+            });
             let task_map = task_names
                 .into_iter()
                 .flat_map(|task_name| {
-                    env.task(&task_name, best_declared_platform)
+                    env.task(&task_name, task_platform)
                         .ok()
                         .map(|task| (task_name, task.clone()))
                 })

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -26,7 +26,7 @@ use pixi_core::{
         errors::UnsupportedPlatformError,
         virtual_packages::{
             EnvironmentRunnability, classify_environment_runnability,
-            verify_current_platform_can_run_environment,
+            minimum_compatible_declared_platform, verify_current_platform_can_run_environment,
         },
     },
 };
@@ -37,6 +37,7 @@ use pixi_task::{
     PreferExecutable, SearchEnvironments, TaskAndEnvironment, TaskGraph, get_task_env,
 };
 use rattler_conda_types::Platform;
+use rattler_lock::LockFile;
 use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
@@ -283,7 +284,12 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
 
     // Print all available tasks if no task is provided
     if args.task.is_empty() {
-        command_not_found(&workspace, explicit_environment);
+        let lock_file = workspace
+            .load_lock_file()
+            .await
+            .ok()
+            .map(|r| r.into_lock_file_or_empty_with_warning());
+        command_not_found(&workspace, explicit_environment, lock_file.as_ref());
         return Ok(());
     }
 
@@ -365,9 +371,13 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
     } else {
         None
     };
-    let search_environment =
-        SearchEnvironments::from_opt_env(&workspace, explicit_environment.clone(), search_platform)
-            .with_disambiguate_fn(disambiguate_task_interactive);
+    let search_environment = SearchEnvironments::from_opt_env_with_lock_file(
+        &workspace,
+        explicit_environment.clone(),
+        search_platform,
+        Some(lock_file.as_lock_file()),
+    )
+    .with_disambiguate_fn(disambiguate_task_interactive);
 
     let task_graph = TaskGraph::from_cmd_args(
         &workspace,
@@ -605,7 +615,11 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             }
             Err(TaskExecutionError::NonZeroExitCode(code)) => {
                 if code == 127 {
-                    command_not_found(&workspace, explicit_environment.clone());
+                    command_not_found(
+                        &workspace,
+                        explicit_environment.clone(),
+                        Some(lock_file.as_lock_file()),
+                    );
                 }
                 process_exit::exit_with_code(code);
             }
@@ -630,15 +644,42 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
 }
 
 /// Called when a command was not found.
-fn command_not_found<'p>(workspace: &'p Workspace, explicit_environment: Option<Environment<'p>>) {
+fn command_not_found<'p>(
+    workspace: &'p Workspace,
+    explicit_environment: Option<Environment<'p>>,
+    lock_file: Option<&LockFile>,
+) {
+    let filtered_tasks = |env: Environment<'p>| {
+        let platform = env.best_declared_platform().or_else(|| {
+            lock_file
+                .and_then(|lock_file| minimum_compatible_declared_platform(&env, lock_file).ok())
+        });
+        env.tasks(platform)
+            .into_iter()
+            .flat_map(|tasks| {
+                tasks.into_iter().filter_map(|(key, _)| {
+                    if !key.as_str().starts_with('_') {
+                        Some(key)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .map(ToOwned::to_owned)
+            .collect::<HashSet<_>>()
+    };
     let available_tasks: HashSet<TaskName> =
         if let Some(explicit_environment) = explicit_environment {
-            explicit_environment.get_filtered_tasks()
+            filtered_tasks(explicit_environment)
         } else {
             workspace
                 .environments()
                 .into_iter()
-                .flat_map(|env| env.get_filtered_tasks())
+                .filter(|env| {
+                    classify_environment_runnability(env, lock_file)
+                        != EnvironmentRunnability::Unsupported
+                })
+                .flat_map(filtered_tasks)
                 .collect()
         };
 

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -358,26 +358,37 @@ mod tests {
     /// is dropped instead of being offered for disambiguation.
     #[test]
     fn test_unrunnable_environment_is_not_a_candidate() {
-        let manifest_str = r#"
+        let current = rattler_conda_types::Platform::current();
+        let foreign = if current == rattler_conda_types::Platform::LinuxRiscv64 {
+            rattler_conda_types::Platform::Linux64
+        } else {
+            rattler_conda_types::Platform::LinuxRiscv64
+        };
+        let manifest_str = format!(
+            r#"
             [project]
             name = "foo"
             channels = ["foo"]
-            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64", "linux-riscv64"]
+            platforms = ["{current}", "{foreign}"]
 
-            [feature.riscv]
-            platforms = ["linux-riscv64"]
+            [feature.foreign]
+            platforms = ["{foreign}"]
 
-            [feature.riscv.tasks]
-            build = "echo riscv"
+            [feature.foreign.dependencies]
+            foo = "*"
+
+            [feature.foreign.tasks]
+            build = "echo foreign"
 
             [feature.portable.tasks]
             build = "echo portable"
 
             [environments]
-            riscv = ["riscv"]
+            foreign = ["foreign"]
             portable = ["portable"]
-        "#;
-        let project = Workspace::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        "#
+        );
+        let project = Workspace::from_str(Path::new("pixi.toml"), &manifest_str).unwrap();
         let search = SearchEnvironments::from_opt_env(&project, None, None);
         let (env, _task) = search
             .find_task("build".into(), FindTaskSource::CmdArgs, None)

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -1,7 +1,13 @@
 use miette::Diagnostic;
 use pixi_core::{
     Workspace,
-    workspace::{Environment, virtual_packages::verify_current_platform_can_run_environment},
+    workspace::{
+        Environment,
+        virtual_packages::{
+            EnvironmentRunnability, classify_environment_runnability,
+            verify_current_platform_can_run_environment,
+        },
+    },
 };
 use pixi_manifest::{FeaturesExt, HasWorkspaceManifest, PixiPlatform, Task, TaskName};
 use thiserror::Error;
@@ -173,6 +179,23 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
         }
     }
 
+    /// Narrows a set of candidate environments to the ones this machine can
+    /// run, so environments declared for foreign platforms only are not
+    /// offered for disambiguation. A pinned `--platform` speaks for the
+    /// machine, and candidates are kept as-is when none of them run here, so
+    /// the task is still found and fails with a platform error later.
+    fn drop_unrunnable_candidates(&self, tasks: &mut Vec<TaskAndEnvironment<'p>>) {
+        if tasks.len() < 2 || self.platform.is_some() {
+            return;
+        }
+        let runnable = |(env, _): &TaskAndEnvironment<'p>| {
+            classify_environment_runnability(env, None) != EnvironmentRunnability::Unsupported
+        };
+        if tasks.iter().any(runnable) {
+            tasks.retain(runnable);
+        }
+    }
+
     /// Finds the task with the given name or returns an error that explains why
     /// the task could not be found.
     pub(crate) fn find_task(
@@ -257,6 +280,8 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
             }
         }
 
+        self.drop_unrunnable_candidates(&mut tasks);
+
         match tasks.len() {
             0 => Err(FindTaskError::MissingTask(MissingTaskError {
                 task_name: name,
@@ -317,6 +342,38 @@ mod tests {
             .find_task("flash".into(), FindTaskSource::CmdArgs, None)
             .expect("task in a foreign-platform environment should be found");
         assert_eq!(env.name().as_str(), "riscv");
+    }
+
+    /// A task defined in both a machine-runnable and a foreign-platform
+    /// environment is not ambiguous: the environment this machine cannot run
+    /// is dropped instead of being offered for disambiguation.
+    #[test]
+    fn test_unrunnable_environment_is_not_a_candidate() {
+        let manifest_str = r#"
+            [project]
+            name = "foo"
+            channels = ["foo"]
+            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64", "linux-riscv64"]
+
+            [feature.riscv]
+            platforms = ["linux-riscv64"]
+
+            [feature.riscv.tasks]
+            build = "echo riscv"
+
+            [feature.portable.tasks]
+            build = "echo portable"
+
+            [environments]
+            riscv = ["riscv"]
+            portable = ["portable"]
+        "#;
+        let project = Workspace::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let search = SearchEnvironments::from_opt_env(&project, None, None);
+        let (env, _task) = search
+            .find_task("build".into(), FindTaskSource::CmdArgs, None)
+            .expect("the only environment this machine can run should be picked");
+        assert_eq!(env.name().as_str(), "portable");
     }
 
     #[test]

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -5,11 +5,12 @@ use pixi_core::{
         Environment,
         virtual_packages::{
             EnvironmentRunnability, classify_environment_runnability,
-            verify_current_platform_can_run_environment,
+            minimum_compatible_declared_platform, verify_current_platform_can_run_environment,
         },
     },
 };
 use pixi_manifest::{FeaturesExt, HasWorkspaceManifest, PixiPlatform, Task, TaskName};
+use rattler_lock::LockFile;
 use thiserror::Error;
 
 use crate::error::{AmbiguousTaskError, MissingTaskError};
@@ -46,10 +47,11 @@ impl<'p, F: Fn(&AmbiguousTask<'p>) -> Option<TaskAndEnvironment<'p>>> TaskDisamb
 }
 
 /// An object to help with searching for tasks.
-pub struct SearchEnvironments<'p, D: TaskDisambiguation<'p> = NoDisambiguation> {
+pub struct SearchEnvironments<'p, 'lock, D: TaskDisambiguation<'p> = NoDisambiguation> {
     pub project: &'p Workspace,
     pub explicit_environment: Option<Environment<'p>>,
     pub platform: Option<&'p PixiPlatform>,
+    pub lock_file: Option<&'lock LockFile>,
     pub disambiguate: D,
 }
 
@@ -82,7 +84,7 @@ pub enum FindTaskError {
     AmbiguousTask(AmbiguousTaskError),
 }
 
-impl<'p> SearchEnvironments<'p, NoDisambiguation> {
+impl<'p, 'lock> SearchEnvironments<'p, 'lock, NoDisambiguation> {
     // Determine which environments we are allowed to check for tasks.
     //
     // If the user specified an environment, look for tasks in the main environment
@@ -95,10 +97,20 @@ impl<'p> SearchEnvironments<'p, NoDisambiguation> {
         explicit_environment: Option<Environment<'p>>,
         platform: Option<&'p PixiPlatform>,
     ) -> Self {
+        Self::from_opt_env_with_lock_file(project, explicit_environment, platform, None)
+    }
+
+    pub fn from_opt_env_with_lock_file(
+        project: &'p Workspace,
+        explicit_environment: Option<Environment<'p>>,
+        platform: Option<&'p PixiPlatform>,
+        lock_file: Option<&'lock LockFile>,
+    ) -> Self {
         Self {
             project,
             explicit_environment,
             platform,
+            lock_file,
             disambiguate: NoDisambiguation,
         }
     }
@@ -146,17 +158,18 @@ pub(crate) fn default_search_platform<'p>(env: &Environment<'p>) -> Option<&'p P
     })
 }
 
-impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
+impl<'p, 'lock, D: TaskDisambiguation<'p>> SearchEnvironments<'p, 'lock, D> {
     /// Returns a new `SearchEnvironments` with the given disambiguation
     /// function.
     pub fn with_disambiguate_fn<F: Fn(&AmbiguousTask<'p>) -> Option<TaskAndEnvironment<'p>>>(
         self,
         func: F,
-    ) -> SearchEnvironments<'p, DisambiguateFn<F>> {
+    ) -> SearchEnvironments<'p, 'lock, DisambiguateFn<F>> {
         SearchEnvironments {
             project: self.project,
             explicit_environment: self.explicit_environment,
             platform: self.platform,
+            lock_file: self.lock_file,
             disambiguate: DisambiguateFn(func),
         }
     }
@@ -165,10 +178,13 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
     /// pinned platform when one was given, otherwise the environment's own
     /// default (installed / best declared / first declared).
     pub(crate) fn search_platform_for(&self, env: &Environment<'p>) -> Option<&'p PixiPlatform> {
-        match self.platform {
-            Some(platform) => Some(platform),
-            None => default_search_platform(env),
+        if let Some(platform) = self.platform {
+            return Some(platform);
         }
+        default_search_platform(env).or_else(|| {
+            self.lock_file
+                .and_then(|lock_file| minimum_compatible_declared_platform(env, lock_file).ok())
+        })
     }
 
     /// Narrows a set of candidate environments to the ones this machine can
@@ -181,7 +197,8 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
             return;
         }
         let runnable = |(env, _): &TaskAndEnvironment<'p>| {
-            classify_environment_runnability(env, None) != EnvironmentRunnability::Unsupported
+            classify_environment_runnability(env, self.lock_file)
+                != EnvironmentRunnability::Unsupported
         };
         if tasks.iter().any(runnable) {
             tasks.retain(runnable);
@@ -366,6 +383,62 @@ mod tests {
             .find_task("build".into(), FindTaskSource::CmdArgs, None)
             .expect("the only environment this machine can run should be picked");
         assert_eq!(env.name().as_str(), "portable");
+    }
+
+    #[test]
+    fn test_lock_file_runnable_environment_is_a_candidate() {
+        let current = rattler_conda_types::Platform::current();
+        let manifest_str = format!(
+            r#"
+            [workspace]
+            name = "foo"
+            channels = ["foo"]
+            platforms = [{{ name = "gpu", platform = "{current}", cuda = "99" }}, "{current}"]
+
+            [feature.gpu]
+            platforms = ["gpu"]
+
+            [feature.gpu.tasks]
+            build = "echo gpu"
+
+            [feature.portable.tasks]
+            build = "echo portable"
+
+            [environments]
+            gpu = ["gpu"]
+            portable = ["portable"]
+        "#
+        );
+        let project = Workspace::from_str(Path::new("pixi.toml"), &manifest_str).unwrap();
+        let lock_file = rattler_lock::LockFile::from_str_with_base_directory(
+            &format!(
+                r#"version: 7
+platforms:
+- name: gpu
+  subdir: {current}
+  virtual-packages:
+  - __cuda=99
+environments:
+  gpu:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      gpu: []
+packages: []
+"#
+            ),
+            None,
+        )
+        .unwrap();
+        let search =
+            SearchEnvironments::from_opt_env_with_lock_file(&project, None, None, Some(&lock_file));
+        let err = search
+            .find_task("build".into(), FindTaskSource::CmdArgs, None)
+            .expect_err("the lock-file-runnable environment should remain ambiguous");
+        let FindTaskError::AmbiguousTask(err) = err else {
+            panic!("expected ambiguous task")
+        };
+        assert_eq!(err.environments.len(), 2);
     }
 
     #[test]

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -1,7 +1,13 @@
 use miette::Diagnostic;
 use pixi_core::{
     Workspace,
-    workspace::{Environment, virtual_packages::verify_current_platform_can_run_environment},
+    workspace::{
+        Environment,
+        virtual_packages::{
+            EnvironmentRunnability, classify_environment_runnability,
+            verify_current_platform_can_run_environment,
+        },
+    },
 };
 use pixi_manifest::{FeaturesExt, HasWorkspaceManifest, PixiPlatform, Task, TaskName};
 use thiserror::Error;
@@ -165,6 +171,23 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
         }
     }
 
+    /// Narrows a set of candidate environments to the ones this machine can
+    /// run, so environments declared for foreign platforms only are not
+    /// offered for disambiguation. A pinned `--platform` speaks for the
+    /// machine, and candidates are kept as-is when none of them run here, so
+    /// the task is still found and fails with a platform error later.
+    fn drop_unrunnable_candidates(&self, tasks: &mut Vec<TaskAndEnvironment<'p>>) {
+        if tasks.len() < 2 || self.platform.is_some() {
+            return;
+        }
+        let runnable = |(env, _): &TaskAndEnvironment<'p>| {
+            classify_environment_runnability(env, None) != EnvironmentRunnability::Unsupported
+        };
+        if tasks.iter().any(runnable) {
+            tasks.retain(runnable);
+        }
+    }
+
     /// Finds the task with the given name or returns an error that explains why
     /// the task could not be found.
     pub(crate) fn find_task(
@@ -249,6 +272,8 @@ impl<'p, D: TaskDisambiguation<'p>> SearchEnvironments<'p, D> {
             }
         }
 
+        self.drop_unrunnable_candidates(&mut tasks);
+
         match tasks.len() {
             0 => Err(FindTaskError::MissingTask(MissingTaskError {
                 task_name: name,
@@ -309,6 +334,38 @@ mod tests {
             .find_task("flash".into(), FindTaskSource::CmdArgs, None)
             .expect("task in a foreign-platform environment should be found");
         assert_eq!(env.name().as_str(), "riscv");
+    }
+
+    /// A task defined in both a machine-runnable and a foreign-platform
+    /// environment is not ambiguous: the environment this machine cannot run
+    /// is dropped instead of being offered for disambiguation.
+    #[test]
+    fn test_unrunnable_environment_is_not_a_candidate() {
+        let manifest_str = r#"
+            [project]
+            name = "foo"
+            channels = ["foo"]
+            platforms = ["linux-64", "osx-arm64", "win-64", "osx-64", "linux-riscv64"]
+
+            [feature.riscv]
+            platforms = ["linux-riscv64"]
+
+            [feature.riscv.tasks]
+            build = "echo riscv"
+
+            [feature.portable.tasks]
+            build = "echo portable"
+
+            [environments]
+            riscv = ["riscv"]
+            portable = ["portable"]
+        "#;
+        let project = Workspace::from_str(Path::new("pixi.toml"), manifest_str).unwrap();
+        let search = SearchEnvironments::from_opt_env(&project, None, None);
+        let (env, _task) = search
+            .find_task("build".into(), FindTaskSource::CmdArgs, None)
+            .expect("the only environment this machine can run should be picked");
+        assert_eq!(env.name().as_str(), "portable");
     }
 
     #[test]

--- a/crates/pixi_task/src/task_graph.rs
+++ b/crates/pixi_task/src/task_graph.rs
@@ -225,7 +225,7 @@ impl<'p> TaskGraph<'p> {
     /// collide with task names.
     pub fn from_cmd_args<D: TaskDisambiguation<'p>>(
         project: &'p Workspace,
-        search_envs: &SearchEnvironments<'p, D>,
+        search_envs: &SearchEnvironments<'p, '_, D>,
         args: Vec<String>,
         skip_deps: bool,
         prefer_executable: PreferExecutable,
@@ -414,7 +414,7 @@ impl<'p> TaskGraph<'p> {
     /// Constructs a new instance of a [`TaskGraph`] from a root task.
     fn from_root<D: TaskDisambiguation<'p>>(
         project: &'p Workspace,
-        search_environments: &SearchEnvironments<'p, D>,
+        search_environments: &SearchEnvironments<'p, '_, D>,
         root: TaskNode<'p>,
         root_args: Option<Vec<TypedDependencyArg>>,
     ) -> Result<Self, TaskGraphError> {


### PR DESCRIPTION
A task defined in several environments asked the user to pick between all of them, including environments declared only for platforms this machine cannot run. Narrow the candidates to the runnable ones, unless a `--platform` was pinned or none of them run here -- then the task is still found and fails with the usual platform error.

Fixes #6624

### How Has This Been Tested?

New unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
