### PR TITLE
feat(completion): rework completion

### DIFF
--- a/crates/pixi_cli/src/completion.rs
+++ b/crates/pixi_cli/src/completion.rs
@@ -1,18 +1,47 @@
 use crate::Args as CommandArgs;
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{Arg, Command, CommandFactory, Parser, ValueEnum};
 use clap_complete::{Generator, shells};
 use clap_complete_nushell::Nushell;
 use miette::IntoDiagnostic;
 use regex::{Captures, Regex};
-use std::borrow::Cow;
+use std::collections::HashMap;
 use std::io::Write;
+use std::iter;
+use std::sync::LazyLock;
 
-/// `pixi` subcommand emitting the space-delimited workspace environment names
-/// used for `run` option-value completion in bash, zsh, and fish.
+/// `pixi` subcommand emitting the space-delimited workspace environment names.
 const ENVIRONMENT_LIST: &str = "workspace environment list --machine-readable";
-/// `pixi` subcommand emitting the space-delimited workspace platform names
-/// used for `run` option-value completion in bash, zsh, and fish.
+/// `pixi` subcommand emitting the space-delimited workspace platform names.
 const PLATFORM_LIST: &str = "workspace platform list --machine-readable";
+/// `pixi` subcommand emitting the space-delimited workspace feature names.
+const FEATURE_LIST: &str = "workspace feature list --machine-readable";
+/// `pixi` subcommand emitting the space-delimited task names.
+const TASK_LIST: &str = "task list --machine-readable";
+
+/// `pixi global` keeps its own environment namespace and installs for conda
+/// subdirs, so workspace names must never be offered below it.
+const GLOBAL_SUBCOMMAND: &str = "global";
+
+/// Line clap_complete emits before the completion function, used to anchor the
+/// helper functions the rewritten value specs call.
+const ZSH_PREAMBLE: &str = "autoload -U is-at-least\n";
+
+/// clap value names marking an option as taking a name a `pixi` subcommand can
+/// list, paired with that subcommand.
+///
+/// Matched on this rather than on the flag, so a completable option has to
+/// declare its value name. `test_value_names_are_normalised` holds it to that.
+const VALUE_SOURCES: [(&str, &str); 4] = [
+    ("ENVIRONMENT", ENVIRONMENT_LIST),
+    ("PLATFORM", PLATFORM_LIST),
+    ("FEATURE", FEATURE_LIST),
+    ("TASK", TASK_LIST),
+];
+
+/// Compile one of this file's own patterns, none of which come from user input.
+fn compile_regex(pattern: &str) -> Regex {
+    Regex::new(pattern).expect("should be able to compile the regex")
+}
 
 /// Generates a completion script for a shell.
 #[derive(Parser, Debug)]
