### PR TITLE
feat(info): report the git commit pixi was built from

### DIFF
--- a/crates/pixi/build.rs
+++ b/crates/pixi/build.rs
@@ -1,0 +1,40 @@
+use std::{env, process::Command};
+
+/// Records the commit `pixi` is built from in the `PIXI_GIT_SHA` compile-time
+/// environment variable, read back by `main.rs`. It lives in the binary crate
+/// so that moving to a new commit only invalidates this package.
+///
+/// Set `PIXI_GIT_SHA` in the build environment to supply it directly, e.g. when
+/// building from a source archive that carries no git metadata. With neither
+/// available `pixi info` omits the `Git SHA` line and reports `null` in its
+/// JSON output.
+fn main() {
+    println!("cargo::rerun-if-env-changed=PIXI_GIT_SHA");
+    if env::var_os("PIXI_GIT_SHA").is_some() {
+        return;
+    }
+
+    let Some(sha) = git(&["rev-parse", "--short=9", "HEAD"]) else {
+        return;
+    };
+    println!("cargo::rustc-env=PIXI_GIT_SHA={sha}");
+
+    // Rebuild when HEAD moves so the recorded SHA cannot go stale.
+    if let Some(git_dir) = git(&["rev-parse", "--absolute-git-dir"]) {
+        println!("cargo::rerun-if-changed={git_dir}/HEAD");
+        if let Some(head_ref) = git(&["symbolic-ref", "--quiet", "HEAD"]) {
+            println!("cargo::rerun-if-changed={git_dir}/{head_ref}");
+        }
+    }
+}
+
+/// Runs `git` with `args`, returning its trimmed stdout on success.
+fn git(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let stdout = stdout.trim();
+    (!stdout.is_empty()).then(|| stdout.to_string())
+}

--- a/crates/pixi/src/main.rs
+++ b/crates/pixi/src/main.rs
@@ -37,7 +37,11 @@ pub fn main() -> miette::Result<()> {
             .expect("Failed building the Runtime");
 
         // Box the large main future to avoid stack overflows.
-        runtime.block_on(Box::pin(pixi_cli::execute()))
+        //
+        // `option_env!` reads the commit at compile time from the env var this
+        // crate's build script sets. Resolving it here, in the leaf binary
+        // crate, keeps moving to a new commit from rebuilding anything else.
+        runtime.block_on(Box::pin(pixi_cli::execute(option_env!("PIXI_GIT_SHA"))))
     };
 
     std::thread::Builder::new()

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, io::Write, path::PathBuf};
+use std::{fmt::Display, io::Write, path::PathBuf, sync::OnceLock};
 
 use chrono::{DateTime, Local};
 use clap::Parser;
@@ -26,6 +26,18 @@ use tokio::task::spawn_blocking;
 use crate::cli_config::WorkspaceConfig;
 
 static WIDTH: usize = 19;
+
+/// The commit the running binary was built from, handed over by the binary
+/// crate through [`crate::execute`].
+static GIT_SHA: OnceLock<&'static str> = OnceLock::new();
+
+/// Records the commit the running binary was built from. Does nothing when the
+/// build carried no commit, or once a commit has been recorded.
+pub(crate) fn set_git_sha(git_sha: Option<&'static str>) {
+    if let Some(git_sha) = git_sha.filter(|sha| !sha.is_empty()) {
+        GIT_SHA.get_or_init(|| git_sha);
+    }
+}
 
 /// Information about the system, workspace and environments for the current machine.
 #[derive(Parser, Debug)]
