### PR TITLE
feat(shell-hook): validate --shell against the shells it accepts

### DIFF
--- a/crates/pixi_cli/src/shell_hook.rs
+++ b/crates/pixi_cli/src/shell_hook.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashMap, default::Default, path::PathBuf};
+use std::{collections::HashMap, default::Default, path::PathBuf, str::FromStr};
 
 use clap::Parser;
+use clap::builder::{PossibleValuesParser, TypedValueParser};
 use miette::IntoDiagnostic;
 use pixi_config::{ConfigCli, ConfigCliActivation, ConfigCliPrompt};
 use rattler_lock::LockFile;
@@ -31,9 +32,8 @@ pub struct Args {
     #[clap(flatten)]
     pub config_source: pixi_config::ConfigSourceCli,
 
-    /// Sets the shell, options: [`bash`,  `zsh`,  `xonsh`,  `cmd`,
-    /// `powershell`,  `fish`,  `nushell`]
-    #[arg(short, long)]
+    /// Sets the shell. Defaults to the shell pixi was invoked from.
+    #[arg(short, long, value_parser = shell_parser())]
     shell: Option<ShellEnum>,
 
     #[clap(flatten)]
@@ -58,6 +58,34 @@ pub struct Args {
 
     #[clap(flatten)]
     prompt_config: ConfigCliPrompt,
+}
+
+/// Every name [`ShellEnum`]'s `FromStr` accepts. Listing them lets clap both
+/// reject unknown shells with the alternatives and offer them as completions.
+/// `test_shell_names_are_accepted` catches a listed name that stopped parsing
+/// and `test_shell_names_cover_every_shell` a new `ShellEnum` variant; neither
+/// notices a new *alias* rattler_shell gives an existing variant.
+const SHELL_NAMES: [&str; 14] = [
+    "bash",
+    "brush",
+    "busybox",
+    "cmd",
+    "dash",
+    "fish",
+    "ksh",
+    "nu",
+    "nushell",
+    "powershell",
+    "powershell_ise",
+    "sh",
+    "xonsh",
+    "zsh",
+];
+
+/// Parses `--shell` from the fixed set of names, so that the value is validated
+/// and every generated completion script offers the list.
+fn shell_parser() -> impl TypedValueParser<Value = ShellEnum> {
+    PossibleValuesParser::new(SHELL_NAMES).try_map(|name: String| ShellEnum::from_str(&name))
 }
 
 #[derive(Serialize)]
@@ -205,6 +233,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use rattler_conda_types::Platform;
     #[cfg(target_family = "windows")]
     use rattler_shell::shell::CmdExe;
@@ -213,6 +243,53 @@ mod tests {
     use rattler_shell::shell::{NuShell, PowerShell};
 
     use super::*;
+
+    /// Number of [`ShellEnum`] variants `SHELL_NAMES` was written against.
+    const SHELL_VARIANTS: usize = 7;
+
+    /// Restricting `--shell` to `SHELL_NAMES` would silently reject a shell
+    /// that used to work, so every listed name must still parse.
+    #[test]
+    fn test_shell_names_are_accepted() {
+        for name in SHELL_NAMES {
+            assert!(
+                ShellEnum::from_str(name).is_ok(),
+                "`--shell {name}` is offered but no longer parses"
+            );
+        }
+    }
+
+    /// `rattler_shell` cannot enumerate the names its `FromStr` accepts, so
+    /// `SHELL_NAMES` copies them. The exhaustive `match` stops compiling once
+    /// `rattler_shell` gains a shell, and the count catches a variant no listed
+    /// name reaches. `BashFlavor` is `#[non_exhaustive]`, so the flavors behind
+    /// [`ShellEnum::Bash`] cannot be guarded the same way.
+    #[test]
+    fn test_shell_names_cover_every_shell() {
+        fn variant(shell: &ShellEnum) -> usize {
+            match shell {
+                ShellEnum::Bash(_) => 0,
+                ShellEnum::Zsh(_) => 1,
+                ShellEnum::Xonsh(_) => 2,
+                ShellEnum::CmdExe(_) => 3,
+                ShellEnum::PowerShell(_) => 4,
+                ShellEnum::Fish(_) => 5,
+                ShellEnum::NuShell(_) => 6,
+            }
+        }
+
+        let covered = SHELL_NAMES
+            .iter()
+            .filter_map(|name| ShellEnum::from_str(name).ok())
+            .map(|shell| variant(&shell))
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            covered.len(),
+            SHELL_VARIANTS,
+            "`SHELL_NAMES` reaches {} of {SHELL_VARIANTS} `ShellEnum` variants",
+            covered.len()
+        );
+    }
 
     #[cfg(not(target_family = "windows"))]
     #[tokio::test]

--- a/docs/reference/cli/pixi/shell-hook.md
+++ b/docs/reference/cli/pixi/shell-hook.md
@@ -15,7 +15,8 @@ pixi shell-hook [OPTIONS]
 
 ## Options
 - <a id="arg---shell" href="#arg---shell">`--shell (-s) <SHELL>`</a>
-:  Sets the shell, options: [`bash`,  `zsh`,  `xonsh`,  `cmd`, `powershell`,  `fish`,  `nushell`]
+:  Sets the shell. Defaults to the shell pixi was invoked from
+<br>**options**: `bash`, `brush`, `busybox`, `cmd`, `dash`, `fish`, `ksh`, `nu`, `nushell`, `powershell`, `powershell_ise`, `sh`, `xonsh`, `zsh`
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  The environment to activate in the script
 - <a id="arg---json" href="#arg---json">`--json`</a>

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -980,6 +980,10 @@ def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
     # `import -p` does take a declared platform name.
     assert complete(["pixi", "import", "-p", ""]) == all_platforms
 
+    # `--shell` is a fixed set, so clap itself supplies the candidates.
+    assert complete(["pixi", "shell-hook", "-s", "z"]) == ["zsh"]
+    assert complete(["pixi", "shell-hook", "--shell", "nu"]) == ["nu", "nushell"]
+
 
 def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")


### PR DESCRIPTION
`--shell` was a plain `Option<ShellEnum>` with the accepted names written out by hand in the doc-string, so the list went stale. `rattler_shell` gained the bash flavors `sh`, `dash`, `ksh` and `busybox`, plus `brush`, `nu` and `powershell_ise`, while `--help` and the CLI reference still named only the original seven. `-s sh` worked and nothing in pixi said so. A typo got a bare parse error with no alternatives, and completion had no candidates to offer.

Listing the names `ShellEnum`'s `FromStr` accepts in a `PossibleValuesParser` lets clap reject an unknown shell with the alternatives, show the set in `--help`, and offer it in every generated completion script. The doc-string drops the hand-maintained list and states the default instead.

The list copies names `rattler_shell` cannot enumerate, so two tests hold it in step: every listed name must still parse, and an exhaustive match over `ShellEnum` plus a variant count catches a shell no listed name reaches. Neither notices a new alias for an existing variant, and the flavors behind `ShellEnum::Bash` cannot be guarded the same way because `BashFlavor` is `#[non_exhaustive]`.

Refs prefix-dev/pixi#5495

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.