### PR TITLE
docs: explain that `$PREFIX` is not expanded on Windows

### DIFF
--- a/docs/build/backends/pixi-build-cmake.md
+++ b/docs/build/backends/pixi-build-cmake.md
@@ -107,6 +107,8 @@ env = { COMMON_VAR = "linux", LINUX_VAR = "value" }
 # Result for linux-64: { CMAKE_VERBOSE_MAKEFILE = "OFF", COMMON_VAR = "linux", LINUX_VAR = "value" }
 ```
 
+--8<-- "docs/partials/build-config-env-expansion.md"
+
 ### `debug-dir`
 
 The backend always writes JSON-RPC request/response logs and the generated intermediate recipe to the `debug` subdirectory inside each work directory (for example `<work_directory>/debug`). The deprecated `debug-dir` configuration option is ignored; if it is present in a manifest a warning is emitted.

--- a/docs/build/backends/pixi-build-python.md
+++ b/docs/build/backends/pixi-build-python.md
@@ -119,6 +119,8 @@ env = { COMMON_VAR = "windows", WIN_SPECIFIC = "value" }
 # Result for win-64: { PYTHONPATH = "/base/path", COMMON_VAR = "windows", WIN_SPECIFIC = "value" }
 ```
 
+--8<-- "docs/partials/build-config-env-expansion.md"
+
 ### `debug-dir`
 
 The backend always writes JSON-RPC request/response logs and the generated intermediate recipe to the `debug` subdirectory inside the work directory (for example `<work_directory>/debug`). The deprecated `debug-dir` configuration option is ignored; if present, a warning is emitted to highlight that the setting no longer has any effect.

--- a/docs/build/backends/pixi-build-r.md
+++ b/docs/build/backends/pixi-build-r.md
@@ -106,7 +106,7 @@ Environment variables to set during the build process. These variables are avail
 
 ```toml
 [package.build.config]
-env = { R_LIBS_USER = "$PREFIX/lib/R/library" }
+env = { R_KEEP_PKG_SOURCE = "yes" }
 ```
 
 For target-specific configuration, platform environment variables are merged with base variables:
@@ -119,6 +119,8 @@ env = { COMMON_VAR = "base" }
 env = { COMMON_VAR = "windows", WIN_SPECIFIC = "value" }
 # Result for win-64: { COMMON_VAR = "windows", WIN_SPECIFIC = "value" }
 ```
+
+--8<-- "docs/partials/build-config-env-expansion.md"
 
 ### `extra-input-globs`
 

--- a/docs/build/backends/pixi-build-ros.md
+++ b/docs/build/backends/pixi-build-ros.md
@@ -199,6 +199,8 @@ The ROS backend keeps the following variables in sync with the selected distro, 
 These values are available both while evaluating `package.xml` conditionals and during the generated build script. Any custom entries you provide in `env` are merged on top of these defaults.
 If you explicitly set `ROS_DISTRO` or `ROS_VERSION` in `env`, your values take precedence over the defaults.
 
+--8<-- "docs/partials/build-config-env-expansion.md"
+
 ### `debug-dir`
 
 The backend always writes JSON-RPC request/response logs and the generated intermediate recipe to the `debug` subdirectory inside the work directory (for example `<work_directory>/debug`). The deprecated `debug-dir` configuration option is ignored; if it is still present in a manifest the backend emits a warning so you can safely remove it.

--- a/docs/build/backends/pixi-build-rust.md
+++ b/docs/build/backends/pixi-build-rust.md
@@ -145,6 +145,8 @@ env = { COMMON_VAR = "linux", CARGO_PROFILE_RELEASE_LTO = "true" }
 # Result for linux-64: { RUST_LOG = "info", COMMON_VAR = "linux", CARGO_PROFILE_RELEASE_LTO = "true" }
 ```
 
+--8<-- "docs/partials/build-config-env-expansion.md"
+
 ### `debug-dir`
 
 The backend always writes JSON-RPC request/response logs and the generated intermediate recipe to the `debug` subdirectory inside the work directory (for example `<work_directory>/debug`). The deprecated `debug-dir` configuration option is ignored; when present a warning is emitted so you can safely remove the setting.

--- a/docs/partials/build-config-env-expansion.md
+++ b/docs/partials/build-config-env-expansion.md
@@ -1,0 +1,18 @@
+!!! warning "Variable references are not expanded by pixi"
+    Values are passed to the build shell unchanged, so a reference like `$PREFIX` is only resolved if that shell understands it.
+    Linux and macOS builds run through `bash`, which expands `$PREFIX`.
+    Windows builds run through `cmd.exe`, which expands `%PREFIX%` and leaves `$PREFIX` as literal text.
+
+    Use target-specific configuration when you need both:
+
+    ```toml
+    [package.build.target.unix.config]
+    env = { MY_INCLUDE_DIR = "$PREFIX/include" }
+
+    [package.build.target.win.config]
+    env = { MY_INCLUDE_DIR = "%PREFIX%\\Library\\include" }
+    ```
+
+    `${{ PREFIX }}` is not an alternative here.
+    Templates in `env` are rendered while the recipe is evaluated, which happens before the build prefix exists.
+    They only work in build scripts.


### PR DESCRIPTION
### Description

`$PREFIX` in `[package.build.config.env]` works on Linux and macOS and silently does not on Windows, see #6510.

The values are handed to the build shell unchanged. `build_env.sh` gets `export CUDA_HOME="$PREFIX/Library"` and bash expands it. `build_env.bat` gets `@SET "CUDA_HOME=$PREFIX/Library"` and cmd.exe leaves it alone. Nothing in pixi or rattler-build expands these values, so the unix behaviour is really just bash doing its job.

This documents the difference rather than changing it. A shared partial now sits at the end of the `env` section on every backend page: `$PREFIX` for unix, `%PREFIX%` for Windows, and `${{ PREFIX }}` is not a way around it because `env` values are rendered while the recipe is evaluated, before a build prefix exists.

The `pixi-build-r` page also had `env = { R_LIBS_USER = "$PREFIX/lib/R/library" }` as its only example, which is exactly the trap from the issue. Replaced it with something platform neutral.

I left #6510 open instead of closing it, in case we want to make the two platforms behave the same. WDYT @Hofer-Julian ?

### How Has This Been Tested?

`pixi run -e docs build-docs` (`mkdocs build --strict`) passes, and the note renders on all five backend pages. `unix` and `win` are both valid target selectors, and `[package.build.target.unix.config]` is already used in `tests/data/pixi-build/env-config-target-cmake-test`.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