@@ -296,6 +308,10 @@ pub struct Info {
     #[serde_as(as = "Vec<DisplayFromStr>")]
     virtual_packages: Vec<GenericVirtualPackage>,
     version: String,
+    /// The commit the binary was built from, or `None` when the build carried
+    /// no git metadata. Omitted from the human-readable output when absent, but
+    /// always present as a (possibly `null`) field in the JSON output.
+    git_sha: Option<&'static str>,
     tls_backend: String,
     cache_dir: Option<PathBuf>,
     cache_size: Option<String>,
@@ -320,6 +336,9 @@ impl Display for Info {
             bold.apply_to("Pixi version"),
             console::style(&self.version).green()
         )?;
+        if let Some(git_sha) = self.git_sha {
+            writeln!(f, "{:>WIDTH$}: {}", bold.apply_to("Git SHA"), git_sha)?;
+        }
         writeln!(
             f,
             "{:>WIDTH$}: {}",
@@ -578,6 +597,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         platform: Platform::current().to_string(),
         virtual_packages,
         version: consts::PIXI_VERSION.to_string(),
+        git_sha: GIT_SHA.get().copied(),
         tls_backend: tls_backend().to_string(),
         cache_dir: Some(pixi_config::get_cache_dir()?),
         cache_size,

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -233,7 +233,14 @@ impl LockFileUsageConfig {
     }
 }
 
-pub async fn execute() -> miette::Result<()> {
+/// Runs the CLI.
+///
+/// `git_sha` is the commit the binary was built from, which only the binary
+/// crate can observe. Without it `pixi info` omits the `Git SHA` line and
+/// reports `null` in its JSON output.
+pub async fn execute(git_sha: Option<&'static str>) -> miette::Result<()> {
+    info::set_git_sha(git_sha);
+
     let args = Args::parse();
 
     // Extract values we need before moving args

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -44,7 +44,7 @@ pub const CACHED_BUILD_BACKENDS: &str = "backends-v0";
 pub const CACHED_PACKAGES: &str = "pkgs";
 /// Base name of the per-workspace backend-metadata cache, versioned
 /// so that entry-schema changes don't collide. Also houses the backend
-/// work directories for `conda/outputs` under `<source>/work/` — the
+/// work directories for `conda/outputs` under `<source>/work/` -- the
 /// cache entries and the backend's scratch space for the same source
 /// live side by side.
 pub const CACHED_BUILD_BACKEND_METADATA: &str = "meta";

--- a/docs/advanced/explain_info_command.md
+++ b/docs/advanced/explain_info_command.md
@@ -34,6 +34,13 @@ default
 
 The first part of the info output is information that is always available and tells you what Pixi can read on your machine.
 
+### Git SHA
+
+The commit this Pixi binary was built from.
+Builds made from a git checkout, including the official releases, report it.
+The line is omitted when the build had no git metadata available, for example a conda package built from a source archive; in that case `pixi info --json` still carries a `git_sha` field, set to `null`.
+Include it when reporting an issue against a Pixi you built yourself.
+
 ### Platform
 
 This defines the platform you're currently on according to pixi.

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1151,6 +1151,9 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
             "platform": IsStr,
             "virtual_packages": IsAnyList,
             "version": IsStr,
+            # The commit; `null` when the build had no git metadata. CI builds
+            # from a git checkout, so it is a string here.
+            "git_sha": IsStr,
             "cache_dir": IsStr,
             "cache_size": AnyThing,
             "auth_dir": IsStr,


### PR DESCRIPTION
`pixi info` prints a `Git SHA` line under `Pixi version`, and `pixi info --json` gains a `git_sha` field, so a bug report identifies the exact commit a binary came from.

A build script in `pixi_consts` resolves the SHA from `git rev-parse HEAD` at compile time, or takes it from a `PIXI_GIT_SHA` build environment variable for builds from a source archive that carries no git metadata. With neither available the field is omitted.

Fixes: prefix-dev/pixi#6628

### How Has This Been Tested?

By building it :-)

```
> pixi info
System
------------
       Pixi version: 0.74.0
            Git SHA: 1c14329a2
        TLS backend: rustls
           Platform: linux-64
   Virtual packages: __unix=0=0
                   : __linux=7.0.12=0
                   : __glibc=2.44=0
                   : __archspec=1=zen5
          Cache dir: /var/home/tobias/.cache/rattler/cache
       Auth storage: /var/home/tobias/.rattler/credentials.json
   Config locations: No config files found
   
[...]
```

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.