### PR TITLE
feat(platforms): validate __archspec microarchitecture names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7003,6 +7003,7 @@ dependencies = [
 name = "pixi_manifest"
 version = "0.1.0"
 dependencies = [
+ "archspec",
  "assert_matches",
  "chrono",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rust-version = "1.90"
 [workspace.dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.102"
+archspec = "0.2.0"
 assert_matches = "1.5.0"
 async-fd-lock = "0.2.0"
 async-once-cell = "0.5.4"

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -52,7 +52,7 @@ pub struct VirtualPackageArgs {
     pub cuda_arch: Option<String>,
 
     /// Declare a `__archspec` virtual package with the given microarchitecture
-    /// string, e.g. `x86-64-v3`. Valid on any subdir.
+    /// string, e.g. `x86_64_v3`. Valid on any subdir.
     #[clap(long, value_name = "ARCH")]
     pub archspec: Option<String>,
 
@@ -128,6 +128,8 @@ impl VirtualPackageArgs {
             if value.is_empty() {
                 miette::bail!("--archspec requires a non-empty microarchitecture string");
             }
+            pixi_manifest::platform::validate_archspec_name(&value)
+                .map_err(|message| miette::miette!("{message}"))?;
             push_unique(
                 &mut specs,
                 &mut seen_names,
@@ -260,6 +262,8 @@ fn parse_raw_virtual_package(spec: &str) -> miette::Result<GenericVirtualPackage
         .transpose()?
         .unwrap_or_else(zero_version);
     let build_string = parts.next().unwrap_or("").to_string();
+    pixi_manifest::platform::validate_virtual_package_build_string(&name, &build_string)
+        .map_err(|message| miette::miette!("{message}"))?;
     Ok(GenericVirtualPackage {
         name,
         version,
@@ -1302,6 +1306,26 @@ mod tests {
         // manifest's raw parser -- rather than being silently dropped.
         let package = parse_raw_virtual_package("__foo=1=special=build").unwrap();
         assert_eq!(package.build_string, "special=build");
+    }
+
+    #[test]
+    fn into_specs_rejects_unknown_archspec() {
+        let args = VirtualPackageArgs {
+            archspec: Some("x86-64-v3".into()),
+            ..Default::default()
+        };
+        let error = args.into_specs(Platform::Linux64, &[]).unwrap_err();
+        assert!(
+            error.to_string().contains("did you mean 'x86_64_v3'"),
+            "{error}"
+        );
+        // The raw form is validated too, including a trailing segment that
+        // only survives because the parser keeps it.
+        let error = parse_raw_virtual_package("__archspec=0=x86_64_v3=oops").unwrap_err();
+        assert!(
+            error.to_string().contains("not a known archspec"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -238,7 +238,9 @@ fn parse_virtual_package_version(flag: &str, value: &str) -> miette::Result<Vers
 }
 
 fn parse_raw_virtual_package(spec: &str) -> miette::Result<GenericVirtualPackage> {
-    let mut parts = spec.split('=');
+    // `splitn` keeps trailing '=' segments in the build string, matching the
+    // manifest's raw parser, instead of silently dropping them.
+    let mut parts = spec.splitn(3, '=');
     let name_str = parts.next().unwrap_or("");
     if name_str.strip_prefix("__").is_none_or(str::is_empty) {
         miette::bail!(
@@ -1292,6 +1294,14 @@ mod tests {
             .collect();
         assert_eq!(by_name.get("__cuda").map(String::as_str), Some("12.0"));
         assert_eq!(by_name.get("__cuda_arch").map(String::as_str), Some("8.6"));
+    }
+
+    #[test]
+    fn parse_raw_virtual_package_keeps_trailing_segments_in_build_string() {
+        // Extra '=' segments belong to the build string -- as in the
+        // manifest's raw parser -- rather than being silently dropped.
+        let package = parse_raw_virtual_package("__foo=1=special=build").unwrap();
+        assert_eq!(package.build_string, "special=build");
     }
 
     #[test]

--- a/crates/pixi_manifest/Cargo.toml
+++ b/crates/pixi_manifest/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
+archspec = { workspace = true }
 chrono = { workspace = true }
 console = { workspace = true }
 dunce = { workspace = true }

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -6175,7 +6175,7 @@ platforms = [
                         rattler_conda_types::GenericVirtualPackage {
                             name: rattler_conda_types::PackageName::try_from("__archspec").unwrap(),
                             version: Version::major(0),
-                            build_string: "x86-64-v3".to_string(),
+                            build_string: "x86_64_v3".to_string(),
                         },
                     ],
                     ..Default::default()
@@ -6189,7 +6189,7 @@ platforms = [
 name = "named-variants"
 channels = ["conda-forge"]
 platforms = [
-    { name = "modern", platform = "linux-64", archspec = "x86-64-v3" },
+    { name = "modern", platform = "linux-64", archspec = "x86_64_v3" },
     "linux-64",
 ]
 "#,

--- a/crates/pixi_manifest/src/platform.rs
+++ b/crates/pixi_manifest/src/platform.rs
@@ -3,6 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::str::FromStr;
 
+use archspec::cpu::Microarchitecture;
 use pixi_default_versions::{
     default_glibc_version, default_linux_version, default_mac_os_version, default_windows_version,
 };
@@ -802,6 +803,81 @@ pub fn is_subdir_default(gvp: &GenericVirtualPackage, subdir: Platform) -> bool 
     })
 }
 
+/// The microarchitecture named by an `__archspec` build string, or `None` when
+/// it encodes "unknown microarchitecture" (empty, or the `"0"` sentinel rattler
+/// serializes `Archspec::Unknown` as). The single owner of that encoding;
+/// validate and render through this rather than re-testing the strings.
+pub fn archspec_microarchitecture(build_string: &str) -> Option<&str> {
+    if build_string.is_empty() || build_string == "0" {
+        None
+    } else {
+        Some(build_string)
+    }
+}
+
+/// Validate a declared `__archspec` microarchitecture name against the archspec
+/// database. An unknown name yields a platform no real host can ever match, so
+/// manifests and the CLI reject it up front; the error suggests the closest
+/// known name when there is a plausible one.
+pub fn validate_archspec_name(name: &str) -> Result<(), String> {
+    if name == "0" || is_known_archspec_name(name) {
+        return Ok(());
+    }
+    match closest_archspec_name(name) {
+        Some(suggestion) => Err(format!(
+            "'{name}' is not a known archspec microarchitecture, did you mean '{suggestion}'?"
+        )),
+        None => Err(format!(
+            "'{name}' is not a known archspec microarchitecture"
+        )),
+    }
+}
+
+/// Validate the build string of a raw `__name = "version[=build]"` entry.
+/// Every user-facing parser routes through this, so the CLI and the manifest
+/// accept exactly the same values. Only `__archspec` constrains its build
+/// string today.
+pub fn validate_virtual_package_build_string(
+    name: &PackageName,
+    build_string: &str,
+) -> Result<(), String> {
+    if name.as_normalized() == "__archspec"
+        && let Some(microarchitecture) = archspec_microarchitecture(build_string)
+    {
+        validate_archspec_name(microarchitecture)?;
+    }
+    Ok(())
+}
+
+/// The best did-you-mean candidate for an unknown microarchitecture name: the
+/// underscore spelling when that is what was meant (conda build strings cannot
+/// contain `-`), otherwise the most similar database entry.
+fn closest_archspec_name(name: &str) -> Option<String> {
+    let underscored = name.replace('-', "_");
+    if is_known_archspec_name(&underscored) {
+        return Some(underscored);
+    }
+    Microarchitecture::known_targets()
+        .keys()
+        .map(|known| (strsim::jaro(known, name), known))
+        .filter(|(similarity, _)| *similarity > 0.8)
+        // Tie-break by name so the suggestion is stable despite the database
+        // being a HashMap.
+        .max_by(|(similarity_a, name_a), (similarity_b, name_b)| {
+            similarity_a
+                .partial_cmp(similarity_b)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| name_b.cmp(name_a))
+        })
+        .map(|(_, known)| known.clone())
+}
+
+/// Returns true if `name` is a microarchitecture the archspec database knows.
+/// Generic (invented) nodes are not part of the DAG, so they don't count.
+fn is_known_archspec_name(name: &str) -> bool {
+    Microarchitecture::known_targets().contains_key(name)
+}
+
 /// Parse a virtual-package entry the way it's stored in `pixi.lock` -- either
 /// `__name=version` or `__name=version=build_string` -- back into a
 /// [`GenericVirtualPackage`]. The lock-file serializer uses the same shape
@@ -872,12 +948,8 @@ fn overrides_from_declared(declared: &[GenericVirtualPackage]) -> VirtualPackage
             "__linux" => overrides.linux = Some(Override::String(gvp.version.to_string())),
             "__cuda" => overrides.cuda = Some(Override::String(gvp.version.to_string())),
             "__archspec" => {
-                let value = if gvp.build_string.is_empty() || gvp.build_string == "0" {
-                    "0".to_string()
-                } else {
-                    gvp.build_string.clone()
-                };
-                overrides.archspec = Some(Override::String(value));
+                let value = archspec_microarchitecture(&gvp.build_string).unwrap_or("0");
+                overrides.archspec = Some(Override::String(value.to_string()));
             }
             // The conda libc family collapses to rattler's single `libc`
             // slot; the family in the name is not preserved (upstream's
@@ -983,6 +1055,53 @@ mod tests {
             .declared_virtual_packages()
             .iter()
             .any(|gvp| gvp.name.as_normalized() == name)
+    }
+
+    #[test]
+    fn validate_archspec_name_rejects_unknown_names() {
+        assert_eq!(validate_archspec_name("x86_64_v3"), Ok(()));
+        assert_eq!(validate_archspec_name("m1"), Ok(()));
+        // The unknown-microarchitecture sentinel is a legal declaration.
+        assert_eq!(validate_archspec_name("0"), Ok(()));
+
+        // Conda build strings can't contain '-', so the dashed spelling of a
+        // known name is the likeliest mistake and gets the direct hint.
+        let error = validate_archspec_name("x86-64-v3").unwrap_err();
+        assert!(error.contains("did you mean 'x86_64_v3'"), "{error}");
+        let error = validate_archspec_name("Skylake").unwrap_err();
+        assert!(error.contains("did you mean 'skylake'"), "{error}");
+        // `armv8-a` is what pixi's own docs used to suggest, so a near-miss
+        // must still point at a real database entry.
+        let error = validate_archspec_name("armv8-a").unwrap_err();
+        assert!(
+            error.contains("'armv8-a' is not a known archspec microarchitecture, did you mean "),
+            "{error}"
+        );
+        // Nothing plausible: rejected without a misleading suggestion.
+        let error = validate_archspec_name("totally-bogus").unwrap_err();
+        assert!(!error.contains("did you mean"), "{error}");
+    }
+
+    #[test]
+    fn validate_virtual_package_build_string_only_constrains_archspec() {
+        let archspec = PackageName::try_from("__archspec").unwrap();
+        let other = PackageName::try_from("__cuda").unwrap();
+        // An unknown-microarchitecture build string is accepted in both of
+        // its encodings, and only `__archspec` is checked at all.
+        assert_eq!(
+            validate_virtual_package_build_string(&archspec, "skylake"),
+            Ok(())
+        );
+        assert_eq!(validate_virtual_package_build_string(&archspec, ""), Ok(()));
+        assert_eq!(
+            validate_virtual_package_build_string(&archspec, "0"),
+            Ok(())
+        );
+        assert!(validate_virtual_package_build_string(&archspec, "nonsense").is_err());
+        assert_eq!(
+            validate_virtual_package_build_string(&other, "nonsense"),
+            Ok(())
+        );
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/platform.rs
+++ b/crates/pixi_manifest/src/toml/platform.rs
@@ -169,7 +169,7 @@ const FRIENDLY_VIRTUAL_PACKAGES: &[FriendlyVirtualPackage] = &[
 /// platforms = [
 ///   { platform = "linux-64", cuda = "12.0", glibc = "2.28" },
 ///   { name = "gpu", platform = "linux-64", cuda = { driver = "12.0", arch = "8.6" } },
-///   { name = "jetson-nano", platform = "linux-aarch64", cuda = "12.8", archspec = "armv8-a" },
+///   { name = "jetson", platform = "linux-aarch64", cuda = "12.8", archspec = "armv8.2a" },
 /// ]
 /// ```
 ///
@@ -414,6 +414,11 @@ fn build_friendly_virtual_package(
                     line_info: None,
                 });
             }
+            crate::platform::validate_archspec_name(&raw.value).map_err(|message| Error {
+                kind: ErrorKind::Custom(message.into()),
+                span: raw.span,
+                line_info: None,
+            })?;
             Ok(GenericVirtualPackage {
                 name: package_name,
                 version: Version::major(0),
@@ -532,6 +537,13 @@ fn parse_raw_virtual_package(
         line_info: None,
     })?;
     let build_string = parts.next().unwrap_or("").to_string();
+    crate::platform::validate_virtual_package_build_string(&name, &build_string).map_err(
+        |message| Error {
+            kind: ErrorKind::Custom(message.into()),
+            span: value_span,
+            line_info: None,
+        },
+    )?;
     Ok(GenericVirtualPackage {
         name,
         version,
@@ -1068,16 +1080,42 @@ mod test {
     #[test]
     fn test_workspace_platform_archspec_goes_to_build_string() {
         let parsed = TopLevel::from_toml_str(
-            r#"platform = { platform = "linux-64", archspec = "x86-64-v3" }"#,
+            r#"platform = { platform = "linux-64", archspec = "x86_64_v3" }"#,
         )
         .unwrap();
         let package = &parsed.platform.declared_virtual_packages()[0];
         assert_eq!(package.name.as_normalized(), "__archspec");
         assert_eq!(package.version, Version::major(0));
-        assert_eq!(package.build_string, "x86-64-v3");
+        assert_eq!(package.build_string, "x86_64_v3");
+        // The synthesised name sanitises the underscores into dashes.
         assert_eq!(
             parsed.platform.name().as_str(),
             "linux-64-archspec-x86-64-v3"
+        );
+    }
+
+    #[test]
+    fn test_workspace_platform_archspec_rejects_unknown_names() {
+        // The dashed spelling of a known microarchitecture gets a hint.
+        let input = r#"platform = { platform = "linux-64", archspec = "x86-64-v3" }"#;
+        let rendered = format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err());
+        assert!(
+            rendered.contains("did you mean 'x86_64_v3'"),
+            "expected a did-you-mean hint, got: {rendered}",
+        );
+        // A name the archspec database does not know is rejected through the
+        // friendly key and the raw `__archspec` form alike.
+        let input = r#"platform = { platform = "linux-aarch64", archspec = "armv8-a" }"#;
+        let rendered = format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err());
+        assert!(
+            rendered.contains("'armv8-a' is not a known archspec microarchitecture"),
+            "expected an unknown-name error, got: {rendered}",
+        );
+        let input = r#"platform = { platform = "linux-64", __archspec = "0=nonsense" }"#;
+        let rendered = format_parse_error(input, TopLevel::from_toml_str(input).unwrap_err());
+        assert!(
+            rendered.contains("'nonsense' is not a known archspec microarchitecture"),
+            "expected an unknown-name error, got: {rendered}",
         );
     }
 
@@ -1446,14 +1484,14 @@ mod test {
         let platform = platform_with_packages(
             "linux-64-archspec-x86-64-v3",
             Platform::Linux64,
-            vec![archspec_virtual_package("x86-64-v3")],
+            vec![archspec_virtual_package("x86_64_v3")],
         );
         let json = serde_json::to_value(TomlPixiPlatform(platform)).unwrap();
         assert_eq!(
             json,
             serde_json::json!({
                 "platform": "linux-64",
-                "archspec": "x86-64-v3",
+                "archspec": "x86_64_v3",
             }),
         );
     }

--- a/docs/conda_ecosystem.md
+++ b/docs/conda_ecosystem.md
@@ -134,7 +134,7 @@ Common virtual packages:
 | `__glibc`       | GNU C Library version |
 | `__osx`         | macOS version |
 | `__cuda`        | NVIDIA driver's CUDA capability |
-| `__archspec`    | CPU microarchitecture (e.g. `x86-64-v3`) |
+| `__archspec`    | CPU microarchitecture (e.g. `x86_64_v3`) |
 
 When a package depends on `__cuda >= 12`, the solver will only
 select it if the system provides a `__cuda` virtual package with

--- a/docs/reference/cli/pixi/workspace/platform/add.md
+++ b/docs/reference/cli/pixi/workspace/platform/add.md
@@ -27,7 +27,7 @@ pixi workspace platform add [OPTIONS] [PLATFORM|NAME=PLATFORM|__NAME[=VERSION[=B
 - <a id="arg---cuda-arch" href="#arg---cuda-arch">`--cuda-arch <VERSION>`</a>
 :  Declare a `__cuda_arch` virtual package (GPU compute capability) at the given version, e.g. `8.6`. Requires `--cuda` (or an existing `__cuda`), matching the conda CEP coupling. Serialized as `cuda = { driver, arch }`
 - <a id="arg---archspec" href="#arg---archspec">`--archspec <ARCH>`</a>
-:  Declare a `__archspec` virtual package with the given microarchitecture string, e.g. `x86-64-v3`. Valid on any subdir
+:  Declare a `__archspec` virtual package with the given microarchitecture string, e.g. `x86_64_v3`. Valid on any subdir
 - <a id="arg---glibc" href="#arg---glibc">`--glibc <VERSION>`</a>
 :  Declare a `__glibc` virtual package at the given version, e.g. `2.28`. Only valid on linux subdirs
 - <a id="arg---linux" href="#arg---linux">`--linux <VERSION>`</a>

--- a/docs/reference/cli/pixi/workspace/platform/edit.md
+++ b/docs/reference/cli/pixi/workspace/platform/edit.md
@@ -29,7 +29,7 @@ pixi workspace platform edit [OPTIONS] <NAME> [__NAME[=VERSION[=BUILD]]]...
 - <a id="arg---cuda-arch" href="#arg---cuda-arch">`--cuda-arch <VERSION>`</a>
 :  Declare a `__cuda_arch` virtual package (GPU compute capability) at the given version, e.g. `8.6`. Requires `--cuda` (or an existing `__cuda`), matching the conda CEP coupling. Serialized as `cuda = { driver, arch }`
 - <a id="arg---archspec" href="#arg---archspec">`--archspec <ARCH>`</a>
-:  Declare a `__archspec` virtual package with the given microarchitecture string, e.g. `x86-64-v3`. Valid on any subdir
+:  Declare a `__archspec` virtual package with the given microarchitecture string, e.g. `x86_64_v3`. Valid on any subdir
 - <a id="arg---glibc" href="#arg---glibc">`--glibc <VERSION>`</a>
 :  Declare a `__glibc` virtual package at the given version, e.g. `2.28`. Only valid on linux subdirs
 - <a id="arg---linux" href="#arg---linux">`--linux <VERSION>`</a>

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -87,6 +87,15 @@ Each inline-table entry has:
   When omitted, Pixi synthesizes a name from `platform` plus the declared virtual packages, so two entries that declare the same set in different key order share the same identifier.
 - Friendly keys for the common virtual packages: `cuda`, `archspec`, `glibc`, `linux`, `macos` (alias `osx`), `windows`.
   Each maps onto the matching `__name` conda virtual package (`cuda` -> `__cuda`, `glibc` -> `__glibc`, `macos` -> `__osx`, etc.).
+- `archspec` names a CPU microarchitecture (`x86_64_v3`, `skylake`, `m1`,
+  `armv8.2a`, ...) rather than a version. The name must be one the bundled
+  [archspec](https://github.com/archspec/archspec) database knows, and Pixi
+  rejects anything else with a suggestion: a name no host can ever report would
+  otherwise silently produce a platform that never matches. Conda build strings
+  cannot contain `-`, so the spelling uses underscores and dots (`x86_64_v3`,
+  not `x86-64-v3`). A CPU newer than the bundled database can't be named until
+  Pixi ships an updated archspec; set `archspec = "0"` to declare the
+  microarchitecture explicitly unknown.
 - `cuda` also accepts a `{ driver, arch }` table that declares the CUDA driver
   version (`__cuda`) together with the GPU compute capability (`__cuda_arch`):
 

--- a/schema/examples/valid/workspace_rich_platform.toml
+++ b/schema/examples/valid/workspace_rich_platform.toml
@@ -5,6 +5,6 @@ name = "rich"
 platforms = [
   "linux-64",
   { name = "linux-64-cuda", platform = "linux-64", cuda = "12.0", glibc = "2.28" },
-  { platform = "linux-aarch64", archspec = "armv8-a" },
+  { platform = "linux-aarch64", archspec = "armv8.2a" },
   { name = "osx-arm64" },
 ]

--- a/schema/model.py
+++ b/schema/model.py
@@ -168,7 +168,7 @@ class WorkspacePlatform(BaseModel):
     )
     archspec: NonEmptyStr | None = Field(
         None,
-        description="Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86-64-v3`.",
+        description="Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86_64_v3`.",
     )
     glibc: NonEmptyStr | None = Field(
         None,

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -3585,7 +3585,7 @@
       "properties": {
         "archspec": {
           "title": "Archspec",
-          "description": "Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86-64-v3`.",
+          "description": "Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86_64_v3`.",
           "type": "string",
           "minLength": 1
         },

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -3623,7 +3623,7 @@
       "properties": {
         "archspec": {
           "title": "Archspec",
-          "description": "Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86-64-v3`.",
+          "description": "Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86_64_v3`.",
           "type": "string",
           "minLength": 1
         },

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -3609,7 +3609,7 @@
       "properties": {
         "archspec": {
           "title": "Archspec",
-          "description": "Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86-64-v3`.",
+          "description": "Declare a `__archspec` virtual package with the given microarchitecture, e.g. `x86_64_v3`.",
           "type": "string",
           "minLength": 1
         },


### PR DESCRIPTION
### Description

These should be the uncontroversial parts of #6533:

A bug fix on how we handle extra `=` in build strings and rejecting invalid archspecs when a user provides one.

### How Has This Been Tested?

Unit tests :-)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
