### PR TITLE
fix(build): reuse cached artifacts for immutable sources when the cache dir is gone

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -2789,6 +2789,98 @@ my-package = {{ path = "./my-package" }}
     );
 }
 
+/// A CI runner that restores only the workspace's `.pixi` directory must
+/// reuse the built artifact of a git source dependency even though the cache
+/// dir holding the git checkout is gone. The artifact cache used to track
+/// the checkout's files by absolute path + mtime, which a wiped cache dir
+/// (or the fresh clone replacing it) can never satisfy, forcing a rebuild.
+#[tokio::test]
+async fn install_reuses_git_source_artifact_after_cache_dir_removal() {
+    setup_tracing();
+
+    let fixture = GitRepoFixture::new("conda-build-package");
+    // Layer a commit that makes the backend report input globs, so the
+    // artifact sidecar records files of the checkout in the cache dir.
+    // Without them the staleness checks have nothing to trip over and the
+    // test could not distinguish the immutable shortcut from a plain hit.
+    fs::write(
+        fixture.repo_path.join("boost-check").join("pixi.toml"),
+        r#"
+[workspace]
+channels = []
+platforms = ["win-64", "linux-64", "osx-arm64", "osx-64"]
+preview = ["pixi-build"]
+
+[package]
+name = "boost-check"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+[package.build.config]
+build-globs = ["**/*.txt"]
+"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.repo_path.join("boost-check").join("data.txt"),
+        "payload",
+    )
+    .unwrap();
+    fixture.git(&["add", "."]);
+    fixture.git(&["commit", "-m", "report build globs"]);
+
+    let (instantiator, mut observer) =
+        ObservableBackend::instantiator(PassthroughBackend::instantiator());
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+[workspace]
+name = "cache-dir-removal"
+channels = []
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+boost-check = {{ git = "{url}", subdirectory = "boost-check" }}
+"#,
+        platform = Platform::current(),
+        url = fixture.base_url,
+    ))
+    .unwrap()
+    .with_backend_override(BackendOverride::from_memory(instantiator));
+
+    let cache_dir = TempDir::new().unwrap();
+    temp_env::async_with_vars(
+        [("PIXI_CACHE_DIR", Some(cache_dir.path().as_os_str()))],
+        async { pixi.install().await },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        count_build_events(&observer.events()),
+        1,
+        "first install should build the git source package once"
+    );
+
+    // Wipe the global cache (git checkouts, backend state); the workspace
+    // including `.pixi/artifacts-v0` survives.
+    fs::remove_dir_all(cache_dir.path()).unwrap();
+    fs::create_dir_all(cache_dir.path()).unwrap();
+
+    temp_env::async_with_vars(
+        [("PIXI_CACHE_DIR", Some(cache_dir.path().as_os_str()))],
+        async { pixi.install().await },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        count_build_events(&observer.events()),
+        0,
+        "second install must reuse the cached artifact instead of rebuilding"
+    );
+}
+
 /// A changed source package must be rebuilt by quick-validating commands
 /// (`pixi run` / `pixi shell`) when the workspace declares a rich platform
 /// (e.g. one with CUDA virtual packages). The lock file keys such a platform

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -558,7 +558,15 @@ mod tests {
         key: &ArtifactCacheKey,
         source: &Path,
     ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
-        lookup_with(engine, cache, package, key, source, SourceMutability::Mutable).await
+        lookup_with(
+            engine,
+            cache,
+            package,
+            key,
+            source,
+            SourceMutability::Mutable,
+        )
+        .await
     }
 
     fn dummy_record(name: &str) -> RepoDataRecord {

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -536,7 +536,7 @@ mod tests {
 
     /// Drive [`ArtifactCache::lookup`] (which needs a `ComputeCtx`) through the
     /// provided engine. The test source dirs are absolute tempdirs.
-    async fn lookup_with(
+    async fn lookup(
         engine: &ComputeEngine,
         cache: &ArtifactCache,
         package: &PackageName,
@@ -549,24 +549,6 @@ mod tests {
             .with_ctx(async |ctx| cache.lookup(ctx, package, key, source, mutability).await)
             .await
             .expect("compute engine cycle")
-    }
-
-    async fn lookup(
-        engine: &ComputeEngine,
-        cache: &ArtifactCache,
-        package: &PackageName,
-        key: &ArtifactCacheKey,
-        source: &Path,
-    ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
-        lookup_with(
-            engine,
-            cache,
-            package,
-            key,
-            source,
-            SourceMutability::Mutable,
-        )
-        .await
     }
 
     fn dummy_record(name: &str) -> RepoDataRecord {
@@ -596,9 +578,16 @@ mod tests {
         let engine = ComputeEngine::new();
         let source = tmp.path().join("src");
         fs_err::create_dir_all(&source).unwrap();
-        let got = lookup(&engine, &cache, &pkg("foo"), &key("linux-64-abc"), &source)
-            .await
-            .unwrap();
+        let got = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key("linux-64-abc"),
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
         assert!(got.is_none());
     }
 
@@ -634,9 +623,16 @@ mod tests {
             .await
             .unwrap();
 
-        let hit = lookup(&engine, &cache, &pkg("foo"), &key, &source)
-            .await
-            .unwrap();
+        let hit = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
         let hit = hit.expect("cache hit after store");
         assert_eq!(hit.sha256, stored.sha256);
         assert_eq!(hit.artifact, stored.artifact);
@@ -679,9 +675,16 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(20));
         fs_err::write(&input, b"new").unwrap();
 
-        let got = lookup(&engine, &cache, &pkg("foo"), &key, &source)
-            .await
-            .unwrap();
+        let got = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
         assert!(got.is_none(), "mtime change should invalidate the entry");
     }
 
@@ -722,7 +725,7 @@ mod tests {
         // Simulate a wiped cache dir: every recorded input file is gone.
         fs_err::remove_file(&input).unwrap();
 
-        let got = lookup_with(
+        let got = lookup(
             &engine,
             &cache,
             &pkg("foo"),
@@ -737,7 +740,7 @@ mod tests {
             "an immutable source must hit even when the recorded input files are gone",
         );
 
-        let got = lookup_with(
+        let got = lookup(
             &engine,
             &cache,
             &pkg("foo"),
@@ -785,9 +788,16 @@ mod tests {
         // Introduce a new file that matches the stored glob.
         fs_err::write(source.join("extra.py"), b"new module").unwrap();
 
-        let got = lookup(&engine, &cache, &pkg("foo"), &key, &source)
-            .await
-            .unwrap();
+        let got = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
         assert!(
             got.is_none(),
             "a newly-added matching file should invalidate the entry"
@@ -830,10 +840,17 @@ mod tests {
             .await
             .unwrap();
 
-        let hit = lookup(&engine, &cache, &pkg("foo"), &key, &source)
-            .await
-            .unwrap()
-            .expect("cache should hit");
+        let hit = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap()
+        .expect("cache should hit");
 
         // Package record identity.
         assert_eq!(hit.record.package_record.name, record.package_record.name);
@@ -916,7 +933,16 @@ mod tests {
                 // Ignore whether it's a hit or miss; racing with stores
                 // the lookup may see either. The contract under test is
                 // that it never errors out.
-                let _ = lookup(&engine, &cache, &pkg, &key, &source).await.unwrap();
+                let _ = lookup(
+                    &engine,
+                    &cache,
+                    &pkg,
+                    &key,
+                    &source,
+                    SourceMutability::Mutable,
+                )
+                .await
+                .unwrap();
             }));
         }
         for h in handles {
@@ -937,9 +963,16 @@ mod tests {
         fs_err::create_dir_all(&entry).unwrap();
         fs_err::write(entry.join("sidecar.json"), b"{ this is not valid").unwrap();
 
-        let got = lookup(&engine, &cache, &pkg("foo"), &key("linux-64-abc"), &source)
-            .await
-            .unwrap();
+        let got = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key("linux-64-abc"),
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
         assert!(got.is_none());
     }
 
@@ -1003,9 +1036,16 @@ mod tests {
             .unwrap();
 
         // Second run with nothing changed: must hit, not rebuild.
-        let hit = lookup(&engine, &cache, &pkg("foo"), &key, &source)
-            .await
-            .unwrap();
+        let hit = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
         assert!(
             hit.is_some(),
             "issue #6232: a `../`-recipe glob must not force a rebuild on the next run",

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -10,9 +10,11 @@
 //! ```
 //!
 //! The cache key is structural (identity of the build inputs plus content
-//! addresses of its dependencies). Freshness of the source files themselves
-//! is tracked in the sidecar via per-file mtimes, plus a re-glob pass that
-//! detects added files.
+//! addresses of its dependencies). For mutable sources, freshness of the
+//! source files themselves is tracked in the sidecar via per-file mtimes,
+//! plus a re-glob pass that detects added files. Immutable sources are
+//! fully pinned by the key, so their entries carry no file lists and skip
+//! those checks.
 //!
 //! On a hit, the cached `.conda` is returned along with its sha256; no
 //! backend work happens. On a miss (or stale sidecar), the caller rebuilds
@@ -43,6 +45,22 @@ use serde_with::serde_as;
 use thiserror::Error;
 use url::Url;
 use xxhash_rust::xxh3::Xxh3;
+
+/// Whether the source files behind a cache entry can change without the
+/// pinned source spec changing.
+///
+/// Derived from the pinned manifest and build sources: only path pins are
+/// mutable, git commits and url archives are immutable. For an immutable
+/// source the cache key fully determines the artifact content, so lookup
+/// skips the per-file freshness checks entirely. This keeps entries valid
+/// when the recorded input files (which live in the global cache dir for
+/// git sources) have been deleted, e.g. on a CI runner that only restored
+/// the workspace's `.pixi` directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceMutability {
+    Mutable,
+    Immutable,
+}
 
 /// Opaque content-addressed handle for an artifact cache entry.
 ///
@@ -259,7 +277,9 @@ impl ArtifactCache {
 
     /// Look up an entry. Returns `Ok(None)` if the entry is missing or
     /// stale (parse failure, mtime mismatch, missing file, or a newly-added
-    /// file matches the recorded globs).
+    /// file matches the recorded globs). For an immutable source only the
+    /// first two apply; the file-level checks are skipped because the cache
+    /// key already pins the exact source content.
     ///
     /// Holds a shared read lock on the entry's `.lock` file while
     /// reading the sidecar, so a concurrent [`store`](Self::store) (which
@@ -272,6 +292,7 @@ impl ArtifactCache {
         package: &PackageName,
         key: &ArtifactCacheKey,
         source_dir: &AbsPath,
+        mutability: SourceMutability,
     ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
         let sidecar_path = self.sidecar_path(package, key);
         // Fast-path the common "no entry yet" case: skip creating the
@@ -302,27 +323,35 @@ impl ArtifactCache {
         };
         drop(_guard);
 
-        // Check every recorded file still matches its mtime.
-        for (path, expected_mtime) in &sidecar.input_files {
-            let modified = match fs_err::metadata(path).and_then(|m| m.modified()) {
-                Ok(m) => DateTime::<Utc>::from(m),
-                Err(_) => return Ok(None),
-            };
-            if modified != *expected_mtime {
-                return Ok(None);
+        // For an immutable source the cache key already pins the exact
+        // content, so the per-file checks below would only report noise:
+        // a re-cloned git checkout gets fresh mtimes, and a wiped cache
+        // dir removes the recorded files entirely. Skipping them also
+        // covers sidecars written by older versions, which still carry
+        // file lists for immutable sources.
+        if mutability == SourceMutability::Mutable {
+            // Check every recorded file still matches its mtime.
+            for (path, expected_mtime) in &sidecar.input_files {
+                let modified = match fs_err::metadata(path).and_then(|m| m.modified()) {
+                    Ok(m) => DateTime::<Utc>::from(m),
+                    Err(_) => return Ok(None),
+                };
+                if modified != *expected_mtime {
+                    return Ok(None);
+                }
             }
-        }
 
-        // Detect newly-added files that match the stored globs. This catches
-        // sources added after the cache entry was written. Uses the same
-        // engine-deduped walk as `build_backend_metadata`.
-        let current =
-            crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir)
-                .await
-                .map_err(ArtifactCacheError::Glob)?;
-        for matched in current {
-            if !sidecar.input_files.contains_key(&matched) {
-                return Ok(None);
+            // Detect newly-added files that match the stored globs. This
+            // catches sources added after the cache entry was written. Uses
+            // the same engine-deduped walk as `build_backend_metadata`.
+            let current =
+                crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir)
+                    .await
+                    .map_err(ArtifactCacheError::Glob)?;
+            for matched in current {
+                if !sidecar.input_files.contains_key(&matched) {
+                    return Ok(None);
+                }
             }
         }
 
@@ -507,6 +536,21 @@ mod tests {
 
     /// Drive [`ArtifactCache::lookup`] (which needs a `ComputeCtx`) through the
     /// provided engine. The test source dirs are absolute tempdirs.
+    async fn lookup_with(
+        engine: &ComputeEngine,
+        cache: &ArtifactCache,
+        package: &PackageName,
+        key: &ArtifactCacheKey,
+        source: &Path,
+        mutability: SourceMutability,
+    ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
+        let source = AbsPath::new(source).unwrap();
+        engine
+            .with_ctx(async |ctx| cache.lookup(ctx, package, key, source, mutability).await)
+            .await
+            .expect("compute engine cycle")
+    }
+
     async fn lookup(
         engine: &ComputeEngine,
         cache: &ArtifactCache,
@@ -514,11 +558,7 @@ mod tests {
         key: &ArtifactCacheKey,
         source: &Path,
     ) -> Result<Option<CachedArtifact>, ArtifactCacheError> {
-        let source = AbsPath::new(source).unwrap();
-        engine
-            .with_ctx(async |ctx| cache.lookup(ctx, package, key, source).await)
-            .await
-            .expect("compute engine cycle")
+        lookup_with(engine, cache, package, key, source, SourceMutability::Mutable).await
     }
 
     fn dummy_record(name: &str) -> RepoDataRecord {
@@ -635,6 +675,74 @@ mod tests {
             .await
             .unwrap();
         assert!(got.is_none(), "mtime change should invalidate the entry");
+    }
+
+    /// An immutable source (git commit, url archive) is fully identified by
+    /// the cache key; the recorded input files may be long gone (e.g. the
+    /// global cache dir holding the git checkout was wiped) without making
+    /// the entry stale. This also covers sidecars written by older versions,
+    /// which still carry file lists for immutable sources.
+    #[tokio::test]
+    async fn lookup_immutable_hits_despite_deleted_input_files() {
+        let tmp = TempDir::new().unwrap();
+        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let engine = ComputeEngine::new();
+
+        let source = tmp.path().join("src");
+        fs_err::create_dir_all(&source).unwrap();
+        let input = source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+
+        let scratch = tmp.path().join("scratch");
+        fs_err::create_dir_all(&scratch).unwrap();
+        let artifact = scratch.join("foo-1.0.0-h0.conda");
+        fs_err::write(&artifact, b"artifact").unwrap();
+
+        let key = key("linux-64-abc");
+        cache
+            .store(
+                &pkg("foo"),
+                &key,
+                &artifact,
+                vec![glob_group(&["**/*.py"])],
+                vec![abs(input.clone())],
+                dummy_record("foo"),
+            )
+            .await
+            .unwrap();
+
+        // Simulate a wiped cache dir: every recorded input file is gone.
+        fs_err::remove_file(&input).unwrap();
+
+        let got = lookup_with(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Immutable,
+        )
+        .await
+        .unwrap();
+        assert!(
+            got.is_some(),
+            "an immutable source must hit even when the recorded input files are gone",
+        );
+
+        let got = lookup_with(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
+        assert!(
+            got.is_none(),
+            "a mutable source with deleted input files must stay a miss",
+        );
     }
 
     #[tokio::test]

--- a/crates/pixi_command_dispatcher/src/cache/mod.rs
+++ b/crates/pixi_command_dispatcher/src/cache/mod.rs
@@ -19,7 +19,7 @@ pub mod workspace;
 
 pub use artifact::{
     ArtifactCache, ArtifactCacheError, ArtifactCacheKey, ArtifactSidecar, CachedArtifact,
-    compute_artifact_cache_key,
+    SourceMutability, compute_artifact_cache_key,
 };
 pub use backend_metadata::{
     BuildBackendMetadataCache, BuildBackendMetadataCacheEntry, BuildBackendMetadataCacheError,

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -26,7 +26,7 @@ use url::Url;
 
 pub use crate::cache::{ArtifactCache, WorkspaceCache};
 use crate::cache::{
-    ArtifactCacheError, compute_artifact_cache_key, compute_workspace_key,
+    ArtifactCacheError, SourceMutability, compute_artifact_cache_key, compute_workspace_key,
     markers::{SourceBuildArtifactsDir, SourceBuildWorkspacesDir},
 };
 use crate::{
@@ -223,8 +223,15 @@ async fn compute_inner(
         .path
         .as_dir_or_file_parent()
         .to_path_buf();
+    // Only path pins are mutable; a git commit or url archive pin fully
+    // determines the source content, so the artifact key alone suffices.
+    let mutability = if spec.record.has_mutable_source() {
+        SourceMutability::Mutable
+    } else {
+        SourceMutability::Immutable
+    };
     if let Some(hit) = artifact_cache
-        .lookup(ctx, spec.record.name(), &cache_key, &source_dir)
+        .lookup(ctx, spec.record.name(), &cache_key, &source_dir, mutability)
         .await
         .map_err(map_cache_err)?
     {
@@ -466,17 +473,26 @@ async fn compute_inner(
 
     // Resolve the files matching the build's reported globs through the
     // compute engine (same deduped walk as `build_backend_metadata`).
-    let input_files =
-        crate::input_globs::collect_input_files(ctx, &built.input_glob_sets, &source_dir)
-            .await
-            .map_err(SourceBuildError::GlobSet)?;
+    // An immutable source is fully pinned by the cache key, so its entry
+    // carries no file lists; recording them would only embed absolute
+    // paths into the machine-local cache dir that lookup never consults.
+    let (input_glob_sets, input_files) = match mutability {
+        SourceMutability::Mutable => {
+            let input_files =
+                crate::input_globs::collect_input_files(ctx, &built.input_glob_sets, &source_dir)
+                    .await
+                    .map_err(SourceBuildError::GlobSet)?;
+            (built.input_glob_sets, input_files)
+        }
+        SourceMutability::Immutable => (Vec::new(), Vec::new()),
+    };
 
     let stored = artifact_cache
         .store(
             spec.record.name(),
             &cache_key,
             &built.output_file,
-            built.input_glob_sets,
+            input_glob_sets,
             input_files,
             record,
         )


### PR DESCRIPTION
### Description

Source dependencies pinned to a git commit were rebuilt from scratch whenever `PIXI_CACHE_DIR` was missing, even though the built `.conda` still sat in the workspace's `.pixi/artifacts-v0`. This hits setup-pixi directly: its cache only restores `.pixi`, so every CI run rebuilt all git source dependencies while path dependencies were reused fine.

The artifact cache tracked freshness through the sidecar's input files: absolute paths into `$PIXI_CACHE_DIR/git-v0/checkouts/...` plus their mtimes. A wiped cache dir removes those files, and even a fresh clone of the same commit can never reproduce the recorded mtimes, so the entry was always declared stale.

For an immutable source (git commit, url archive) the cache key already pins the exact content: pinned sources, backend identifier, sha256 of every dependency, variants. There is no file-level state left to validate. The metadata cache draws the same conclusion in `verify_cache_freshness`; the artifact cache now does too:

* `ArtifactCache::lookup` takes a `SourceMutability` and skips the mtime loop and the re-glob pass for immutable sources
* immutable sidecars store no `input_files`/`input_glob_sets` anymore; those entries only embedded machine-local absolute paths that lookup never needs
* old sidecars keep working: lookup simply ignores their file lists

Fixes prefix-dev/pixi#6702

### How Has This Been Tested?

* Reproduced the original setup-pixi scenario end to end with the real `pixi-build-python` backend before porting it to the fast test
* Added tests

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added sufficient tests to cover my changes.