@@ -66,16 +95,16 @@ impl Generator for Shell {
 
 /// Generate completions for the pixi cli, and print those to the stdout
 pub fn execute(args: Args) -> miette::Result<()> {
-    // Generate the original completion script.
-    let script = get_completion_script(args.shell);
+    let cli = Cli::new();
 
     // For supported shells, modify the script to include more context sensitive completions.
+    let script = cli.generate(args.shell);
     let script = match args.shell {
-        Shell::Bash => replace_bash_completion(&script, pixi_utils::executable_name()),
-        Shell::Zsh => replace_zsh_completion(&script),
-        Shell::Fish => replace_fish_completion(&script),
-        Shell::Nushell => replace_nushell_completion(&script),
-        _ => Cow::Owned(script),
+        Shell::Bash => replace_bash_completion(&cli, &script),
+        Shell::Zsh => replace_zsh_completion(&cli, &script),
+        Shell::Fish => replace_fish_completion(&cli, &script),
+        Shell::Nushell => replace_nushell_completion(&cli, &script),
+        _ => script,
     };
 
     // Write the result to the standard output
@@ -86,55 +115,300 @@ pub fn execute(args: Args) -> miette::Result<()> {
     Ok(())
 }
 
-/// Generate the completion script using clap_complete for a specified shell.
-fn get_completion_script(shell: Shell) -> String {
-    let mut buf = vec![];
-    let bin_name: &str = pixi_utils::executable_name();
-    clap_complete::generate(shell, &mut CommandArgs::command(), bin_name, &mut buf);
-    String::from_utf8(buf).expect("clap_complete did not generate a valid UTF8 script")
+/// What every shell's rewrite is driven by: how `pixi` was invoked, its command
+/// tree, and the options whose values a `pixi` subcommand can list.
+///
+/// Built once per invocation, because walking the tree is not free and all four
+/// shells need the same answers from it.
+struct Cli {
+    /// Name `pixi` was invoked as.
+    bin_name: &'static str,
+    /// The clap command tree, before the generators build it.
+    root: Command,
+    /// Every option a shell should complete from a `pixi` subcommand.
+    targets: Vec<OptionTarget>,
+    /// Name of the shell function bash and zsh route every rewritten site
+    /// through. Both take the `pixi` subcommand to run as arguments, so one
+    /// definition serves every candidate source.
+    helper: String,
+}
+
+impl Cli {
+    fn new() -> Self {
+        Self::with_bin_name(pixi_utils::executable_name())
+    }
+
+    /// The CLI as it looks when `pixi` is invoked as `bin_name`, which decides
+    /// both the completion function names and the command every rewritten site
+    /// shells out to.
+    fn with_bin_name(bin_name: &'static str) -> Self {
+        let root = CommandArgs::command();
+        let targets = option_targets(&root);
+        Self {
+            bin_name,
+            root,
+            targets,
+            helper: format!("_{}_complete_values", bin_name.replace('-', "_")),
+        }
+    }
+
+    /// Generate the completion script using clap_complete for a specified shell.
+    fn generate(&self, shell: Shell) -> String {
+        let mut buf = vec![];
+        clap_complete::generate(shell, &mut CommandArgs::command(), self.bin_name, &mut buf);
+        String::from_utf8(buf).expect("clap_complete did not generate a valid UTF8 script")
+    }
+
+    fn helper(&self) -> &str {
+        &self.helper
+    }
+}
+
+/// An option of one subcommand whose values a shell should complete from a
+/// `pixi` subcommand's output instead of from file paths.
+#[derive(Debug)]
+struct OptionTarget {
+    /// Subcommand path below the binary, e.g. `["workspace", "export",
+    /// "conda-environment"]`.
+    path: Vec<String>,
+    /// Long flag name, without the leading dashes.
+    long: String,
+    /// Short flag, when the option has one.
+    short: Option<char>,
+    /// The clap value name that opted this option in.
+    value_name: &'static str,
+    /// `pixi` subcommand emitting the candidates.
+    command: &'static str,
+}
+
+/// Visit every argument below `cmd`, together with the subcommand path it sits
+/// on. The path is empty for the arguments of `cmd` itself.
+fn walk_arguments<'a>(cmd: &'a Command, visit: &mut impl FnMut(&[&'a str], &'a Arg)) {
+    fn walk<'a>(
+        cmd: &'a Command,
+        path: &mut Vec<&'a str>,
+        visit: &mut impl FnMut(&[&'a str], &'a Arg),
+    ) {
+        for arg in cmd.get_arguments() {
+            visit(path, arg);
+        }
+        for sub in cmd.get_subcommands() {
+            path.push(sub.get_name());
+            walk(sub, path, visit);
+            path.pop();
+        }
+    }
+
+    walk(cmd, &mut Vec::new(), visit);
+}
+
+/// The candidate source `arg` opted into through the clap value name it
+/// declares, or `None` when it does not name something a `pixi` subcommand can
+/// list.
+fn value_source(arg: &Arg) -> Option<(&'static str, &'static str)> {
+    let declared = arg.get_value_names()?.first()?;
+    VALUE_SOURCES
+        .iter()
+        .find(|(value_name, _)| *value_name == declared.as_str())
+        .copied()
+}
+
+/// Every option below `root` whose values a `pixi` subcommand can list,
+/// recognised by the clap value name it declares.
+fn option_targets(root: &Command) -> Vec<OptionTarget> {
+    let mut targets = Vec::new();
+    walk_arguments(root, &mut |path, arg| {
+        // `pixi help <cmd>` mirrors the tree without carrying any options, and
+        // `pixi global` names things from its own namespaces.
+        if path
+            .iter()
+            .any(|segment| *segment == "help" || *segment == GLOBAL_SUBCOMMAND)
+        {
+            return;
+        }
+        let (Some(long), Some((value_name, command))) = (arg.get_long(), value_source(arg)) else {
+            return;
+        };
+        targets.push(OptionTarget {
+            path: path.iter().map(|segment| (*segment).to_string()).collect(),
+            long: long.to_string(),
+            short: arg.get_short(),
+            value_name,
+            command,
+        });
+    });
+    targets
+}
+
+/// Every spelling a fish predicate can use for a top-level subcommand: its name
+/// and its visible aliases.
+fn subcommand_spellings(root: &Command) -> HashMap<&str, Vec<&str>> {
+    root.get_subcommands()
+        .map(|sub| {
+            let spellings = iter::once(sub.get_name())
+                .chain(sub.get_visible_aliases())
+                .collect();
+            (sub.get_name(), spellings)
+        })
+        .collect()
+}
+
+/// Candidate sources keyed by `(subcommand spelling, long flag)`.
+///
+/// A fish predicate names only an option's first path segment, and clap_complete
+/// emits no line at all three deep, so that segment is all there is to match on.
+/// `test_fish_first_segment_is_unambiguous` and
+/// `test_fish_predicates_are_at_most_two_deep` hold both halves.
+fn fish_option_sources(
+    root: &Command,
+    targets: &[OptionTarget],
+) -> HashMap<(String, String), &'static str> {
+    let spellings = subcommand_spellings(root);
+    targets
+        .iter()
+        .filter_map(|target| {
+            let first = target.path.first()?;
+            Some((spellings.get(first.as_str())?, target))
+        })
+        .flat_map(|(spellings, target)| {
+            spellings.iter().map(|spelling| {
+                (
+                    ((*spelling).to_string(), target.long.clone()),
+                    target.command,
+                )
+            })
+        })
+        .collect()
 }
 
 /// Replace the parts of the bash completion script that need different functionality.
-fn replace_bash_completion<'a>(script: &'a str, bin_name: &str) -> Cow<'a, str> {
-    // Adds tab completion to the pixi run command.
+fn replace_bash_completion(cli: &Cli, script: &str) -> String {
+    let script = replace_bash_option_values(cli, script);
+    let script = replace_bash_run_tasks(cli, &script);
+    format!("{}{script}", bash_helper_definition(cli.helper()))
+}
+
+/// Complete from the output of a `pixi` subcommand, falling back to file paths
+/// when it yields nothing (for instance outside a workspace).
+fn bash_helper_definition(helper: &str) -> String {
+    format!(
+        r#"{helper}() {{
+    local current="$1"
+    shift
+    local candidates
+    if candidates=$("$@" 2> /dev/null) && [[ -n "${{candidates}}" ]]; then
+        COMPREPLY=( $(compgen -W "${{candidates}}" -- "${{current}}") )
+    else
+        COMPREPLY=( $(compgen -f "${{current}}") )
+    fi
+}}
+
+"#
+    )
+}
+
+/// The bash call that offers what `command` lists.
+fn bash_candidates(cli: &Cli, command: &str) -> String {
+    format!(r#"{} "${{cur}}" {} {command}"#, cli.helper(), cli.bin_name)
+}
+
+/// clap's bash generator mangles the command path into the variable it matches
+/// on: segments are joined with `__`, every `-` becomes `__`, and every `__`
+/// then becomes `__subcmd__`.
+fn bash_arm_name(bin_name: &str, path: &[String]) -> String {
+    iter::once(bin_name)
+        .chain(path.iter().map(String::as_str))
+        .collect::<Vec<_>>()
+        .join("__")
+        .replace('-', "__")
+        .replace("__", "__subcmd__")
+}
+
+/// clap_complete indents the subcommand labels of the dispatch `case` by eight
+/// spaces, which is what separates them from the nested option arms.
+static BASH_ARM_LABEL: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"(?m)^ {8}(?P<arm>[A-Za-z0-9_]+)\)$"));
+
+/// Rewrite the `case "${prev}"` arms of every completable option, in the
+/// subcommand arm it belongs to.
+///
+/// Arms are delimited by their `<cmd>)` labels rather than by the `;;` that
+/// closes them, because the body contains a nested `case` with `;;` of its own.
+fn replace_bash_option_values(cli: &Cli, script: &str) -> String {
+    let by_arm = cli.targets.iter().fold(
+        HashMap::<String, Vec<&OptionTarget>>::new(),
+        |mut acc, target| {
+            acc.entry(bash_arm_name(cli.bin_name, &target.path))
+                .or_default()
+                .push(target);
+            acc
+        },
+    );
+
+    let labels: Vec<Captures> = BASH_ARM_LABEL.captures_iter(script).collect();
+    let mut result = String::with_capacity(script.len());
+    let mut cursor = 0;
+    for (index, caps) in labels.iter().enumerate() {
+        let label = caps.get(0).expect("group 0 always participates");
+        let body_end = labels.get(index + 1).map_or(script.len(), |next| {
+            next.get(0).expect("group 0 always participates").start()
+        });
+        result.push_str(&script[cursor..label.end()]);
+        let body = &script[label.end()..body_end];
+        match by_arm.get(&caps["arm"]) {
+            Some(arm_targets) => {
+                let patched = arm_targets.iter().fold(body.to_string(), |body, target| {
+                    complete_bash_option(cli, &body, target)
+                });
+                result.push_str(&patched);
+            }
+            None => result.push_str(body),
+        }
+        cursor = body_end;
+    }
+    result.push_str(&script[cursor..]);
+    result
+}
+
+/// Point one option's `case "${prev}"` arms at the shared helper.
+fn complete_bash_option(cli: &Cli, body: &str, target: &OptionTarget) -> String {
+    let long = regex::escape(&target.long);
+    let labels = match target.short {
+        Some(short) => format!("--{long}|-{}", regex::escape(&short.to_string())),
+        None => format!("--{long}"),
+    };
+    let pattern = format!(
+        r#"(?m)^(?P<indent>\s*)(?P<label>{labels})\)\n\s*COMPREPLY=\(\$\(compgen -f "\$\{{cur\}}"\)\)"#
+    );
+    let candidates = bash_candidates(cli, target.command);
+    compile_regex(&pattern)
+        .replace_all(body, |caps: &Captures| {
+            let indent = &caps["indent"];
+            let label = &caps["label"];
+            format!(
+                r#"{indent}{label})
+{indent}    {candidates}"#
+            )
+        })
+        .into_owned()
+}
+
+/// Complete task names for `pixi run` at any position on the command line.
+fn replace_bash_run_tasks(cli: &Cli, script: &str) -> String {
     // NOTE THIS IS FORMATTED BY HAND
-    // Replace the '-' with '__' since that's what clap's generator does as well for Bash Shell completion.
-    let clap_name = bin_name.replace("-", "__");
-    // clap_complete >=4.6.2 separates each segment of the bin name from each
-    // subcommand with an explicit `__subcmd__` marker, so the function for the
-    // `run` subcommand of `pixi` is `pixi__subcmd__run`.
-    let func_prefix = clap_name.replace("__", "__subcmd__");
+    let arm = bash_arm_name(cli.bin_name, &["run".to_string()]);
     // Keep the generated `case "${prev}"` block (option-value completion) and
     // run task completion after it, so tasks complete at any position.
-    let pattern = format!(
-        r#"(?s){}__subcmd__run\).*?opts="(?P<opts>.*?)".*?if.*?fi\s*(?P<case>case.*?esac)"#,
-        func_prefix
-    );
-    let re = Regex::new(pattern.as_str()).expect("should be able to compile the regex");
-    re.replace(script, |caps: &Captures| {
-        let opts = &caps["opts"];
-        // Complete environment and platform names after their options instead
-        // of files.
-        let case = complete_bash_option(
-            &caps["case"],
-            bin_name,
-            &BashOptionCompletion {
-                labels: "--environment|-e",
-                var: "environments",
-                command: ENVIRONMENT_LIST,
-            },
-        );
-        let case = complete_bash_option(
-            &case,
-            bin_name,
-            &BashOptionCompletion {
-                labels: "--platform|-p",
-                var: "platforms",
-                command: PLATFORM_LIST,
-            },
-        );
-        format!(
-            r#"{func_prefix}__subcmd__run)
+    let pattern =
+        format!(r#"(?s){arm}\).*?opts="(?P<opts>.*?)".*?if.*?fi\s*(?P<case>case.*?esac)"#);
+    compile_regex(&pattern)
+        .replace(script, |caps: &Captures| {
+            let opts = &caps["opts"];
+            let case = &caps["case"];
+            // Not `bash_candidates`: with no tasks to offer this falls through to
+            // the generated tail, which lists the flags, rather than to file paths.
+            format!(
+                r#"{arm})
             opts="{opts}"
             if [[ ${{cur}} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${{opts}}" -- "${{cur}}") )
@@ -142,258 +416,313 @@ fn replace_bash_completion<'a>(script: &'a str, bin_name: &str) -> Cow<'a, str> 
             fi
             {case}
             local tasks
-            if tasks=$({bin_name} task list --machine-readable 2> /dev/null) && [[ -n "${{tasks}}" ]]; then
+            if tasks=$({bin_name} {TASK_LIST} 2> /dev/null) && [[ -n "${{tasks}}" ]]; then
                 COMPREPLY=( $(compgen -W "${{tasks}}" -- "${{cur}}") )
                 return 0
-            fi"#
-        )
-    })
-}
-
-/// A `run` option whose value bash should complete from the space-delimited
-/// output of a `pixi` subcommand instead of file paths.
-struct BashOptionCompletion<'a> {
-    /// Regex alternation matching the option's `case` labels, e.g.
-    /// `--environment|-e`.
-    labels: &'a str,
-    /// Shell variable holding the candidate list.
-    var: &'a str,
-    /// `pixi` subcommand emitting the candidates.
-    command: &'a str,
-}
-
-/// Complete an option's value in the bash `case "${prev}"` block from a `pixi`
-/// subcommand's output, falling back to file completion when it yields nothing.
-fn complete_bash_option(case_block: &str, bin_name: &str, opt: &BashOptionCompletion) -> String {
-    let pattern = format!(
-        r#"(?m)^(?P<indent>\s*)(?P<label>{})\)\n\s*COMPREPLY=\(\$\(compgen -f "\$\{{cur\}}"\)\)"#,
-        opt.labels
-    );
-    let re = Regex::new(&pattern).expect("should be able to compile the regex");
-    let (var, command) = (opt.var, opt.command);
-    re.replace_all(case_block, |caps: &Captures| {
-        let indent = &caps["indent"];
-        let label = &caps["label"];
-        format!(
-            r#"{indent}{label})
-{indent}    local {var}
-{indent}    if {var}=$({bin_name} {command} 2> /dev/null) && [[ -n "${{{var}}}" ]]; then
-{indent}        COMPREPLY=( $(compgen -W "${{{var}}}" -- "${{cur}}") )
-{indent}    else
-{indent}        COMPREPLY=($(compgen -f "${{cur}}"))
-{indent}    fi"#
-        )
-    })
-    .into_owned()
+            fi"#,
+                bin_name = cli.bin_name
+            )
+        })
+        .into_owned()
 }
 
 /// Replace the parts of the zsh completion script that need different functionality.
-fn replace_zsh_completion(script: &str) -> Cow<'_, str> {
+fn replace_zsh_completion(cli: &Cli, script: &str) -> String {
+    // zsh spec lines carry no subcommand path, but they do carry the clap value
+    // name, which identifies the option. `pixi global` is ruled out inside the
+    // helper instead, from the command line being completed.
+    let script = VALUE_SOURCES
+        .iter()
+        .fold(script.to_string(), |script, (value_name, command)| {
+            script.replace(
+                &format!(":{value_name}:_default"),
+                &format!(":{value_name}:{}", zsh_candidates(cli, command)),
+            )
+        });
+
+    // Anchor on the preamble rather than on `_<bin_name>()`, whose spelling
+    // depends on the binary name.
+    let script = script.replace(
+        ZSH_PREAMBLE,
+        &format!("{ZSH_PREAMBLE}\n{}", zsh_helper_definition(cli)),
+    );
+
+    replace_zsh_run_tasks(cli, &script)
+}
+
+/// The zsh action that offers what `command` lists.
+///
+/// Wrapped in braces, which `_arguments` evaluates verbatim. A bare word list
+/// would also be run as a command, but `_arguments` prepends its own `compadd`
+/// options to it (`-J -default- …`), and those would reach `pixi` as arguments.
+fn zsh_candidates(cli: &Cli, command: &str) -> String {
+    format!("{{{} {command}}}", cli.helper())
+}
+
+/// Complete from the output of a `pixi` subcommand, deferring to the default
+/// completion below `pixi global`, which has its own namespaces.
+///
+/// The generated script rewrites `curcontext` into the canonical subcommand
+/// path, so it identifies the subtree even behind an alias or an option value.
+fn zsh_helper_definition(cli: &Cli) -> String {
+    format!(
+        r#"{helper}() {{
+    if [[ $curcontext == *:{bin_name}-{GLOBAL_SUBCOMMAND}-* ]]; then
+        _default
+        return
+    fi
+    local -a candidates
+    candidates=(${{=$({bin_name} "$@" 2> /dev/null)}})
+    if (( ${{#candidates}} )); then
+        compadd -a candidates
+    else
+        _default
+    fi
+}}
+
+"#,
+        helper = cli.helper(),
+        bin_name = cli.bin_name
+    )
+}
+
+/// The `*::task` rest-argument spec of `pixi run`, whose action clap leaves at
+/// the default. There is one per spelling of `run`, the name and its alias.
+static ZSH_RUN_POSITIONAL: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"(?m)^(?P<spec>'\*::task[^\n]*?):_default(?P<tail>' \\)$"));
+
+/// Complete task names for the rest arguments of `pixi run`.
+///
+/// Rewrites that spec's action rather than calling `_values` ahead of
+/// `_arguments`, which offered tasks in every context (even as an option value),
+/// skipped `_arguments` when there were no tasks, and missed the `r` alias arm.
+fn replace_zsh_run_tasks(cli: &Cli, script: &str) -> String {
+    ZSH_RUN_POSITIONAL
+        .replace_all(script, |caps: &Captures| {
+            format!(
+                "{spec}:{action}{tail}",
+                spec = &caps["spec"],
+                action = zsh_candidates(cli, TASK_LIST),
+                tail = &caps["tail"]
+            )
+        })
+        .into_owned()
+}
+
+/// Replace the parts of the fish completion script that need different functionality.
+fn replace_fish_completion(cli: &Cli, script: &str) -> String {
+    let script = complete_fish_options(cli, script, &fish_option_sources(&cli.root, &cli.targets));
+
+    // Adds tab completion to the pixi run command, under both its spellings.
+    let addition = format!(
+        "complete -c {bin_name} -n \"__fish_seen_subcommand_from run; or __fish_seen_subcommand_from r\" {}\n",
+        fish_candidates(cli, TASK_LIST),
+        bin_name = cli.bin_name
+    );
+    format!("{script}{addition}")
+}
+
+/// The fish fragment that offers what `command` lists, and nothing else.
+fn fish_candidates(cli: &Cli, command: &str) -> String {
+    format!(
+        r#"-f -a "(string split ' ' ({} {command} 2> /dev/null))""#,
+        cli.bin_name
+    )
+}
+
+/// The subcommand a fish `complete` line's predicate is gated on.
+static FISH_SUBCOMMAND: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"_using_subcommand (?P<name>[^\s;]+)"));
+
+/// Append `-f -a "..."` to every `complete` line whose subcommand and long flag
+/// name something a `pixi` subcommand can list.
+///
+/// fish emits one line per subcommand and per visible alias, each gated by a
+/// `__fish_..._using_subcommand` predicate, which is where the subcommand
+/// comes from.
+fn complete_fish_options(
+    cli: &Cli,
+    script: &str,
+    sources: &HashMap<(String, String), &'static str>,
+) -> String {
+    // Longest first, so a flag that is a prefix of another cannot shadow it,
+    // and so the pattern does not depend on `HashMap` iteration order.
+    let mut longs = sources
+        .keys()
+        .map(|(_, long)| regex::escape(long))
+        .collect::<Vec<_>>();
+    longs.sort_unstable_by(|a, b| b.len().cmp(&a.len()).then_with(|| a.cmp(b)));
+    longs.dedup();
+    let longs = longs.join("|");
+    let pattern = format!(
+        r#"(?m)^(?P<line>complete -c {bin} -n "(?P<predicate>[^"]*)"[^\n]*? -l (?P<long>{longs}) [^\n]*? -r)$"#,
+        bin = regex::escape(cli.bin_name)
+    );
+    compile_regex(&pattern)
+        .replace_all(script, |caps: &Captures| {
+            let line = &caps["line"];
+            let Some(name) = FISH_SUBCOMMAND
+                .captures(&caps["predicate"])
+                .map(|predicate| predicate["name"].to_string())
+            else {
+                return line.to_string();
+            };
+            let Some(command) = sources.get(&(name, caps["long"].to_string())) else {
+                return line.to_string();
+            };
+            format!("{line} {}", fish_candidates(cli, command))
+        })
+        .into_owned()
+}
+
+/// Line opening the module every generated nushell definition lives in.
+const NUSHELL_MODULE: &str = "module completions {";
+
+/// Matches one argument line of a nushell `export extern` block, splitting the
+/// declared type off so that a completer can be appended after it.
+///
+/// Boolean flags carry no `: type` and so do not match.
+static NUSHELL_ARG_LINE: LazyLock<Regex> = LazyLock::new(|| {
+    compile_regex(r"^(?P<pre>\s*(?P<name>[^\s:]+)\s*:\s*)(?P<ty>[^\s#@]+)(?P<tail>.*)$")
+});
+
+/// Replace the parts of the nushell completion script that need different functionality.
+fn replace_nushell_completion(cli: &Cli, script: &str) -> String {
     // Adds tab completion to the pixi run command.
     // NOTE THIS IS FORMATTED BY HAND
-    let pattern = r"(?ms)(?P<run>\(run\))(?:.*?)(?P<args>_arguments.*?)(\*::task)";
-    let bin_name: &str = pixi_utils::executable_name();
-    let re = Regex::new(pattern).expect("should be able to compile the regex");
-    re.replace(script, |caps: &Captures| {
-        let run = &caps["run"];
-        // Complete environment and platform names after their options instead
-        // of files.
-        let args = caps["args"]
-            .replace(
-                ":ENVIRONMENT:_default",
-                &format!(":ENVIRONMENT:($({bin_name} {ENVIRONMENT_LIST} 2> /dev/null))"),
-            )
-            .replace(
-                ":PLATFORM:_default",
-                &format!(":PLATFORM:($({bin_name} {PLATFORM_LIST} 2> /dev/null))"),
-            );
-        format!(
-            r#"{run}
-local tasks
-tasks=("${{(@s/ /)$({bin_name} task list --machine-readable 2> /dev/null)}}")
 
-if [[ -n "$tasks" ]]; then
-    _values 'task' "${{tasks[@]}}"
-else
-    return 1
-fi
-{args}::task"#
-        )
+    // One definition per candidate source, plus the `r` alias the generator
+    // does not emit for `run`. nushell completers take no arguments, so unlike
+    // bash and zsh it needs one definition per source rather than one helper.
+    let definitions = VALUE_SOURCES
+        .iter()
+        .map(|(value_name, command)| nushell_definition(cli, value_name, command))
+        .collect::<String>();
+    let script = script.replacen(
+        NUSHELL_MODULE,
+        &format!(
+            "{NUSHELL_MODULE}{definitions}\n    export alias \"{bin_name} r\" = {bin_name} run\n    \n",
+            bin_name = cli.bin_name
+        ),
+        1,
+    );
+
+    // Point each argument that names something listable at the definition for
+    // its value name. The `...task` of `pixi run` names the same things as
+    // `--depends-on`, so it shares the task definition.
+    let run = format!("{} run", cli.bin_name);
+    rewrite_nushell_blocks(&script, |command, line| {
+        let caps = NUSHELL_ARG_LINE.captures(line)?;
+        // A type the generator already gave a completer is not ours to touch.
+        if caps["tail"].starts_with('@') {
+            return None;
+        }
+        let name = &caps["name"];
+        let completion = if name == "...task" && command == run {
+            nushell_candidates(cli, "TASK")
+        } else {
+            let long = name.strip_prefix("--")?.split('(').next()?;
+            nushell_completion(cli, command, long)?
+        };
+        Some(format!(
+            "{pre}{ty}{completion}{tail}",
+            pre = &caps["pre"],
+            ty = &caps["ty"],
+            tail = &caps["tail"]
+        ))
     })
 }
 
-fn replace_fish_completion(script: &str) -> Cow<'_, str> {
-    // Adds tab completion to the pixi run command.
-    let bin_name = pixi_utils::executable_name();
+/// Header opening an `export extern` block. The bare binary is declared
+/// unquoted, every subcommand in quotes.
+static NUSHELL_BLOCK_HEADER: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r#"^\s*export extern "?(?P<command>[^"\[]+?)"? \[\s*$"#));
 
-    // Complete environment and platform names for the corresponding options of
-    // `run` (and its `r` alias), which clap otherwise completes as file paths.
-    let script =
-        fish_complete_run_option(script, bin_name, "-s e -l environment", ENVIRONMENT_LIST);
-    let script = fish_complete_run_option(&script, bin_name, "-s p -l platform", PLATFORM_LIST);
-
-    let addition = format!(
-        "complete -c {bin_name} -n \"__fish_seen_subcommand_from run\" -f -a \"(string split ' ' ({bin_name} task list --machine-readable  2> /dev/null))\""
-    );
-    let new_script = format!("{script}{addition}\n");
-    let pattern = r#"-n "__fish_seen_subcommand_from run""#;
-    let replacement = r#"-n "__fish_seen_subcommand_from run; or __fish_seen_subcommand_from r""#;
-    let re = Regex::new(pattern).expect("should be able to compile the regex");
-    let result = re.replace_all(&new_script, replacement);
-    Cow::Owned(result.into_owned())
-}
-
-/// Complete a `run` option's value from a `pixi` subcommand's output by
-/// appending `-f -a "..."` to the clap-generated `complete` line matched by
-/// `flags` (e.g. `-s e -l environment`) for both `run` and its `r` alias.
-fn fish_complete_run_option(script: &str, bin_name: &str, flags: &str, command: &str) -> String {
-    let pattern = format!(
-        r#"(?m)^(complete -c {bin_name} -n "__fish_pixi_using_subcommand r(?:un)?" {flags} [^\n]*? -r)$"#
-    );
-    let re = Regex::new(&pattern).expect("should be able to compile the regex");
-    re.replace_all(
-        script,
-        format!(r#"$1 -f -a "(string split ' ' ({bin_name} {command} 2> /dev/null))""#).as_str(),
-    )
-    .into_owned()
-}
-
-/// Replace the parts of the nushell completion script that need different functionality.
-fn replace_nushell_completion(script: &str) -> Cow<'_, str> {
-    fn insert_after_module<'a>(input: &'a str, insert: &str) -> Cow<'a, str> {
-        // Match the literal line
-        let re = Regex::new(r"(?m)^module completions \{").expect("static regex must be valid");
-
-        re.replace(input, |caps: &regex::Captures| {
-            format!("{}{}\n", &caps[0], insert)
-        })
-    }
-
-    /// For every occurrence of `flag` inside any `export extern "<cmd>" [...]` block:
-    /// - Extract the command name.
-    /// - Extract the type token and the rest of the line.
-    /// - Call `modify(cmd, ty, tail)`
-    ///     - If it returns `Some(extra)`, append `extra` after the type.
-    ///     - If it returns `None`, leave the line unchanged.
-    ///
-    /// The closure gets clean values:
-    ///     cmd  = "pixi run"
-    ///     ty   = "string"  (or "path", etc.)
-    ///     tail = " # comment"
-    pub fn append_after_type<F>(input: &str, flag: &str, modify: F) -> String
-    where
-        F: Fn(&str, &str, &str) -> Option<String>,
-    {
-        let flag_escaped = regex::escape(flag);
-
-        // Captures:
-        //   cmd  = the command name in quotes
-        //   pre  = prefix up to and including ": " on the flag line
-        //   ty   = type token
-        //   tail = rest of the line (comment + spacing)
-        let pattern = format!(
-            r#"(?ms)(export extern "(?P<cmd>[^"]+)" \[[^\]]*?^\s*{flag_escaped}\s*:\s*)(?P<ty>[^\s#@]+)(?P<tail>[^\n]*)"#,
-        );
-
-        let re = Regex::new(&pattern).expect("static regex must be valid");
-
-        re.replace_all(input, |caps: &Captures| {
-            let cmd = &caps["cmd"];
-            let pre = &caps[1];
-            let ty = &caps["ty"];
-            let tail = &caps["tail"];
-
-            match modify(cmd, ty, tail) {
-                Some(extra) => format!("{pre}{ty}{extra}{tail}"),
-                None => caps[0].to_string(),
-            }
-        })
-        .into_owned()
-    }
-
-    /// Append `append` after the `string` type for the argument `...task: string`
-    /// but only inside the `export extern "<command>" [...]` block.
-    pub fn append_to_task_arg(input: &str, command: &str, arg: &str, append: &str) -> String {
-        let cmd_escaped = regex::escape(command);
-
-        // Matches:
-        //   export extern "<command>" [ ... <newline>
-        //   ...task: string[rest]
-        //
-        // Captures:
-        //   1 = prefix up to and including "string"
-        //   2 = rest of line (comments, whitespace)
-        let pattern = format!(
-            r#"(?ms)(export extern "{cmd_escaped}" \[[^\]]*?^\s*\.{{3}}{arg}:\s*string)([^\n]*)"#,
-        );
-
-        let re = Regex::new(&pattern).expect("static regex must be valid");
-
-        re.replace_all(input, |caps: &Captures| {
-            let prefix = &caps[1]; // "...task: string"
-            let tail = &caps[2]; // comment / rest of line
-            format!("{prefix}{append}{tail}")
-        })
-        .into_owned()
-    }
-
-    // Adds tab completion to the pixi run command.
-    // NOTE THIS IS FORMATTED BY HAND
-    let bin_name = pixi_utils::executable_name();
-
-    // Extra definitions we want to add to the completion module.
-    let script = insert_after_module(
-        script,
-        &format!(
-            r#"
-    def "nu-complete {bin_name} run environment" [] {{
-      ^{bin_name} info --json | from json | get environments_info | get name
-    }}
-
-    def "nu-complete {bin_name} run platform" [] {{
-      ^{bin_name} info --json | from json | get environments_info | get platforms | flatten | get name | uniq
-    }}
-
-    def "nu-complete {bin_name} run" [] {{
-      ^{bin_name} info --json | from json | get environments_info | get tasks | flatten | uniq
-    }}
-
-    export alias "{bin_name} r" = {bin_name} run
-    "#
-        ),
-    );
-
-    // Add completion for all `--environment(-e)` flags.
-    let script = append_after_type(&script, "--environment(-e)", |cmd, _ty, _extra| {
-        let cmd = cmd.strip_prefix(bin_name)?.trim_start();
-        if cmd.starts_with("global") {
-            // --environment means something else for pixi global
-            None
-        } else {
-            Some(format!(r#"@"nu-complete {bin_name} run environment""#))
+/// Rewrite the argument lines of every `export extern "<cmd>" [ … ]` block,
+/// replacing a line with whatever `rewrite(command, line)` returns.
+///
+/// Walked line by line, not matched as a bracket-delimited region: a `]` in an
+/// option's help text would end such a match early and silently skip the rest
+/// of the block. `pixi global install --package` has one.
+fn rewrite_nushell_blocks(
+    script: &str,
+    mut rewrite: impl FnMut(&str, &str) -> Option<String>,
+) -> String {
+    let mut result = String::with_capacity(script.len());
+    let mut block = None;
+    for line in script.split_inclusive('\n') {
+        let content = line.trim_end_matches(['\n', '\r']);
+        if let Some(caps) = NUSHELL_BLOCK_HEADER.captures(content) {
+            block = Some(caps["command"].to_string());
+        } else if content.trim() == "]" {
+            block = None;
+        } else if let Some(replacement) = block
+            .as_deref()
+            .and_then(|command| rewrite(command, content))
+        {
+            result.push_str(&replacement);
+            result.push_str(&line[content.len()..]);
+            continue;
         }
-    });
+        result.push_str(line);
+    }
+    result
+}
 
-    // Add completion for `pixi run`'s `--platform(-p)` flag.
-    let script = append_after_type(&script, "--platform(-p)", |cmd, _ty, _extra| {
-        let cmd = cmd.strip_prefix(bin_name)?.trim_start();
-        (cmd == "run").then(|| format!(r#"@"nu-complete {bin_name} run platform""#))
-    });
+/// The nushell reference to the definition for `value_name`.
+fn nushell_candidates(cli: &Cli, value_name: &str) -> String {
+    format!(
+        r#"@"nu-complete {} {}""#,
+        cli.bin_name,
+        value_name.to_lowercase()
+    )
+}
 
-    // Add completion for the `...task: string` argument in pixi run.
-    let script = append_to_task_arg(
-        &script,
-        &format!("{bin_name} run"),
-        "task",
-        &format!("@\"nu-complete {bin_name} run\""),
-    );
+/// A `nu-complete` definition listing the candidates emitted by `command`,
+/// yielding an empty list when it fails, for instance outside a workspace.
+fn nushell_definition(cli: &Cli, value_name: &str, command: &str) -> String {
+    format!(
+        r#"
+    def "nu-complete {bin_name} {kind}" [] {{
+      let result = (^{bin_name} {command} | complete)
+      if $result.exit_code == 0 {{ $result.stdout | str trim | split row " " | where {{|it| $it != "" }} }} else {{ [] }}
+    }}
+"#,
+        bin_name = cli.bin_name,
+        kind = value_name.to_lowercase()
+    )
+}
 
-    script.into()
+/// The `nu-complete` reference for `long` under `cmd`, or `None` when that
+/// command does not take a listable name there.
+///
+/// nushell names the whole command in each `export extern`, so the target is
+/// matched on its full path.
+fn nushell_completion(cli: &Cli, cmd: &str, long: &str) -> Option<String> {
+    let path = cmd.strip_prefix(cli.bin_name)?.split_whitespace();
+    let target = cli.targets.iter().find(|target| {
+        target.long == long && target.path.iter().map(String::as_str).eq(path.clone())
+    })?;
+    Some(nushell_candidates(cli, target.value_name))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
+    use clap::ValueHint;
+
     use super::*;
+
+    /// The real CLI, as every shell's rewrite sees it.
+    fn real_cli() -> Cli {
+        Cli::new()
+    }
+
+    /// The bash fixture spells the binary `pixi`, so the rewrite has to too.
+    fn bash_fixture_cli() -> Cli {
+        Cli::with_bin_name("pixi")
+    }
 
     #[test]
     pub(crate) fn test_zsh_completion() {
@@ -420,7 +749,7 @@ _arguments "${_arguments_options[@]}" \
 '(-v --verbose)*--quiet[Less output per occurrence]' \
 '-h[Print help]' \
 '--help[Print help]' \
-'*::task -- The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.:' \
+'*::task -- The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.:_default' \
 && ret=0
 ;;
 (add)
@@ -433,15 +762,21 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (shell)
 _arguments "${_arguments_options[@]}" \
+'-e+[The environment to activate in the shell]:ENVIRONMENT:_default' \
+'--environment=[The environment to activate in the shell]:ENVIRONMENT:_default' \
 && ret=0
 ;;
 
         "#;
-        let result = replace_zsh_completion(script);
+        let cli = real_cli();
+        let result = replace_zsh_completion(&cli, script);
         // Normalize the test binary name (e.g. `pixi_cli-<hash>`) to `pixi` so
-        // the snapshot is stable across builds.
+        // the snapshot is stable across builds. Helper function names spell it
+        // with underscores, so both forms need filtering.
+        let underscored = cli.bin_name.replace('-', "_");
         insta::with_settings!({filters => vec![
-            (pixi_utils::executable_name(), "pixi"),
+            (cli.bin_name, "pixi"),
+            (underscored.as_str(), "pixi"),
         ]}, {
             insta::assert_snapshot!(result);
         });
@@ -458,7 +793,7 @@ _arguments "${_arguments_options[@]}" \
             ;;
         pixi__subcmd__run)
             opts="-e -p -v -q -h --manifest-path --locked --frozen --environment --platform --verbose --quiet --color --help [TASK]..."
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+            if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -494,9 +829,53 @@ _arguments "${_arguments_options[@]}" \
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        pixi__subcmd__shell)
+            opts="-e -h --environment --help"
+            if [[ ${cur} == -* ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --environment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        pixi__subcmd__global__subcmd__install)
+            opts="-e -h --environment --help"
+            if [[ ${cur} == -* ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --environment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         pixi__subcmd__search)
             opts="-c -l -v -q -h --channel --color --help <PACKAGE>"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+            if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
@@ -513,18 +892,22 @@ _arguments "${_arguments_options[@]}" \
             return 0
             ;;
         "#;
-        let result = replace_bash_completion(script, "pixi");
+        let result = replace_bash_completion(&bash_fixture_cli(), script);
         assert_ne!(result, script);
         insta::assert_snapshot!(result);
     }
 
     #[test]
     pub(crate) fn test_nushell_completion() {
+        // The rewrites key off the binary name, which is the test binary here,
+        // so the fixture has to be built with it rather than a literal `pixi`.
+        let cli = real_cli();
         // NOTE THIS IS FORMATTED BY HAND!
-        let script = r#"
+        let script = format!(
+            r#"
   # Runs task in project
-  export extern "pixi run" [
-    ...task: string@"nu-complete pixi run"           # The pixi task or a task shell command you want to run in the project's environment, which can be an executable in the environment's PATH
+  export extern "{bin_name} run" [
+    ...task: string           # The pixi task or a task shell command you want to run in the project's environment, which can be an executable in the environment's PATH
     --manifest-path: string   # The path to `pixi.toml`, `pyproject.toml`, or the project directory
     --no-lockfile-update      # Legacy flag, do not use, will be removed in subsequent version
     --frozen                  # Install the environment as defined in the lock file, doesn't update lock file if it isn't up-to-date with the manifest file
@@ -532,67 +915,507 @@ _arguments "${_arguments_options[@]}" \
     --no-install              # Don't modify the environment, only modify the lock file
     --tls-no-verify           # Do not verify the TLS certificate of the server
     --auth-file: string       # Path to the file containing the authentication token
-    --pypi-keyring-provider: string@"nu-complete pixi run pypi_keyring_provider" # Specifies if we want to use uv keyring provider
+    --pypi-keyring-provider: string # Specifies if we want to use uv keyring provider
     --concurrent-solves: string # Max concurrent solves, default is the number of CPUs
     --concurrent-downloads: string # Max concurrent network requests, default is 50
     --force-activate          # Do not use the environment activation cache. (default: true except in experimental mode)
-    --environment(-e): string@"nu-complete pixi run environment" # The environment to run the task in
+    --environment(-e): string # The environment to run the task in
+    --platform(-p): string    # Install and run in the environment for the given platform
     --clean-env               # Use a clean environment to run the task
     --skip-deps               # Don't run the dependencies of the task ('depends-on' field in the task definition)
     --verbose(-v)             # Increase logging verbosity
     --quiet(-q)               # Decrease logging verbosity
-    --color: string@"nu-complete pixi run color" # Whether the log needs to be colored
     --no-progress             # Hide all progress bars, always turned on if stderr is not a terminal
     --help(-h)                # Print help (see more with '--help')
-  ]"#;
-        let result = replace_nushell_completion(script);
-        let replacement = format!("{} run", pixi_utils::executable_name());
-        let nu_complete_run = format!("nu-complete {} run", pixi_utils::executable_name());
-        println!("{result}");
+  ]
+
+  # Activate a shell
+  export extern "{bin_name} shell" [
+    --environment(-e): string # The environment to activate in the shell
+  ]
+
+  # Install a global tool
+  export extern "{bin_name} global install" [
+    --environment(-e): string # Ensures that all packages will be installed in the same environment
+    --platform(-p): string    # The platform to install the packages for
+  ]"#,
+            bin_name = cli.bin_name
+        );
+        let result = replace_nushell_completion(&cli, &script);
+        // Normalize the test binary name (e.g. `pixi_cli-<hash>`) to `pixi` so
+        // the snapshot is stable across builds.
         insta::with_settings!({filters => vec![
-            (replacement.as_str(), "[PIXI RUN]"),
-            (nu_complete_run.as_str(), "[nu_complete_run PIXI COMMAND]"),
+            (cli.bin_name, "pixi"),
         ]}, {
             insta::assert_snapshot!(result);
         });
     }
 
+    /// The tree walk must find the options the issue is about, and must leave
+    /// `pixi global` alone.
     #[test]
-    pub(crate) fn test_bash_completion_working_regex() {
-        // Generate the original completion script.
-        let script = get_completion_script(Shell::Bash);
-        // Test if there was a replacement done on the clap generated completions
-        assert_ne!(
-            replace_bash_completion(&script, pixi_utils::executable_name()),
-            script
+    fn test_option_targets_cover_workspace_commands_only() {
+        let cli = real_cli();
+        let targets = &cli.targets;
+        let completed = targets
+            .iter()
+            .map(|target| format!("{} --{}", target.path.join(" "), target.long))
+            .collect::<Vec<_>>();
+
+        for option in [
+            "shell --environment",
+            "shell-hook --environment",
+            "install --environment",
+            "add --environment",
+            "task add --environment",
+            "run --platform",
+            "task add --feature",
+            "task add --depends-on",
+        ] {
+            assert!(
+                completed.iter().any(|entry| entry == option),
+                "`pixi {option}` should complete workspace names"
+            );
+        }
+        assert!(
+            targets
+                .iter()
+                .all(|target| target.path.first().map(String::as_str) != Some(GLOBAL_SUBCOMMAND)),
+            "`pixi global` has its own namespaces and must be left alone"
         );
     }
 
+    /// The tree walk skips `pixi global` by name and the zsh helper matches
+    /// `curcontext` against the same spelling. Renaming or emptying it would
+    /// make both silently start offering workspace names, and would make every
+    /// "global is excluded" assertion pass with nothing left to exclude.
     #[test]
-    pub(crate) fn test_zsh_completion_working_regex() {
-        // Generate the original completion script.
-        let script = get_completion_script(Shell::Zsh);
-        // Test if there was a replacement done on the clap generated completions
-        assert_ne!(replace_zsh_completion(&script), script);
+    fn test_global_subcommand_is_worth_excluding() {
+        /// Does `cmd` or anything below it take a name a shell would rewrite?
+        fn completable(cmd: &Command) -> bool {
+            let mut found = false;
+            walk_arguments(cmd, &mut |_, arg| {
+                found |= arg.get_long().is_some() && value_source(arg).is_some();
+            });
+            found
+        }
+
+        let cli = real_cli();
+        let global = cli
+            .root
+            .get_subcommands()
+            .find(|sub| sub.get_name() == GLOBAL_SUBCOMMAND)
+            .expect("`pixi global` is gone, so the exclusions naming it are dead code");
+        assert!(
+            completable(global),
+            "`pixi {GLOBAL_SUBCOMMAND}` no longer takes a name any shell would rewrite, so \
+             excluding it has become a no-op"
+        );
     }
 
+    /// Options that name something the workspace does not have yet, and so must
+    /// keep a value name outside [`VALUE_SOURCES`], paired with that name.
+    ///
+    /// `pixi init` and `pixi exec` resolve their platform without a workspace,
+    /// and `pixi import` names the environment and feature it creates.
+    const OPTED_OUT: [(&str, &str, &str); 4] = [
+        ("exec", "platform", "SUBDIR"),
+        ("import", "environment", "NEW_ENVIRONMENT"),
+        ("import", "feature", "NEW_FEATURE"),
+        ("init", "platform", "NEW_PLATFORM"),
+    ];
+
+    /// Options are matched on their clap value name, which clap derives from
+    /// the field name unless told otherwise. Any completable option that lets it
+    /// do so silently drops out of every completion, so hold the whole CLI to
+    /// the normalised spelling — or, for the deliberate exceptions, to the
+    /// spelling that keeps them out.
     #[test]
-    pub(crate) fn test_fish_completion_working_regex() {
-        // Generate the original completion script.
-        let script = get_completion_script(Shell::Fish);
-        let replaced_script = replace_fish_completion(&script);
-        // Test if there was a replacement done on the clap generated completions
-        assert_ne!(replaced_script, script);
+    fn test_value_names_are_normalised() {
+        let mut wrong = Vec::new();
+        walk_arguments(&CommandArgs::command(), &mut |path, arg| {
+            let (Some(long), Some(value_name)) =
+                (arg.get_long(), arg.get_value_names().and_then(<[_]>::first))
+            else {
+                return;
+            };
+            let opted_out = OPTED_OUT
+                .iter()
+                .find(|(command, flag, _)| [*command] == *path && *flag == long)
+                .map(|(_, _, value_name)| *value_name);
+            let expected = match (opted_out, long) {
+                (Some(value_name), _) => value_name,
+                (None, "environment" | "default-environment") => "ENVIRONMENT",
+                (None, "platform") => "PLATFORM",
+                (None, "feature") => "FEATURE",
+                (None, "depends-on") => "TASK",
+                (None, _) => return,
+            };
+            if value_name.as_str() != expected {
+                wrong.push(format!(
+                    "`pixi {} --{long}` should declare `value_name = \"{expected}\"`, not \
+                     `{value_name}`",
+                    path.join(" ")
+                ));
+            }
+        });
+        assert!(wrong.is_empty(), "{wrong:#?}");
     }
 
+    /// The opted-out options must stay out of the tree walk, so that bash never
+    /// addresses them and zsh never sees their value name.
     #[test]
-    pub(crate) fn test_nushell_completion_working_regex() {
-        // Generate the original completion script.
-        let script = get_completion_script(Shell::Nushell);
-        // Test if there was a replacement done on the clap generated completions
-        if replace_nushell_completion(&script) == script {
-            panic!(
-                "Completion replacement did not work as expected\n\n======================\n= Original script\n======================\n{script}"
+    fn test_opted_out_options_are_not_targets() {
+        let cli = real_cli();
+        let targets = &cli.targets;
+        let mut hints = HashMap::new();
+        walk_arguments(&cli.root, &mut |path, arg| {
+            if let Some(long) = arg.get_long() {
+                hints.insert((path.to_vec(), long), arg.get_value_hint());
+            }
+        });
+
+        for (command, flag, value_name) in OPTED_OUT {
+            assert!(
+                !targets
+                    .iter()
+                    .any(|target| target.path == [command] && target.long == flag),
+                "`pixi {command} --{flag}` names something the workspace cannot list yet"
+            );
+            assert!(
+                !VALUE_SOURCES.iter().any(|(name, _)| *name == value_name),
+                "`{value_name}` is a candidate source, so it cannot opt an option out"
+            );
+            // Nothing can be offered for these, so they must not fall back to
+            // the shell default either, which is file paths.
+            assert_eq!(
+                hints.get(&(vec![command], flag)).copied(),
+                Some(ValueHint::Other),
+                "`pixi {command} --{flag}` should declare `value_hint = ValueHint::Other`"
+            );
+        }
+    }
+
+    /// fish and nushell name the flag rather than the value name, so they are the
+    /// two that could rewrite an opted-out option anyway.
+    #[test]
+    fn test_opted_out_options_are_not_rewritten() {
+        let cli = real_cli();
+        let fish_script = cli.generate(Shell::Fish);
+        let nushell_script = cli.generate(Shell::Nushell);
+        let fish = replace_fish_completion(&cli, &fish_script);
+        let nushell = replace_nushell_completion(&cli, &nushell_script);
+
+        // Each half locates the option first and asserts it was found, because
+        // "nothing leaked" reads the same as "nothing was looked at" -- a
+        // predicate or block header that stops matching would pass silently.
+        for (command, flag, _) in OPTED_OUT {
+            let addressed = fish
+                .lines()
+                .filter(|line| {
+                    line.contains(&format!("_using_subcommand {command}\""))
+                        && line.contains(&format!(" -l {flag} "))
+                })
+                .collect::<Vec<_>>();
+            assert!(
+                !addressed.is_empty(),
+                "no fish line completes `pixi {command} --{flag}` at all any more"
+            );
+            let leaked = addressed
+                .iter()
+                .filter(|line| line.contains("--machine-readable"))
+                .collect::<Vec<_>>();
+            assert!(
+                leaked.is_empty(),
+                "fish still completes `pixi {command} --{flag}`: {leaked:#?}"
+            );
+
+            let block = format!("{} {command}", cli.bin_name);
+            let mut addressed = Vec::new();
+            rewrite_nushell_blocks(&nushell, |declared, line| {
+                if declared == block && line.trim_start().starts_with(&format!("--{flag}")) {
+                    addressed.push(line.to_string());
+                }
+                None
+            });
+            assert!(
+                !addressed.is_empty(),
+                "no `{block}` argument line names `--{flag}` any more"
+            );
+            let leaked = addressed
+                .iter()
+                .filter(|line| line.contains("nu-complete"))
+                .collect::<Vec<_>>();
+            assert!(
+                leaked.is_empty(),
+                "nushell still completes `pixi {command} --{flag}`: {leaked:#?}"
+            );
+        }
+    }
+
+    /// clap_complete gates a fish `complete` line on at most two subcommands, so
+    /// anything deeper than that cannot be addressed in fish at all. Record the
+    /// limit, and which targets it costs, so that a clap_complete bump which
+    /// starts emitting deeper predicates shows up as a failure here.
+    #[test]
+    fn test_fish_predicates_are_at_most_two_deep() {
+        let cli = real_cli();
+        let script = cli.generate(Shell::Fish);
+        let nested = Regex::new(r"_using_subcommand [^\n]*?_from [^\n]*?_from ")
+            .expect("should be able to compile the regex");
+        let unreachable = cli
+            .targets
+            .iter()
+            .filter(|target| target.path.len() > 2)
+            .map(|target| format!("pixi {} --{}", target.path.join(" "), target.long))
+            .collect::<Vec<_>>();
+        assert!(
+            !nested.is_match(&script),
+            "fish now addresses three subcommands, so `fish_option_sources` can stop \
+             keying on the first segment alone and reach {unreachable:#?}"
+        );
+        assert!(
+            !unreachable.is_empty(),
+            "nothing is out of fish's reach any more, so drop this test and the note \
+             on `fish_option_sources`"
+        );
+    }
+
+    /// fish matches only the first segment of an option's path, so a subcommand
+    /// must not mix completable and opted-out spellings of one long flag.
+    #[test]
+    fn test_fish_first_segment_is_unambiguous() {
+        let cli = real_cli();
+        let targets = &cli.targets;
+        let completable = targets
+            .iter()
+            .map(|target| target.long.as_str())
+            .collect::<HashSet<_>>();
+
+        let root = CommandArgs::command();
+        let mut found = Vec::new();
+        walk_arguments(&root, &mut |path, arg| {
+            if let Some(long) = arg.get_long()
+                && !path.is_empty()
+                && completable.contains(long)
+            {
+                found.push((path.to_vec(), long));
+            }
+        });
+
+        let mut verdicts: HashMap<(&str, &str), HashSet<bool>> = HashMap::new();
+        for (path, long) in &found {
+            let is_target = targets.iter().any(|target| {
+                target.long == *long
+                    && target
+                        .path
+                        .iter()
+                        .map(String::as_str)
+                        .eq(path.iter().copied())
+            });
+            verdicts
+                .entry((path[0], long))
+                .or_default()
+                .insert(is_target);
+        }
+        let mixed = verdicts
+            .iter()
+            .filter(|(_, verdicts)| verdicts.len() > 1)
+            .map(|((command, long), _)| format!("pixi {command} … --{long}"))
+            .collect::<Vec<_>>();
+        assert!(
+            mixed.is_empty(),
+            "fish cannot tell these apart from the subcommand alone: {mixed:#?}"
+        );
+
+        // Two targets sharing a key must at least agree on what to offer:
+        // `fish_option_sources` keeps whichever the walk inserted last.
+        let mut sources: HashMap<(&str, &str), HashSet<&str>> = HashMap::new();
+        for target in targets {
+            if let Some(first) = target.path.first() {
+                sources
+                    .entry((first.as_str(), target.long.as_str()))
+                    .or_default()
+                    .insert(target.command);
+            }
+        }
+        let disagreeing = sources
+            .iter()
+            .filter(|(_, commands)| commands.len() > 1)
+            .map(|((command, long), _)| format!("pixi {command} … --{long}"))
+            .collect::<Vec<_>>();
+        assert!(
+            disagreeing.is_empty(),
+            "fish would silently pick one source for each of these: {disagreeing:#?}"
+        );
+    }
+
+    /// Every targeted option must actually be rewritten; a clap_complete bump
+    /// that changes the generated layout has to fail here rather than silently
+    /// drop completions.
+    #[test]
+    fn test_bash_rewrites_every_target() {
+        let cli = real_cli();
+        let script = cli.generate(Shell::Bash);
+        let patched = replace_bash_completion(&cli, &script);
+
+        for target in &cli.targets {
+            let labels = iter::once(format!("--{}", target.long))
+                .chain(target.short.map(|short| format!("-{short}")));
+            for label in labels {
+                let expected = format!(
+                    "{label})\n                    {helper} \"${{cur}}\" {bin_name} {command}",
+                    helper = cli.helper(),
+                    bin_name = cli.bin_name,
+                    command = target.command
+                );
+                assert!(
+                    patched.contains(&expected),
+                    "`pixi {} {label}` still falls back to file completion",
+                    target.path.join(" ")
+                );
+            }
+        }
+    }
+
+    /// `pixi global` keeps the clap default of file completion.
+    #[test]
+    fn test_bash_leaves_global_alone() {
+        let cli = real_cli();
+        let script = cli.generate(Shell::Bash);
+        let patched = replace_bash_completion(&cli, &script);
+        let arm = format!(
+            "{}__subcmd__install)",
+            bash_arm_name(cli.bin_name, &[GLOBAL_SUBCOMMAND.to_string()])
+        );
+        let body = patched
+            .split(&arm)
+            .nth(1)
+            .expect("the `pixi global install` arm should exist");
+        let body = body.split_once("\n        ").map_or(body, |(body, _)| body);
+        assert!(
+            !body.contains(cli.helper()),
+            "`pixi global install` must not complete workspace names"
+        );
+    }
+
+    /// fish gets one `complete` line per subcommand and per visible alias. Each
+    /// must be rewritten exactly when its subcommand and long flag name
+    /// something a `pixi` subcommand can list — no more, no less.
+    #[test]
+    fn test_fish_rewrites_exactly_the_completable_lines() {
+        let cli = real_cli();
+        let sources = fish_option_sources(&cli.root, &cli.targets);
+        let script = cli.generate(Shell::Fish);
+        let patched = replace_fish_completion(&cli, &script);
+
+        // Matched against the whole line here, so the quote closing the
+        // predicate has to be excluded too.
+        let subcommand = Regex::new(r#"_using_subcommand (?P<name>[^\s;"]+)"#)
+            .expect("should be able to compile the regex");
+        let flag =
+            Regex::new(r" -l (?P<long>[\w-]+) ").expect("should be able to compile the regex");
+
+        let wrong = patched
+            .lines()
+            .filter(|line| line.starts_with("complete -c"))
+            .filter_map(|line| {
+                let name = subcommand.captures(line)?["name"].to_string();
+                let long = flag.captures(line)?["long"].to_string();
+                let completable = sources.contains_key(&(name, long));
+                let rewritten = line.contains("--machine-readable");
+                (completable != rewritten).then_some((completable, line))
+            })
+            .map(|(completable, line)| {
+                let verb = if completable { "should" } else { "must not" };
+                format!("{verb} complete workspace names: {line}")
+            })
+            .collect::<Vec<_>>();
+        assert!(wrong.is_empty(), "{wrong:#?}");
+
+        assert!(
+            patched.contains(&format!(
+                "-l environment -d 'The environment to activate in the shell' -r -f -a \"(string split ' ' ({bin_name} {ENVIRONMENT_LIST} 2> /dev/null))\"",
+                bin_name = cli.bin_name
+            )),
+            "`pixi shell --environment` should complete environment names"
+        );
+    }
+
+    /// nushell is the one shell whose flags the generator names literally, so
+    /// it is the one that can silently miss a source. Every flag has to carry a
+    /// definition, and every definition it names has to exist.
+    #[test]
+    fn test_nushell_rewrites_exactly_the_completable_arguments() {
+        let cli = real_cli();
+        let script = cli.generate(Shell::Nushell);
+        let patched = replace_nushell_completion(&cli, &script);
+        let run = format!("{} run", cli.bin_name);
+
+        let mut wrong = Vec::new();
+        rewrite_nushell_blocks(&patched, |command, line| {
+            let caps = NUSHELL_ARG_LINE.captures(line)?;
+            let name = caps["name"].to_string();
+            // The generator gives its own `nu-complete` definitions to every
+            // `ValueEnum` flag, so only our four count as a rewrite.
+            let completed = VALUE_SOURCES.iter().any(|(value_name, _)| {
+                caps["tail"].starts_with(&nushell_candidates(&cli, value_name))
+            });
+            let expected = if name == "...task" && command == run {
+                true
+            } else {
+                name.strip_prefix("--")
+                    .and_then(|long| long.split('(').next())
+                    .is_some_and(|long| nushell_completion(&cli, command, long).is_some())
+            };
+            if completed != expected {
+                let verb = if expected { "should" } else { "must not" };
+                wrong.push(format!("`{command} {name}` {verb} be completed"));
+            }
+            None
+        });
+        assert!(wrong.is_empty(), "{wrong:#?}");
+
+        for kind in patched
+            .split("string@\"nu-complete ")
+            .skip(1)
+            .filter_map(|rest| rest.split('"').next())
+        {
+            let definitions = patched
+                .matches(&format!("def \"nu-complete {kind}\" []"))
+                .count();
+            assert_eq!(
+                definitions, 1,
+                "`nu-complete {kind}` should be defined exactly once, not {definitions} times"
+            );
+        }
+    }
+
+    /// zsh keys off the clap value name, so no `_default` action may survive on
+    /// a completable spec, and every action the specs name has to be defined in
+    /// the same script.
+    #[test]
+    fn test_zsh_rewrites_every_value_spec() {
+        let cli = real_cli();
+        let script = cli.generate(Shell::Zsh);
+        let patched = replace_zsh_completion(&cli, &script);
+        let helper = cli.helper();
+        assert!(
+            patched.contains(&format!("{helper}() {{")),
+            "`{helper}` is called but never defined"
+        );
+        for (value_name, command) in VALUE_SOURCES {
+            // Counted rather than merely searched for: one rewritten spec is no
+            // evidence about the rest, and a spec clap emits with some other
+            // action (a `value_hint` would do it) would slip through.
+            let marker = format!(":{value_name}:");
+            let action = format!("{marker}{}", zsh_candidates(&cli, command));
+            let declared = patched.matches(marker.as_str()).count();
+            assert!(declared > 0, "no spec declares `{value_name}` any more");
+            assert_eq!(
+                patched.matches(action.as_str()).count(),
+                declared,
+                "only some of the {declared} `{value_name}` specs call `{action}`"
             );
         }
     }

--- a/crates/pixi_cli/src/exec.rs
+++ b/crates/pixi_cli/src/exec.rs
@@ -50,7 +50,7 @@ pub struct Args {
     /// current machine's subdir. Accepts a workspace platform name or a
     /// bare conda subdir (e.g. `linux-64`); `pixi exec` runs outside any
     /// workspace so the value resolves to a conda subdir either way.
-    #[clap(long, short)]
+    #[clap(long, short, value_name = "SUBDIR", value_hint = ValueHint::Other)]
     pub platform: Option<PixiPlatformName>,
 
     /// If specified a new environment is always created even if one already

--- a/crates/pixi_cli/src/import.rs
+++ b/crates/pixi_cli/src/import.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, ValueEnum, ValueHint};
 use indexmap::IndexSet;
 use pixi_api::workspace::platforms::resolve_platforms;
 use pixi_config::ConfigCli;
@@ -54,12 +54,12 @@ pub struct Args {
 
     /// A name for the created environment. Without `--feature` the imported
     /// content is written inline on the environment.
-    #[clap(long, short)]
+    #[clap(long, short, value_name = "NEW_ENVIRONMENT", value_hint = ValueHint::Other)]
     pub environment: Option<String>,
 
     /// A name for the created feature. The feature is added to the
     /// environment of the same name unless `--environment` is given.
-    #[clap(long, short)]
+    #[clap(long, short, value_name = "NEW_FEATURE", value_hint = ValueHint::Other)]
     pub feature: Option<FeatureName>,
 
     #[clap(flatten)]

--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -1,6 +1,6 @@
 use std::{cmp::PartialEq, collections::HashMap, path::PathBuf, str::FromStr};
 
-use clap::{Parser, ValueEnum};
+use clap::{Parser, ValueEnum, ValueHint};
 use pixi_api::{WorkspaceContext, workspace::InitOptions};
 use pixi_manifest::{CondaPypiMap, CondaPypiMapEntry};
 use rattler_conda_types::NamedChannelOrUrl;
@@ -32,7 +32,13 @@ pub struct Args {
     pub channels: Option<Vec<NamedChannelOrUrl>>,
 
     /// Platforms that the workspace supports.
-    #[arg(short, long = "platform", id = "PLATFORM")]
+    #[arg(
+        short,
+        long = "platform",
+        id = "PLATFORM",
+        value_name = "NEW_PLATFORM",
+        value_hint = ValueHint::Other
+    )]
     pub platforms: Vec<String>,
 
     /// Environment.yml file to bootstrap the workspace.

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__bash_completion.snap
@@ -2,6 +2,18 @@
 source: crates/pixi_cli/src/completion.rs
 expression: result
 ---
+_pixi_complete_values() {
+    local current="$1"
+    shift
+    local candidates
+    if candidates=$("$@" 2> /dev/null) && [[ -n "${candidates}" ]]; then
+        COMPREPLY=( $(compgen -W "${candidates}" -- "${current}") )
+    else
+        COMPREPLY=( $(compgen -f "${current}") )
+    fi
+}
+
+
         pixi__subcmd__project__subcmd__help__subcmd__help)
             opts=""
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
@@ -19,39 +31,19 @@ expression: result
                     return 0
                     ;;
                 --environment)
-                    local environments
-                    if environments=$(pixi workspace environment list --machine-readable 2> /dev/null) && [[ -n "${environments}" ]]; then
-                        COMPREPLY=( $(compgen -W "${environments}" -- "${cur}") )
-                    else
-                        COMPREPLY=($(compgen -f "${cur}"))
-                    fi
+                    _pixi_complete_values "${cur}" pixi workspace environment list --machine-readable
                     return 0
                     ;;
                 -e)
-                    local environments
-                    if environments=$(pixi workspace environment list --machine-readable 2> /dev/null) && [[ -n "${environments}" ]]; then
-                        COMPREPLY=( $(compgen -W "${environments}" -- "${cur}") )
-                    else
-                        COMPREPLY=($(compgen -f "${cur}"))
-                    fi
+                    _pixi_complete_values "${cur}" pixi workspace environment list --machine-readable
                     return 0
                     ;;
                 --platform)
-                    local platforms
-                    if platforms=$(pixi workspace platform list --machine-readable 2> /dev/null) && [[ -n "${platforms}" ]]; then
-                        COMPREPLY=( $(compgen -W "${platforms}" -- "${cur}") )
-                    else
-                        COMPREPLY=($(compgen -f "${cur}"))
-                    fi
+                    _pixi_complete_values "${cur}" pixi workspace platform list --machine-readable
                     return 0
                     ;;
                 -p)
-                    local platforms
-                    if platforms=$(pixi workspace platform list --machine-readable 2> /dev/null) && [[ -n "${platforms}" ]]; then
-                        COMPREPLY=( $(compgen -W "${platforms}" -- "${cur}") )
-                    else
-                        COMPREPLY=($(compgen -f "${cur}"))
-                    fi
+                    _pixi_complete_values "${cur}" pixi workspace platform list --machine-readable
                     return 0
                     ;;
                 --color)
@@ -70,9 +62,53 @@ expression: result
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
+        pixi__subcmd__shell)
+            opts="-e -h --environment --help"
+            if [[ ${cur} == -* ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --environment)
+                    _pixi_complete_values "${cur}" pixi workspace environment list --machine-readable
+                    return 0
+                    ;;
+                -e)
+                    _pixi_complete_values "${cur}" pixi workspace environment list --machine-readable
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        pixi__subcmd__global__subcmd__install)
+            opts="-e -h --environment --help"
+            if [[ ${cur} == -* ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --environment)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
         pixi__subcmd__search)
             opts="-c -l -v -q -h --channel --color --help <PACKAGE>"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+            if [[ ${cur} == -* ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__nushell_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__nushell_completion.snap
@@ -1,10 +1,10 @@
 ---
-source: src/cli/completion.rs
+source: crates/pixi_cli/src/completion.rs
 expression: result
 ---
   # Runs task in project
   export extern "pixi run" [
-    ...task: string@"nu-complete pixi run"           # The pixi task or a task shell command you want to run in the project's environment, which can be an executable in the environment's PATH
+    ...task: string@"nu-complete pixi task"           # The pixi task or a task shell command you want to run in the project's environment, which can be an executable in the environment's PATH
     --manifest-path: string   # The path to `pixi.toml`, `pyproject.toml`, or the project directory
     --no-lockfile-update      # Legacy flag, do not use, will be removed in subsequent version
     --frozen                  # Install the environment as defined in the lock file, doesn't update lock file if it isn't up-to-date with the manifest file
@@ -12,16 +12,27 @@ expression: result
     --no-install              # Don't modify the environment, only modify the lock file
     --tls-no-verify           # Do not verify the TLS certificate of the server
     --auth-file: string       # Path to the file containing the authentication token
-    --pypi-keyring-provider: string@"nu-complete pixi run pypi_keyring_provider" # Specifies if we want to use uv keyring provider
+    --pypi-keyring-provider: string # Specifies if we want to use uv keyring provider
     --concurrent-solves: string # Max concurrent solves, default is the number of CPUs
     --concurrent-downloads: string # Max concurrent network requests, default is 50
     --force-activate          # Do not use the environment activation cache. (default: true except in experimental mode)
-    --environment(-e): string@"nu-complete pixi run environment" # The environment to run the task in
+    --environment(-e): string@"nu-complete pixi environment" # The environment to run the task in
+    --platform(-p): string@"nu-complete pixi platform"    # Install and run in the environment for the given platform
     --clean-env               # Use a clean environment to run the task
     --skip-deps               # Don't run the dependencies of the task ('depends-on' field in the task definition)
     --verbose(-v)             # Increase logging verbosity
     --quiet(-q)               # Decrease logging verbosity
-    --color: string@"nu-complete pixi run color" # Whether the log needs to be colored
     --no-progress             # Hide all progress bars, always turned on if stderr is not a terminal
     --help(-h)                # Print help (see more with '--help')
+  ]
+
+  # Activate a shell
+  export extern "pixi shell" [
+    --environment(-e): string@"nu-complete pixi environment" # The environment to activate in the shell
+  ]
+
+  # Install a global tool
+  export extern "pixi global install" [
+    --environment(-e): string # Ensures that all packages will be installed in the same environment
+    --platform(-p): string    # The platform to install the packages for
   ]

--- a/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__zsh_completion.snap
+++ b/crates/pixi_cli/src/snapshots/pixi_cli__completion__tests__zsh_completion.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/completion.rs
+source: crates/pixi_cli/src/completion.rs
 expression: result
 ---
 
@@ -10,20 +10,12 @@ _arguments "${_arguments_options[@]}" \
 && ret=0
 ;;
 (run)
-local tasks
-tasks=("${(@s/ /)$(pixi task list --machine-readable 2> /dev/null)}")
-
-if [[ -n "$tasks" ]]; then
-    _values 'task' "${tasks[@]}"
-else
-    return 1
-fi
 _arguments "${_arguments_options[@]}" \
 '--manifest-path=[The path to '\''pixi.toml'\'']:MANIFEST_PATH:_files' \
-'-e+[The environment to run the task in]:ENVIRONMENT:($(pixi workspace environment list --machine-readable 2> /dev/null))' \
-'--environment=[The environment to run the task in]:ENVIRONMENT:($(pixi workspace environment list --machine-readable 2> /dev/null))' \
-'-p+[Install and run in the environment for the given platform]:PLATFORM:($(pixi workspace platform list --machine-readable 2> /dev/null))' \
-'--platform=[Install and run in the environment for the given platform]:PLATFORM:($(pixi workspace platform list --machine-readable 2> /dev/null))' \
+'-e+[The environment to run the task in]:ENVIRONMENT:{_pixi_complete_values workspace environment list --machine-readable}' \
+'--environment=[The environment to run the task in]:ENVIRONMENT:{_pixi_complete_values workspace environment list --machine-readable}' \
+'-p+[Install and run in the environment for the given platform]:PLATFORM:{_pixi_complete_values workspace platform list --machine-readable}' \
+'--platform=[Install and run in the environment for the given platform]:PLATFORM:{_pixi_complete_values workspace platform list --machine-readable}' \
 '--color=[Whether the log needs to be colored]:COLOR:(always never auto)' \
 '(--frozen)--locked[Require pixi.lock is up-to-date]' \
 '(--locked)--frozen[Don'\''t check if pixi.lock is up-to-date, install as lock file states]' \
@@ -33,7 +25,7 @@ _arguments "${_arguments_options[@]}" \
 '(-v --verbose)*--quiet[Less output per occurrence]' \
 '-h[Print help]' \
 '--help[Print help]' \
-'::task -- The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.:' \
+'*::task -- The pixi task or a deno task shell command you want to run in the project's environment, which can be an executable in the environment's PATH.:{_pixi_complete_values task list --machine-readable}' \
 && ret=0
 ;;
 (add)
@@ -46,7 +38,7 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (shell)
 _arguments "${_arguments_options[@]}" \
+'-e+[The environment to activate in the shell]:ENVIRONMENT:{_pixi_complete_values workspace environment list --machine-readable}' \
+'--environment=[The environment to activate in the shell]:ENVIRONMENT:{_pixi_complete_values workspace environment list --machine-readable}' \
 && ret=0
 ;;
-
-

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -77,7 +77,7 @@ pub struct AddArgs {
     pub commands: Vec<String>,
 
     /// Depends on these other commands.
-    #[clap(long)]
+    #[clap(long, value_name = "TASK")]
     #[clap(num_args = 1..)]
     pub depends_on: Option<Vec<Dependency>>,
 
@@ -105,7 +105,7 @@ pub struct AddArgs {
     pub env: Vec<(String, String)>,
 
     /// Add a default environment for the task.
-    #[arg(long)]
+    #[arg(long, value_name = "ENVIRONMENT")]
     pub default_environment: Option<EnvironmentName>,
 
     /// A description of the task to be added.

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -56,14 +56,14 @@ pub struct UpdateSpecsArgs {
 
     /// The environments to update. If none is specified, all environments are
     /// updated.
-    #[clap(long = "environment", short = 'e')]
+    #[clap(long = "environment", short = 'e', value_name = "ENVIRONMENT")]
     pub environments: Option<Vec<EnvironmentName>>,
 
     /// The platforms to update. If none is specified, all platforms are
     /// updated. Accepts a workspace platform name; a bare conda subdir
     /// (e.g. `linux-64`) is also accepted so users don't have to declare
     /// a platform before targeting it.
-    #[clap(long = "platform", short = 'p')]
+    #[clap(long = "platform", short = 'p', value_name = "PLATFORM")]
     pub platforms: Option<Vec<PixiPlatformName>>,
 }
 

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -32,7 +32,7 @@ pub struct AddArgs {
     pub name: EnvironmentName,
 
     /// Features to add to the environment.
-    #[arg(short, long = "feature")]
+    #[arg(short, long = "feature", value_name = "FEATURE")]
     pub features: Option<Vec<String>>,
 
     /// The solve-group to add the environment to.

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -32,10 +32,18 @@ pub struct RemoveArgs {
 }
 
 #[derive(Parser, Debug)]
+pub struct ListArgs {
+    /// Output the feature names in machine readable format (space delimited).
+    /// This output is used for autocomplete.
+    #[arg(long, hide(true))]
+    pub machine_readable: bool,
+}
+
+#[derive(Parser, Debug)]
 pub enum Command {
     /// List the features in the manifest file.
     #[clap(visible_alias = "ls")]
-    List,
+    List(ListArgs),
     /// Remove a feature from the manifest file.
     #[clap(visible_alias = "rm")]
     Remove(RemoveArgs),
@@ -50,9 +58,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
 
     match args.command {
-        Command::List => {
+        Command::List(list_args) => {
             let features = workspace_ctx.list_features().await;
-            writeln!(std::io::stdout(), "{}", format_feature_list(&features))
+            let output = if list_args.machine_readable {
+                features.keys().map(FeatureName::as_str).join(" ")
+            } else {
+                format_feature_list(&features)
+            };
+            writeln!(std::io::stdout(), "{output}")
                 .inspect_err(|e| {
                     if e.kind() == std::io::ErrorKind::BrokenPipe {
                         std::process::exit(0);

--- a/docs/reference/cli/pixi/exec.md
+++ b/docs/reference/cli/pixi/exec.md
@@ -28,7 +28,7 @@ pixi exec [OPTIONS] [COMMAND]...
 - <a id="arg---channel" href="#arg---channel">`--channel (-c) <CHANNEL>`</a>
 :  The channels to consider as a name or a url. Multiple channels can be specified by using this field multiple times
 <br>May be provided more than once.
-- <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
+- <a id="arg---platform" href="#arg---platform">`--platform (-p) <SUBDIR>`</a>
 :  The platform to create the environment for. Defaults to the current machine's subdir. Accepts a workspace platform name or a bare conda subdir (e.g. `linux-64`); `pixi exec` runs outside any workspace so the value resolves to a conda subdir either way
 - <a id="arg---force-reinstall" href="#arg---force-reinstall">`--force-reinstall`</a>
 :  If specified a new environment is always created even if one already exists

--- a/docs/reference/cli/pixi/import.md
+++ b/docs/reference/cli/pixi/import.md
@@ -25,9 +25,9 @@ pixi import [OPTIONS] <FILE>
 - <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
 :  The platforms for the imported environment. Accepts a workspace platform name; a bare conda subdir (e.g. `linux-64`) is also accepted. Names that aren't yet declared get auto-added as subdir platforms
 <br>May be provided more than once.
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <NEW_ENVIRONMENT>`</a>
 :  A name for the created environment. Without `--feature` the imported content is written inline on the environment
-- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
+- <a id="arg---feature" href="#arg---feature">`--feature (-f) <NEW_FEATURE>`</a>
 :  A name for the created feature. The feature is added to the environment of the same name unless `--environment` is given
 
 ## Config Options

--- a/docs/reference/cli/pixi/init.md
+++ b/docs/reference/cli/pixi/init.md
@@ -22,7 +22,7 @@ pixi init [OPTIONS] [PATH]
 - <a id="arg---channel" href="#arg---channel">`--channel (-c) <CHANNEL>`</a>
 :  Channel to use in the workspace
 <br>May be provided more than once.
-- <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
+- <a id="arg---platform" href="#arg---platform">`--platform (-p) <NEW_PLATFORM>`</a>
 :  Platforms that the workspace supports
 <br>May be provided more than once.
 - <a id="arg---import" href="#arg---import">`--import (-i) <ENVIRONMENT_FILE>`</a>

--- a/docs/reference/cli/pixi/task/add.md
+++ b/docs/reference/cli/pixi/task/add.md
@@ -23,7 +23,7 @@ pixi task add [OPTIONS] <NAME> <COMMAND>...
 <br>**required**: `true`
 
 ## Options
-- <a id="arg---depends-on" href="#arg---depends-on">`--depends-on <DEPENDS_ON>`</a>
+- <a id="arg---depends-on" href="#arg---depends-on">`--depends-on <TASK>`</a>
 :  Depends on these other commands
 <br>May be provided more than once.
 - <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
@@ -37,7 +37,7 @@ pixi task add [OPTIONS] <NAME> <COMMAND>...
 - <a id="arg---env" href="#arg---env">`--env <ENV>`</a>
 :  The environment variable to set, use --env key=value multiple times for more than one variable
 <br>May be provided more than once.
-- <a id="arg---default-environment" href="#arg---default-environment">`--default-environment <DEFAULT_ENVIRONMENT>`</a>
+- <a id="arg---default-environment" href="#arg---default-environment">`--default-environment <ENVIRONMENT>`</a>
 :  Add a default environment for the task
 - <a id="arg---description" href="#arg---description">`--description <DESCRIPTION>`</a>
 :  A description of the task to be added

--- a/docs/reference/cli/pixi/update.md
+++ b/docs/reference/cli/pixi/update.md
@@ -24,10 +24,10 @@ pixi update [OPTIONS] [PACKAGES]...
 <br>**env**: `PIXI_NO_INSTALL`
 - <a id="arg---dry-run" href="#arg---dry-run">`--dry-run (-n)`</a>
 :  Don't actually write the lock file or update any environment
-- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENTS>`</a>
+- <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  The environments to update. If none is specified, all environments are updated
 <br>May be provided more than once.
-- <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORMS>`</a>
+- <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>
 :  The platforms to update. If none is specified, all platforms are updated. Accepts a workspace platform name; a bare conda subdir (e.g. `linux-64`) is also accepted so users don't have to declare a platform before targeting it
 <br>May be provided more than once.
 - <a id="arg---json" href="#arg---json">`--json`</a>

--- a/docs/reference/cli/pixi/workspace/environment/add.md
+++ b/docs/reference/cli/pixi/workspace/environment/add.md
@@ -19,7 +19,7 @@ pixi workspace environment add [OPTIONS] <NAME>
 <br>**required**: `true`
 
 ## Options
-- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURES>`</a>
+- <a id="arg---feature" href="#arg---feature">`--feature (-f) <FEATURE>`</a>
 :  Features to add to the environment
 <br>May be provided more than once.
 - <a id="arg---solve-group" href="#arg---solve-group">`--solve-group <SOLVE_GROUP>`</a>

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -13,6 +13,7 @@ from dirty_equals import AnyThing, IsDict, IsList, IsStr
 from inline_snapshot import snapshot
 
 from .common import (
+    ALL_PLATFORMS,
     CONDA_FORGE_CHANNEL,
     CURRENT_PLATFORM,
     EMPTY_BOILERPLATE_PROJECT,
@@ -877,11 +878,11 @@ def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     # An explicit multi-platform list (always including the current platform)
     # keeps the platform-completion assertions deterministic across machines.
-    toml = """
+    toml = f"""
         [workspace]
         name = "test"
         channels = []
-        platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+        platforms = {ALL_PLATFORMS}
 
         [tasks]
         hello = "echo hello"
@@ -934,10 +935,50 @@ def test_bash_run_task_completion(pixi: Path, tmp_pixi_workspace: Path) -> None:
     assert complete(["pixi", "run", "-e", "te"]) == ["test"]
 
     # `-p`/`--platform` complete platform names instead of file paths.
-    all_platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+    all_platforms = sorted(json.loads(ALL_PLATFORMS))
     assert complete(["pixi", "run", "-p", ""]) == all_platforms
     assert complete(["pixi", "run", "--platform", ""]) == all_platforms
     assert complete(["pixi", "run", "-p", "osx"]) == ["osx-64", "osx-arm64"]
+
+    # Every subcommand taking a workspace environment or platform completes
+    # them, not just `run` (https://github.com/prefix-dev/pixi/issues/6674).
+    # `update` takes both as a repeated `Vec`, which only completes as long as
+    # the args pin their `value_name` (clap would derive `ENVIRONMENTS`).
+    for subcommand in (["shell"], ["shell-hook"], ["install"], ["task", "add"], ["update"]):
+        assert complete(["pixi", *subcommand, "-e", ""]) == all_environments, subcommand
+        assert complete(["pixi", *subcommand, "--environment", ""]) == all_environments, subcommand
+    for subcommand in (["install"], ["add"], ["task", "add"], ["update"]):
+        assert complete(["pixi", *subcommand, "-p", ""]) == all_platforms, subcommand
+        assert complete(["pixi", *subcommand, "--platform", ""]) == all_platforms, subcommand
+    assert complete(["pixi", "task", "add", "--default-environment", ""]) == all_environments
+
+    # `--feature` completes feature names, `--depends-on` task names.
+    all_features = ["default", "test"]
+    for subcommand in (["add"], ["remove"], ["upgrade"], ["task", "add"]):
+        assert complete(["pixi", *subcommand, "-f", ""]) == all_features, subcommand
+        assert complete(["pixi", *subcommand, "--feature", ""]) == all_features, subcommand
+    assert complete(["pixi", "task", "add", "t", "--depends-on", ""]) == all_tasks
+
+    # `pixi global` has its own environment namespace and installs for conda
+    # subdirs, so it must keep falling back to the default file completion.
+    paths = complete(["pixi", "install", "--manifest-path", ""])
+    assert complete(["pixi", "global", "install", "-e", ""]) == paths
+    assert complete(["pixi", "global", "install", "-p", ""]) == paths
+
+    # `pixi workspace register -p` is a path, not a platform.
+    assert complete(["pixi", "workspace", "register", "-p", ""]) == paths
+
+    # Options naming something the workspace does not have yet offer nothing at
+    # all: `init` and `exec` resolve a platform without a workspace, and
+    # `import` names the environment and feature it creates. There is no list to
+    # draw on, and file paths would be pure noise, so they declare
+    # `ValueHint::Other` and complete to nothing.
+    assert complete(["pixi", "init", "-p", ""]) == []
+    assert complete(["pixi", "exec", "-p", ""]) == []
+    assert complete(["pixi", "import", "-e", ""]) == []
+    assert complete(["pixi", "import", "-f", ""]) == []
+    # `import -p` does take a declared platform name.
+    assert complete(["pixi", "import", "-p", ""]) == all_platforms
 
 
 def test_pixi_info_tasks(pixi: Path, tmp_pixi_workspace: Path) -> None:

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -3,7 +3,6 @@ import os
 import platform
 import shlex
 import shutil
-import sys
 import tomllib
 from pathlib import Path
 
@@ -20,6 +19,7 @@ from .common import (
     PIXI_VERSION,
     ExitCode,
     find_commands_supporting_frozen_and_no_install,
+    repo_root,
     verify_cli_command,
 )
 
@@ -1244,11 +1244,27 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Fish shell is not supported on Windows",
+    platform.system() == "Windows",
+    reason="fish, zsh and nushell are not available on Windows",
 )
 @pytest.mark.slow
-def test_fish_completions(pixi: Path, tmp_pixi_workspace: Path) -> None:
+@pytest.mark.parametrize(
+    ("shell", "package", "parse_command"),
+    [
+        # `pixi completion` writes hand-rolled shell code for these three, so
+        # each one has to at least parse in the shell it targets.
+        ("fish", "fish", ["fish", "-c", "source {script}"]),
+        ("zsh", "zsh", ["zsh", "-n", "{script}"]),
+        ("nushell", "nushell", ["nu", "-c", "source {script}"]),
+    ],
+)
+def test_completion_scripts_parse(
+    pixi: Path,
+    tmp_pixi_workspace: Path,
+    shell: str,
+    package: str,
+    parse_command: list[str],
+) -> None:
     manifest = tmp_pixi_workspace.joinpath("pixi.toml")
     toml = f"""
 [workspace]
@@ -1257,28 +1273,123 @@ channels = ["{CONDA_FORGE_CHANNEL}"]
 platforms = ["{CURRENT_PLATFORM}"]
         """
     manifest.write_text(toml)
-    # install fish
-    verify_cli_command([pixi, "add", "fish", "--manifest-path", tmp_pixi_workspace])
+    verify_cli_command([pixi, "add", package, "--manifest-path", tmp_pixi_workspace])
 
-    # Verify that the shell hook generates the correct completions
-    output = verify_cli_command([pixi, "completion", "--shell", "fish"])
-    out = output.stdout
-    # write output to file
-    fish_completion_file = tmp_pixi_workspace / "pixi.fish"
-    fish_completion_file.write_text(out)
+    script = tmp_pixi_workspace / f"pixi-completion.{shell}"
+    script.write_text(verify_cli_command([pixi, "completion", "--shell", shell]).stdout)
 
-    # Check that the file can be parsed by fish
     verify_cli_command(
-        [
-            pixi,
-            "run",
-            "--manifest-path",
-            tmp_pixi_workspace,
-            "fish",
-            "-c",
-            f"source {fish_completion_file}",
-        ],
+        [pixi, "run", "--manifest-path", tmp_pixi_workspace]
+        + [word.format(script=script) for word in parse_command],
     )
+
+
+def complete_in_zsh(pixi: Path, workspace: Path, line: str) -> str:
+    """Type `line` in a real zsh with the generated completion loaded.
+
+    Returns the resulting command line. `workspace` must already hold a
+    manifest.
+
+    Whether a candidate source is actually reached is invisible to the snapshot
+    tests: a spec that names the helper the wrong way still looks right and just
+    silently falls back to completing files.
+    """
+    # zsh autoloads the script by file name, from a directory on `fpath`.
+    completion_dir = workspace / "completions"
+    completion_dir.mkdir()
+    completion_dir.joinpath("_pixi").write_text(
+        verify_cli_command([pixi, "completion", "--shell", "zsh"]).stdout
+    )
+
+    probe = repo_root() / "tests" / "scripts" / "zsh-completion-probe.zsh"
+    probe_arguments = [str(probe), str(completion_dir), str(workspace), line]
+    command: list[Path | str]
+    if platform.system() == "Darwin":
+        # conda-forge's macOS zsh is built without loadable modules, so it
+        # cannot `zmodload zsh/zpty`. The system zsh can, and the probe shell
+        # needs nothing from the workspace.
+        command = ["/bin/zsh", *probe_arguments]
+    else:
+        # Elsewhere the shell comes from the workspace, so the test does not
+        # depend on the host having a zsh at all.
+        verify_cli_command([pixi, "add", "zsh", "--manifest-path", workspace])
+        command = [pixi, "run", "--manifest-path", workspace, "zsh", *probe_arguments]
+
+    return verify_cli_command(
+        command,
+        # The completion script shells out to bare `pixi`.
+        env={"PATH": f"{pixi.parent.resolve()}{os.pathsep}{os.environ['PATH']}"},
+    ).stdout.strip()
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(platform.system() == "Windows", reason="zsh and zpty are not available")
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        # `--environment` and `--platform` reach the helper through `_arguments`,
+        # which invokes an action with its own `compadd` options prepended --
+        # something only a real shell exercises.
+        ("pixi run -e te", "pixi run -e test"),
+        ("pixi run -p osx-a", "pixi run -p osx-arm64"),
+        ("pixi task add t --depends-on he", "pixi task add t --depends-on hello"),
+        # Task names belong to the positional argument of `pixi run` -- there
+        # they complete, and as the value of one of its options they must not:
+        # `he` after `-e` matches no environment and so completes to nothing.
+        ("pixi run he", "pixi run hello"),
+        ("pixi run -e he", "pixi run -e he"),
+        # `pixi init -p` names a platform the workspace does not have yet, so it
+        # offers nothing -- not the `tea.txt` the shell default would find.
+        ("pixi init -p tea", "pixi init -p tea"),
+        # Below `pixi global` the helper has to defer to the default completion,
+        # which here means the file `tea.txt` rather than the `test` environment.
+        ("pixi global install -e tea", "pixi global install -e tea.txt"),
+    ],
+)
+def test_zsh_completion_offers_workspace_names(
+    pixi: Path, tmp_pixi_workspace: Path, line: str, expected: str
+) -> None:
+    # `osx-arm64` gives `-p` something to complete that is not the host, but on
+    # an osx-arm64 host naming it twice is a duplicate platform and rejected.
+    platforms = ", ".join(f'"{name}"' for name in sorted({CURRENT_PLATFORM, "osx-arm64"}))
+    tmp_pixi_workspace.joinpath("pixi.toml").write_text(f"""
+[workspace]
+name = "test"
+channels = ["{CONDA_FORGE_CHANNEL}"]
+platforms = [{platforms}]
+
+[tasks]
+hello = "echo hello"
+
+[environments]
+test = []
+""")
+    # `tea.txt` is what the `pixi global` case must fall back to, and it also
+    # keeps `te` from being a unique file prefix in the other cases.
+    tmp_pixi_workspace.joinpath("tea.txt").touch()
+
+    assert complete_in_zsh(pixi, tmp_pixi_workspace, line) == expected
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(platform.system() == "Windows", reason="zsh and zpty are not available")
+def test_zsh_completion_offers_run_flags_without_tasks(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """`pixi run` must keep completing its own flags when there are no tasks.
+
+    Task completion is bolted onto the `run` arm by hand, so an empty task list
+    must not cost the arm the option completion `_arguments` gives every other
+    subcommand.
+    """
+    tmp_pixi_workspace.joinpath("pixi.toml").write_text(f"""
+[workspace]
+name = "test"
+channels = ["{CONDA_FORGE_CHANNEL}"]
+platforms = ["{CURRENT_PLATFORM}"]
+""")
+
+    assert complete_in_zsh(pixi, tmp_pixi_workspace, "pixi run --froz") == "pixi run --frozen"
 
 
 @pytest.mark.slow

--- a/tests/scripts/zsh-completion-probe.zsh
+++ b/tests/scripts/zsh-completion-probe.zsh
@@ -1,0 +1,101 @@
+#!/usr/bin/env zsh
+#
+# Report what the generated zsh completion inserts for one command line.
+#
+#   zsh-completion-probe.zsh <completion-dir> <workspace-dir> <line>
+#
+# Loads `<completion-dir>/_pixi` into a real interactive zsh, types <line>,
+# presses Tab, and prints the resulting command line on stdout. Driving an
+# actual shell is the only way to cover how `_arguments` invokes our action:
+# it prepends its own `compadd` options, which a direct call to the helper
+# would never show.
+#
+# The command line is read back through a widget that writes `$BUFFER` to a
+# file rather than by scraping the terminal, so the result is exact.
+#
+# Every wait below gives up after $TIMEOUT seconds. A probe shell that never
+# prompts, never finishes setup or never reports a buffer has to fail the
+# caller rather than hang it.
+
+emulate -L zsh
+setopt no_unset
+
+zmodload zsh/zpty
+zmodload zsh/datetime
+
+# Seconds to wait for each step, and how often to look while waiting. Plain
+# scalars, not `typeset -F`, so they read as `5` rather than `5.000000000` in
+# the messages below and in `sleep`.
+typeset TIMEOUT=5
+typeset POLL=0.05
+
+completion_dir=${1:?completion dir}
+workspace=${2:?workspace dir}
+line=${3:?line to complete}
+
+buffer_file=$workspace/.probe-buffer
+rm -f -- $buffer_file
+
+typeset prompt='PROBE-READY>'
+typeset chunk
+
+# `-f` keeps the user's startup files out of it; `-i` is needed for zle, which
+# is what makes Tab run completion at all.
+zpty -b probe "PS1='$prompt' zsh -f -i"
+trap 'zpty -d probe 2>/dev/null' EXIT
+
+# Wait until the shell prompts, so setup cannot race its startup.
+#
+# Polls and accumulates instead of letting `zpty -r` block on the pattern
+# itself: a blocking read has no timeout, and whether `-t` keeps unmatched
+# output for the next call is not something to depend on.
+await_prompt() {
+    local seen=
+    local -F deadline=$(( EPOCHREALTIME + TIMEOUT ))
+    while (( EPOCHREALTIME < deadline )); do
+        while zpty -r -t probe chunk 2>/dev/null; do
+            seen+=$chunk
+            [[ $seen == *${prompt}* ]] && return 0
+        done
+        sleep $POLL
+    done
+    return 1
+}
+
+if ! await_prompt; then
+    print -u2 "zsh-completion-probe: no prompt from the probe shell within ${TIMEOUT}s"
+    exit 1
+fi
+
+zpty -w probe "fpath=(${(q)completion_dir} \$fpath)"
+zpty -w probe "autoload -Uz compinit && compinit -u -d ${(q)workspace}/.zcompdump"
+# Tab must insert a unique match outright instead of opening a menu, so that
+# the buffer alone tells us what was offered.
+zpty -w probe 'unsetopt auto_menu auto_list'
+zpty -w probe "report_buffer() { print -r -- \$BUFFER >! ${(q)buffer_file} }"
+zpty -w probe 'zle -N report_buffer; bindkey "^G" report_buffer'
+zpty -w probe "cd ${(q)workspace}"
+if ! await_prompt; then
+    print -u2 "zsh-completion-probe: the probe shell did not finish setup within ${TIMEOUT}s"
+    exit 1
+fi
+
+# `-n` sends the keys without a newline, so nothing is executed.
+zpty -w -n probe "$line"
+zpty -w -n probe $'\t'
+zpty -w -n probe $'\C-g'
+
+typeset -F deadline=$(( EPOCHREALTIME + TIMEOUT ))
+while (( EPOCHREALTIME < deadline )); do
+    [[ -s $buffer_file ]] && break
+    # Keep draining, or the pty fills up and the shell stops making progress.
+    zpty -r -t probe chunk >/dev/null 2>&1
+    sleep $POLL
+done
+
+if [[ ! -s $buffer_file ]]; then
+    print -u2 "zsh-completion-probe: the probe shell reported no buffer within ${TIMEOUT}s"
+    exit 1
+fi
+
+cat -- $buffer_file


### PR DESCRIPTION
### Description

Completion of environment, platform, feature and task names was hand-wired into the pixi run arm of each generated script. Every other subcommand that takes one of those names fell back to completing file paths, so pixi shell -e offered the contents of the current directory.

This walks the clap command tree instead and rewrites every option whose declared value name says it takes a listable name, in all four shells whose scripts pixi completion hand-patches.

Fixes [#1616](<https://github.com/prefix-dev/pixi/issues/1616>)  <br>Fixes prefix-dev/pixi#6674

What this fixes

* Options naming a workspace environment, platform, feature or task completed file paths everywhere except pixi run. They now complete names under every subcommand — pixi shell -e, pixi  <br>update -p, pixi add -f, pixi task add --depends-on, and the rest — in bash, zsh, fish and nushell.
* Feature names could not be completed at all: there was nothing to list them. pixi workspace feature list gains the hidden --machine-readable its environment and platform counterparts  <br>already had.
* zsh offered task names as the value of an option, so pixi run -e proposed tasks alongside environments. Task names now come from the rest argument's own completion spec, which only fires where a task can go.
* zsh gave pixi run no completion at all — not even its own flags — when the workspace had no tasks, or when run outside a workspace. The task lookup used to return before \_arguments ran.
* zsh recognised only one rest argument for pixi run: the rewrite dropped the leading \* from the \*::task spec.
* zsh never completed task names for pixi r, the alias: only the first of the two generated arms was rewritten.
* nushell stopped scanning an export extern block at the first \] in an option's help text, silently leaving every later argument in that block alone. pixi shell-hook --shell has one in its help, which is why pixi shell-hook -e did not complete in nushell.
* Options that name something the workspace does not have yet completed file paths: pixi init -p, pixi exec -p, pixi import -e and pixi import -f. There is nothing to offer for these, so  <br>they now offer nothing rather than directory contents.

### How Has This Been Tested?

Unit tests and some manual testing in different shells

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.