### PR TITLE
fix: avoid rebuilds for mtime-only source changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6567,6 +6567,7 @@ dependencies = [
  "rattler_solve 9.0.0",
  "rattler_virtual_packages",
  "regex",
+ "same-file",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6551,6 +6551,7 @@ dependencies = [
  "rattler_solve",
  "rattler_virtual_packages",
  "regex",
+ "same-file",
  "serde",
  "serde_json",
  "serde_with",

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -27,6 +27,7 @@ pin-project-lite = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+same-file = { workspace = true }
 strsim = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -30,6 +30,7 @@ pin-project-lite = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+same-file = { workspace = true }
 strsim = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -1082,14 +1082,15 @@ impl BuildBackendMetadataInner {
             InputSnapshot::default()
         } else {
             // A file modified after the backend returned may not be
-            // represented by its output, so it gets no state and falls back
-            // to the entry timestamp on the next probe.
+            // represented by its output; the previous entry's snapshot lets
+            // a stable fingerprint be confirmed on the next build.
             InputSnapshot::capture(
                 raw.input_files
                     .iter()
                     .map(|path| path.as_std_path().to_path_buf())
                     .chain(self.variant_files.iter().cloned()),
                 Some(raw.timestamp),
+                stale.as_ref().map(|entry| &entry.input_file_states),
                 ctx.global_data().io_concurrency_semaphore().cloned(),
             )
             .await

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -20,7 +20,7 @@ use crate::cache::markers::BackendMetadataDir;
 use crate::cache::{
     BuildBackendMetadataCache, BuildBackendMetadataCacheEntry, BuildBackendMetadataCacheError,
     BuildBackendMetadataCacheKey, CacheEntry, CacheKey, CacheKeyString, CacheRevision,
-    MetadataCache, MetadataCacheKey, WriteResult,
+    MetadataCache, MetadataCacheKey, RefreshResult, WriteResult,
 };
 use crate::compute_data::{
     HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter, HasIoConcurrencySemaphore,
@@ -951,10 +951,10 @@ impl BuildBackendMetadataInner {
                     .try_refresh(&cache_key, &fresh, fresh.cache_version)
                     .await
                 {
-                    Ok(WriteResult::Written) => {
+                    Ok(RefreshResult::Written) => {
                         tracing::debug!("Updated cached input fingerprints");
                     }
-                    Ok(WriteResult::Conflict(_)) => {
+                    Ok(RefreshResult::Skipped(_)) => {
                         tracing::debug!(
                             "Metadata cache changed while refreshing input fingerprints; using the verified entry without persisting the refresh"
                         );

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -23,6 +23,7 @@ use crate::cache::{
     MetadataCache, MetadataCacheKey, WriteResult,
 };
 use crate::compute_data::{HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter};
+use crate::file_fingerprint::{FileFingerprintError, MetadataComparison, fingerprint_files};
 use crate::injected_config::{BackendOverrideKey, EnabledProtocolsKey};
 use crate::input_hash::{
     BackendBinaryFingerprint, BackendSpecHash, ConfigurationHash, ProjectModelHash,
@@ -322,12 +323,12 @@ impl BuildBackendMetadataInner {
         requested_variants: &BTreeMap<String, Vec<VariantValue>>,
     ) -> Result<
         Result<
-            CacheEntry<BuildBackendMetadataCache>,
+            (CacheEntry<BuildBackendMetadataCache>, bool),
             Option<CacheEntry<BuildBackendMetadataCache>>,
         >,
         BuildBackendMetadataError,
     > {
-        let Some(cache_entry) = cache_entry else {
+        let Some(mut cache_entry) = cache_entry else {
             return Ok(Err(None));
         };
 
@@ -376,10 +377,11 @@ impl BuildBackendMetadataInner {
 
         // If the build source is immutable, we don't check the contents of the files.
         if build_source_checkout.is_immutable() {
-            return Ok(Ok(cache_entry));
+            return Ok(Ok((cache_entry, false)));
         }
 
         let build_source_dir = build_source_checkout.path.as_dir_or_file_parent();
+        let mut fingerprints_to_compute = Vec::new();
 
         // Check the files that were explicitly mentioned.
         for source_file_path in cache_entry
@@ -388,14 +390,47 @@ impl BuildBackendMetadataInner {
             .map(|path| path.as_std_path().to_path_buf())
             .chain(cache_entry.build_variant_files.iter().cloned())
         {
-            match source_file_path.metadata().and_then(|m| m.modified()) {
-                Ok(modified_date) => {
-                    if modified_date > cache_entry.timestamp {
-                        tracing::info!(
-                            "found cached outputs but '{}' has been modified, invalidating cache.",
-                            source_file_path.display()
-                        );
-                        return Ok(Err(Some(cache_entry)));
+            match source_file_path.metadata() {
+                Ok(metadata) => {
+                    match cache_entry.file_fingerprints.get(&source_file_path) {
+                        Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
+                            Ok(MetadataComparison::Unchanged) => continue,
+                            Ok(MetadataComparison::HashRequired) => {
+                                fingerprints_to_compute.push(source_file_path);
+                            }
+                            Ok(MetadataComparison::Changed) | Err(_) => {
+                                tracing::info!(
+                                    "found cached outputs but '{}' has changed, invalidating cache.",
+                                    source_file_path.display()
+                                );
+                                return Ok(Err(Some(cache_entry)));
+                            }
+                        },
+                        None => {
+                            let modified_date = match metadata.modified() {
+                                Ok(modified_date) => modified_date,
+                                Err(err) => {
+                                    tracing::info!(
+                                        "found cached outputs but requested metadata for '{}' failed with: {}",
+                                        source_file_path.display(),
+                                        err
+                                    );
+                                    return Ok(Err(Some(cache_entry)));
+                                }
+                            };
+                            if modified_date <= cache_entry.timestamp {
+                                // Upgrade entries written before fingerprints
+                                // were introduced without invalidating them.
+                                fingerprints_to_compute.push(source_file_path);
+                                continue;
+                            }
+
+                            tracing::info!(
+                                "found cached outputs but '{}' has been modified, invalidating cache.",
+                                source_file_path.display()
+                            );
+                            return Ok(Err(Some(cache_entry)));
+                        }
                     }
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
@@ -414,6 +449,33 @@ impl BuildBackendMetadataInner {
                     return Ok(Err(Some(cache_entry)));
                 }
             };
+        }
+
+        let fingerprints_refreshed = !fingerprints_to_compute.is_empty();
+        if fingerprints_refreshed {
+            let current_fingerprints = match fingerprint_files(fingerprints_to_compute).await {
+                Ok(fingerprints) => fingerprints,
+                Err(err) => {
+                    tracing::info!(
+                        "failed to refresh cached input fingerprints, invalidating cache: {err}"
+                    );
+                    return Ok(Err(Some(cache_entry)));
+                }
+            };
+
+            for (path, current) in current_fingerprints {
+                if let Some(expected) = cache_entry.file_fingerprints.get(&path)
+                    && expected.hash != current.hash
+                {
+                    tracing::info!(
+                        "found cached outputs but '{}' has changed, invalidating cache.",
+                        path.display()
+                    );
+                    return Ok(Err(Some(cache_entry)));
+                }
+
+                cache_entry.file_fingerprints.insert(path, current);
+            }
         }
 
         // Invalidate when the walk picks up a file the cache entry never
@@ -440,7 +502,7 @@ impl BuildBackendMetadataInner {
             }
         }
 
-        Ok(Ok(cache_entry))
+        Ok(Ok((cache_entry, fingerprints_refreshed)))
     }
 
     /// Validates that outputs with the same name have unique variants.
@@ -839,7 +901,6 @@ impl BuildBackendMetadataInner {
         };
 
         let manifest_source_location = checkouts.manifest_source_location();
-        let cache = ctx.global_data().build_backend_metadata_cache();
         let cache_key: CacheKey<BuildBackendMetadataCache> = BuildBackendMetadataCacheKey {
             channel_urls: self.channels.clone(),
             build_environment: self.build_environment.clone(),
@@ -848,7 +909,9 @@ impl BuildBackendMetadataInner {
             source: manifest_source_location.clone().into(),
             inline_content_hash: self.inline.as_ref().map(|inline| inline.content_hash),
         };
-        let cache_read_result = cache
+        let cache_read_result = ctx
+            .global_data()
+            .build_backend_metadata_cache()
             .read(&cache_key)
             .await
             .map_err(BuildBackendMetadataError::Cache)?;
@@ -906,7 +969,35 @@ impl BuildBackendMetadataInner {
         )
         .await?
         {
-            Ok(fresh) => {
+            Ok((fresh, fingerprints_refreshed)) => {
+                if fingerprints_refreshed {
+                    match ctx
+                        .global_data()
+                        .build_backend_metadata_cache()
+                        .try_write(&cache_key, fresh.clone(), fresh.cache_version)
+                        .await
+                        .map_err(BuildBackendMetadataError::Cache)?
+                    {
+                        WriteResult::Written => {
+                            tracing::debug!("Updated cached input fingerprints");
+                        }
+                        WriteResult::Conflict(current) => {
+                            tracing::debug!(
+                                "Metadata cache changed while refreshing input fingerprints"
+                            );
+                            return Ok(CacheProbe::Miss {
+                                cache_key,
+                                stale: Some(current),
+                                project_model_hash,
+                                configuration_hash,
+                                backend_spec_hash,
+                                backend_binary_fingerprint,
+                                skip_cache,
+                            });
+                        }
+                    }
+                }
+
                 tracing::debug!("Using cached build backend metadata");
                 Ok(CacheProbe::Hit(BuildBackendMetadata {
                     source: manifest_source_location,
@@ -1043,6 +1134,21 @@ impl BuildBackendMetadataInner {
         };
 
         let prev_cache_version = stale.as_ref().map(|cache| cache.cache_version);
+        let mut file_fingerprints = if checkouts.build_source_checkout.is_immutable() {
+            BTreeMap::new()
+        } else {
+            fingerprint_files(
+                raw.input_files
+                    .iter()
+                    .map(|path| path.as_std_path().to_path_buf())
+                    .chain(self.variant_files.iter().cloned()),
+            )
+            .await?
+        };
+        // A file modified after the backend returned may not be represented by
+        // its output. Keep the timestamp fallback for that path so the next
+        // cache probe invokes the backend again.
+        file_fingerprints.retain(|_, fingerprint| fingerprint.modified <= raw.timestamp);
         let metadata = BuildBackendMetadataCacheEntry {
             revision,
             cache_version: prev_cache_version.map_or(0, |version| version + 1),
@@ -1051,6 +1157,7 @@ impl BuildBackendMetadataInner {
             build_variant_files: self.variant_files.iter().cloned().collect(),
             input_glob_sets: raw.input_glob_sets,
             input_files: raw.input_files,
+            file_fingerprints,
             source: canonical_source,
             project_model_hash,
             configuration_hash,
@@ -1136,6 +1243,13 @@ pub enum BuildBackendMetadataError {
     #[error("could not compute hash of input files")]
     GlobHash(Arc<pixi_glob::GlobHashError>),
 
+    #[error("failed to fingerprint input file at {}", path.display())]
+    FileFingerprint {
+        path: PathBuf,
+        #[source]
+        source: Arc<std::io::Error>,
+    },
+
     #[error("failed to determine input file modification times")]
     GlobSet(Arc<pixi_glob::GlobSetError>),
 
@@ -1173,6 +1287,15 @@ impl From<pixi_build_frontend::json_rpc::CommunicationError> for BuildBackendMet
 impl From<pixi_glob::GlobHashError> for BuildBackendMetadataError {
     fn from(err: pixi_glob::GlobHashError) -> Self {
         Self::GlobHash(Arc::new(err))
+    }
+}
+
+impl From<FileFingerprintError> for BuildBackendMetadataError {
+    fn from(err: FileFingerprintError) -> Self {
+        Self::FileFingerprint {
+            path: err.path,
+            source: err.source,
+        }
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -535,6 +535,10 @@ impl BuildBackendMetadataInner {
                 .into_std_path_buf(),
         };
         let backend_call_started = std::time::Instant::now();
+        // Taken before the backend runs: a file modified while it reads the
+        // sources may not match its outputs, so it must land past this
+        // cutoff and stay unconfirmed.
+        let timestamp = SystemTime::now();
         let outputs = backend_guard
             .conda_outputs(params, move |line| {
                 let _err = futures::executor::block_on(log_sink.send(line));
@@ -542,7 +546,6 @@ impl BuildBackendMetadataInner {
             .await
             .map_err(|e| BuildBackendMetadataError::Communication(Arc::new(e)))?;
         let backend_call_elapsed_ms = backend_call_started.elapsed().as_millis() as u64;
-        let timestamp = SystemTime::now();
         tracing::debug!(
             backend = %backend_identifier,
             outputs = outputs.outputs.len(),

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -25,13 +25,11 @@ use crate::cache::{
 use crate::compute_data::{
     HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter, HasIoConcurrencySemaphore,
 };
-use crate::file_fingerprint::{
-    MetadataComparison, fingerprint_files, fingerprint_files_lenient,
-};
 use crate::injected_config::{BackendOverrideKey, EnabledProtocolsKey};
 use crate::input_hash::{
     BackendBinaryFingerprint, BackendSpecHash, ConfigurationHash, ProjectModelHash,
 };
+use crate::input_snapshot::{InputSnapshot, SnapshotFreshness};
 use crate::keys::BackendBinaryFingerprintKey;
 use crate::{
     BackendHandle, BuildEnvironment, EnvironmentRef, InlinePackage, InstantiateBackendError,
@@ -375,155 +373,52 @@ impl BuildBackendMetadataInner {
         if build_source_checkout.is_immutable() {
             return Ok(CacheFreshness::Fresh {
                 entry: cache_entry,
-                fingerprints: FingerprintRefresh::NotNeeded,
+                refreshed: false,
             });
         }
 
         let build_source_dir = build_source_checkout.path.as_dir_or_file_parent();
-        let mut fingerprints_to_compute = Vec::new();
-        // Mtimes observed for files without a recorded fingerprint. A hash
-        // computed later only counts if the file still has this mtime.
-        let mut legacy_stat_mtimes = BTreeMap::new();
-
-        // Check the files that were explicitly mentioned.
-        for source_file_path in cache_entry
+        let files = cache_entry
             .input_files
             .iter()
             .map(|path| path.as_std_path().to_path_buf())
             .chain(cache_entry.build_variant_files.iter().cloned())
-        {
-            match source_file_path.metadata() {
-                Ok(metadata) => {
-                    match cache_entry.file_fingerprints.get(&source_file_path) {
-                        Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
-                            Ok(MetadataComparison::Unchanged) => continue,
-                            Ok(MetadataComparison::HashRequired) if metadata.is_file() => {
-                                fingerprints_to_compute.push(source_file_path);
-                            }
-                            Ok(MetadataComparison::HashRequired)
-                            | Ok(MetadataComparison::Changed)
-                            | Err(_) => {
-                                tracing::info!(
-                                    "found cached outputs but '{}' has changed, invalidating cache.",
-                                    source_file_path.display()
-                                );
-                                return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                            }
-                        },
-                        None => {
-                            let modified_date = match metadata.modified() {
-                                Ok(modified_date) => modified_date,
-                                Err(err) => {
-                                    tracing::info!(
-                                        "found cached outputs but requested metadata for '{}' failed with: {}",
-                                        source_file_path.display(),
-                                        err
-                                    );
-                                    return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                                }
-                            };
-                            if modified_date <= cache_entry.timestamp {
-                                // Upgrade entries written before fingerprints
-                                // were introduced without invalidating them.
-                                // Special files cannot be hashed and keep
-                                // timestamp-only validation.
-                                if metadata.is_file() {
-                                    legacy_stat_mtimes
-                                        .insert(source_file_path.clone(), modified_date);
-                                    fingerprints_to_compute.push(source_file_path);
-                                }
-                                continue;
-                            }
+            .collect::<Vec<_>>();
 
-                            tracing::info!(
-                                "found cached outputs but '{}' has been modified, invalidating cache.",
-                                source_file_path.display()
-                            );
-                            return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                        }
-                    }
-                }
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    tracing::info!(
-                        "found cached outputs but '{}' has been deleted, invalidating cache.",
-                        source_file_path.display()
-                    );
-                    return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                }
-                Err(err) => {
-                    tracing::info!(
-                        "found cached outputs but requested metadata for '{}' failed with: {}",
-                        source_file_path.display(),
-                        err
-                    );
-                    return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                }
-            };
-        }
-
-        // Invalidate when the walk picks up a file the cache entry never
-        // recorded (i.e. one that was added since the last run). The
-        // existing entries in `input_files` were freshness-checked above;
-        // this second pass only catches newcomers. Both the walk and the
-        // stored `input_files` are absolute, so they compare directly. The
-        // structured `input_glob_sets` can express the marker-driven
-        // workspace walk for ROS-style backends.
+        // The snapshot check and the glob walk inspect independent aspects of
+        // the source tree, so they run concurrently. The walk catches files
+        // that were added since the entry was written; the recorded files
+        // themselves are verified through the snapshot.
         let io_semaphore = ctx.global_data().io_concurrency_semaphore().cloned();
-        let fingerprint_future = async move {
-            if fingerprints_to_compute.is_empty() {
-                None
-            } else {
-                Some(fingerprint_files(fingerprints_to_compute, io_semaphore).await)
-            }
-        };
+        let verify_future =
+            cache_entry
+                .input_file_states
+                .verify(files, Some(cache_entry.timestamp), io_semaphore);
         let glob_future = crate::input_globs::collect_input_files(
             ctx,
             &cache_entry.input_glob_sets,
             build_source_dir,
         );
-        let (current_fingerprints, new_file_candidates) =
-            tokio::join!(fingerprint_future, glob_future);
+        let (freshness, new_file_candidates) = tokio::join!(verify_future, glob_future);
 
-        let fingerprint_refresh = match current_fingerprints {
-            None => FingerprintRefresh::NotNeeded,
-            Some(Err(err)) => {
+        let refreshed = match freshness {
+            SnapshotFreshness::Fresh => false,
+            SnapshotFreshness::Refreshed(snapshot) => {
+                cache_entry.input_file_states = snapshot;
+                true
+            }
+            SnapshotFreshness::Stale(stale) => {
                 tracing::info!(
-                    "failed to refresh cached input fingerprints, invalidating cache: {err}"
+                    "found cached outputs but '{}' has changed, invalidating cache.",
+                    stale.path.display()
                 );
                 return Ok(CacheFreshness::Stale(Some(cache_entry)));
             }
-            Some(Ok(current_fingerprints)) => {
-                for (path, current) in current_fingerprints {
-                    match cache_entry.file_fingerprints.get(&path) {
-                        Some(expected) => {
-                            if expected.hash != current.hash {
-                                tracing::info!(
-                                    "found cached outputs but '{}' has changed, invalidating cache.",
-                                    path.display()
-                                );
-                                return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                            }
-                        }
-                        None => {
-                            // Without a recorded hash the computed hash only
-                            // vouches for the cached outputs if the file did
-                            // not change since the stat pass.
-                            if legacy_stat_mtimes.get(&path) != Some(&current.modified) {
-                                tracing::info!(
-                                    "found cached outputs but '{}' changed while validating, invalidating cache.",
-                                    path.display()
-                                );
-                                return Ok(CacheFreshness::Stale(Some(cache_entry)));
-                            }
-                        }
-                    }
-
-                    cache_entry.file_fingerprints.insert(path, current);
-                }
-                FingerprintRefresh::Refreshed
-            }
         };
 
+        // Both the walk and the stored `input_files` are absolute, so they
+        // compare directly. The structured `input_glob_sets` can express the
+        // marker-driven workspace walk for ROS-style backends.
         let new_file_candidates =
             new_file_candidates.map_err(BuildBackendMetadataError::GlobSet)?;
         for abs_path in new_file_candidates {
@@ -538,7 +433,7 @@ impl BuildBackendMetadataInner {
 
         Ok(CacheFreshness::Fresh {
             entry: cache_entry,
-            fingerprints: fingerprint_refresh,
+            refreshed,
         })
     }
 
@@ -780,18 +675,13 @@ impl ResolvedCheckouts {
     }
 }
 
-/// Whether verifying a cache hit updated its in-memory file fingerprints.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-enum FingerprintRefresh {
-    NotNeeded,
-    Refreshed,
-}
-
 /// Result of validating an entry read from the metadata cache.
 enum CacheFreshness {
     Fresh {
         entry: CacheEntry<BuildBackendMetadataCache>,
-        fingerprints: FingerprintRefresh,
+        /// Whether verification updated the in-memory input file states;
+        /// persisting them (best-effort) avoids rehashing on the next probe.
+        refreshed: bool,
     },
     Stale(Option<CacheEntry<BuildBackendMetadataCache>>),
 }
@@ -1024,9 +914,9 @@ impl BuildBackendMetadataInner {
         {
             CacheFreshness::Fresh {
                 entry: fresh,
-                fingerprints,
+                refreshed,
             } => {
-                if fingerprints == FingerprintRefresh::Refreshed {
+                if refreshed {
                     // Keeps the version unchanged so a concurrent rebuild
                     // does not lose the version CAS to this read path.
                     match ctx
@@ -1188,25 +1078,22 @@ impl BuildBackendMetadataInner {
         };
 
         let prev_cache_version = stale.as_ref().map(|cache| cache.cache_version);
-        let mut file_fingerprints = if checkouts.build_source_checkout.is_immutable() {
-            BTreeMap::new()
+        let input_file_states = if checkouts.build_source_checkout.is_immutable() {
+            InputSnapshot::default()
         } else {
-            // A file that cannot be hashed gets no fingerprint and keeps
-            // timestamp-based validation instead of failing the build.
-            fingerprint_files_lenient(
+            // A file modified after the backend returned may not be
+            // represented by its output, so it gets no state and falls back
+            // to the entry timestamp on the next probe.
+            InputSnapshot::capture(
                 raw.input_files
                     .iter()
                     .map(|path| path.as_std_path().to_path_buf())
                     .chain(self.variant_files.iter().cloned()),
+                Some(raw.timestamp),
                 ctx.global_data().io_concurrency_semaphore().cloned(),
             )
             .await
-            .fingerprints
         };
-        // A file modified after the backend returned may not be represented by
-        // its output. Keep the timestamp fallback for that path so the next
-        // cache probe invokes the backend again.
-        file_fingerprints.retain(|_, fingerprint| fingerprint.modified <= raw.timestamp);
         let metadata = BuildBackendMetadataCacheEntry {
             revision,
             cache_version: prev_cache_version.map_or(0, |version| version + 1),
@@ -1215,7 +1102,7 @@ impl BuildBackendMetadataInner {
             build_variant_files: self.variant_files.iter().cloned().collect(),
             input_glob_sets: raw.input_glob_sets,
             input_files: raw.input_files,
-            file_fingerprints,
+            input_file_states,
             source: canonical_source,
             project_model_hash,
             configuration_hash,

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -394,6 +394,15 @@ impl BuildBackendMetadataInner {
             )
             .collect::<Vec<_>>();
 
+        // Only entries written before fingerprints existed validate their
+        // files against the entry timestamp. In a current entry a file
+        // without a state vanished during capture, and a hash-less
+        // reappearance cannot be trusted.
+        let fallback_cutoff = cache_entry
+            .input_file_states
+            .is_empty()
+            .then_some(cache_entry.timestamp);
+
         // The snapshot check and the glob walk inspect independent aspects of
         // the source tree, so they run concurrently. The walk catches files
         // that were added since the entry was written; the recorded files
@@ -402,7 +411,7 @@ impl BuildBackendMetadataInner {
         let verify_future =
             cache_entry
                 .input_file_states
-                .verify(files, Some(cache_entry.timestamp), io_semaphore);
+                .verify(files, fallback_cutoff, io_semaphore);
         let glob_future = crate::input_globs::collect_input_files(
             ctx,
             &cache_entry.input_glob_sets,
@@ -1114,7 +1123,7 @@ impl BuildBackendMetadataInner {
         };
         let metadata = BuildBackendMetadataCacheEntry {
             revision,
-            cache_version: prev_cache_version.map_or(0, |version| version + 1),
+            cache_version: prev_cache_version.unwrap_or(0) + 1,
             outputs: raw.outputs,
             build_variants: self.variant_configuration.clone(),
             build_variant_files: self.variant_files.iter().cloned().collect(),

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -55,6 +55,13 @@ fn warn_once_per_backend(backend_name: &str) {
     }
 }
 
+/// Variant files come from user configuration and may be relative; anchor
+/// them to the working directory once so the recorded paths are stable.
+fn absolute_variant_file(path: &std::path::Path) -> Option<pixi_path::AbsPathBuf> {
+    let absolute = std::path::absolute(path).ok()?;
+    pixi_path::AbsPathBuf::new(absolute).ok()
+}
+
 /// Return the checkout root sent to the backend as `checkout_root`,
 /// or `None` for local-path sources.  Git and url checkouts have a
 /// well-defined unpack root that may differ from the manifest's own
@@ -371,18 +378,20 @@ impl BuildBackendMetadataInner {
 
         // If the build source is immutable, we don't check the contents of the files.
         if build_source_checkout.is_immutable() {
-            return Ok(CacheFreshness::Fresh {
-                entry: cache_entry,
-                refreshed: false,
-            });
+            return Ok(CacheFreshness::Fresh(cache_entry));
         }
 
         let build_source_dir = build_source_checkout.path.as_dir_or_file_parent();
         let files = cache_entry
             .input_files
             .iter()
-            .map(|path| path.as_std_path().to_path_buf())
-            .chain(cache_entry.build_variant_files.iter().cloned())
+            .cloned()
+            .chain(
+                cache_entry
+                    .build_variant_files
+                    .iter()
+                    .filter_map(|path| absolute_variant_file(path)),
+            )
             .collect::<Vec<_>>();
 
         // The snapshot check and the glob walk inspect independent aspects of
@@ -403,14 +412,14 @@ impl BuildBackendMetadataInner {
 
         let refreshed = match freshness {
             SnapshotFreshness::Fresh => false,
-            SnapshotFreshness::Refreshed(snapshot) => {
-                cache_entry.input_file_states = snapshot;
+            SnapshotFreshness::Refreshed(refreshed) => {
+                cache_entry.input_file_states.apply_refresh(refreshed);
                 true
             }
             SnapshotFreshness::Stale(stale) => {
                 tracing::info!(
                     "found cached outputs but '{}' has changed, invalidating cache.",
-                    stale.path.display()
+                    stale.path
                 );
                 return Ok(CacheFreshness::Stale(Some(cache_entry)));
             }
@@ -431,9 +440,10 @@ impl BuildBackendMetadataInner {
             }
         }
 
-        Ok(CacheFreshness::Fresh {
-            entry: cache_entry,
-            refreshed,
+        Ok(if refreshed {
+            CacheFreshness::Refreshed(cache_entry)
+        } else {
+            CacheFreshness::Fresh(cache_entry)
         })
     }
 
@@ -680,12 +690,11 @@ impl ResolvedCheckouts {
 
 /// Result of validating an entry read from the metadata cache.
 enum CacheFreshness {
-    Fresh {
-        entry: CacheEntry<BuildBackendMetadataCache>,
-        /// Whether verification updated the in-memory input file states;
-        /// persisting them (best-effort) avoids rehashing on the next probe.
-        refreshed: bool,
-    },
+    /// The entry is valid as stored.
+    Fresh(CacheEntry<BuildBackendMetadataCache>),
+    /// The entry is valid and verification updated its input file states;
+    /// persisting them (best-effort) avoids rehashing on the next probe.
+    Refreshed(CacheEntry<BuildBackendMetadataCache>),
     Stale(Option<CacheEntry<BuildBackendMetadataCache>>),
 }
 
@@ -915,33 +924,37 @@ impl BuildBackendMetadataInner {
         )
         .await?
         {
-            CacheFreshness::Fresh {
-                entry: fresh,
-                refreshed,
-            } => {
-                if refreshed {
-                    // Keeps the version unchanged so a concurrent rebuild
-                    // does not lose the version CAS to this read path.
-                    match ctx
-                        .global_data()
-                        .build_backend_metadata_cache()
-                        .try_refresh(&cache_key, fresh.clone(), fresh.cache_version)
-                        .await
-                    {
-                        Ok(WriteResult::Written) => {
-                            tracing::debug!("Updated cached input fingerprints");
-                        }
-                        Ok(WriteResult::Conflict(_)) => {
-                            tracing::debug!(
-                                "Metadata cache changed while refreshing input fingerprints; using the verified entry without persisting the refresh"
-                            );
-                        }
-                        Err(err) => {
-                            tracing::debug!(
-                                error = %err,
-                                "Failed to persist refreshed input fingerprints; using the verified entry"
-                            );
-                        }
+            CacheFreshness::Fresh(fresh) => {
+                tracing::debug!("Using cached build backend metadata");
+                Ok(CacheProbe::Hit(BuildBackendMetadata {
+                    source: manifest_source_location,
+                    cache_key: cache_key.key(),
+                    metadata: fresh,
+                    skip_cache,
+                }))
+            }
+            CacheFreshness::Refreshed(fresh) => {
+                // Keeps the version unchanged so a concurrent rebuild does
+                // not lose the version CAS to this read path.
+                match ctx
+                    .global_data()
+                    .build_backend_metadata_cache()
+                    .try_refresh(&cache_key, &fresh, fresh.cache_version)
+                    .await
+                {
+                    Ok(WriteResult::Written) => {
+                        tracing::debug!("Updated cached input fingerprints");
+                    }
+                    Ok(WriteResult::Conflict(_)) => {
+                        tracing::debug!(
+                            "Metadata cache changed while refreshing input fingerprints; using the verified entry without persisting the refresh"
+                        );
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            error = %err,
+                            "Failed to persist refreshed input fingerprints; using the verified entry"
+                        );
                     }
                 }
 
@@ -1088,10 +1101,11 @@ impl BuildBackendMetadataInner {
             // represented by its output; the previous entry's snapshot lets
             // a stable fingerprint be confirmed on the next build.
             InputSnapshot::capture(
-                raw.input_files
-                    .iter()
-                    .map(|path| path.as_std_path().to_path_buf())
-                    .chain(self.variant_files.iter().cloned()),
+                raw.input_files.iter().cloned().chain(
+                    self.variant_files
+                        .iter()
+                        .filter_map(|path| absolute_variant_file(path)),
+                ),
                 Some(raw.timestamp),
                 stale.as_ref().map(|entry| &entry.input_file_states),
                 ctx.global_data().io_concurrency_semaphore().cloned(),
@@ -1117,11 +1131,7 @@ impl BuildBackendMetadataInner {
 
         let cache = ctx.global_data().build_backend_metadata_cache();
         match cache
-            .try_write(
-                &cache_key,
-                metadata.clone(),
-                prev_cache_version.unwrap_or(0),
-            )
+            .try_write(&cache_key, &metadata, prev_cache_version.unwrap_or(0))
             .await
             .map_err(BuildBackendMetadataError::Cache)?
         {

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -976,24 +976,20 @@ impl BuildBackendMetadataInner {
                         .build_backend_metadata_cache()
                         .try_write(&cache_key, fresh.clone(), fresh.cache_version)
                         .await
-                        .map_err(BuildBackendMetadataError::Cache)?
                     {
-                        WriteResult::Written => {
+                        Ok(WriteResult::Written) => {
                             tracing::debug!("Updated cached input fingerprints");
                         }
-                        WriteResult::Conflict(current) => {
+                        Ok(WriteResult::Conflict(_)) => {
                             tracing::debug!(
-                                "Metadata cache changed while refreshing input fingerprints"
+                                "Metadata cache changed while refreshing input fingerprints; using the verified entry without persisting the refresh"
                             );
-                            return Ok(CacheProbe::Miss {
-                                cache_key,
-                                stale: Some(current),
-                                project_model_hash,
-                                configuration_hash,
-                                backend_spec_hash,
-                                backend_binary_fingerprint,
-                                skip_cache,
-                            });
+                        }
+                        Err(err) => {
+                            tracing::debug!(
+                                error = %err,
+                                "Failed to persist refreshed input fingerprints; using the verified entry"
+                            );
                         }
                     }
                 }

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -25,7 +25,9 @@ use crate::cache::{
 use crate::compute_data::{
     HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter, HasIoConcurrencySemaphore,
 };
-use crate::file_fingerprint::{FileFingerprintError, MetadataComparison, fingerprint_files};
+use crate::file_fingerprint::{
+    MetadataComparison, fingerprint_files, fingerprint_files_lenient,
+};
 use crate::injected_config::{BackendOverrideKey, EnabledProtocolsKey};
 use crate::input_hash::{
     BackendBinaryFingerprint, BackendSpecHash, ConfigurationHash, ProjectModelHash,
@@ -379,6 +381,9 @@ impl BuildBackendMetadataInner {
 
         let build_source_dir = build_source_checkout.path.as_dir_or_file_parent();
         let mut fingerprints_to_compute = Vec::new();
+        // Mtimes observed for files without a recorded fingerprint. A hash
+        // computed later only counts if the file still has this mtime.
+        let mut legacy_stat_mtimes = BTreeMap::new();
 
         // Check the files that were explicitly mentioned.
         for source_file_path in cache_entry
@@ -392,10 +397,12 @@ impl BuildBackendMetadataInner {
                     match cache_entry.file_fingerprints.get(&source_file_path) {
                         Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
                             Ok(MetadataComparison::Unchanged) => continue,
-                            Ok(MetadataComparison::HashRequired) => {
+                            Ok(MetadataComparison::HashRequired) if metadata.is_file() => {
                                 fingerprints_to_compute.push(source_file_path);
                             }
-                            Ok(MetadataComparison::Changed) | Err(_) => {
+                            Ok(MetadataComparison::HashRequired)
+                            | Ok(MetadataComparison::Changed)
+                            | Err(_) => {
                                 tracing::info!(
                                     "found cached outputs but '{}' has changed, invalidating cache.",
                                     source_file_path.display()
@@ -418,7 +425,13 @@ impl BuildBackendMetadataInner {
                             if modified_date <= cache_entry.timestamp {
                                 // Upgrade entries written before fingerprints
                                 // were introduced without invalidating them.
-                                fingerprints_to_compute.push(source_file_path);
+                                // Special files cannot be hashed and keep
+                                // timestamp-only validation.
+                                if metadata.is_file() {
+                                    legacy_stat_mtimes
+                                        .insert(source_file_path.clone(), modified_date);
+                                    fingerprints_to_compute.push(source_file_path);
+                                }
                                 continue;
                             }
 
@@ -481,14 +494,28 @@ impl BuildBackendMetadataInner {
             }
             Some(Ok(current_fingerprints)) => {
                 for (path, current) in current_fingerprints {
-                    if let Some(expected) = cache_entry.file_fingerprints.get(&path)
-                        && expected.hash != current.hash
-                    {
-                        tracing::info!(
-                            "found cached outputs but '{}' has changed, invalidating cache.",
-                            path.display()
-                        );
-                        return Ok(CacheFreshness::Stale(Some(cache_entry)));
+                    match cache_entry.file_fingerprints.get(&path) {
+                        Some(expected) => {
+                            if expected.hash != current.hash {
+                                tracing::info!(
+                                    "found cached outputs but '{}' has changed, invalidating cache.",
+                                    path.display()
+                                );
+                                return Ok(CacheFreshness::Stale(Some(cache_entry)));
+                            }
+                        }
+                        None => {
+                            // Without a recorded hash the computed hash only
+                            // vouches for the cached outputs if the file did
+                            // not change since the stat pass.
+                            if legacy_stat_mtimes.get(&path) != Some(&current.modified) {
+                                tracing::info!(
+                                    "found cached outputs but '{}' changed while validating, invalidating cache.",
+                                    path.display()
+                                );
+                                return Ok(CacheFreshness::Stale(Some(cache_entry)));
+                            }
+                        }
                     }
 
                     cache_entry.file_fingerprints.insert(path, current);
@@ -1000,10 +1027,12 @@ impl BuildBackendMetadataInner {
                 fingerprints,
             } => {
                 if fingerprints == FingerprintRefresh::Refreshed {
+                    // Keeps the version unchanged so a concurrent rebuild
+                    // does not lose the version CAS to this read path.
                     match ctx
                         .global_data()
                         .build_backend_metadata_cache()
-                        .try_write(&cache_key, fresh.clone(), fresh.cache_version)
+                        .try_refresh(&cache_key, fresh.clone(), fresh.cache_version)
                         .await
                     {
                         Ok(WriteResult::Written) => {
@@ -1162,14 +1191,17 @@ impl BuildBackendMetadataInner {
         let mut file_fingerprints = if checkouts.build_source_checkout.is_immutable() {
             BTreeMap::new()
         } else {
-            fingerprint_files(
+            // A file that cannot be hashed gets no fingerprint and keeps
+            // timestamp-based validation instead of failing the build.
+            fingerprint_files_lenient(
                 raw.input_files
                     .iter()
                     .map(|path| path.as_std_path().to_path_buf())
                     .chain(self.variant_files.iter().cloned()),
                 ctx.global_data().io_concurrency_semaphore().cloned(),
             )
-            .await?
+            .await
+            .fingerprints
         };
         // A file modified after the backend returned may not be represented by
         // its output. Keep the timestamp fallback for that path so the next
@@ -1269,13 +1301,6 @@ pub enum BuildBackendMetadataError {
     #[error("could not compute hash of input files")]
     GlobHash(Arc<pixi_glob::GlobHashError>),
 
-    #[error("failed to fingerprint input file at {}", path.display())]
-    FileFingerprint {
-        path: PathBuf,
-        #[source]
-        source: Arc<std::io::Error>,
-    },
-
     #[error("failed to determine input file modification times")]
     GlobSet(Arc<pixi_glob::GlobSetError>),
 
@@ -1313,15 +1338,6 @@ impl From<pixi_build_frontend::json_rpc::CommunicationError> for BuildBackendMet
 impl From<pixi_glob::GlobHashError> for BuildBackendMetadataError {
     fn from(err: pixi_glob::GlobHashError) -> Self {
         Self::GlobHash(Arc::new(err))
-    }
-}
-
-impl From<FileFingerprintError> for BuildBackendMetadataError {
-    fn from(err: FileFingerprintError) -> Self {
-        Self::FileFingerprint {
-            path: err.path,
-            source: err.source,
-        }
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -22,7 +22,9 @@ use crate::cache::{
     BuildBackendMetadataCacheKey, CacheEntry, CacheKey, CacheKeyString, CacheRevision,
     MetadataCache, MetadataCacheKey, WriteResult,
 };
-use crate::compute_data::{HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter};
+use crate::compute_data::{
+    HasBuildBackendMetadataCache, HasBuildBackendMetadataReporter, HasIoConcurrencySemaphore,
+};
 use crate::file_fingerprint::{FileFingerprintError, MetadataComparison, fingerprint_files};
 use crate::injected_config::{BackendOverrideKey, EnabledProtocolsKey};
 use crate::input_hash::{
@@ -306,11 +308,9 @@ impl BuildBackendMetadataInner {
 
     /// Verifies if the cached metadata is still fresh.
     ///
-    /// Returns:
-    /// - `Ok(Ok(metadata))` if the cache is fresh and can be used as-is.
-    /// - `Ok(Err(Some(metadata)))` if the cache is stale but the metadata is
-    ///   returned for comparison (e.g. to reuse the ID if outputs match).
-    /// - `Ok(Err(None))` if no cache entry exists.
+    /// Returns whether the cache is fresh or stale. A stale entry is retained
+    /// for comparison so its revision can be reused when the backend returns
+    /// identical outputs.
     #[allow(clippy::too_many_arguments)]
     async fn verify_cache_freshness(
         ctx: &mut ComputeCtx,
@@ -321,15 +321,9 @@ impl BuildBackendMetadataInner {
         backend_spec_hash: BackendSpecHash,
         backend_binary_fingerprint: Option<BackendBinaryFingerprint>,
         requested_variants: &BTreeMap<String, Vec<VariantValue>>,
-    ) -> Result<
-        Result<
-            (CacheEntry<BuildBackendMetadataCache>, bool),
-            Option<CacheEntry<BuildBackendMetadataCache>>,
-        >,
-        BuildBackendMetadataError,
-    > {
+    ) -> Result<CacheFreshness, BuildBackendMetadataError> {
         let Some(mut cache_entry) = cache_entry else {
-            return Ok(Err(None));
+            return Ok(CacheFreshness::Stale(None));
         };
 
         // Check the project model
@@ -337,7 +331,7 @@ impl BuildBackendMetadataInner {
             tracing::info!(
                 "found cached outputs with different project model, invalidating cache."
             );
-            return Ok(Err(Some(cache_entry)));
+            return Ok(CacheFreshness::Stale(Some(cache_entry)));
         }
 
         // Check the build configuration
@@ -345,7 +339,7 @@ impl BuildBackendMetadataInner {
             tracing::info!(
                 "found cached outputs with different build configuration, invalidating cache."
             );
-            return Ok(Err(Some(cache_entry)));
+            return Ok(CacheFreshness::Stale(Some(cache_entry)));
         }
 
         // Check the backend spec. Entries written before this field existed
@@ -355,7 +349,7 @@ impl BuildBackendMetadataInner {
             tracing::info!(
                 "found cached outputs with different backend specification, invalidating cache."
             );
-            return Ok(Err(Some(cache_entry)));
+            return Ok(CacheFreshness::Stale(Some(cache_entry)));
         }
 
         // Check the backend binary fingerprint. Both sides are `None` for
@@ -366,18 +360,21 @@ impl BuildBackendMetadataInner {
             tracing::info!(
                 "found cached outputs with different backend binary fingerprint, invalidating cache."
             );
-            return Ok(Err(Some(cache_entry)));
+            return Ok(CacheFreshness::Stale(Some(cache_entry)));
         }
 
         // Check if the build variants match
         if &cache_entry.build_variants != requested_variants {
             tracing::info!("found cached outputs with different variants, invalidating cache.");
-            return Ok(Err(Some(cache_entry)));
+            return Ok(CacheFreshness::Stale(Some(cache_entry)));
         }
 
         // If the build source is immutable, we don't check the contents of the files.
         if build_source_checkout.is_immutable() {
-            return Ok(Ok((cache_entry, false)));
+            return Ok(CacheFreshness::Fresh {
+                entry: cache_entry,
+                fingerprints: FingerprintRefresh::NotNeeded,
+            });
         }
 
         let build_source_dir = build_source_checkout.path.as_dir_or_file_parent();
@@ -403,7 +400,7 @@ impl BuildBackendMetadataInner {
                                     "found cached outputs but '{}' has changed, invalidating cache.",
                                     source_file_path.display()
                                 );
-                                return Ok(Err(Some(cache_entry)));
+                                return Ok(CacheFreshness::Stale(Some(cache_entry)));
                             }
                         },
                         None => {
@@ -415,7 +412,7 @@ impl BuildBackendMetadataInner {
                                         source_file_path.display(),
                                         err
                                     );
-                                    return Ok(Err(Some(cache_entry)));
+                                    return Ok(CacheFreshness::Stale(Some(cache_entry)));
                                 }
                             };
                             if modified_date <= cache_entry.timestamp {
@@ -429,7 +426,7 @@ impl BuildBackendMetadataInner {
                                 "found cached outputs but '{}' has been modified, invalidating cache.",
                                 source_file_path.display()
                             );
-                            return Ok(Err(Some(cache_entry)));
+                            return Ok(CacheFreshness::Stale(Some(cache_entry)));
                         }
                     }
                 }
@@ -438,7 +435,7 @@ impl BuildBackendMetadataInner {
                         "found cached outputs but '{}' has been deleted, invalidating cache.",
                         source_file_path.display()
                     );
-                    return Ok(Err(Some(cache_entry)));
+                    return Ok(CacheFreshness::Stale(Some(cache_entry)));
                 }
                 Err(err) => {
                     tracing::info!(
@@ -446,36 +443,9 @@ impl BuildBackendMetadataInner {
                         source_file_path.display(),
                         err
                     );
-                    return Ok(Err(Some(cache_entry)));
+                    return Ok(CacheFreshness::Stale(Some(cache_entry)));
                 }
             };
-        }
-
-        let fingerprints_refreshed = !fingerprints_to_compute.is_empty();
-        if fingerprints_refreshed {
-            let current_fingerprints = match fingerprint_files(fingerprints_to_compute).await {
-                Ok(fingerprints) => fingerprints,
-                Err(err) => {
-                    tracing::info!(
-                        "failed to refresh cached input fingerprints, invalidating cache: {err}"
-                    );
-                    return Ok(Err(Some(cache_entry)));
-                }
-            };
-
-            for (path, current) in current_fingerprints {
-                if let Some(expected) = cache_entry.file_fingerprints.get(&path)
-                    && expected.hash != current.hash
-                {
-                    tracing::info!(
-                        "found cached outputs but '{}' has changed, invalidating cache.",
-                        path.display()
-                    );
-                    return Ok(Err(Some(cache_entry)));
-                }
-
-                cache_entry.file_fingerprints.insert(path, current);
-            }
         }
 
         // Invalidate when the walk picks up a file the cache entry never
@@ -485,24 +455,64 @@ impl BuildBackendMetadataInner {
         // stored `input_files` are absolute, so they compare directly. The
         // structured `input_glob_sets` can express the marker-driven
         // workspace walk for ROS-style backends.
-        let new_file_candidates = crate::input_globs::collect_input_files(
+        let io_semaphore = ctx.global_data().io_concurrency_semaphore().cloned();
+        let fingerprint_future = async move {
+            if fingerprints_to_compute.is_empty() {
+                None
+            } else {
+                Some(fingerprint_files(fingerprints_to_compute, io_semaphore).await)
+            }
+        };
+        let glob_future = crate::input_globs::collect_input_files(
             ctx,
             &cache_entry.input_glob_sets,
             build_source_dir,
-        )
-        .await
-        .map_err(BuildBackendMetadataError::GlobSet)?;
+        );
+        let (current_fingerprints, new_file_candidates) =
+            tokio::join!(fingerprint_future, glob_future);
+
+        let fingerprint_refresh = match current_fingerprints {
+            None => FingerprintRefresh::NotNeeded,
+            Some(Err(err)) => {
+                tracing::info!(
+                    "failed to refresh cached input fingerprints, invalidating cache: {err}"
+                );
+                return Ok(CacheFreshness::Stale(Some(cache_entry)));
+            }
+            Some(Ok(current_fingerprints)) => {
+                for (path, current) in current_fingerprints {
+                    if let Some(expected) = cache_entry.file_fingerprints.get(&path)
+                        && expected.hash != current.hash
+                    {
+                        tracing::info!(
+                            "found cached outputs but '{}' has changed, invalidating cache.",
+                            path.display()
+                        );
+                        return Ok(CacheFreshness::Stale(Some(cache_entry)));
+                    }
+
+                    cache_entry.file_fingerprints.insert(path, current);
+                }
+                FingerprintRefresh::Refreshed
+            }
+        };
+
+        let new_file_candidates =
+            new_file_candidates.map_err(BuildBackendMetadataError::GlobSet)?;
         for abs_path in new_file_candidates {
             if !cache_entry.input_files.contains(&abs_path) {
                 tracing::info!(
                     "found cached outputs but a new matching file at '{}' has been detected, invalidating cache.",
                     abs_path.as_std_path().display()
                 );
-                return Ok(Err(Some(cache_entry)));
+                return Ok(CacheFreshness::Stale(Some(cache_entry)));
             }
         }
 
-        Ok(Ok((cache_entry, fingerprints_refreshed)))
+        Ok(CacheFreshness::Fresh {
+            entry: cache_entry,
+            fingerprints: fingerprint_refresh,
+        })
     }
 
     /// Validates that outputs with the same name have unique variants.
@@ -743,6 +753,22 @@ impl ResolvedCheckouts {
     }
 }
 
+/// Whether verifying a cache hit updated its in-memory file fingerprints.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum FingerprintRefresh {
+    NotNeeded,
+    Refreshed,
+}
+
+/// Result of validating an entry read from the metadata cache.
+enum CacheFreshness {
+    Fresh {
+        entry: CacheEntry<BuildBackendMetadataCache>,
+        fingerprints: FingerprintRefresh,
+    },
+    Stale(Option<CacheEntry<BuildBackendMetadataCache>>),
+}
+
 /// Outcome of probing the on-disk metadata cache.
 enum CacheProbe {
     /// Cache contained a fresh entry; the caller can return it
@@ -969,8 +995,11 @@ impl BuildBackendMetadataInner {
         )
         .await?
         {
-            Ok((fresh, fingerprints_refreshed)) => {
-                if fingerprints_refreshed {
+            CacheFreshness::Fresh {
+                entry: fresh,
+                fingerprints,
+            } => {
+                if fingerprints == FingerprintRefresh::Refreshed {
                     match ctx
                         .global_data()
                         .build_backend_metadata_cache()
@@ -1002,7 +1031,7 @@ impl BuildBackendMetadataInner {
                     skip_cache,
                 }))
             }
-            Err(stale) => Ok(CacheProbe::Miss {
+            CacheFreshness::Stale(stale) => Ok(CacheProbe::Miss {
                 cache_key,
                 stale,
                 project_model_hash,
@@ -1138,6 +1167,7 @@ impl BuildBackendMetadataInner {
                     .iter()
                     .map(|path| path.as_std_path().to_path_buf())
                     .chain(self.variant_files.iter().cloned()),
+                ctx.global_data().io_concurrency_semaphore().cloned(),
             )
             .await?
         };

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -842,6 +842,17 @@ mod tests {
             .unwrap();
     }
 
+    fn mtime(path: &Path) -> SystemTime {
+        fs_err::metadata(path).unwrap().modified().unwrap()
+    }
+
+    /// Moves the mtime forward by `secs` and returns the new mtime.
+    fn touch(path: &Path, secs: u64) -> SystemTime {
+        let modified = mtime(path) + std::time::Duration::from_secs(secs);
+        set_modified(path, modified);
+        modified
+    }
+
     /// Drive [`ArtifactCache::lookup`] (which needs a `ComputeCtx`) through the
     /// provided engine. The test source dirs are absolute tempdirs.
     async fn lookup(
@@ -857,14 +868,6 @@ mod tests {
             .with_ctx(async |ctx| cache.lookup(ctx, package, key, source, mutability).await)
             .await
             .expect("compute engine cycle")
-    }
-
-    /// Unwrap a lookup that is expected to hit.
-    fn expect_hit(lookup: CacheLookup) -> CachedArtifact {
-        match lookup {
-            CacheLookup::Hit(hit) => hit,
-            CacheLookup::Miss(reason) => panic!("expected a cache hit, got a miss: {reason}"),
-        }
     }
 
     /// Unwrap a lookup that is expected to miss, yielding its reason.
@@ -910,69 +913,19 @@ mod tests {
 
     #[tokio::test]
     async fn lookup_missing_entry_is_a_miss() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
-        let engine = ComputeEngine::new();
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let got = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key("linux-64-abc"),
-            &source,
-            SourceMutability::Mutable,
-        )
-        .await
-        .unwrap();
-        assert!(matches!(expect_miss(got), CacheMissReason::NoEntry));
+        let f = Fixture::new();
+        assert!(matches!(f.lookup_miss().await, CacheMissReason::NoEntry));
     }
 
     #[tokio::test]
     async fn round_trip_store_then_lookup() {
-        let tmp = TempDir::new().unwrap();
-        let cache_root = tmp.path().join("artifacts");
-        let cache = ArtifactCache::new(&cache_root);
-        let engine = ComputeEngine::new();
+        let f = Fixture::new();
+        let input = f.write("main.py", b"print(1)");
+        let stored = f
+            .store(vec![glob_group(&["**/*.py"])], vec![abs(input)])
+            .await;
 
-        // A fake source tree with one input file.
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let input = source.join("main.py");
-        fs_err::write(&input, b"print(1)").unwrap();
-
-        // A fake .conda artifact somewhere outside the cache.
-        let scratch = tmp.path().join("scratch");
-        fs_err::create_dir_all(&scratch).unwrap();
-        let artifact = scratch.join("foo-1.0.0-h0.conda");
-        fs_err::write(&artifact, b"pretend this is a conda").unwrap();
-
-        let key = key("linux-64-abc");
-        let stored = cache
-            .store(
-                &pkg("foo"),
-                &key,
-                &artifact,
-                vec![glob_group(&["**/*.py"])],
-                vec![abs(input.clone())],
-                SystemTime::now(),
-                dummy_record("foo"),
-            )
-            .await
-            .unwrap();
-
-        let hit = expect_hit(
-            lookup(
-                &engine,
-                &cache,
-                &pkg("foo"),
-                &key,
-                &source,
-                SourceMutability::Mutable,
-            )
-            .await
-            .unwrap(),
-        );
+        let hit = f.lookup().await.expect("cache hit after store");
         assert_eq!(hit.sha256, stored.sha256);
         assert_eq!(hit.artifact, stored.artifact);
         assert_eq!(
@@ -983,78 +936,31 @@ mod tests {
 
     #[tokio::test]
     async fn lookup_hashes_source_file_when_mtime_changes() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
-        let engine = ComputeEngine::new();
-
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let input = source.join("main.py");
-        fs_err::write(&input, b"old").unwrap();
-
-        let scratch = tmp.path().join("scratch");
-        fs_err::create_dir_all(&scratch).unwrap();
-        let artifact = scratch.join("foo-1.0.0-h0.conda");
-        fs_err::write(&artifact, b"artifact").unwrap();
-
-        let key = key("linux-64-abc");
-        cache
-            .store(
-                &pkg("foo"),
-                &key,
-                &artifact,
-                Vec::new(),
-                vec![abs(input.clone())],
-                SystemTime::now(),
-                dummy_record("foo"),
-            )
-            .await
-            .unwrap();
+        let (f, input) = Fixture::with_input("main.py", b"old").await;
 
         // Touching the input without changing its contents keeps the cache
         // valid and refreshes the stored mtime.
-        let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
-        let touched_mtime = original_mtime + std::time::Duration::from_secs(1);
-        set_modified(&input, touched_mtime);
-
-        let hit = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key,
-            &source,
-            SourceMutability::Mutable,
-        )
-        .await
-        .unwrap();
-        expect_hit(hit);
-
-        let sidecar: ArtifactSidecar =
-            serde_json::from_slice(&fs_err::read(cache.sidecar_path(&pkg("foo"), &key)).unwrap())
-                .unwrap();
+        let touched_mtime = touch(&input, 1);
+        assert!(
+            f.lookup().await.is_some(),
+            "an mtime-only change should remain cached"
+        );
         assert_eq!(
-            sidecar.input_file_states.get(&input).unwrap().modified(),
+            f.sidecar()
+                .input_file_states
+                .get(&input)
+                .unwrap()
+                .modified(),
             touched_mtime,
             "the refreshed mtime should be persisted"
         );
 
         // A same-size content change still invalidates the entry.
         fs_err::write(&input, b"new").unwrap();
-        set_modified(&input, touched_mtime + std::time::Duration::from_secs(1));
-
-        let got = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key,
-            &source,
-            SourceMutability::Mutable,
-        )
-        .await
-        .unwrap();
+        touch(&input, 1);
         assert!(
             matches!(
-                expect_miss(got),
+                f.lookup_miss().await,
                 CacheMissReason::InputFileModified { ref path, .. } if path.as_std_path() == input,
             ),
             "mtime change should invalidate the entry and name the file",
@@ -1068,114 +974,33 @@ mod tests {
     /// which still carry file lists for immutable sources.
     #[tokio::test]
     async fn lookup_immutable_hits_despite_deleted_input_files() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
-        let engine = ComputeEngine::new();
-
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let input = source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-
-        let scratch = tmp.path().join("scratch");
-        fs_err::create_dir_all(&scratch).unwrap();
-        let artifact = scratch.join("foo-1.0.0-h0.conda");
-        fs_err::write(&artifact, b"artifact").unwrap();
-
-        let key = key("linux-64-abc");
-        cache
-            .store(
-                &pkg("foo"),
-                &key,
-                &artifact,
-                vec![glob_group(&["**/*.py"])],
-                vec![abs(input.clone())],
-                SystemTime::now(),
-                dummy_record("foo"),
-            )
-            .await
-            .unwrap();
+        let (f, input) = Fixture::with_input("main.py", b"body").await;
 
         // Simulate a wiped cache dir: every recorded input file is gone.
         fs_err::remove_file(&input).unwrap();
 
-        let got = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key,
-            &source,
-            SourceMutability::Immutable,
-        )
-        .await
-        .unwrap();
         assert!(
-            matches!(got, CacheLookup::Hit(_)),
+            f.lookup_with(SourceMutability::Immutable).await.is_some(),
             "an immutable source must hit even when the recorded input files are gone",
         );
-
-        let got = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key,
-            &source,
-            SourceMutability::Mutable,
-        )
-        .await
-        .unwrap();
         assert!(
-            matches!(expect_miss(got), CacheMissReason::InputFileRemoved { .. }),
+            matches!(
+                f.lookup_miss().await,
+                CacheMissReason::InputFileRemoved { .. }
+            ),
             "a mutable source with deleted input files must stay a miss",
         );
     }
 
     #[tokio::test]
     async fn lookup_stale_when_new_file_matches_glob() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
-        let engine = ComputeEngine::new();
-
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let input = source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-
-        let scratch = tmp.path().join("scratch");
-        fs_err::create_dir_all(&scratch).unwrap();
-        let artifact = scratch.join("foo-1.0.0-h0.conda");
-        fs_err::write(&artifact, b"artifact").unwrap();
-
-        let key = key("linux-64-abc");
-        cache
-            .store(
-                &pkg("foo"),
-                &key,
-                &artifact,
-                vec![glob_group(&["**/*.py"])],
-                vec![abs(input.clone())],
-                SystemTime::now(),
-                dummy_record("foo"),
-            )
-            .await
-            .unwrap();
+        let (f, _input) = Fixture::with_input("main.py", b"body").await;
 
         // Introduce a new file that matches the stored glob.
-        fs_err::write(source.join("extra.py"), b"new module").unwrap();
-
-        let got = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key,
-            &source,
-            SourceMutability::Mutable,
-        )
-        .await
-        .unwrap();
+        f.write("extra.py", b"new module");
         assert!(
             matches!(
-                expect_miss(got),
+                f.lookup_miss().await,
                 CacheMissReason::InputFileAdded { ref path } if path.as_std_path().ends_with("extra.py"),
             ),
             "a newly-added matching file should invalidate the entry and name the file"
@@ -1189,28 +1014,17 @@ mod tests {
         // round-trips through the sidecar, and that the url is rewritten to
         // the cached artifact. A future refactor that accidentally drops a
         // field will fail this test.
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
-        let engine = ComputeEngine::new();
-
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let scratch = tmp.path().join("scratch");
-        fs_err::create_dir_all(&scratch).unwrap();
-        let artifact = scratch.join("foo-1.0.0-h0.conda");
-        fs_err::write(&artifact, b"pretend-conda").unwrap();
-
+        let f = Fixture::new();
         let mut record = dummy_record("foo");
         record.package_record.depends = vec!["python >=3.8".into(), "numpy".into()];
         record.package_record.build_number = 42;
         record.url = url::Url::parse("https://example.test/foo-1.0.0-h0.conda").unwrap();
 
-        let key = key("linux-64-abc");
-        cache
+        f.cache
             .store(
                 &pkg("foo"),
-                &key,
-                &artifact,
+                &key("linux-64-abc"),
+                &f.artifact,
                 Vec::new(),
                 Vec::<AbsPathBuf>::new(),
                 SystemTime::now(),
@@ -1219,18 +1033,7 @@ mod tests {
             .await
             .unwrap();
 
-        let hit = expect_hit(
-            lookup(
-                &engine,
-                &cache,
-                &pkg("foo"),
-                &key,
-                &source,
-                SourceMutability::Mutable,
-            )
-            .await
-            .unwrap(),
-        );
+        let hit = f.lookup().await.expect("cache should hit");
 
         // Package record identity.
         assert_eq!(hit.record.package_record.name, record.package_record.name);
@@ -1267,33 +1070,20 @@ mod tests {
     /// IO errors fall out.
     #[tokio::test]
     async fn concurrent_store_and_lookup_do_not_error() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+        let f = Fixture::new();
+        let input = f.write("main.py", b"body");
         let engine = ComputeEngine::new();
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-        let input = source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-        let scratch = tmp.path().join("scratch");
-        fs_err::create_dir_all(&scratch).unwrap();
-        let artifact = scratch.join("foo-1.0.0-h0.conda");
-        fs_err::write(&artifact, b"pretend").unwrap();
-
-        let key = key("linux-64-abc");
-        let pkg = pkg("foo");
 
         let mut handles = Vec::new();
         for _ in 0..4 {
-            let cache = cache.clone();
+            let cache = f.cache.clone();
             let input = input.clone();
-            let artifact = artifact.clone();
-            let pkg = pkg.clone();
-            let key = key.clone();
+            let artifact = f.artifact.clone();
             handles.push(tokio::spawn(async move {
                 cache
                     .store(
-                        &pkg,
-                        &key,
+                        &pkg("foo"),
+                        &key("linux-64-abc"),
                         &artifact,
                         Vec::new(),
                         vec![abs(input)],
@@ -1305,11 +1095,9 @@ mod tests {
             }));
         }
         for _ in 0..8 {
-            let cache = cache.clone();
+            let cache = f.cache.clone();
             let engine = engine.clone();
-            let source = source.clone();
-            let pkg = pkg.clone();
-            let key = key.clone();
+            let source = f.source.clone();
             handles.push(tokio::spawn(async move {
                 // Ignore whether it's a hit or miss; racing with stores
                 // the lookup may see either. The contract under test is
@@ -1317,8 +1105,8 @@ mod tests {
                 let _ = lookup(
                     &engine,
                     &cache,
-                    &pkg,
-                    &key,
+                    &pkg("foo"),
+                    &key("linux-64-abc"),
                     &source,
                     SourceMutability::Mutable,
                 )
@@ -1333,28 +1121,15 @@ mod tests {
 
     #[tokio::test]
     async fn corrupt_sidecar_is_a_miss() {
-        let tmp = TempDir::new().unwrap();
-        let cache = ArtifactCache::new(tmp.path().join("artifacts"));
-        let engine = ComputeEngine::new();
-
-        let source = tmp.path().join("src");
-        fs_err::create_dir_all(&source).unwrap();
-
-        let entry = cache.entry_dir(&pkg("foo"), &key("linux-64-abc"));
+        let f = Fixture::new();
+        let entry = f.cache.entry_dir(&pkg("foo"), &key("linux-64-abc"));
         fs_err::create_dir_all(&entry).unwrap();
         fs_err::write(entry.join("sidecar.json"), b"{ this is not valid").unwrap();
 
-        let got = lookup(
-            &engine,
-            &cache,
-            &pkg("foo"),
-            &key("linux-64-abc"),
-            &source,
-            SourceMutability::Mutable,
-        )
-        .await
-        .unwrap();
-        assert!(matches!(expect_miss(got), CacheMissReason::CorruptSidecar));
+        assert!(matches!(
+            f.lookup_miss().await,
+            CacheMissReason::CorruptSidecar
+        ));
     }
 
     /// Regression for prefix-dev/pixi#6232: a thin package whose manifest
@@ -1461,9 +1236,26 @@ mod tests {
             }
         }
 
-        async fn store(&self, globs: Vec<InputGlobSet>, inputs: Vec<AbsPathBuf>) {
-            self.store_with_build_started(globs, inputs, SystemTime::now())
+        /// Fixture with a single stored input file matched by `**/*.py`.
+        async fn with_input(name: &str, contents: &[u8]) -> (Self, PathBuf) {
+            let fixture = Self::new();
+            let input = fixture.write(name, contents);
+            fixture
+                .store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
                 .await;
+            (fixture, input)
+        }
+
+        /// Writes `contents` to `name` inside the source dir.
+        fn write(&self, name: &str, contents: &[u8]) -> PathBuf {
+            let path = self.source.join(name);
+            fs_err::write(&path, contents).unwrap();
+            path
+        }
+
+        async fn store(&self, globs: Vec<InputGlobSet>, inputs: Vec<AbsPathBuf>) -> CachedArtifact {
+            self.store_with_build_started(globs, inputs, SystemTime::now())
+                .await
         }
 
         async fn store_with_build_started(
@@ -1471,7 +1263,7 @@ mod tests {
             globs: Vec<InputGlobSet>,
             inputs: Vec<AbsPathBuf>,
             build_started: SystemTime,
-        ) {
+        ) -> CachedArtifact {
             self.cache
                 .store(
                     &pkg("foo"),
@@ -1483,25 +1275,36 @@ mod tests {
                     dummy_record("foo"),
                 )
                 .await
-                .unwrap();
+                .unwrap()
         }
 
         /// Each call gets a fresh engine, modelling a separate pixi run.
         /// Reusing one engine would reuse its memoized glob walk (see
         /// [`crate::input_globs`]) and hide newly-added files.
         async fn lookup(&self) -> Option<CachedArtifact> {
-            as_hit(
-                lookup(
-                    &ComputeEngine::new(),
-                    &self.cache,
-                    &pkg("foo"),
-                    &key("linux-64-abc"),
-                    &self.source,
-                    SourceMutability::Mutable,
-                )
-                .await
-                .unwrap(),
+            self.lookup_with(SourceMutability::Mutable).await
+        }
+
+        async fn lookup_with(&self, mutability: SourceMutability) -> Option<CachedArtifact> {
+            as_hit(self.lookup_raw(mutability).await)
+        }
+
+        /// The miss reason, panicking on a hit.
+        async fn lookup_miss(&self) -> CacheMissReason {
+            expect_miss(self.lookup_raw(SourceMutability::Mutable).await)
+        }
+
+        async fn lookup_raw(&self, mutability: SourceMutability) -> CacheLookup {
+            lookup(
+                &ComputeEngine::new(),
+                &self.cache,
+                &pkg("foo"),
+                &key("linux-64-abc"),
+                &self.source,
+                mutability,
             )
+            .await
+            .unwrap()
         }
 
         fn sidecar_path(&self) -> PathBuf {
@@ -1529,13 +1332,9 @@ mod tests {
     /// one.
     #[tokio::test]
     async fn same_size_edit_with_restored_mtime_is_not_detected() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"old").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("main.py", b"old").await;
 
-        let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        let original_mtime = mtime(&input);
         fs_err::write(&input, b"new").unwrap();
         set_modified(&input, original_mtime);
 
@@ -1552,11 +1351,7 @@ mod tests {
     /// different contents, permanently.
     #[tokio::test]
     async fn legacy_sidecar_without_fingerprints_is_never_upgraded() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("main.py", b"body").await;
 
         // Strip the states to emulate an entry written by an older pixi.
         let mut json = f.sidecar_json();
@@ -1574,8 +1369,7 @@ mod tests {
         );
 
         // A touch costs one rebuild; only a fresh store records fingerprints.
-        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
-        set_modified(&input, mtime + std::time::Duration::from_secs(5));
+        touch(&input, 5);
         assert!(
             f.lookup().await.is_none(),
             "a legacy entry cannot prove a touched file is unchanged",
@@ -1592,8 +1386,7 @@ mod tests {
     #[tokio::test]
     async fn store_tolerates_an_input_file_that_vanished_before_fingerprinting() {
         let f = Fixture::new();
-        let present = f.source.join("main.py");
-        fs_err::write(&present, b"body").unwrap();
+        let present = f.write("main.py", b"body");
         let vanished = f.source.join("gone.py");
 
         f.store(
@@ -1613,7 +1406,7 @@ mod tests {
         );
 
         // If it comes back, the glob walk sees a file the entry does not know.
-        fs_err::write(&vanished, b"back").unwrap();
+        f.write("gone.py", b"back");
         assert!(
             f.lookup().await.is_none(),
             "a reappearing input file must invalidate the entry",
@@ -1627,11 +1420,7 @@ mod tests {
     /// single pixi run; recorded so it is not mistaken for a fingerprint bug.
     #[tokio::test]
     async fn glob_walk_is_memoized_per_engine_so_one_run_sees_one_file_set() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, _input) = Fixture::with_input("main.py", b"body").await;
 
         let engine = ComputeEngine::new();
         let probe = async |source: &Path| {
@@ -1650,7 +1439,7 @@ mod tests {
         };
 
         assert!(probe(&f.source).await.is_some());
-        fs_err::write(f.source.join("extra.py"), b"new module").unwrap();
+        f.write("extra.py", b"new module");
         assert!(
             probe(&f.source).await.is_some(),
             "within one engine the memoized walk still reports the old file set",
@@ -1669,10 +1458,9 @@ mod tests {
         let f = Fixture::new();
         let dir = f.source.join("assets");
         fs_err::create_dir_all(&dir).unwrap();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
+        let input = f.write("main.py", b"body");
 
-        f.store(Vec::new(), vec![abs(input.clone()), abs(dir.clone())])
+        f.store(Vec::new(), vec![abs(input), abs(dir.clone())])
             .await;
 
         let sidecar = f.sidecar();
@@ -1696,11 +1484,7 @@ mod tests {
     /// process a rebuild at worst, never a wrong hit.
     #[tokio::test]
     async fn sidecar_with_unknown_fields_hits_and_only_loses_them_on_refresh() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("main.py", b"body").await;
 
         let mut json = f.sidecar_json();
         json.as_object_mut()
@@ -1720,8 +1504,7 @@ mod tests {
 
         // A touch forces a refresh, which rewrites the sidecar from the
         // fields this version knows about.
-        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
-        set_modified(&input, mtime + std::time::Duration::from_secs(3));
+        touch(&input, 3);
         assert!(f.lookup().await.is_some(), "a touch must still hit");
         assert!(
             f.sidecar_json().get("future_field").is_none(),
@@ -1734,16 +1517,10 @@ mod tests {
     /// leave the sidecar converged on the mtime it just observed.
     #[tokio::test]
     async fn a_file_touched_before_every_probe_keeps_hitting_and_converges() {
-        let f = Fixture::new();
-        let input = f.source.join("generated.py");
-        fs_err::write(&input, b"body").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("generated.py", b"body").await;
 
-        let base = fs_err::metadata(&input).unwrap().modified().unwrap();
         for round in 1..=3u64 {
-            let mtime = base + std::time::Duration::from_secs(round);
-            set_modified(&input, mtime);
+            let touched = touch(&input, 1);
             assert!(
                 f.lookup().await.is_some(),
                 "round {round}: a touched-but-unchanged file must stay cached",
@@ -1754,7 +1531,7 @@ mod tests {
                     .get(&input)
                     .unwrap()
                     .modified(),
-                mtime,
+                touched,
                 "round {round}: the refreshed mtime should be persisted",
             );
         }
@@ -1765,8 +1542,7 @@ mod tests {
     #[tokio::test]
     async fn pre_epoch_input_mtime_round_trips_through_store_and_lookup() {
         let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
+        let input = f.write("main.py", b"body");
 
         let pre_epoch = SystemTime::UNIX_EPOCH - std::time::Duration::from_secs(86_400);
         let settable = OpenOptions::new()
@@ -1801,23 +1577,19 @@ mod tests {
     /// bring the entry back rather than wedging it.
     #[tokio::test]
     async fn zero_byte_input_file_round_trips() {
-        let f = Fixture::new();
-        let input = f.source.join("__init__.py");
-        fs_err::write(&input, b"").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("__init__.py", b"").await;
         assert!(f.lookup().await.is_some(), "an empty input file must hit");
 
-        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        let base = mtime(&input);
         fs_err::write(&input, b"x").unwrap();
-        set_modified(&input, mtime + std::time::Duration::from_secs(1));
+        set_modified(&input, base + std::time::Duration::from_secs(1));
         assert!(
             f.lookup().await.is_none(),
             "growing the file must invalidate the entry",
         );
 
         fs_err::write(&input, b"").unwrap();
-        set_modified(&input, mtime + std::time::Duration::from_secs(2));
+        set_modified(&input, base + std::time::Duration::from_secs(2));
         assert!(
             f.lookup().await.is_some(),
             "restoring the empty contents must restore the hit",
@@ -1829,14 +1601,9 @@ mod tests {
     /// decides: identical contents keep the hit, different contents do not.
     #[tokio::test]
     async fn an_mtime_moving_backwards_is_decided_by_the_hash() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"old").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("main.py", b"old").await;
 
-        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
-        let older = mtime - std::time::Duration::from_secs(3600);
+        let older = mtime(&input) - std::time::Duration::from_secs(3600);
         set_modified(&input, older);
         assert!(
             f.lookup().await.is_some(),
@@ -1855,16 +1622,11 @@ mod tests {
     /// contents. Only the hash can tell these apart.
     #[tokio::test]
     async fn grow_then_truncate_to_the_original_size_invalidates() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"aaa").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, input) = Fixture::with_input("main.py", b"aaa").await;
 
-        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
         fs_err::write(&input, b"bbbbbbbbb").unwrap();
         fs_err::write(&input, b"ccc").unwrap();
-        set_modified(&input, mtime + std::time::Duration::from_secs(1));
+        touch(&input, 1);
 
         assert!(
             f.lookup().await.is_none(),
@@ -1878,10 +1640,8 @@ mod tests {
     #[tokio::test]
     async fn unconfirmed_input_converges_after_one_rebuild() {
         let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-        let before_mtime = fs_err::metadata(&input).unwrap().modified().unwrap()
-            - std::time::Duration::from_secs(10);
+        let input = f.write("main.py", b"body");
+        let before_mtime = mtime(&input) - std::time::Duration::from_secs(10);
 
         f.store_with_build_started(
             vec![glob_group(&["**/*.py"])],
@@ -1911,11 +1671,7 @@ mod tests {
     /// explicit invalidation wins.
     #[tokio::test]
     async fn refresh_does_not_resurrect_a_cleared_entry() {
-        let f = Fixture::new();
-        let input = f.source.join("main.py");
-        fs_err::write(&input, b"body").unwrap();
-        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
-            .await;
+        let (f, _input) = Fixture::with_input("main.py", b"body").await;
 
         let key = key("linux-64-abc");
         let sidecar_path = f.cache.sidecar_path(&pkg("foo"), &key);

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -65,7 +65,7 @@ pub enum SourceMutability {
 }
 
 use crate::file_fingerprint::{
-    FileFingerprint, FileFingerprintError, MetadataComparison, fingerprint_files,
+    FileFingerprint, MetadataComparison, fingerprint_files, fingerprint_files_lenient,
     spawn_blocking_with_io_permit,
 };
 
@@ -455,10 +455,12 @@ impl ArtifactCache {
                 match sidecar.input_file_fingerprints.get(path) {
                     Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
                         Ok(MetadataComparison::Unchanged) => {}
-                        Ok(MetadataComparison::HashRequired) => {
+                        Ok(MetadataComparison::HashRequired) if metadata.is_file() => {
                             fingerprints_to_compute.push(path.as_std_path().to_path_buf());
                         }
-                        Ok(MetadataComparison::Changed) | Err(_) => {
+                        Ok(MetadataComparison::HashRequired)
+                        | Ok(MetadataComparison::Changed)
+                        | Err(_) => {
                             return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
                                 path: path.clone(),
                                 built_at: DateTime::<Utc>::from(fingerprint.modified),
@@ -476,7 +478,11 @@ impl ArtifactCache {
                                 modified_at: modified,
                             }));
                         }
-                        fingerprints_to_compute.push(path.as_std_path().to_path_buf());
+                        // Special files cannot be hashed and keep
+                        // timestamp-only validation.
+                        if metadata.is_file() {
+                            fingerprints_to_compute.push(path.as_std_path().to_path_buf());
+                        }
                     }
                 }
             }
@@ -508,14 +514,34 @@ impl ArtifactCache {
                 };
                 for (path, current) in current_fingerprints {
                     let path = AbsPathBuf::new(path).expect("recorded input paths are absolute");
-                    if let Some(expected) = sidecar.input_file_fingerprints.get(&path)
-                        && expected.hash != current.hash
-                    {
-                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
-                            path: path.clone(),
-                            built_at: DateTime::<Utc>::from(expected.modified),
-                            modified_at: DateTime::<Utc>::from(current.modified),
-                        }));
+                    match sidecar.input_file_fingerprints.get(&path) {
+                        Some(expected) => {
+                            if expected.hash != current.hash {
+                                return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
+                                    path: path.clone(),
+                                    built_at: DateTime::<Utc>::from(expected.modified),
+                                    modified_at: DateTime::<Utc>::from(current.modified),
+                                }));
+                            }
+                        }
+                        None => {
+                            // Without a recorded hash the computed hash only
+                            // vouches for the cached artifact if the file did
+                            // not change since the stat pass.
+                            let recorded = sidecar
+                                .input_files
+                                .get(&path)
+                                .copied()
+                                .expect("only recorded files are queued for hashing");
+                            let observed = DateTime::<Utc>::from(current.modified);
+                            if recorded != observed {
+                                return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
+                                    path: path.clone(),
+                                    built_at: recorded,
+                                    modified_at: observed,
+                                }));
+                            }
+                        }
                     }
 
                     sidecar
@@ -601,6 +627,9 @@ impl ArtifactCache {
             return Ok(());
         }
 
+        // Re-serializing the parsed sidecar drops fields written by a newer
+        // pixi. With the fields-are-only-added policy that costs the newer
+        // process a rebuild at worst, never a wrong hit.
         let bytes = serde_json::to_vec(sidecar).expect("sidecar serialization cannot fail");
         tokio::fs::write(&sidecar_path, bytes)
             .await
@@ -674,19 +703,22 @@ impl ArtifactCache {
             }
         };
 
+        // A file that cannot be hashed keeps timestamp-based validation, and
+        // a file that vanished is dropped; the glob check treats it as new if
+        // it reappears. Neither fails the store.
         let input_fingerprints = async {
-            fingerprint_files(
+            fingerprint_files_lenient(
                 input_files
                     .into_iter()
                     .map(|path| path.as_std_path().to_path_buf()),
                 self.io_concurrency_semaphore.clone(),
             )
             .await
-            .map_err(ArtifactCacheError::from)
         };
-        let (sha256, input_file_fingerprints) =
-            tokio::try_join!(artifact_digest, input_fingerprints)?;
-        let input_file_fingerprints = input_file_fingerprints
+        let (sha256, fingerprinted) = tokio::join!(artifact_digest, input_fingerprints);
+        let sha256 = sha256?;
+        let input_file_fingerprints = fingerprinted
+            .fingerprints
             .into_iter()
             .map(|(path, fingerprint)| {
                 (
@@ -695,10 +727,16 @@ impl ArtifactCache {
                 )
             })
             .collect::<BTreeMap<_, _>>();
-        let input_files_mtimes = input_file_fingerprints
+        let mut input_files_mtimes: BTreeMap<AbsPathBuf, DateTime<Utc>> = input_file_fingerprints
             .iter()
             .map(|(path, fingerprint)| (path.clone(), DateTime::<Utc>::from(fingerprint.modified)))
             .collect();
+        for (path, mtime) in fingerprinted.mtime_only {
+            input_files_mtimes.insert(
+                AbsPathBuf::new(path).expect("recorded input paths are absolute"),
+                DateTime::<Utc>::from(mtime),
+            );
+        }
 
         let sidecar = ArtifactSidecar {
             input_glob_sets,
@@ -737,13 +775,6 @@ pub enum ArtifactCacheError {
 
     #[error("artifact path has no filename: {}", .0.display())]
     ArtifactFilename(PathBuf),
-
-    #[error("failed to fingerprint input file at {}", path.display())]
-    Fingerprint {
-        path: PathBuf,
-        #[source]
-        source: Arc<std::io::Error>,
-    },
 }
 
 impl ArtifactCacheError {
@@ -759,15 +790,6 @@ impl ArtifactCacheError {
 impl From<pixi_glob::GlobSetError> for ArtifactCacheError {
     fn from(err: pixi_glob::GlobSetError) -> Self {
         Self::Glob(Arc::new(err))
-    }
-}
-
-impl From<FileFingerprintError> for ArtifactCacheError {
-    fn from(err: FileFingerprintError) -> Self {
-        Self::Fingerprint {
-            path: err.path,
-            source: err.source,
-        }
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -25,6 +25,7 @@
 //! memory for the lifetime of the process.
 
 use std::{
+    borrow::Cow,
     collections::BTreeMap,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
@@ -49,6 +50,11 @@ use tokio::sync::Semaphore;
 use url::Url;
 use xxhash_rust::xxh3::Xxh3;
 
+use crate::file_fingerprint::spawn_blocking_with_io_permit;
+use crate::input_snapshot::{
+    InputFileState, InputSnapshot, SnapshotFreshness, StaleFile, StaleFileReason,
+};
+
 /// Whether the source files behind a cache entry can change without the
 /// pinned source spec changing.
 ///
@@ -64,11 +70,6 @@ pub enum SourceMutability {
     Mutable,
     Immutable,
 }
-
-use crate::file_fingerprint::spawn_blocking_with_io_permit;
-use crate::input_snapshot::{
-    InputFileState, InputSnapshot, SnapshotFreshness, StaleFile, StaleFileReason,
-};
 
 /// Opaque content-addressed handle for an artifact cache entry.
 ///
@@ -205,33 +206,45 @@ pub struct ArtifactSidecar {
 }
 
 impl ArtifactSidecar {
-    /// The snapshot to verify against: recorded states, with the
-    /// `input_files` mtimes as fallback for sidecars written before
-    /// fingerprints existed.
-    fn input_snapshot(&self) -> InputSnapshot {
-        let mut snapshot = self.input_file_states.clone();
+    /// Builds the record for a freshly stored artifact. `input_files` is
+    /// derived from the snapshot; it stays on the wire so older pixi
+    /// versions can keep validating the entry.
+    fn new(
+        input_glob_sets: Vec<InputGlobSet>,
+        snapshot: InputSnapshot,
+        artifact_sha256: Sha256Hash,
+        artifact_filename: String,
+        record: RepoDataRecord,
+    ) -> Self {
+        let input_files = snapshot
+            .iter()
+            .map(|(path, state)| (path.clone(), DateTime::<Utc>::from(state.modified())))
+            .collect();
+        Self {
+            input_glob_sets,
+            input_files,
+            input_file_states: snapshot,
+            artifact_sha256,
+            artifact_filename,
+            record,
+        }
+    }
+
+    /// The snapshot to verify against. Sidecars written before fingerprints
+    /// existed carry only `input_files` mtimes, which become mtime-only
+    /// states; everything newer verifies its recorded states directly.
+    fn input_snapshot(&self) -> Cow<'_, InputSnapshot> {
+        if !self.input_file_states.is_empty() {
+            return Cow::Borrowed(&self.input_file_states);
+        }
+        let mut snapshot = InputSnapshot::default();
         for (path, mtime) in &self.input_files {
             snapshot.insert_fallback(
-                path.as_std_path().to_path_buf(),
+                path.clone(),
                 InputFileState::MtimeOnly(SystemTime::from(*mtime)),
             );
         }
-        snapshot
-    }
-
-    /// Records `snapshot` and mirrors its mtimes into `input_files` so older
-    /// pixi versions can keep validating the entry.
-    fn set_input_snapshot(&mut self, snapshot: InputSnapshot) {
-        self.input_files = snapshot
-            .iter()
-            .map(|(path, state)| {
-                (
-                    AbsPathBuf::new(path.clone()).expect("recorded input paths are absolute"),
-                    DateTime::<Utc>::from(state.modified()),
-                )
-            })
-            .collect();
-        self.input_file_states = snapshot;
+        Cow::Owned(snapshot)
     }
 }
 
@@ -241,6 +254,15 @@ pub struct CachedArtifact {
     pub artifact: PathBuf,
     pub sha256: Sha256Hash,
     pub record: RepoDataRecord,
+}
+
+/// Outcome of [`ArtifactCache::try_refresh_sidecar`].
+enum SidecarRefresh {
+    /// The refreshed sidecar was persisted over the validated bytes.
+    Written,
+    /// Another process changed the entry in the meantime; nothing was
+    /// written.
+    Changed,
 }
 
 /// Outcome of an [`ArtifactCache::lookup`].
@@ -485,19 +507,10 @@ impl ArtifactCache {
         };
         let Ok(mut sidecar) = serde_json::from_slice::<ArtifactSidecar>(&bytes) else {
             // Treat unparsable sidecars as misses; the caller will rebuild
-            // and overwrite.
+            // and overwrite. This also covers semantically invalid entries:
+            // relative path keys fail `AbsPathBuf` deserialization.
             return Ok(CacheLookup::Miss(CacheMissReason::CorruptSidecar));
         };
-        // A parsable sidecar can still carry garbage: state keys must be
-        // absolute like the `input_files` keys, or the refresh rewrite
-        // would panic converting them.
-        if sidecar
-            .input_file_states
-            .iter()
-            .any(|(path, _)| AbsPathBuf::new(path.clone()).is_err())
-        {
-            return Ok(CacheLookup::Miss(CacheMissReason::CorruptSidecar));
-        }
         drop(_guard);
 
         // For an immutable source the cache key already pins the exact
@@ -511,21 +524,28 @@ impl ArtifactCache {
             // The snapshot check and the glob walk inspect independent
             // aspects of the source tree, so they run concurrently. The walk
             // catches files added since the entry was written.
-            let snapshot = sidecar.input_snapshot();
-            let files = sidecar
-                .input_files
-                .keys()
-                .map(|path| path.as_std_path().to_path_buf())
-                .collect::<Vec<_>>();
-            let verify_future = snapshot.verify(files, None, self.io_concurrency_semaphore.clone());
-            let glob_future =
-                crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir);
-            let (freshness, current) = tokio::join!(verify_future, glob_future);
+            let (freshness, current) = {
+                let snapshot = sidecar.input_snapshot();
+                let files = sidecar.input_files.keys().cloned().collect::<Vec<_>>();
+                let verify_future =
+                    snapshot.verify(files, None, self.io_concurrency_semaphore.clone());
+                let glob_future = crate::input_globs::collect_input_files(
+                    ctx,
+                    &sidecar.input_glob_sets,
+                    source_dir,
+                );
+                tokio::join!(verify_future, glob_future)
+            };
 
             match freshness {
                 SnapshotFreshness::Fresh => {}
-                SnapshotFreshness::Refreshed(snapshot) => {
-                    sidecar.set_input_snapshot(snapshot);
+                SnapshotFreshness::Refreshed(pairs) => {
+                    for (path, fingerprint) in &pairs {
+                        sidecar
+                            .input_files
+                            .insert(path.clone(), DateTime::<Utc>::from(fingerprint.modified));
+                    }
+                    sidecar.input_file_states.apply_refresh(pairs);
                     refreshed = true;
                 }
                 SnapshotFreshness::Stale(stale) => {
@@ -541,28 +561,6 @@ impl ArtifactCache {
                     }));
                 }
             }
-
-            // The lock was dropped during validation, so a concurrent store
-            // may have replaced the entry; the recorded sha256 would then
-            // describe a different artifact. Reject the hit when the sidecar
-            // bytes moved.
-            let Some(lock_file) = self.open_lock_file_if_exists(package, key).await? else {
-                return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged));
-            };
-            let _guard = lock_file.lock_read().await.map_err(|err| {
-                ArtifactCacheError::io(
-                    "acquiring shared lock",
-                    self.lock_path(package, key),
-                    err.error,
-                )
-            })?;
-            let current_bytes = match tokio::fs::read(&sidecar_path).await {
-                Ok(current_bytes) => current_bytes,
-                Err(_) => return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged)),
-            };
-            if current_bytes != bytes {
-                return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged));
-            }
         }
 
         let artifact_path = self
@@ -574,15 +572,35 @@ impl ArtifactCache {
             }));
         }
 
-        if refreshed
-            && let Err(err) = self
-                .try_refresh_sidecar(package, key, &bytes, &sidecar)
-                .await
-        {
-            tracing::debug!(
-                error = %err,
-                "Failed to persist refreshed artifact input fingerprints; using the verified entry"
-            );
+        // The lock was dropped during validation, so a concurrent store may
+        // have replaced the entry; the recorded sha256 would then describe a
+        // different artifact. The refresh write doubles as that check: its
+        // byte compare-and-swap only persists over the bytes this probe
+        // validated.
+        if mutability == SourceMutability::Mutable {
+            let unchanged = if refreshed {
+                match self
+                    .try_refresh_sidecar(package, key, &bytes, &sidecar)
+                    .await
+                {
+                    Ok(SidecarRefresh::Written) => true,
+                    Ok(SidecarRefresh::Changed) => false,
+                    Err(err) => {
+                        // Best-effort: an I/O failure leaves the old entry in
+                        // place, which this probe already validated.
+                        tracing::debug!(
+                            error = %err,
+                            "Failed to persist refreshed artifact input fingerprints; using the verified entry"
+                        );
+                        true
+                    }
+                }
+            } else {
+                self.sidecar_unchanged(package, key, &bytes).await?
+            };
+            if !unchanged {
+                return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged));
+            }
         }
 
         // Point the record at the artifact being returned. Sidecars written
@@ -626,12 +644,12 @@ impl ArtifactCache {
         key: &ArtifactCacheKey,
         expected_bytes: &[u8],
         sidecar: &ArtifactSidecar,
-    ) -> Result<(), ArtifactCacheError> {
+    ) -> Result<SidecarRefresh, ArtifactCacheError> {
         let sidecar_path = self.sidecar_path(package, key);
         // Never recreate the entry directory here: a concurrent
         // `clear_package` must not be undone by a refresh.
         let Some(lock_file) = self.open_lock_file_if_exists(package, key).await? else {
-            return Ok(());
+            return Ok(SidecarRefresh::Changed);
         };
         let _guard = lock_file.lock_write().await.map_err(|err| {
             ArtifactCacheError::io(
@@ -643,13 +661,15 @@ impl ArtifactCache {
 
         let current_bytes = match tokio::fs::read(&sidecar_path).await {
             Ok(bytes) => bytes,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(SidecarRefresh::Changed);
+            }
             Err(err) => {
                 return Err(ArtifactCacheError::io("reading sidecar", sidecar_path, err));
             }
         };
         if current_bytes != expected_bytes {
-            return Ok(());
+            return Ok(SidecarRefresh::Changed);
         }
 
         // Re-serializing the parsed sidecar drops fields written by a newer
@@ -658,7 +678,32 @@ impl ArtifactCache {
         let bytes = serde_json::to_vec(sidecar).expect("sidecar serialization cannot fail");
         tokio::fs::write(&sidecar_path, bytes)
             .await
-            .map_err(|err| ArtifactCacheError::io("writing sidecar", sidecar_path, err))
+            .map_err(|err| ArtifactCacheError::io("writing sidecar", sidecar_path, err))?;
+        Ok(SidecarRefresh::Written)
+    }
+
+    /// Whether the sidecar still holds exactly `expected_bytes`, checked
+    /// under a shared lock. `false` when the entry changed or vanished.
+    async fn sidecar_unchanged(
+        &self,
+        package: &PackageName,
+        key: &ArtifactCacheKey,
+        expected_bytes: &[u8],
+    ) -> Result<bool, ArtifactCacheError> {
+        let Some(lock_file) = self.open_lock_file_if_exists(package, key).await? else {
+            return Ok(false);
+        };
+        let _guard = lock_file.lock_read().await.map_err(|err| {
+            ArtifactCacheError::io(
+                "acquiring shared lock",
+                self.lock_path(package, key),
+                err.error,
+            )
+        })?;
+        Ok(matches!(
+            tokio::fs::read(self.sidecar_path(package, key)).await,
+            Ok(current) if current == expected_bytes
+        ))
     }
 
     /// Place `artifact_source` into the cache and write its sidecar.
@@ -703,7 +748,7 @@ impl ArtifactCache {
             .await
             .ok()
             .and_then(|bytes| serde_json::from_slice::<ArtifactSidecar>(&bytes).ok())
-            .map(|sidecar| sidecar.input_snapshot());
+            .map(|sidecar| sidecar.input_file_states);
 
         let filename = artifact_source
             .file_name()
@@ -727,43 +772,28 @@ impl ArtifactCache {
         // cleaned before the record is consumed again.
         record.url = Url::from_file_path(&dest).expect("cache entry paths are absolute");
 
-        let artifact_digest = {
-            let path = dest.clone();
-            let error_path = dest.clone();
-            let io_semaphore = self.io_concurrency_semaphore.clone();
-            async move {
-                spawn_blocking_with_io_permit(io_semaphore, move || {
-                    rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&path)
-                })
-                .await
-                .expect("sha256 task panicked")
-                .map_err(|err| ArtifactCacheError::io("hashing artifact", error_path, err))
-            }
-        };
+        let digest_path = dest.clone();
+        let artifact_digest =
+            spawn_blocking_with_io_permit(self.io_concurrency_semaphore.clone(), move || {
+                rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&digest_path)
+            });
 
         // A file that cannot be hashed keeps mtime-only validation, and a
         // file that vanished is dropped; the glob check treats it as new if
         // it reappears. Neither fails the store.
         let snapshot_future = InputSnapshot::capture(
-            input_files
-                .into_iter()
-                .map(|path| path.as_std_path().to_path_buf()),
+            input_files,
             Some(build_started),
             previous_snapshot.as_ref(),
             self.io_concurrency_semaphore.clone(),
         );
         let (sha256, snapshot) = tokio::join!(artifact_digest, snapshot_future);
-        let sha256 = sha256?;
+        let sha256 = sha256
+            .expect("sha256 task panicked")
+            .map_err(|err| ArtifactCacheError::io("hashing artifact", dest.clone(), err))?;
 
-        let mut sidecar = ArtifactSidecar {
-            input_glob_sets,
-            input_files: BTreeMap::new(),
-            input_file_states: InputSnapshot::default(),
-            artifact_sha256: sha256,
-            artifact_filename: filename,
-            record: record.clone(),
-        };
-        sidecar.set_input_snapshot(snapshot);
+        let sidecar =
+            ArtifactSidecar::new(input_glob_sets, snapshot, sha256, filename, record.clone());
         let sidecar_path = self.sidecar_path(package, key);
         let bytes = serde_json::to_vec(&sidecar).expect("sidecar serialization cannot fail");
         tokio::fs::write(&sidecar_path, &bytes)
@@ -1142,9 +1172,9 @@ mod tests {
         ));
     }
 
-    /// A parsable sidecar can still be semantically corrupt: a relative key
-    /// under `input_file_states` must miss instead of panicking when the
-    /// refresh rewrites the sidecar.
+    /// A relative key under `input_file_states` fails `AbsPathBuf`
+    /// deserialization, so the whole sidecar counts as corrupt instead of
+    /// reaching any code that assumes absolute paths.
     #[tokio::test]
     async fn a_sidecar_with_a_relative_state_key_is_a_corrupt_miss() {
         let (f, input) = Fixture::with_input("main.py", b"body").await;

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -668,7 +668,7 @@ impl From<FileFingerprintError> for ArtifactCacheError {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{fs::OpenOptions, str::FromStr, time::SystemTime};
 
     use pixi_compute_engine::ComputeEngine;
     use rattler_conda_types::{PackageName, PackageRecord};
@@ -696,6 +696,15 @@ mod tests {
 
     fn abs(path: impl Into<PathBuf>) -> AbsPathBuf {
         AbsPathBuf::new(path).unwrap()
+    }
+
+    fn set_modified(path: &Path, modified: SystemTime) {
+        OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(modified)
+            .unwrap();
     }
 
     /// Drive [`ArtifactCache::lookup`] (which needs a `ComputeCtx`) through the
@@ -839,10 +848,7 @@ mod tests {
         // valid and refreshes the stored mtime.
         let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
         let touched_mtime = original_mtime + std::time::Duration::from_secs(1);
-        std::fs::File::open(&input)
-            .unwrap()
-            .set_modified(touched_mtime)
-            .unwrap();
+        set_modified(&input, touched_mtime);
 
         let hit = lookup(
             &engine,
@@ -871,10 +877,7 @@ mod tests {
 
         // A same-size content change still invalidates the entry.
         fs_err::write(&input, b"new").unwrap();
-        std::fs::File::open(&input)
-            .unwrap()
-            .set_modified(touched_mtime + std::time::Duration::from_secs(1))
-            .unwrap();
+        set_modified(&input, touched_mtime + std::time::Duration::from_secs(1));
 
         let got = lookup(
             &engine,

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -292,6 +292,11 @@ pub enum CacheMissReason {
     /// The sidecar is valid but the `.conda` it points at is gone.
     ArtifactRemoved { path: PathBuf },
 
+    /// A recorded input file was modified while the entry was being built,
+    /// so its recorded hash cannot vouch for what the build read. One
+    /// rebuild confirms it.
+    InputFileUnconfirmed { path: AbsPathBuf },
+
     /// The entry changed while it was being validated: a concurrent store
     /// replaced it or a concurrent clear removed it.
     EntryChanged,
@@ -315,6 +320,12 @@ impl std::fmt::Display for CacheMissReason {
             Self::ArtifactRemoved { path } => {
                 write!(f, "cached artifact removed: {}", path.display())
             }
+            Self::InputFileUnconfirmed { path } => {
+                write!(
+                    f,
+                    "input file was modified while the entry was being built; rebuilding to confirm it: {path}"
+                )
+            }
             Self::EntryChanged => {
                 write!(f, "entry changed while it was being validated")
             }
@@ -335,6 +346,7 @@ impl StaleFile {
                     modified_at: DateTime::<Utc>::from(observed),
                 }
             }
+            StaleFileReason::Unconfirmed => CacheMissReason::InputFileUnconfirmed { path },
         }
     }
 }
@@ -646,6 +658,10 @@ impl ArtifactCache {
     /// is persisted in the sidecar so cache hits can skip re-reading
     /// index.json.
     ///
+    /// `build_started` is when the backend began reading the sources: a file
+    /// modified after it gets an unconfirmed fingerprint (see
+    /// `InputSnapshot::capture`).
+    ///
     /// Holds an exclusive write lock on the entry's `.lock` file for
     /// the artifact copy + sidecar write, so a concurrent
     /// [`lookup`](Self::lookup) blocks until the new state is fully
@@ -658,6 +674,7 @@ impl ArtifactCache {
         artifact_source: &Path,
         input_glob_sets: Vec<InputGlobSet>,
         input_files: impl IntoIterator<Item = AbsPathBuf>,
+        build_started: SystemTime,
         mut record: RepoDataRecord,
     ) -> Result<CachedArtifact, ArtifactCacheError> {
         let entry_dir = self.entry_dir(package, key);
@@ -669,6 +686,14 @@ impl ArtifactCache {
                 err.error,
             )
         })?;
+
+        // The entry being replaced supplies the previous observation that
+        // can confirm an unconfirmed fingerprint.
+        let previous_snapshot = tokio::fs::read(self.sidecar_path(package, key))
+            .await
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<ArtifactSidecar>(&bytes).ok())
+            .map(|sidecar| sidecar.input_snapshot());
 
         let filename = artifact_source
             .file_name()
@@ -713,7 +738,8 @@ impl ArtifactCache {
             input_files
                 .into_iter()
                 .map(|path| path.as_std_path().to_path_buf()),
-            None,
+            Some(build_started),
+            previous_snapshot.as_ref(),
             self.io_concurrency_semaphore.clone(),
         );
         let (sha256, snapshot) = tokio::join!(artifact_digest, snapshot_future);
@@ -929,6 +955,7 @@ mod tests {
                 &artifact,
                 vec![glob_group(&["**/*.py"])],
                 vec![abs(input.clone())],
+                SystemTime::now(),
                 dummy_record("foo"),
             )
             .await
@@ -978,6 +1005,7 @@ mod tests {
                 &artifact,
                 Vec::new(),
                 vec![abs(input.clone())],
+                SystemTime::now(),
                 dummy_record("foo"),
             )
             .await
@@ -1062,6 +1090,7 @@ mod tests {
                 &artifact,
                 vec![glob_group(&["**/*.py"])],
                 vec![abs(input.clone())],
+                SystemTime::now(),
                 dummy_record("foo"),
             )
             .await
@@ -1125,6 +1154,7 @@ mod tests {
                 &artifact,
                 vec![glob_group(&["**/*.py"])],
                 vec![abs(input.clone())],
+                SystemTime::now(),
                 dummy_record("foo"),
             )
             .await
@@ -1183,6 +1213,7 @@ mod tests {
                 &artifact,
                 Vec::new(),
                 Vec::<AbsPathBuf>::new(),
+                SystemTime::now(),
                 record.clone(),
             )
             .await
@@ -1266,6 +1297,7 @@ mod tests {
                         &artifact,
                         Vec::new(),
                         vec![abs(input)],
+                        SystemTime::now(),
                         dummy_record("foo"),
                     )
                     .await
@@ -1379,6 +1411,7 @@ mod tests {
                 &artifact,
                 groups,
                 input_files,
+                SystemTime::now(),
                 dummy_record("foo"),
             )
             .await
@@ -1429,6 +1462,16 @@ mod tests {
         }
 
         async fn store(&self, globs: Vec<InputGlobSet>, inputs: Vec<AbsPathBuf>) {
+            self.store_with_build_started(globs, inputs, SystemTime::now())
+                .await;
+        }
+
+        async fn store_with_build_started(
+            &self,
+            globs: Vec<InputGlobSet>,
+            inputs: Vec<AbsPathBuf>,
+            build_started: SystemTime,
+        ) {
             self.cache
                 .store(
                     &pkg("foo"),
@@ -1436,6 +1479,7 @@ mod tests {
                     &self.artifact,
                     globs,
                     inputs,
+                    build_started,
                     dummy_record("foo"),
                 )
                 .await
@@ -1828,6 +1872,41 @@ mod tests {
         );
     }
 
+    /// A file modified after the build started (future-dated mtime, or the
+    /// build rewriting it) gets an unconfirmed fingerprint: one more rebuild,
+    /// then the stable content is promoted and the entry hits again.
+    #[tokio::test]
+    async fn unconfirmed_input_converges_after_one_rebuild() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+        let before_mtime = fs_err::metadata(&input).unwrap().modified().unwrap()
+            - std::time::Duration::from_secs(10);
+
+        f.store_with_build_started(
+            vec![glob_group(&["**/*.py"])],
+            vec![abs(input.clone())],
+            before_mtime,
+        )
+        .await;
+        assert!(
+            f.lookup().await.is_none(),
+            "an unconfirmed fingerprint cannot vouch for the entry",
+        );
+
+        // The rebuild observes the same content and promotes it.
+        f.store_with_build_started(
+            vec![glob_group(&["**/*.py"])],
+            vec![abs(input.clone())],
+            before_mtime,
+        )
+        .await;
+        assert!(
+            f.lookup().await.is_some(),
+            "content stable across two builds must be trusted",
+        );
+    }
+
     /// A refresh racing a `clear_package` must not write the sidecar back;
     /// explicit invalidation wins.
     #[tokio::test]
@@ -1852,6 +1931,171 @@ mod tests {
         assert!(
             fs_err::metadata(f.cache.entry_dir(&pkg("foo"), &key)).is_err(),
             "a refresh must not recreate a cleared entry directory",
+        );
+    }
+
+    /// The promotion that trusts an unconfirmed fingerprint lives entirely in
+    /// the entry being replaced. Clearing the package throws that observation
+    /// away, so the next build is a cold one again: unconfirmed, one rebuild,
+    /// then trusted.
+    #[tokio::test]
+    async fn clearing_the_package_resets_the_unconfirmed_promotion() {
+        let f = Fixture::new();
+        let input = f.write("main.py", b"body");
+        let before_mtime = mtime(&input) - std::time::Duration::from_secs(10);
+        let store = async || {
+            f.store_with_build_started(
+                vec![glob_group(&["**/*.py"])],
+                vec![abs(input.clone())],
+                before_mtime,
+            )
+            .await;
+        };
+
+        store().await;
+        assert!(f.lookup().await.is_none());
+        store().await;
+        assert!(
+            f.lookup().await.is_some(),
+            "the second build promotes the stable content",
+        );
+
+        f.cache.clear_package(&pkg("foo")).unwrap();
+        store().await;
+        assert!(
+            f.lookup().await.is_none(),
+            "with the previous observation cleared the entry is cold again",
+        );
+        store().await;
+        assert!(
+            f.lookup().await.is_some(),
+            "and it converges again after one rebuild",
+        );
+    }
+
+    /// An unconfirmed fingerprint misses with its own reason that names the
+    /// file, instead of an `InputFileModified` claiming a change from an
+    /// instant to that same instant.
+    #[tokio::test]
+    async fn an_unconfirmed_input_misses_with_a_dedicated_reason() {
+        let f = Fixture::new();
+        let input = f.write("main.py", b"body");
+        let observed = mtime(&input);
+
+        f.store_with_build_started(
+            vec![glob_group(&["**/*.py"])],
+            vec![abs(input.clone())],
+            observed - std::time::Duration::from_secs(10),
+        )
+        .await;
+
+        match f.lookup_miss().await {
+            CacheMissReason::InputFileUnconfirmed { path } => {
+                assert_eq!(path.as_std_path(), input, "the miss must name the file");
+            }
+            other => panic!("expected an input-file-unconfirmed miss, got {other:?}"),
+        }
+    }
+
+    /// The refresh write is a compare-and-swap on the sidecar bytes: another
+    /// process that rewrote the entry in the meantime must win.
+    #[tokio::test]
+    async fn refresh_does_not_overwrite_a_sidecar_that_moved() {
+        let (f, _input) = Fixture::with_input("main.py", b"body").await;
+
+        let key = key("linux-64-abc");
+        let stale_bytes = fs_err::read(f.sidecar_path()).unwrap();
+        let mut sidecar: ArtifactSidecar = serde_json::from_slice(&stale_bytes).unwrap();
+        sidecar.artifact_filename = "refreshed.conda".into();
+
+        // Emulate a concurrent store landing between the read and the refresh.
+        let mut json = f.sidecar_json();
+        json.as_object_mut()
+            .unwrap()
+            .insert("artifact_filename".into(), "concurrent.conda".into());
+        f.write_sidecar_json(&json);
+
+        f.cache
+            .try_refresh_sidecar(&pkg("foo"), &key, &stale_bytes, &sidecar)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            f.sidecar().artifact_filename,
+            "concurrent.conda",
+            "the refresh must not clobber the entry another writer committed",
+        );
+    }
+
+    /// An entry whose lock file is gone can no longer be re-validated, which
+    /// is the condition `lookup` reports as `EntryChanged`.
+    #[tokio::test]
+    async fn a_cleared_entry_has_no_lock_file_to_revalidate_against() {
+        let (f, _input) = Fixture::with_input("main.py", b"body").await;
+
+        let key = key("linux-64-abc");
+        assert!(
+            f.cache
+                .open_lock_file_if_exists(&pkg("foo"), &key)
+                .await
+                .unwrap()
+                .is_some(),
+        );
+
+        f.cache.clear_package(&pkg("foo")).unwrap();
+        assert!(
+            f.cache
+                .open_lock_file_if_exists(&pkg("foo"), &key)
+                .await
+                .unwrap()
+                .is_none(),
+            "a cleared entry must report a missing lock rather than recreating it",
+        );
+    }
+
+    /// A directory input whose mtime lands after the build started is dropped
+    /// from the entry instead of being recorded, so nothing validates it any
+    /// more. A regular file in the same position gets an unconfirmed
+    /// fingerprint and costs one rebuild; the directory silently loses its
+    /// validation and every later change to it is invisible.
+    #[tokio::test]
+    async fn a_directory_input_past_the_build_start_stays_validated() {
+        let f = Fixture::new();
+        let dir = f.source.join("assets");
+        fs_err::create_dir_all(&dir).unwrap();
+        let input = f.write("main.py", b"body");
+
+        // The regular file predates the build, the directory does not.
+        let build_started = mtime(&dir) - std::time::Duration::from_secs(10);
+        set_modified(&input, build_started - std::time::Duration::from_secs(10));
+
+        // Control: a store that starts after both mtimes records the
+        // directory, and adding a file inside it then invalidates the entry.
+        f.store(Vec::new(), vec![abs(input.clone()), abs(dir.clone())])
+            .await;
+        assert!(f.sidecar().input_files.contains_key(&abs(dir.clone())));
+        fs_err::write(dir.join("control.txt"), b"x").unwrap();
+        assert!(
+            f.lookup().await.is_none(),
+            "control: a recorded directory whose contents changed invalidates",
+        );
+
+        f.store_with_build_started(
+            Vec::new(),
+            vec![abs(input.clone()), abs(dir.clone())],
+            build_started,
+        )
+        .await;
+        assert!(
+            f.sidecar().input_files.contains_key(&abs(dir.clone())),
+            "an input the build read must stay recorded; dropping it means no \
+             later change to it can ever invalidate the entry",
+        );
+
+        fs_err::write(dir.join("added.txt"), b"x").unwrap();
+        assert!(
+            f.lookup().await.is_none(),
+            "changing a recorded input directory must invalidate the entry",
         );
     }
 }

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -773,7 +773,7 @@ impl From<FileFingerprintError> for ArtifactCacheError {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{fs::OpenOptions, str::FromStr, time::SystemTime};
 
     use pixi_compute_engine::ComputeEngine;
     use rattler_conda_types::{PackageName, PackageRecord};
@@ -801,6 +801,15 @@ mod tests {
 
     fn abs(path: impl Into<PathBuf>) -> AbsPathBuf {
         AbsPathBuf::new(path).unwrap()
+    }
+
+    fn set_modified(path: &Path, modified: SystemTime) {
+        OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(modified)
+            .unwrap();
     }
 
     /// Drive [`ArtifactCache::lookup`] (which needs a `ComputeCtx`) through the
@@ -966,10 +975,7 @@ mod tests {
         // valid and refreshes the stored mtime.
         let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
         let touched_mtime = original_mtime + std::time::Duration::from_secs(1);
-        std::fs::File::open(&input)
-            .unwrap()
-            .set_modified(touched_mtime)
-            .unwrap();
+        set_modified(&input, touched_mtime);
 
         let hit = lookup(
             &engine,
@@ -998,10 +1004,7 @@ mod tests {
 
         // A same-size content change still invalidates the entry.
         fs_err::write(&input, b"new").unwrap();
-        std::fs::File::open(&input)
-            .unwrap()
-            .set_modified(touched_mtime + std::time::Duration::from_secs(1))
-            .unwrap();
+        set_modified(&input, touched_mtime + std::time::Duration::from_secs(1));
 
         let got = lookup(
             &engine,

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -44,6 +44,7 @@ use rattler_digest::Sha256Hash;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
+use tokio::sync::Semaphore;
 use url::Url;
 use xxhash_rust::xxh3::Xxh3;
 
@@ -65,6 +66,7 @@ pub enum SourceMutability {
 
 use crate::file_fingerprint::{
     FileFingerprint, FileFingerprintError, MetadataComparison, fingerprint_files,
+    spawn_blocking_with_io_permit,
 };
 
 /// Opaque content-addressed handle for an artifact cache entry.
@@ -214,11 +216,23 @@ pub struct CachedArtifact {
 #[derive(Clone, Debug)]
 pub struct ArtifactCache {
     root: PathBuf,
+    io_concurrency_semaphore: Option<Arc<Semaphore>>,
 }
 
 impl ArtifactCache {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            io_concurrency_semaphore: None,
+        }
+    }
+
+    pub fn with_io_concurrency_semaphore(
+        mut self,
+        io_concurrency_semaphore: Option<Arc<Semaphore>>,
+    ) -> Self {
+        self.io_concurrency_semaphore = io_concurrency_semaphore;
+        self
     }
 
     /// Directory that holds every entry for `package`.
@@ -376,8 +390,22 @@ impl ArtifactCache {
             }
 
             fingerprints_refreshed = !fingerprints_to_compute.is_empty();
-            if fingerprints_refreshed {
-                let current_fingerprints = match fingerprint_files(fingerprints_to_compute).await {
+            // Fingerprinting and re-globbing inspect independent aspects of
+            // the source tree, so run them concurrently on the slow path.
+            let io_semaphore = self.io_concurrency_semaphore.clone();
+            let fingerprint_future = async move {
+                if fingerprints_to_compute.is_empty() {
+                    None
+                } else {
+                    Some(fingerprint_files(fingerprints_to_compute, io_semaphore).await)
+                }
+            };
+            let glob_future =
+                crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir);
+            let (current_fingerprints, current) = tokio::join!(fingerprint_future, glob_future);
+
+            if let Some(current_fingerprints) = current_fingerprints {
+                let current_fingerprints = match current_fingerprints {
                     Ok(fingerprints) => fingerprints,
                     Err(_) => return Ok(None),
                 };
@@ -399,10 +427,7 @@ impl ArtifactCache {
             // Detect newly-added files that match the stored globs. This
             // catches sources added after the cache entry was written. Uses
             // the same engine-deduped walk as `build_backend_metadata`.
-            let current =
-                crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir)
-                    .await
-                    .map_err(ArtifactCacheError::Glob)?;
+            let current = current.map_err(ArtifactCacheError::Glob)?;
             for matched in current {
                 if !sidecar.input_files.contains_key(&matched) {
                     return Ok(None);
@@ -530,30 +555,41 @@ impl ArtifactCache {
         // cleaned before the record is consumed again.
         record.url = Url::from_file_path(&dest).expect("cache entry paths are absolute");
 
-        let sha256 = {
+        let artifact_digest = {
             let path = dest.clone();
-            tokio::task::spawn_blocking(move || {
-                rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&path)
-            })
-            .await
-            .expect("sha256 task panicked")
-            .map_err(|err| ArtifactCacheError::io("hashing artifact", dest.clone(), err))?
+            let error_path = dest.clone();
+            let io_semaphore = self.io_concurrency_semaphore.clone();
+            async move {
+                spawn_blocking_with_io_permit(io_semaphore, move || {
+                    rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&path)
+                })
+                .await
+                .expect("sha256 task panicked")
+                .map_err(|err| ArtifactCacheError::io("hashing artifact", error_path, err))
+            }
         };
 
-        let input_file_fingerprints = fingerprint_files(
-            input_files
-                .into_iter()
-                .map(|path| path.as_std_path().to_path_buf()),
-        )
-        .await?
-        .into_iter()
-        .map(|(path, fingerprint)| {
-            (
-                AbsPathBuf::new(path).expect("recorded input paths are absolute"),
-                fingerprint,
+        let input_fingerprints = async {
+            fingerprint_files(
+                input_files
+                    .into_iter()
+                    .map(|path| path.as_std_path().to_path_buf()),
+                self.io_concurrency_semaphore.clone(),
             )
-        })
-        .collect::<BTreeMap<_, _>>();
+            .await
+            .map_err(ArtifactCacheError::from)
+        };
+        let (sha256, input_file_fingerprints) =
+            tokio::try_join!(artifact_digest, input_fingerprints)?;
+        let input_file_fingerprints = input_file_fingerprints
+            .into_iter()
+            .map(|(path, fingerprint)| {
+                (
+                    AbsPathBuf::new(path).expect("recorded input paths are absolute"),
+                    fingerprint,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
         let input_files_mtimes = input_file_fingerprints
             .iter()
             .map(|(path, fingerprint)| (path.clone(), DateTime::<Utc>::from(fingerprint.modified)))

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -184,6 +184,8 @@ pub struct ArtifactSidecar {
 
     /// Content fingerprints for the input files. Entries written by older
     /// pixi versions omit this map and are upgraded on their first cache hit.
+    // TODO: Collapse this and `input_files` in the next artifact cache format.
+    // They are separate so sidecars written before fingerprints remain readable.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) input_file_fingerprints: BTreeMap<AbsPathBuf, FileFingerprint>,
 
@@ -415,9 +417,15 @@ impl ArtifactCache {
             return Ok(None);
         }
 
-        if fingerprints_refreshed {
-            self.try_refresh_sidecar(package, key, &bytes, &sidecar)
-                .await?;
+        if fingerprints_refreshed
+            && let Err(err) = self
+                .try_refresh_sidecar(package, key, &bytes, &sidecar)
+                .await
+        {
+            tracing::debug!(
+                error = %err,
+                "Failed to persist refreshed artifact input fingerprints; using the verified entry"
+            );
         }
 
         // Point the record at the artifact being returned. Sidecars written

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -295,9 +295,16 @@ pub enum CacheMissReason {
     /// the entry can be trusted.
     CorruptSidecar,
 
-    /// A file that was recorded as a build input can no longer be stat'ed,
-    /// because it was removed or became unreadable.
+    /// A file that was recorded as a build input no longer exists.
     InputFileRemoved { path: AbsPathBuf },
+
+    /// A recorded input file exists but could not be read, so its contents
+    /// cannot be verified.
+    InputFileUnreadable { path: AbsPathBuf },
+
+    /// The entry records no validation state for a file it lists as an
+    /// input, so nothing can verify it.
+    InputFileUntracked { path: AbsPathBuf },
 
     /// A recorded input file's mtime no longer matches the one captured when
     /// the artifact was built.
@@ -330,6 +337,12 @@ impl std::fmt::Display for CacheMissReason {
             Self::NoEntry => write!(f, "no entry stored for this cache key"),
             Self::CorruptSidecar => write!(f, "sidecar could not be parsed"),
             Self::InputFileRemoved { path } => write!(f, "input file removed: {path}"),
+            Self::InputFileUnreadable { path } => {
+                write!(f, "input file could not be read: {path}")
+            }
+            Self::InputFileUntracked { path } => {
+                write!(f, "input file has no recorded validation state: {path}")
+            }
             Self::InputFileModified {
                 path,
                 built_at,
@@ -361,6 +374,8 @@ impl StaleFile {
         let path = AbsPathBuf::new(self.path).expect("recorded input paths are absolute");
         match self.reason {
             StaleFileReason::Removed => CacheMissReason::InputFileRemoved { path },
+            StaleFileReason::Unreadable => CacheMissReason::InputFileUnreadable { path },
+            StaleFileReason::Untracked => CacheMissReason::InputFileUntracked { path },
             StaleFileReason::Modified { recorded, observed } => {
                 CacheMissReason::InputFileModified {
                     path,
@@ -1959,7 +1974,7 @@ mod tests {
         let edited = fs_err::read(f.sidecar_path()).unwrap();
 
         match f.lookup_miss().await {
-            CacheMissReason::InputFileModified { path, .. } => {
+            CacheMissReason::InputFileUntracked { path } => {
                 assert_eq!(
                     path.as_std_path(),
                     other,
@@ -1970,12 +1985,12 @@ mod tests {
         }
 
         // Touching the file that *does* have a state runs the same partial map
-        // through the hashing half of `verify`. It must still miss, and leave
-        // the entry byte-identical.
+        // through `verify` again. It must still miss on the stateless file,
+        // and leave the entry byte-identical.
         touch(&main, 5);
         assert!(matches!(
             f.lookup_miss().await,
-            CacheMissReason::InputFileModified { .. }
+            CacheMissReason::InputFileUntracked { .. }
         ));
         assert_eq!(
             fs_err::read(f.sidecar_path()).unwrap(),

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -44,6 +44,7 @@ use rattler_digest::Sha256Hash;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
+use tokio::sync::Semaphore;
 use url::Url;
 use xxhash_rust::xxh3::Xxh3;
 
@@ -65,6 +66,7 @@ pub enum SourceMutability {
 
 use crate::file_fingerprint::{
     FileFingerprint, FileFingerprintError, MetadataComparison, fingerprint_files,
+    spawn_blocking_with_io_permit,
 };
 
 /// Opaque content-addressed handle for an artifact cache entry.
@@ -286,11 +288,23 @@ impl std::fmt::Display for CacheMissReason {
 #[derive(Clone, Debug)]
 pub struct ArtifactCache {
     root: PathBuf,
+    io_concurrency_semaphore: Option<Arc<Semaphore>>,
 }
 
 impl ArtifactCache {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            io_concurrency_semaphore: None,
+        }
+    }
+
+    pub fn with_io_concurrency_semaphore(
+        mut self,
+        io_concurrency_semaphore: Option<Arc<Semaphore>>,
+    ) -> Self {
+        self.io_concurrency_semaphore = io_concurrency_semaphore;
+        self
     }
 
     /// Directory that holds every entry for `package`.
@@ -468,8 +482,22 @@ impl ArtifactCache {
             }
 
             fingerprints_refreshed = !fingerprints_to_compute.is_empty();
-            if fingerprints_refreshed {
-                let current_fingerprints = match fingerprint_files(fingerprints_to_compute).await {
+            // Fingerprinting and re-globbing inspect independent aspects of
+            // the source tree, so run them concurrently on the slow path.
+            let io_semaphore = self.io_concurrency_semaphore.clone();
+            let fingerprint_future = async move {
+                if fingerprints_to_compute.is_empty() {
+                    None
+                } else {
+                    Some(fingerprint_files(fingerprints_to_compute, io_semaphore).await)
+                }
+            };
+            let glob_future =
+                crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir);
+            let (current_fingerprints, current) = tokio::join!(fingerprint_future, glob_future);
+
+            if let Some(current_fingerprints) = current_fingerprints {
+                let current_fingerprints = match current_fingerprints {
                     Ok(fingerprints) => fingerprints,
                     Err(err) => {
                         return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
@@ -500,10 +528,7 @@ impl ArtifactCache {
             // Detect newly-added files that match the stored globs. This
             // catches sources added after the cache entry was written. Uses
             // the same engine-deduped walk as `build_backend_metadata`.
-            let current =
-                crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir)
-                    .await
-                    .map_err(ArtifactCacheError::Glob)?;
+            let current = current.map_err(ArtifactCacheError::Glob)?;
             for matched in current {
                 if !sidecar.input_files.contains_key(&matched) {
                     return Ok(CacheLookup::Miss(CacheMissReason::InputFileAdded {
@@ -635,30 +660,41 @@ impl ArtifactCache {
         // cleaned before the record is consumed again.
         record.url = Url::from_file_path(&dest).expect("cache entry paths are absolute");
 
-        let sha256 = {
+        let artifact_digest = {
             let path = dest.clone();
-            tokio::task::spawn_blocking(move || {
-                rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&path)
-            })
-            .await
-            .expect("sha256 task panicked")
-            .map_err(|err| ArtifactCacheError::io("hashing artifact", dest.clone(), err))?
+            let error_path = dest.clone();
+            let io_semaphore = self.io_concurrency_semaphore.clone();
+            async move {
+                spawn_blocking_with_io_permit(io_semaphore, move || {
+                    rattler_digest::compute_file_digest::<rattler_digest::Sha256>(&path)
+                })
+                .await
+                .expect("sha256 task panicked")
+                .map_err(|err| ArtifactCacheError::io("hashing artifact", error_path, err))
+            }
         };
 
-        let input_file_fingerprints = fingerprint_files(
-            input_files
-                .into_iter()
-                .map(|path| path.as_std_path().to_path_buf()),
-        )
-        .await?
-        .into_iter()
-        .map(|(path, fingerprint)| {
-            (
-                AbsPathBuf::new(path).expect("recorded input paths are absolute"),
-                fingerprint,
+        let input_fingerprints = async {
+            fingerprint_files(
+                input_files
+                    .into_iter()
+                    .map(|path| path.as_std_path().to_path_buf()),
+                self.io_concurrency_semaphore.clone(),
             )
-        })
-        .collect::<BTreeMap<_, _>>();
+            .await
+            .map_err(ArtifactCacheError::from)
+        };
+        let (sha256, input_file_fingerprints) =
+            tokio::try_join!(artifact_digest, input_fingerprints)?;
+        let input_file_fingerprints = input_file_fingerprints
+            .into_iter()
+            .map(|(path, fingerprint)| {
+                (
+                    AbsPathBuf::new(path).expect("recorded input paths are absolute"),
+                    fingerprint,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
         let input_files_mtimes = input_file_fingerprints
             .iter()
             .map(|(path, fingerprint)| (path.clone(), DateTime::<Utc>::from(fingerprint.modified)))

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -11,10 +11,11 @@
 //!
 //! The cache key is structural (identity of the build inputs plus content
 //! addresses of its dependencies). For mutable sources, freshness of the
-//! source files themselves is tracked in the sidecar via per-file mtimes,
-//! plus a re-glob pass that detects added files. Immutable sources are
-//! fully pinned by the key, so their entries carry no file lists and skip
-//! those checks.
+//! source files themselves is tracked in the sidecar via per-file
+//! fingerprints, plus a re-glob pass that detects added files. The mtime
+//! remains the fast path; contents are hashed only when it changes.
+//! Immutable sources are fully pinned by the key, so their entries carry no
+//! file lists and skip those checks.
 //!
 //! On a hit, the cached `.conda` is returned along with its sha256; no
 //! backend work happens. On a miss (or stale sidecar), the caller rebuilds
@@ -61,6 +62,10 @@ pub enum SourceMutability {
     Mutable,
     Immutable,
 }
+
+use crate::file_fingerprint::{
+    FileFingerprint, FileFingerprintError, MetadataComparison, fingerprint_files,
+};
 
 /// Opaque content-addressed handle for an artifact cache entry.
 ///
@@ -176,6 +181,11 @@ pub struct ArtifactSidecar {
     /// round-trip directly against the engine walk at lookup time.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub input_files: BTreeMap<AbsPathBuf, DateTime<Utc>>,
+
+    /// Content fingerprints for the input files. Entries written by older
+    /// pixi versions omit this map and are upgraded on their first cache hit.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) input_file_fingerprints: BTreeMap<AbsPathBuf, FileFingerprint>,
 
     /// sha256 of the cached `.conda`. Callers rely on this for transitive
     /// invalidation of dependents.
@@ -316,7 +326,7 @@ impl ArtifactCache {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(ArtifactCacheError::io("reading sidecar", sidecar_path, err)),
         };
-        let Ok(sidecar) = serde_json::from_slice::<ArtifactSidecar>(&bytes) else {
+        let Ok(mut sidecar) = serde_json::from_slice::<ArtifactSidecar>(&bytes) else {
             // Treat unparsable sidecars as misses; the caller will rebuild
             // and overwrite.
             return Ok(None);
@@ -329,15 +339,58 @@ impl ArtifactCache {
         // dir removes the recorded files entirely. Skipping them also
         // covers sidecars written by older versions, which still carry
         // file lists for immutable sources.
+        let mut fingerprints_refreshed = false;
         if mutability == SourceMutability::Mutable {
-            // Check every recorded file still matches its mtime.
+            // Check every recorded file. Size and mtime provide a cheap fast
+            // path; only files with a changed mtime need to be hashed.
+            let mut fingerprints_to_compute = Vec::new();
             for (path, expected_mtime) in &sidecar.input_files {
-                let modified = match fs_err::metadata(path).and_then(|m| m.modified()) {
-                    Ok(m) => DateTime::<Utc>::from(m),
+                let metadata = match fs_err::metadata(path) {
+                    Ok(metadata) => metadata,
                     Err(_) => return Ok(None),
                 };
-                if modified != *expected_mtime {
-                    return Ok(None);
+
+                match sidecar.input_file_fingerprints.get(path) {
+                    Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
+                        Ok(MetadataComparison::Unchanged) => {}
+                        Ok(MetadataComparison::HashRequired) => {
+                            fingerprints_to_compute.push(path.as_std_path().to_path_buf());
+                        }
+                        Ok(MetadataComparison::Changed) | Err(_) => return Ok(None),
+                    },
+                    None => {
+                        let modified = match metadata.modified() {
+                            Ok(modified) => DateTime::<Utc>::from(modified),
+                            Err(_) => return Ok(None),
+                        };
+                        if modified != *expected_mtime {
+                            // Without a previously recorded hash there is no
+                            // way to prove that a touched file is unchanged.
+                            return Ok(None);
+                        }
+                        fingerprints_to_compute.push(path.as_std_path().to_path_buf());
+                    }
+                }
+            }
+
+            fingerprints_refreshed = !fingerprints_to_compute.is_empty();
+            if fingerprints_refreshed {
+                let current_fingerprints = match fingerprint_files(fingerprints_to_compute).await {
+                    Ok(fingerprints) => fingerprints,
+                    Err(_) => return Ok(None),
+                };
+                for (path, current) in current_fingerprints {
+                    let path = AbsPathBuf::new(path).expect("recorded input paths are absolute");
+                    if let Some(expected) = sidecar.input_file_fingerprints.get(&path)
+                        && expected.hash != current.hash
+                    {
+                        return Ok(None);
+                    }
+
+                    sidecar
+                        .input_files
+                        .insert(path.clone(), DateTime::<Utc>::from(current.modified));
+                    sidecar.input_file_fingerprints.insert(path, current);
                 }
             }
 
@@ -362,6 +415,11 @@ impl ArtifactCache {
             return Ok(None);
         }
 
+        if fingerprints_refreshed {
+            self.try_refresh_sidecar(package, key, &bytes, &sidecar)
+                .await?;
+        }
+
         // Point the record at the artifact being returned. Sidecars written
         // by older versions carry the work-directory output path, which does
         // not survive workspace-cache cleanups.
@@ -373,6 +431,42 @@ impl ArtifactCache {
             sha256: sidecar.artifact_sha256,
             record,
         }))
+    }
+
+    /// Persist refreshed mtimes and hashes if no other process changed the
+    /// sidecar while the files were being inspected.
+    async fn try_refresh_sidecar(
+        &self,
+        package: &PackageName,
+        key: &ArtifactCacheKey,
+        expected_bytes: &[u8],
+        sidecar: &ArtifactSidecar,
+    ) -> Result<(), ArtifactCacheError> {
+        let sidecar_path = self.sidecar_path(package, key);
+        let lock_file = self.open_lock_file(package, key).await?;
+        let _guard = lock_file.lock_write().await.map_err(|err| {
+            ArtifactCacheError::io(
+                "acquiring exclusive lock",
+                self.lock_path(package, key),
+                err.error,
+            )
+        })?;
+
+        let current_bytes = match tokio::fs::read(&sidecar_path).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => {
+                return Err(ArtifactCacheError::io("reading sidecar", sidecar_path, err));
+            }
+        };
+        if current_bytes != expected_bytes {
+            return Ok(());
+        }
+
+        let bytes = serde_json::to_vec(sidecar).expect("sidecar serialization cannot fail");
+        tokio::fs::write(&sidecar_path, bytes)
+            .await
+            .map_err(|err| ArtifactCacheError::io("writing sidecar", sidecar_path, err))
     }
 
     /// Place `artifact_source` into the cache and write its sidecar.
@@ -438,19 +532,29 @@ impl ArtifactCache {
             .map_err(|err| ArtifactCacheError::io("hashing artifact", dest.clone(), err))?
         };
 
-        let mut input_files_mtimes = BTreeMap::new();
-        for path in input_files {
-            let modified = fs_err::metadata(&path)
-                .and_then(|m| m.modified())
-                .map_err(|err| {
-                    ArtifactCacheError::io("stat input file", path.clone().into(), err)
-                })?;
-            input_files_mtimes.insert(path, DateTime::<Utc>::from(modified));
-        }
+        let input_file_fingerprints = fingerprint_files(
+            input_files
+                .into_iter()
+                .map(|path| path.as_std_path().to_path_buf()),
+        )
+        .await?
+        .into_iter()
+        .map(|(path, fingerprint)| {
+            (
+                AbsPathBuf::new(path).expect("recorded input paths are absolute"),
+                fingerprint,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+        let input_files_mtimes = input_file_fingerprints
+            .iter()
+            .map(|(path, fingerprint)| (path.clone(), DateTime::<Utc>::from(fingerprint.modified)))
+            .collect();
 
         let sidecar = ArtifactSidecar {
             input_glob_sets,
             input_files: input_files_mtimes,
+            input_file_fingerprints,
             artifact_sha256: sha256,
             artifact_filename: filename,
             record: record.clone(),
@@ -484,6 +588,13 @@ pub enum ArtifactCacheError {
 
     #[error("artifact path has no filename: {}", .0.display())]
     ArtifactFilename(PathBuf),
+
+    #[error("failed to fingerprint input file at {}", path.display())]
+    Fingerprint {
+        path: PathBuf,
+        #[source]
+        source: Arc<std::io::Error>,
+    },
 }
 
 impl ArtifactCacheError {
@@ -499,6 +610,15 @@ impl ArtifactCacheError {
 impl From<pixi_glob::GlobSetError> for ArtifactCacheError {
     fn from(err: pixi_glob::GlobSetError) -> Self {
         Self::Glob(Arc::new(err))
+    }
+}
+
+impl From<FileFingerprintError> for ArtifactCacheError {
+    fn from(err: FileFingerprintError) -> Self {
+        Self::Fingerprint {
+            path: err.path,
+            source: err.source,
+        }
     }
 }
 
@@ -643,7 +763,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_stale_when_source_file_changes() {
+    async fn lookup_hashes_source_file_when_mtime_changes() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
         let engine = ComputeEngine::new();
@@ -671,9 +791,46 @@ mod tests {
             .await
             .unwrap();
 
-        // Modify the source file's mtime by rewriting it after a sleep.
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Touching the input without changing its contents keeps the cache
+        // valid and refreshes the stored mtime.
+        let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        let touched_mtime = original_mtime + std::time::Duration::from_secs(1);
+        std::fs::File::open(&input)
+            .unwrap()
+            .set_modified(touched_mtime)
+            .unwrap();
+
+        let hit = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
+        assert!(hit.is_some(), "an mtime-only change should remain cached");
+
+        let sidecar: ArtifactSidecar =
+            serde_json::from_slice(&fs_err::read(cache.sidecar_path(&pkg("foo"), &key)).unwrap())
+                .unwrap();
+        assert_eq!(
+            sidecar
+                .input_file_fingerprints
+                .get(&abs(input.clone()))
+                .unwrap()
+                .modified,
+            touched_mtime,
+            "the refreshed mtime should be persisted"
+        );
+
+        // A same-size content change still invalidates the entry.
         fs_err::write(&input, b"new").unwrap();
+        std::fs::File::open(&input)
+            .unwrap()
+            .set_modified(touched_mtime + std::time::Duration::from_secs(1))
+            .unwrap();
 
         let got = lookup(
             &engine,

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -29,6 +29,7 @@ use std::{
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
+    time::SystemTime,
 };
 
 use async_fd_lock::{LockRead, LockWrite};
@@ -64,9 +65,9 @@ pub enum SourceMutability {
     Immutable,
 }
 
-use crate::file_fingerprint::{
-    FileFingerprint, MetadataComparison, fingerprint_files, fingerprint_files_lenient,
-    spawn_blocking_with_io_permit,
+use crate::file_fingerprint::spawn_blocking_with_io_permit;
+use crate::input_snapshot::{
+    InputFileState, InputSnapshot, SnapshotFreshness, StaleFile, StaleFileReason,
 };
 
 /// Opaque content-addressed handle for an artifact cache entry.
@@ -184,12 +185,11 @@ pub struct ArtifactSidecar {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub input_files: BTreeMap<AbsPathBuf, DateTime<Utc>>,
 
-    /// Content fingerprints for the input files. Entries written by older
-    /// pixi versions omit this map and are upgraded on their first cache hit.
-    // TODO: Collapse this and `input_files` in the next artifact cache format.
-    // They are separate so sidecars written before fingerprints remain readable.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub(crate) input_file_fingerprints: BTreeMap<AbsPathBuf, FileFingerprint>,
+    /// Validation state for the input files. Sidecars written by older pixi
+    /// versions omit this map; those files keep mtime-only validation via
+    /// `input_files`.
+    #[serde(default, skip_serializing_if = "InputSnapshot::is_empty")]
+    pub(crate) input_file_states: InputSnapshot,
 
     /// sha256 of the cached `.conda`. Callers rely on this for transitive
     /// invalidation of dependents.
@@ -202,6 +202,37 @@ pub struct ArtifactSidecar {
     /// Fully-assembled `RepoDataRecord` for the artifact. Stored so cache
     /// hits can return it without re-reading index.json from the `.conda`.
     pub record: RepoDataRecord,
+}
+
+impl ArtifactSidecar {
+    /// The snapshot to verify against: recorded states, with the
+    /// `input_files` mtimes as fallback for sidecars written before
+    /// fingerprints existed.
+    fn input_snapshot(&self) -> InputSnapshot {
+        let mut snapshot = self.input_file_states.clone();
+        for (path, mtime) in &self.input_files {
+            snapshot.insert_fallback(
+                path.as_std_path().to_path_buf(),
+                InputFileState::MtimeOnly(SystemTime::from(*mtime)),
+            );
+        }
+        snapshot
+    }
+
+    /// Records `snapshot` and mirrors its mtimes into `input_files` so older
+    /// pixi versions can keep validating the entry.
+    fn set_input_snapshot(&mut self, snapshot: InputSnapshot) {
+        self.input_files = snapshot
+            .iter()
+            .map(|(path, state)| {
+                (
+                    AbsPathBuf::new(path.clone()).expect("recorded input paths are absolute"),
+                    DateTime::<Utc>::from(state.modified()),
+                )
+            })
+            .collect();
+        self.input_file_states = snapshot;
+    }
 }
 
 /// Result of a successful cache lookup.
@@ -260,6 +291,10 @@ pub enum CacheMissReason {
 
     /// The sidecar is valid but the `.conda` it points at is gone.
     ArtifactRemoved { path: PathBuf },
+
+    /// The entry changed while it was being validated: a concurrent store
+    /// replaced it or a concurrent clear removed it.
+    EntryChanged,
 }
 
 impl std::fmt::Display for CacheMissReason {
@@ -279,6 +314,26 @@ impl std::fmt::Display for CacheMissReason {
             Self::InputFileAdded { path } => write!(f, "input file added: {path}"),
             Self::ArtifactRemoved { path } => {
                 write!(f, "cached artifact removed: {}", path.display())
+            }
+            Self::EntryChanged => {
+                write!(f, "entry changed while it was being validated")
+            }
+        }
+    }
+}
+
+impl StaleFile {
+    /// Maps a snapshot verification failure onto the cache miss reasons.
+    fn into_artifact_miss_reason(self) -> CacheMissReason {
+        let path = AbsPathBuf::new(self.path).expect("recorded input paths are absolute");
+        match self.reason {
+            StaleFileReason::Removed => CacheMissReason::InputFileRemoved { path },
+            StaleFileReason::Modified { recorded, observed } => {
+                CacheMissReason::InputFileModified {
+                    path,
+                    built_at: DateTime::<Utc>::from(recorded),
+                    modified_at: DateTime::<Utc>::from(observed),
+                }
             }
         }
     }
@@ -429,131 +484,33 @@ impl ArtifactCache {
         // dir removes the recorded files entirely. Skipping them also
         // covers sidecars written by older versions, which still carry
         // file lists for immutable sources.
-        let mut fingerprints_refreshed = false;
+        let mut refreshed = false;
         if mutability == SourceMutability::Mutable {
-            // Check every recorded file. Size and mtime provide a cheap fast
-            // path; only files with a changed mtime need to be hashed.
-            let mut fingerprints_to_compute = Vec::new();
-            for (path, expected_mtime) in &sidecar.input_files {
-                let metadata = match fs_err::metadata(path) {
-                    Ok(metadata) => metadata,
-                    Err(_) => {
-                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
-                            path: path.clone(),
-                        }));
-                    }
-                };
-                let modified = match metadata.modified() {
-                    Ok(modified) => DateTime::<Utc>::from(modified),
-                    Err(_) => {
-                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
-                            path: path.clone(),
-                        }));
-                    }
-                };
-
-                match sidecar.input_file_fingerprints.get(path) {
-                    Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
-                        Ok(MetadataComparison::Unchanged) => {}
-                        Ok(MetadataComparison::HashRequired) if metadata.is_file() => {
-                            fingerprints_to_compute.push(path.as_std_path().to_path_buf());
-                        }
-                        Ok(MetadataComparison::HashRequired)
-                        | Ok(MetadataComparison::Changed)
-                        | Err(_) => {
-                            return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
-                                path: path.clone(),
-                                built_at: DateTime::<Utc>::from(fingerprint.modified),
-                                modified_at: modified,
-                            }));
-                        }
-                    },
-                    None => {
-                        if modified != *expected_mtime {
-                            // Without a previously recorded hash there is no
-                            // way to prove that a touched file is unchanged.
-                            return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
-                                path: path.clone(),
-                                built_at: *expected_mtime,
-                                modified_at: modified,
-                            }));
-                        }
-                        // Special files cannot be hashed and keep
-                        // timestamp-only validation.
-                        if metadata.is_file() {
-                            fingerprints_to_compute.push(path.as_std_path().to_path_buf());
-                        }
-                    }
-                }
-            }
-
-            fingerprints_refreshed = !fingerprints_to_compute.is_empty();
-            // Fingerprinting and re-globbing inspect independent aspects of
-            // the source tree, so run them concurrently on the slow path.
-            let io_semaphore = self.io_concurrency_semaphore.clone();
-            let fingerprint_future = async move {
-                if fingerprints_to_compute.is_empty() {
-                    None
-                } else {
-                    Some(fingerprint_files(fingerprints_to_compute, io_semaphore).await)
-                }
-            };
+            // The snapshot check and the glob walk inspect independent
+            // aspects of the source tree, so they run concurrently. The walk
+            // catches files added since the entry was written.
+            let snapshot = sidecar.input_snapshot();
+            let files = sidecar
+                .input_files
+                .keys()
+                .map(|path| path.as_std_path().to_path_buf())
+                .collect::<Vec<_>>();
+            let verify_future = snapshot.verify(files, None, self.io_concurrency_semaphore.clone());
             let glob_future =
                 crate::input_globs::collect_input_files(ctx, &sidecar.input_glob_sets, source_dir);
-            let (current_fingerprints, current) = tokio::join!(fingerprint_future, glob_future);
+            let (freshness, current) = tokio::join!(verify_future, glob_future);
 
-            if let Some(current_fingerprints) = current_fingerprints {
-                let current_fingerprints = match current_fingerprints {
-                    Ok(fingerprints) => fingerprints,
-                    Err(err) => {
-                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
-                            path: AbsPathBuf::new(err.path)
-                                .expect("recorded input paths are absolute"),
-                        }));
-                    }
-                };
-                for (path, current) in current_fingerprints {
-                    let path = AbsPathBuf::new(path).expect("recorded input paths are absolute");
-                    match sidecar.input_file_fingerprints.get(&path) {
-                        Some(expected) => {
-                            if expected.hash != current.hash {
-                                return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
-                                    path: path.clone(),
-                                    built_at: DateTime::<Utc>::from(expected.modified),
-                                    modified_at: DateTime::<Utc>::from(current.modified),
-                                }));
-                            }
-                        }
-                        None => {
-                            // Without a recorded hash the computed hash only
-                            // vouches for the cached artifact if the file did
-                            // not change since the stat pass.
-                            let recorded = sidecar
-                                .input_files
-                                .get(&path)
-                                .copied()
-                                .expect("only recorded files are queued for hashing");
-                            let observed = DateTime::<Utc>::from(current.modified);
-                            if recorded != observed {
-                                return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
-                                    path: path.clone(),
-                                    built_at: recorded,
-                                    modified_at: observed,
-                                }));
-                            }
-                        }
-                    }
-
-                    sidecar
-                        .input_files
-                        .insert(path.clone(), DateTime::<Utc>::from(current.modified));
-                    sidecar.input_file_fingerprints.insert(path, current);
+            match freshness {
+                SnapshotFreshness::Fresh => {}
+                SnapshotFreshness::Refreshed(snapshot) => {
+                    sidecar.set_input_snapshot(snapshot);
+                    refreshed = true;
+                }
+                SnapshotFreshness::Stale(stale) => {
+                    return Ok(CacheLookup::Miss(stale.into_artifact_miss_reason()));
                 }
             }
 
-            // Detect newly-added files that match the stored globs. This
-            // catches sources added after the cache entry was written. Uses
-            // the same engine-deduped walk as `build_backend_metadata`.
             let current = current.map_err(ArtifactCacheError::Glob)?;
             for matched in current {
                 if !sidecar.input_files.contains_key(&matched) {
@@ -561,6 +518,28 @@ impl ArtifactCache {
                         path: matched,
                     }));
                 }
+            }
+
+            // The lock was dropped during validation, so a concurrent store
+            // may have replaced the entry; the recorded sha256 would then
+            // describe a different artifact. Reject the hit when the sidecar
+            // bytes moved.
+            let Some(lock_file) = self.open_lock_file_if_exists(package, key).await? else {
+                return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged));
+            };
+            let _guard = lock_file.lock_read().await.map_err(|err| {
+                ArtifactCacheError::io(
+                    "acquiring shared lock",
+                    self.lock_path(package, key),
+                    err.error,
+                )
+            })?;
+            let current_bytes = match tokio::fs::read(&sidecar_path).await {
+                Ok(current_bytes) => current_bytes,
+                Err(_) => return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged)),
+            };
+            if current_bytes != bytes {
+                return Ok(CacheLookup::Miss(CacheMissReason::EntryChanged));
             }
         }
 
@@ -573,7 +552,7 @@ impl ArtifactCache {
             }));
         }
 
-        if fingerprints_refreshed
+        if refreshed
             && let Err(err) = self
                 .try_refresh_sidecar(package, key, &bytes, &sidecar)
                 .await
@@ -597,6 +576,26 @@ impl ArtifactCache {
         }))
     }
 
+    /// Open the entry's lock file without creating anything. `None` when the
+    /// entry is gone, e.g. after a concurrent `clear_package`.
+    async fn open_lock_file_if_exists(
+        &self,
+        package: &PackageName,
+        key: &ArtifactCacheKey,
+    ) -> Result<Option<tokio::fs::File>, ArtifactCacheError> {
+        let lock_path = self.lock_path(package, key);
+        match tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .await
+        {
+            Ok(file) => Ok(Some(file)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(ArtifactCacheError::io("opening lock file", lock_path, err)),
+        }
+    }
+
     /// Persist refreshed mtimes and hashes if no other process changed the
     /// sidecar while the files were being inspected.
     async fn try_refresh_sidecar(
@@ -607,7 +606,11 @@ impl ArtifactCache {
         sidecar: &ArtifactSidecar,
     ) -> Result<(), ArtifactCacheError> {
         let sidecar_path = self.sidecar_path(package, key);
-        let lock_file = self.open_lock_file(package, key).await?;
+        // Never recreate the entry directory here: a concurrent
+        // `clear_package` must not be undone by a refresh.
+        let Some(lock_file) = self.open_lock_file_if_exists(package, key).await? else {
+            return Ok(());
+        };
         let _guard = lock_file.lock_write().await.map_err(|err| {
             ArtifactCacheError::io(
                 "acquiring exclusive lock",
@@ -703,49 +706,28 @@ impl ArtifactCache {
             }
         };
 
-        // A file that cannot be hashed keeps timestamp-based validation, and
-        // a file that vanished is dropped; the glob check treats it as new if
+        // A file that cannot be hashed keeps mtime-only validation, and a
+        // file that vanished is dropped; the glob check treats it as new if
         // it reappears. Neither fails the store.
-        let input_fingerprints = async {
-            fingerprint_files_lenient(
-                input_files
-                    .into_iter()
-                    .map(|path| path.as_std_path().to_path_buf()),
-                self.io_concurrency_semaphore.clone(),
-            )
-            .await
-        };
-        let (sha256, fingerprinted) = tokio::join!(artifact_digest, input_fingerprints);
+        let snapshot_future = InputSnapshot::capture(
+            input_files
+                .into_iter()
+                .map(|path| path.as_std_path().to_path_buf()),
+            None,
+            self.io_concurrency_semaphore.clone(),
+        );
+        let (sha256, snapshot) = tokio::join!(artifact_digest, snapshot_future);
         let sha256 = sha256?;
-        let input_file_fingerprints = fingerprinted
-            .fingerprints
-            .into_iter()
-            .map(|(path, fingerprint)| {
-                (
-                    AbsPathBuf::new(path).expect("recorded input paths are absolute"),
-                    fingerprint,
-                )
-            })
-            .collect::<BTreeMap<_, _>>();
-        let mut input_files_mtimes: BTreeMap<AbsPathBuf, DateTime<Utc>> = input_file_fingerprints
-            .iter()
-            .map(|(path, fingerprint)| (path.clone(), DateTime::<Utc>::from(fingerprint.modified)))
-            .collect();
-        for (path, mtime) in fingerprinted.mtime_only {
-            input_files_mtimes.insert(
-                AbsPathBuf::new(path).expect("recorded input paths are absolute"),
-                DateTime::<Utc>::from(mtime),
-            );
-        }
 
-        let sidecar = ArtifactSidecar {
+        let mut sidecar = ArtifactSidecar {
             input_glob_sets,
-            input_files: input_files_mtimes,
-            input_file_fingerprints,
+            input_files: BTreeMap::new(),
+            input_file_states: InputSnapshot::default(),
             artifact_sha256: sha256,
             artifact_filename: filename,
             record: record.clone(),
         };
+        sidecar.set_input_snapshot(snapshot);
         let sidecar_path = self.sidecar_path(package, key);
         let bytes = serde_json::to_vec(&sidecar).expect("sidecar serialization cannot fail");
         tokio::fs::write(&sidecar_path, &bytes)
@@ -869,6 +851,14 @@ mod tests {
                     hit.artifact.display()
                 )
             }
+        }
+    }
+
+    /// The hit, if the lookup was one.
+    fn as_hit(lookup: CacheLookup) -> Option<CachedArtifact> {
+        match lookup {
+            CacheLookup::Hit(hit) => Some(hit),
+            CacheLookup::Miss(_) => None,
         }
     }
 
@@ -1015,11 +1005,7 @@ mod tests {
             serde_json::from_slice(&fs_err::read(cache.sidecar_path(&pkg("foo"), &key)).unwrap())
                 .unwrap();
         assert_eq!(
-            sidecar
-                .input_file_fingerprints
-                .get(&abs(input.clone()))
-                .unwrap()
-                .modified,
+            sidecar.input_file_states.get(&input).unwrap().modified(),
             touched_mtime,
             "the refreshed mtime should be persisted"
         );
@@ -1412,6 +1398,460 @@ mod tests {
         assert!(
             matches!(hit, CacheLookup::Hit(_)),
             "issue #6232: a `../`-recipe glob must not force a rebuild on the next run",
+        );
+    }
+
+    /// Everything a store + lookup round trip needs: a source dir, a fake
+    /// `.conda` outside the cache, and the cache itself.
+    struct Fixture {
+        _tmp: TempDir,
+        cache: ArtifactCache,
+        source: PathBuf,
+        artifact: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let tmp = TempDir::new().unwrap();
+            let cache = ArtifactCache::new(tmp.path().join("artifacts"));
+            let source = tmp.path().join("src");
+            fs_err::create_dir_all(&source).unwrap();
+            let scratch = tmp.path().join("scratch");
+            fs_err::create_dir_all(&scratch).unwrap();
+            let artifact = scratch.join("foo-1.0.0-h0.conda");
+            fs_err::write(&artifact, b"pretend this is a conda").unwrap();
+            Self {
+                _tmp: tmp,
+                cache,
+                source,
+                artifact,
+            }
+        }
+
+        async fn store(&self, globs: Vec<InputGlobSet>, inputs: Vec<AbsPathBuf>) {
+            self.cache
+                .store(
+                    &pkg("foo"),
+                    &key("linux-64-abc"),
+                    &self.artifact,
+                    globs,
+                    inputs,
+                    dummy_record("foo"),
+                )
+                .await
+                .unwrap();
+        }
+
+        /// Each call gets a fresh engine, modelling a separate pixi run.
+        /// Reusing one engine would reuse its memoized glob walk (see
+        /// [`crate::input_globs`]) and hide newly-added files.
+        async fn lookup(&self) -> Option<CachedArtifact> {
+            as_hit(
+                lookup(
+                    &ComputeEngine::new(),
+                    &self.cache,
+                    &pkg("foo"),
+                    &key("linux-64-abc"),
+                    &self.source,
+                    SourceMutability::Mutable,
+                )
+                .await
+                .unwrap(),
+            )
+        }
+
+        fn sidecar_path(&self) -> PathBuf {
+            self.cache.sidecar_path(&pkg("foo"), &key("linux-64-abc"))
+        }
+
+        fn sidecar(&self) -> ArtifactSidecar {
+            serde_json::from_slice(&fs_err::read(self.sidecar_path()).unwrap()).unwrap()
+        }
+
+        fn sidecar_json(&self) -> serde_json::Value {
+            serde_json::from_slice(&fs_err::read(self.sidecar_path()).unwrap()).unwrap()
+        }
+
+        fn write_sidecar_json(&self, value: &serde_json::Value) {
+            fs_err::write(self.sidecar_path(), serde_json::to_vec(value).unwrap()).unwrap();
+        }
+    }
+
+    /// The cache treats an unchanged (size, mtime) pair as proof that the
+    /// contents are unchanged, so a same-size edit that also restores the
+    /// original mtime is invisible. This is the documented fast path, not a
+    /// regression: without it every probe would have to hash every input.
+    /// Recorded here so a future change to `compare_metadata` is a conscious
+    /// one.
+    #[tokio::test]
+    async fn same_size_edit_with_restored_mtime_is_not_detected() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"old").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        fs_err::write(&input, b"new").unwrap();
+        set_modified(&input, original_mtime);
+
+        assert!(
+            f.lookup().await.is_some(),
+            "known limitation: an edit that preserves both size and mtime is not detected",
+        );
+    }
+
+    /// A sidecar written before fingerprints existed carries only mtimes.
+    /// Its files keep mtime-only validation: an untouched file hits, and no
+    /// hash is ever recorded for it. Hashing the current contents would let
+    /// a same-size edit with a preserved mtime vouch for outputs built from
+    /// different contents, permanently.
+    #[tokio::test]
+    async fn legacy_sidecar_without_fingerprints_is_never_upgraded() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        // Strip the states to emulate an entry written by an older pixi.
+        let mut json = f.sidecar_json();
+        json.as_object_mut().unwrap().remove("input_file_states");
+        f.write_sidecar_json(&json);
+        assert!(f.sidecar().input_file_states.is_empty());
+
+        assert!(
+            f.lookup().await.is_some(),
+            "a legacy sidecar with untouched files must still hit",
+        );
+        assert!(
+            f.sidecar().input_file_states.is_empty(),
+            "a hit must not record a hash it cannot vouch for",
+        );
+
+        // A touch costs one rebuild; only a fresh store records fingerprints.
+        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        set_modified(&input, mtime + std::time::Duration::from_secs(5));
+        assert!(
+            f.lookup().await.is_none(),
+            "a legacy entry cannot prove a touched file is unchanged",
+        );
+        assert!(
+            f.sidecar().input_file_states.is_empty(),
+            "a miss must not poison the sidecar with a hash of the new contents",
+        );
+    }
+
+    /// The store-time glob walk and the fingerprint pass are separate, so a
+    /// file can vanish in between. The store must succeed, and the resulting
+    /// entry must not claim a file it never fingerprinted.
+    #[tokio::test]
+    async fn store_tolerates_an_input_file_that_vanished_before_fingerprinting() {
+        let f = Fixture::new();
+        let present = f.source.join("main.py");
+        fs_err::write(&present, b"body").unwrap();
+        let vanished = f.source.join("gone.py");
+
+        f.store(
+            vec![glob_group(&["**/*.py"])],
+            vec![abs(present.clone()), abs(vanished.clone())],
+        )
+        .await;
+
+        let sidecar = f.sidecar();
+        assert!(
+            !sidecar.input_files.contains_key(&abs(vanished.clone())),
+            "a file that could not be stat'ed must be dropped from the record",
+        );
+        assert!(
+            f.lookup().await.is_some(),
+            "a dropped file must not turn every later lookup into a miss",
+        );
+
+        // If it comes back, the glob walk sees a file the entry does not know.
+        fs_err::write(&vanished, b"back").unwrap();
+        assert!(
+            f.lookup().await.is_none(),
+            "a reappearing input file must invalidate the entry",
+        );
+    }
+
+    /// The new-file check depends on the glob walk, which the compute engine
+    /// memoizes for its lifetime. Two lookups sharing an engine therefore
+    /// share one walk, and a file added in between is invisible to the
+    /// second. This predates fingerprinting and only bounds detection to a
+    /// single pixi run; recorded so it is not mistaken for a fingerprint bug.
+    #[tokio::test]
+    async fn glob_walk_is_memoized_per_engine_so_one_run_sees_one_file_set() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let engine = ComputeEngine::new();
+        let probe = async |source: &Path| {
+            as_hit(
+                lookup(
+                    &engine,
+                    &f.cache,
+                    &pkg("foo"),
+                    &key("linux-64-abc"),
+                    source,
+                    SourceMutability::Mutable,
+                )
+                .await
+                .unwrap(),
+            )
+        };
+
+        assert!(probe(&f.source).await.is_some());
+        fs_err::write(f.source.join("extra.py"), b"new module").unwrap();
+        assert!(
+            probe(&f.source).await.is_some(),
+            "within one engine the memoized walk still reports the old file set",
+        );
+        assert!(
+            f.lookup().await.is_none(),
+            "the next run walks again and must see the new file",
+        );
+    }
+
+    /// Input globs can match a directory. Hashing one is impossible, so it
+    /// must fall back to mtime-only validation instead of failing the store
+    /// or hanging.
+    #[tokio::test]
+    async fn directory_input_falls_back_to_mtime_only_validation() {
+        let f = Fixture::new();
+        let dir = f.source.join("assets");
+        fs_err::create_dir_all(&dir).unwrap();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+
+        f.store(Vec::new(), vec![abs(input.clone()), abs(dir.clone())])
+            .await;
+
+        let sidecar = f.sidecar();
+        assert!(
+            sidecar.input_files.contains_key(&abs(dir.clone())),
+            "a directory should keep timestamp-based validation",
+        );
+        assert!(
+            matches!(
+                sidecar.input_file_states.get(&dir),
+                Some(InputFileState::MtimeOnly(_))
+            ),
+            "a directory must never be hashed",
+        );
+        assert!(f.lookup().await.is_some(), "a directory input must hit");
+    }
+
+    /// Sidecars gain fields over time. An entry written by a newer pixi must
+    /// still be usable, and the byte-CAS refresh must not corrupt it. The
+    /// refresh write does drop the unknown fields; that costs the newer
+    /// process a rebuild at worst, never a wrong hit.
+    #[tokio::test]
+    async fn sidecar_with_unknown_fields_hits_and_only_loses_them_on_refresh() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let mut json = f.sidecar_json();
+        json.as_object_mut()
+            .unwrap()
+            .insert("future_field".into(), serde_json::json!({"a": 1}));
+        f.write_sidecar_json(&json);
+
+        // Nothing changed, so no refresh happens and the field survives.
+        assert!(
+            f.lookup().await.is_some(),
+            "unknown fields must not break parsing"
+        );
+        assert!(
+            f.sidecar_json().get("future_field").is_some(),
+            "a lookup that refreshes nothing must leave the sidecar bytes alone",
+        );
+
+        // A touch forces a refresh, which rewrites the sidecar from the
+        // fields this version knows about.
+        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        set_modified(&input, mtime + std::time::Duration::from_secs(3));
+        assert!(f.lookup().await.is_some(), "a touch must still hit");
+        assert!(
+            f.sidecar_json().get("future_field").is_none(),
+            "the refresh rewrite drops fields this version does not know",
+        );
+    }
+
+    /// A build that rewrites a source-tree file on every run makes its mtime
+    /// change on every probe. Each probe must re-hash, keep the hit, and
+    /// leave the sidecar converged on the mtime it just observed.
+    #[tokio::test]
+    async fn a_file_touched_before_every_probe_keeps_hitting_and_converges() {
+        let f = Fixture::new();
+        let input = f.source.join("generated.py");
+        fs_err::write(&input, b"body").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let base = fs_err::metadata(&input).unwrap().modified().unwrap();
+        for round in 1..=3u64 {
+            let mtime = base + std::time::Duration::from_secs(round);
+            set_modified(&input, mtime);
+            assert!(
+                f.lookup().await.is_some(),
+                "round {round}: a touched-but-unchanged file must stay cached",
+            );
+            assert_eq!(
+                f.sidecar()
+                    .input_file_states
+                    .get(&input)
+                    .unwrap()
+                    .modified(),
+                mtime,
+                "round {round}: the refreshed mtime should be persisted",
+            );
+        }
+    }
+
+    /// Timestamps before the unix epoch are representable on both NTFS and
+    /// most unix filesystems and must survive the sidecar round trip.
+    #[tokio::test]
+    async fn pre_epoch_input_mtime_round_trips_through_store_and_lookup() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+
+        let pre_epoch = SystemTime::UNIX_EPOCH - std::time::Duration::from_secs(86_400);
+        let settable = OpenOptions::new()
+            .write(true)
+            .open(&input)
+            .unwrap()
+            .set_modified(pre_epoch)
+            .is_ok();
+        if !settable {
+            // Some filesystems clamp timestamps to the epoch; nothing to test.
+            return;
+        }
+
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+        assert_eq!(
+            f.sidecar()
+                .input_file_states
+                .get(&input)
+                .unwrap()
+                .modified(),
+            pre_epoch,
+        );
+        assert!(
+            f.lookup().await.is_some(),
+            "a pre-epoch input mtime must not invalidate the entry",
+        );
+    }
+
+    /// A zero-byte input is a degenerate hash case: every empty file has the
+    /// same digest. Growing it must invalidate, and emptying it again must
+    /// bring the entry back rather than wedging it.
+    #[tokio::test]
+    async fn zero_byte_input_file_round_trips() {
+        let f = Fixture::new();
+        let input = f.source.join("__init__.py");
+        fs_err::write(&input, b"").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+        assert!(f.lookup().await.is_some(), "an empty input file must hit");
+
+        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        fs_err::write(&input, b"x").unwrap();
+        set_modified(&input, mtime + std::time::Duration::from_secs(1));
+        assert!(
+            f.lookup().await.is_none(),
+            "growing the file must invalidate the entry",
+        );
+
+        fs_err::write(&input, b"").unwrap();
+        set_modified(&input, mtime + std::time::Duration::from_secs(2));
+        assert!(
+            f.lookup().await.is_some(),
+            "restoring the empty contents must restore the hit",
+        );
+    }
+
+    /// Restoring a file from a backup or checking it out again can move its
+    /// mtime backwards. The hash, not the direction of the mtime change,
+    /// decides: identical contents keep the hit, different contents do not.
+    #[tokio::test]
+    async fn an_mtime_moving_backwards_is_decided_by_the_hash() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"old").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        let older = mtime - std::time::Duration::from_secs(3600);
+        set_modified(&input, older);
+        assert!(
+            f.lookup().await.is_some(),
+            "an older mtime with identical contents must stay cached",
+        );
+
+        fs_err::write(&input, b"new").unwrap();
+        set_modified(&input, older - std::time::Duration::from_secs(3600));
+        assert!(
+            f.lookup().await.is_none(),
+            "an older mtime with changed contents must invalidate",
+        );
+    }
+
+    /// Grow a file and truncate it back to its original length with different
+    /// contents. Only the hash can tell these apart.
+    #[tokio::test]
+    async fn grow_then_truncate_to_the_original_size_invalidates() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"aaa").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        fs_err::write(&input, b"bbbbbbbbb").unwrap();
+        fs_err::write(&input, b"ccc").unwrap();
+        set_modified(&input, mtime + std::time::Duration::from_secs(1));
+
+        assert!(
+            f.lookup().await.is_none(),
+            "same size, different contents must invalidate",
+        );
+    }
+
+    /// A refresh racing a `clear_package` must not write the sidecar back;
+    /// explicit invalidation wins.
+    #[tokio::test]
+    async fn refresh_does_not_resurrect_a_cleared_entry() {
+        let f = Fixture::new();
+        let input = f.source.join("main.py");
+        fs_err::write(&input, b"body").unwrap();
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+
+        let key = key("linux-64-abc");
+        let sidecar_path = f.cache.sidecar_path(&pkg("foo"), &key);
+        let bytes = fs_err::read(&sidecar_path).unwrap();
+        let sidecar: ArtifactSidecar = serde_json::from_slice(&bytes).unwrap();
+
+        f.cache.clear_package(&pkg("foo")).unwrap();
+        f.cache
+            .try_refresh_sidecar(&pkg("foo"), &key, &bytes, &sidecar)
+            .await
+            .unwrap();
+
+        assert!(
+            fs_err::metadata(f.cache.entry_dir(&pkg("foo"), &key)).is_err(),
+            "a refresh must not recreate a cleared entry directory",
         );
     }
 }

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -586,13 +586,13 @@ impl ArtifactCache {
                     Ok(SidecarRefresh::Written) => true,
                     Ok(SidecarRefresh::Changed) => false,
                     Err(err) => {
-                        // Best-effort: an I/O failure leaves the old entry in
-                        // place, which this probe already validated.
+                        // The refresh is best-effort, but its failure leaves
+                        // the entry state unknown; re-validate the bytes.
                         tracing::debug!(
                             error = %err,
                             "Failed to persist refreshed artifact input fingerprints; using the verified entry"
                         );
-                        true
+                        self.sidecar_unchanged(package, key, &bytes).await?
                     }
                 }
             } else {
@@ -1631,6 +1631,19 @@ mod tests {
                 .modified(),
             pre_epoch,
         );
+        let persisted = f.sidecar_json()["input_files"]
+            .as_object()
+            .unwrap()
+            .values()
+            .next()
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(
+            persisted.starts_with("1969-12-31T"),
+            "timestamps persist as RFC3339, which represents pre-epoch instants; got {persisted}",
+        );
         assert!(
             f.lookup().await.is_some(),
             "a pre-epoch input mtime must not invalidate the entry",
@@ -1911,6 +1924,273 @@ mod tests {
         assert!(
             f.lookup().await.is_none(),
             "changing a recorded input directory must invalidate the entry",
+        );
+    }
+
+    /// The single key of the sidecar's state map.
+    fn only_state_key(json: &serde_json::Value) -> String {
+        let files = json["input_file_states"]["files"].as_object().unwrap();
+        assert_eq!(files.len(), 1, "fixture stores exactly one input file");
+        files.keys().next().unwrap().clone()
+    }
+
+    /// A sidecar can carry a file in `input_files` with no matching entry in
+    /// the state map (a hand-edited or partially written entry). The artifact
+    /// path verifies without a fallback cutoff, so nothing vouches for that
+    /// file: it must miss rather than pass unvalidated.
+    #[tokio::test]
+    async fn a_state_map_missing_one_file_misses_instead_of_trusting_it() {
+        let f = Fixture::new();
+        let main = f.write("main.py", b"body");
+        let other = f.write("other.py", b"other");
+        f.store(
+            vec![glob_group(&["**/*.py"])],
+            vec![abs(main.clone()), abs(other.clone())],
+        )
+        .await;
+
+        // Drop only `other.py`'s state; it stays listed in `input_files`.
+        let mut json = f.sidecar_json();
+        json["input_file_states"]["files"]
+            .as_object_mut()
+            .unwrap()
+            .retain(|path, _| !path.ends_with("other.py"));
+        f.write_sidecar_json(&json);
+        let edited = fs_err::read(f.sidecar_path()).unwrap();
+
+        match f.lookup_miss().await {
+            CacheMissReason::InputFileModified { path, .. } => {
+                assert_eq!(
+                    path.as_std_path(),
+                    other,
+                    "the file without a recorded state is the one that invalidates",
+                );
+            }
+            reason => panic!("expected a miss on the stateless file, got {reason:?}"),
+        }
+
+        // Touching the file that *does* have a state runs the same partial map
+        // through the hashing half of `verify`. It must still miss, and leave
+        // the entry byte-identical.
+        touch(&main, 5);
+        assert!(matches!(
+            f.lookup_miss().await,
+            CacheMissReason::InputFileModified { .. }
+        ));
+        assert_eq!(
+            fs_err::read(f.sidecar_path()).unwrap(),
+            edited,
+            "a miss must not rewrite the entry it rejected",
+        );
+    }
+
+    /// The same absolute path can reach a capture more than once (a variant
+    /// file that is also a glob-matched input). It must be recorded once and
+    /// keep validating normally.
+    #[tokio::test]
+    async fn an_input_path_listed_twice_is_recorded_once() {
+        let f = Fixture::new();
+        let input = f.write("main.py", b"body");
+        f.store(
+            vec![glob_group(&["**/*.py"])],
+            vec![abs(input.clone()), abs(input.clone()), abs(input.clone())],
+        )
+        .await;
+
+        let sidecar = f.sidecar();
+        assert_eq!(
+            sidecar.input_files.len(),
+            1,
+            "a duplicate must not be recorded twice"
+        );
+        assert_eq!(sidecar.input_file_states.iter().count(), 1);
+
+        assert!(f.lookup().await.is_some(), "a deduplicated entry must hit");
+
+        // The verify pass sees the duplicate too, through `input_files`.
+        touch(&input, 5);
+        assert!(
+            f.lookup().await.is_some(),
+            "a touched but unchanged duplicate must refresh, not miss",
+        );
+        assert_eq!(f.sidecar().input_files.len(), 1);
+    }
+
+    /// A legacy entry that misses must leave its recorded mtimes untouched;
+    /// only the rebuild that follows may rewrite them.
+    #[tokio::test]
+    async fn a_legacy_sidecar_miss_does_not_rewrite_the_recorded_mtimes() {
+        let (f, input) = Fixture::with_input("main.py", b"body").await;
+
+        let mut json = f.sidecar_json();
+        json.as_object_mut().unwrap().remove("input_file_states");
+        f.write_sidecar_json(&json);
+        let legacy_bytes = fs_err::read(f.sidecar_path()).unwrap();
+
+        touch(&input, 7);
+        assert!(matches!(
+            f.lookup_miss().await,
+            CacheMissReason::InputFileModified { .. }
+        ));
+        assert_eq!(
+            fs_err::read(f.sidecar_path()).unwrap(),
+            legacy_bytes,
+            "a legacy miss must not rewrite the entry",
+        );
+    }
+
+    /// An `MtimeOnly` state records no size, so a file that was unhashable at
+    /// store time and is an ordinary file at probe time is validated on its
+    /// mtime alone: a rewrite that restores the mtime is invisible even when
+    /// the size changes. This is weaker than the fingerprint path (which
+    /// compares the size first) and is recorded here so the gap is a
+    /// conscious one.
+    #[tokio::test]
+    async fn an_mtime_only_state_accepts_a_size_change_that_restores_the_mtime() {
+        let (f, input) = Fixture::with_input("main.py", b"body").await;
+
+        // Emulate a file that could not be hashed when the entry was stored.
+        let mut json = f.sidecar_json();
+        let path_key = only_state_key(&json);
+        let recorded_mtime = json["input_files"][&path_key].clone();
+        json["input_file_states"]["files"][&path_key] =
+            serde_json::json!({ "mtime_only": recorded_mtime });
+        f.write_sidecar_json(&json);
+        assert!(matches!(
+            f.sidecar().input_file_states.get(&input),
+            Some(InputFileState::MtimeOnly(_)),
+        ));
+
+        let original = mtime(&input);
+        assert!(
+            f.lookup().await.is_some(),
+            "an untouched mtime-only file must hit",
+        );
+
+        fs_err::write(&input, b"a much longer body than before").unwrap();
+        set_modified(&input, original);
+        assert!(
+            f.lookup().await.is_some(),
+            "known limitation: mtime-only validation records no size, so a \
+             rewrite that restores the mtime is not detected",
+        );
+        assert!(matches!(
+            f.sidecar().input_file_states.get(&input),
+            Some(InputFileState::MtimeOnly(_)),
+        ));
+    }
+
+    /// The concurrent-store recheck is a byte compare-and-swap on the
+    /// sidecar. Both halves (the refresh write and the plain check) must
+    /// report "changed" for a byte image the entry never held; `lookup` maps
+    /// that onto [`CacheMissReason::EntryChanged`].
+    #[tokio::test]
+    async fn a_byte_image_the_entry_never_held_fails_both_halves_of_the_recheck() {
+        let (f, _input) = Fixture::with_input("main.py", b"body").await;
+        let key = key("linux-64-abc");
+        let stale_bytes = b"{}".to_vec();
+        let sidecar = f.sidecar();
+        let committed = fs_err::read(f.sidecar_path()).unwrap();
+
+        assert!(matches!(
+            f.cache
+                .try_refresh_sidecar(&pkg("foo"), &key, &stale_bytes, &sidecar)
+                .await
+                .unwrap(),
+            SidecarRefresh::Changed,
+        ));
+        assert!(
+            !f.cache
+                .sidecar_unchanged(&pkg("foo"), &key, &stale_bytes)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(
+            fs_err::read(f.sidecar_path()).unwrap(),
+            committed,
+            "a lost compare-and-swap must not write anything",
+        );
+
+        // A cleared entry reports the same, without resurrecting the entry.
+        f.cache.clear_package(&pkg("foo")).unwrap();
+        assert!(matches!(
+            f.cache
+                .try_refresh_sidecar(&pkg("foo"), &key, &committed, &sidecar)
+                .await
+                .unwrap(),
+            SidecarRefresh::Changed,
+        ));
+        assert!(
+            !f.sidecar_path().exists(),
+            "a refresh must never recreate a cleared entry",
+        );
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(target: &Path, link: &Path) -> std::io::Result<()> {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+
+    /// Input files are stat'ed and hashed through the link, so an edit to the
+    /// target invalidates the entry even when the link itself is untouched
+    /// and the size is unchanged.
+    #[tokio::test]
+    async fn editing_the_target_of_a_symlinked_input_invalidates_the_entry() {
+        let f = Fixture::new();
+        // The target lives outside the source dir so the glob walk only ever
+        // sees the link.
+        let target = f.source.parent().unwrap().join("target.py");
+        fs_err::write(&target, b"old").unwrap();
+        let link = f.source.join("main.py");
+        if let Err(err) = symlink_file(&target, &link) {
+            // Creating symlinks needs a privilege or developer mode on Windows.
+            eprintln!("skipping: cannot create symlinks here ({err})");
+            return;
+        }
+
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(link.clone())])
+            .await;
+        assert!(f.lookup().await.is_some(), "an untouched link must hit");
+
+        let base = mtime(&link);
+        fs_err::write(&target, b"new").unwrap();
+        set_modified(&target, base + std::time::Duration::from_secs(1));
+        assert!(
+            f.lookup().await.is_none(),
+            "a same-size edit to the link target must invalidate the entry",
+        );
+    }
+
+    /// The hard-link counterpart of the symlink case, which needs no
+    /// privileges: an input edited through a second name for the same file
+    /// must invalidate the entry.
+    #[tokio::test]
+    async fn editing_a_hard_linked_input_through_its_other_name_invalidates_the_entry() {
+        let f = Fixture::new();
+        // The second name lives outside the source dir so the glob walk only
+        // ever sees the recorded input.
+        let other_name = f.source.parent().unwrap().join("other-name.py");
+        let input = f.write("main.py", b"old");
+        if let Err(err) = fs_err::hard_link(&input, &other_name) {
+            eprintln!("skipping: cannot create hard links here ({err})");
+            return;
+        }
+
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
+        assert!(f.lookup().await.is_some(), "an untouched input must hit");
+
+        let base = mtime(&input);
+        fs_err::write(&other_name, b"new").unwrap();
+        set_modified(&other_name, base + std::time::Duration::from_secs(1));
+        assert!(
+            f.lookup().await.is_none(),
+            "a same-size edit through the other name must invalidate the entry",
         );
     }
 }

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -11,10 +11,11 @@
 //!
 //! The cache key is structural (identity of the build inputs plus content
 //! addresses of its dependencies). For mutable sources, freshness of the
-//! source files themselves is tracked in the sidecar via per-file mtimes,
-//! plus a re-glob pass that detects added files. Immutable sources are
-//! fully pinned by the key, so their entries carry no file lists and skip
-//! those checks.
+//! source files themselves is tracked in the sidecar via per-file
+//! fingerprints, plus a re-glob pass that detects added files. The mtime
+//! remains the fast path; contents are hashed only when it changes.
+//! Immutable sources are fully pinned by the key, so their entries carry no
+//! file lists and skip those checks.
 //!
 //! On a hit, the cached `.conda` is returned along with its sha256; no
 //! backend work happens. On a miss (or stale sidecar), the caller rebuilds
@@ -61,6 +62,10 @@ pub enum SourceMutability {
     Mutable,
     Immutable,
 }
+
+use crate::file_fingerprint::{
+    FileFingerprint, FileFingerprintError, MetadataComparison, fingerprint_files,
+};
 
 /// Opaque content-addressed handle for an artifact cache entry.
 ///
@@ -176,6 +181,11 @@ pub struct ArtifactSidecar {
     /// round-trip directly against the engine walk at lookup time.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub input_files: BTreeMap<AbsPathBuf, DateTime<Utc>>,
+
+    /// Content fingerprints for the input files. Entries written by older
+    /// pixi versions omit this map and are upgraded on their first cache hit.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) input_file_fingerprints: BTreeMap<AbsPathBuf, FileFingerprint>,
 
     /// sha256 of the cached `.conda`. Callers rely on this for transitive
     /// invalidation of dependents.
@@ -390,7 +400,7 @@ impl ArtifactCache {
             }
             Err(err) => return Err(ArtifactCacheError::io("reading sidecar", sidecar_path, err)),
         };
-        let Ok(sidecar) = serde_json::from_slice::<ArtifactSidecar>(&bytes) else {
+        let Ok(mut sidecar) = serde_json::from_slice::<ArtifactSidecar>(&bytes) else {
             // Treat unparsable sidecars as misses; the caller will rebuild
             // and overwrite.
             return Ok(CacheLookup::Miss(CacheMissReason::CorruptSidecar));
@@ -403,23 +413,85 @@ impl ArtifactCache {
         // dir removes the recorded files entirely. Skipping them also
         // covers sidecars written by older versions, which still carry
         // file lists for immutable sources.
+        let mut fingerprints_refreshed = false;
         if mutability == SourceMutability::Mutable {
-            // Check every recorded file still matches its mtime.
+            // Check every recorded file. Size and mtime provide a cheap fast
+            // path; only files with a changed mtime need to be hashed.
+            let mut fingerprints_to_compute = Vec::new();
             for (path, expected_mtime) in &sidecar.input_files {
-                let modified = match fs_err::metadata(path).and_then(|m| m.modified()) {
-                    Ok(m) => DateTime::<Utc>::from(m),
+                let metadata = match fs_err::metadata(path) {
+                    Ok(metadata) => metadata,
                     Err(_) => {
                         return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
                             path: path.clone(),
                         }));
                     }
                 };
-                if modified != *expected_mtime {
-                    return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
-                        path: path.clone(),
-                        built_at: *expected_mtime,
-                        modified_at: modified,
-                    }));
+                let modified = match metadata.modified() {
+                    Ok(modified) => DateTime::<Utc>::from(modified),
+                    Err(_) => {
+                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
+                            path: path.clone(),
+                        }));
+                    }
+                };
+
+                match sidecar.input_file_fingerprints.get(path) {
+                    Some(fingerprint) => match fingerprint.compare_metadata(&metadata) {
+                        Ok(MetadataComparison::Unchanged) => {}
+                        Ok(MetadataComparison::HashRequired) => {
+                            fingerprints_to_compute.push(path.as_std_path().to_path_buf());
+                        }
+                        Ok(MetadataComparison::Changed) | Err(_) => {
+                            return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
+                                path: path.clone(),
+                                built_at: DateTime::<Utc>::from(fingerprint.modified),
+                                modified_at: modified,
+                            }));
+                        }
+                    },
+                    None => {
+                        if modified != *expected_mtime {
+                            // Without a previously recorded hash there is no
+                            // way to prove that a touched file is unchanged.
+                            return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
+                                path: path.clone(),
+                                built_at: *expected_mtime,
+                                modified_at: modified,
+                            }));
+                        }
+                        fingerprints_to_compute.push(path.as_std_path().to_path_buf());
+                    }
+                }
+            }
+
+            fingerprints_refreshed = !fingerprints_to_compute.is_empty();
+            if fingerprints_refreshed {
+                let current_fingerprints = match fingerprint_files(fingerprints_to_compute).await {
+                    Ok(fingerprints) => fingerprints,
+                    Err(err) => {
+                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileRemoved {
+                            path: AbsPathBuf::new(err.path)
+                                .expect("recorded input paths are absolute"),
+                        }));
+                    }
+                };
+                for (path, current) in current_fingerprints {
+                    let path = AbsPathBuf::new(path).expect("recorded input paths are absolute");
+                    if let Some(expected) = sidecar.input_file_fingerprints.get(&path)
+                        && expected.hash != current.hash
+                    {
+                        return Ok(CacheLookup::Miss(CacheMissReason::InputFileModified {
+                            path: path.clone(),
+                            built_at: DateTime::<Utc>::from(expected.modified),
+                            modified_at: DateTime::<Utc>::from(current.modified),
+                        }));
+                    }
+
+                    sidecar
+                        .input_files
+                        .insert(path.clone(), DateTime::<Utc>::from(current.modified));
+                    sidecar.input_file_fingerprints.insert(path, current);
                 }
             }
 
@@ -448,6 +520,11 @@ impl ArtifactCache {
             }));
         }
 
+        if fingerprints_refreshed {
+            self.try_refresh_sidecar(package, key, &bytes, &sidecar)
+                .await?;
+        }
+
         // Point the record at the artifact being returned. Sidecars written
         // by older versions carry the work-directory output path, which does
         // not survive workspace-cache cleanups.
@@ -459,6 +536,42 @@ impl ArtifactCache {
             sha256: sidecar.artifact_sha256,
             record,
         }))
+    }
+
+    /// Persist refreshed mtimes and hashes if no other process changed the
+    /// sidecar while the files were being inspected.
+    async fn try_refresh_sidecar(
+        &self,
+        package: &PackageName,
+        key: &ArtifactCacheKey,
+        expected_bytes: &[u8],
+        sidecar: &ArtifactSidecar,
+    ) -> Result<(), ArtifactCacheError> {
+        let sidecar_path = self.sidecar_path(package, key);
+        let lock_file = self.open_lock_file(package, key).await?;
+        let _guard = lock_file.lock_write().await.map_err(|err| {
+            ArtifactCacheError::io(
+                "acquiring exclusive lock",
+                self.lock_path(package, key),
+                err.error,
+            )
+        })?;
+
+        let current_bytes = match tokio::fs::read(&sidecar_path).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => {
+                return Err(ArtifactCacheError::io("reading sidecar", sidecar_path, err));
+            }
+        };
+        if current_bytes != expected_bytes {
+            return Ok(());
+        }
+
+        let bytes = serde_json::to_vec(sidecar).expect("sidecar serialization cannot fail");
+        tokio::fs::write(&sidecar_path, bytes)
+            .await
+            .map_err(|err| ArtifactCacheError::io("writing sidecar", sidecar_path, err))
     }
 
     /// Place `artifact_source` into the cache and write its sidecar.
@@ -524,19 +637,29 @@ impl ArtifactCache {
             .map_err(|err| ArtifactCacheError::io("hashing artifact", dest.clone(), err))?
         };
 
-        let mut input_files_mtimes = BTreeMap::new();
-        for path in input_files {
-            let modified = fs_err::metadata(&path)
-                .and_then(|m| m.modified())
-                .map_err(|err| {
-                    ArtifactCacheError::io("stat input file", path.clone().into(), err)
-                })?;
-            input_files_mtimes.insert(path, DateTime::<Utc>::from(modified));
-        }
+        let input_file_fingerprints = fingerprint_files(
+            input_files
+                .into_iter()
+                .map(|path| path.as_std_path().to_path_buf()),
+        )
+        .await?
+        .into_iter()
+        .map(|(path, fingerprint)| {
+            (
+                AbsPathBuf::new(path).expect("recorded input paths are absolute"),
+                fingerprint,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+        let input_files_mtimes = input_file_fingerprints
+            .iter()
+            .map(|(path, fingerprint)| (path.clone(), DateTime::<Utc>::from(fingerprint.modified)))
+            .collect();
 
         let sidecar = ArtifactSidecar {
             input_glob_sets,
             input_files: input_files_mtimes,
+            input_file_fingerprints,
             artifact_sha256: sha256,
             artifact_filename: filename,
             record: record.clone(),
@@ -570,6 +693,13 @@ pub enum ArtifactCacheError {
 
     #[error("artifact path has no filename: {}", .0.display())]
     ArtifactFilename(PathBuf),
+
+    #[error("failed to fingerprint input file at {}", path.display())]
+    Fingerprint {
+        path: PathBuf,
+        #[source]
+        source: Arc<std::io::Error>,
+    },
 }
 
 impl ArtifactCacheError {
@@ -585,6 +715,15 @@ impl ArtifactCacheError {
 impl From<pixi_glob::GlobSetError> for ArtifactCacheError {
     fn from(err: pixi_glob::GlobSetError) -> Self {
         Self::Glob(Arc::new(err))
+    }
+}
+
+impl From<FileFingerprintError> for ArtifactCacheError {
+    fn from(err: FileFingerprintError) -> Self {
+        Self::Fingerprint {
+            path: err.path,
+            source: err.source,
+        }
     }
 }
 
@@ -751,7 +890,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn lookup_stale_when_source_file_changes() {
+    async fn lookup_hashes_source_file_when_mtime_changes() {
         let tmp = TempDir::new().unwrap();
         let cache = ArtifactCache::new(tmp.path().join("artifacts"));
         let engine = ComputeEngine::new();
@@ -779,9 +918,46 @@ mod tests {
             .await
             .unwrap();
 
-        // Modify the source file's mtime by rewriting it after a sleep.
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Touching the input without changing its contents keeps the cache
+        // valid and refreshes the stored mtime.
+        let original_mtime = fs_err::metadata(&input).unwrap().modified().unwrap();
+        let touched_mtime = original_mtime + std::time::Duration::from_secs(1);
+        std::fs::File::open(&input)
+            .unwrap()
+            .set_modified(touched_mtime)
+            .unwrap();
+
+        let hit = lookup(
+            &engine,
+            &cache,
+            &pkg("foo"),
+            &key,
+            &source,
+            SourceMutability::Mutable,
+        )
+        .await
+        .unwrap();
+        expect_hit(hit);
+
+        let sidecar: ArtifactSidecar =
+            serde_json::from_slice(&fs_err::read(cache.sidecar_path(&pkg("foo"), &key)).unwrap())
+                .unwrap();
+        assert_eq!(
+            sidecar
+                .input_file_fingerprints
+                .get(&abs(input.clone()))
+                .unwrap()
+                .modified,
+            touched_mtime,
+            "the refreshed mtime should be persisted"
+        );
+
+        // A same-size content change still invalidates the entry.
         fs_err::write(&input, b"new").unwrap();
+        std::fs::File::open(&input)
+            .unwrap()
+            .set_modified(touched_mtime + std::time::Duration::from_secs(1))
+            .unwrap();
 
         let got = lookup(
             &engine,

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -184,6 +184,8 @@ pub struct ArtifactSidecar {
 
     /// Content fingerprints for the input files. Entries written by older
     /// pixi versions omit this map and are upgraded on their first cache hit.
+    // TODO: Collapse this and `input_files` in the next artifact cache format.
+    // They are separate so sidecars written before fingerprints remain readable.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub(crate) input_file_fingerprints: BTreeMap<AbsPathBuf, FileFingerprint>,
 
@@ -520,9 +522,15 @@ impl ArtifactCache {
             }));
         }
 
-        if fingerprints_refreshed {
-            self.try_refresh_sidecar(package, key, &bytes, &sidecar)
-                .await?;
+        if fingerprints_refreshed
+            && let Err(err) = self
+                .try_refresh_sidecar(package, key, &bytes, &sidecar)
+                .await
+        {
+            tracing::debug!(
+                error = %err,
+                "Failed to persist refreshed artifact input fingerprints; using the verified entry"
+            );
         }
 
         // Point the record at the artifact being returned. Sidecars written

--- a/crates/pixi_command_dispatcher/src/cache/artifact.rs
+++ b/crates/pixi_command_dispatcher/src/cache/artifact.rs
@@ -488,6 +488,16 @@ impl ArtifactCache {
             // and overwrite.
             return Ok(CacheLookup::Miss(CacheMissReason::CorruptSidecar));
         };
+        // A parsable sidecar can still carry garbage: state keys must be
+        // absolute like the `input_files` keys, or the refresh rewrite
+        // would panic converting them.
+        if sidecar
+            .input_file_states
+            .iter()
+            .any(|(path, _)| AbsPathBuf::new(path.clone()).is_err())
+        {
+            return Ok(CacheLookup::Miss(CacheMissReason::CorruptSidecar));
+        }
         drop(_guard);
 
         // For an immutable source the cache key already pins the exact
@@ -1132,6 +1142,31 @@ mod tests {
         ));
     }
 
+    /// A parsable sidecar can still be semantically corrupt: a relative key
+    /// under `input_file_states` must miss instead of panicking when the
+    /// refresh rewrites the sidecar.
+    #[tokio::test]
+    async fn a_sidecar_with_a_relative_state_key_is_a_corrupt_miss() {
+        let (f, input) = Fixture::with_input("main.py", b"body").await;
+
+        let mut json = f.sidecar_json();
+        let states = json
+            .pointer_mut("/input_file_states/files")
+            .unwrap()
+            .as_object_mut()
+            .unwrap();
+        let state = states.values().next().unwrap().clone();
+        states.insert("relative.py".into(), state);
+        f.write_sidecar_json(&json);
+
+        // A touch forces the refresh rewrite that would hit the bad key.
+        touch(&input, 1);
+        assert!(matches!(
+            f.lookup_miss().await,
+            CacheMissReason::CorruptSidecar
+        ));
+    }
+
     /// Regression for prefix-dev/pixi#6232: a thin package whose manifest
     /// points at `../recipe.yaml` makes the build report a `../**` input
     /// glob. The walker rebases that onto the parent directory, so it matches
@@ -1641,26 +1676,21 @@ mod tests {
     async fn unconfirmed_input_converges_after_one_rebuild() {
         let f = Fixture::new();
         let input = f.write("main.py", b"body");
-        let before_mtime = mtime(&input) - std::time::Duration::from_secs(10);
+        set_modified(
+            &input,
+            SystemTime::now() + std::time::Duration::from_secs(3600),
+        );
 
-        f.store_with_build_started(
-            vec![glob_group(&["**/*.py"])],
-            vec![abs(input.clone())],
-            before_mtime,
-        )
-        .await;
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
         assert!(
             f.lookup().await.is_none(),
             "an unconfirmed fingerprint cannot vouch for the entry",
         );
 
         // The rebuild observes the same content and promotes it.
-        f.store_with_build_started(
-            vec![glob_group(&["**/*.py"])],
-            vec![abs(input.clone())],
-            before_mtime,
-        )
-        .await;
+        f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+            .await;
         assert!(
             f.lookup().await.is_some(),
             "content stable across two builds must be trusted",
@@ -1698,14 +1728,13 @@ mod tests {
     async fn clearing_the_package_resets_the_unconfirmed_promotion() {
         let f = Fixture::new();
         let input = f.write("main.py", b"body");
-        let before_mtime = mtime(&input) - std::time::Duration::from_secs(10);
+        set_modified(
+            &input,
+            SystemTime::now() + std::time::Duration::from_secs(3600),
+        );
         let store = async || {
-            f.store_with_build_started(
-                vec![glob_group(&["**/*.py"])],
-                vec![abs(input.clone())],
-                before_mtime,
-            )
-            .await;
+            f.store(vec![glob_group(&["**/*.py"])], vec![abs(input.clone())])
+                .await;
         };
 
         store().await;

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -219,7 +219,15 @@ pub struct BuildBackendMetadataCacheEntry {
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub input_files: BTreeSet<pixi_path::AbsPathBuf>,
 
+    /// Content fingerprints for the input and variant files. The metadata
+    /// cache first compares size and mtime and only re-hashes files whose
+    /// mtime changed.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) file_fingerprints: BTreeMap<PathBuf, crate::file_fingerprint::FileFingerprint>,
+
     /// The timestamp of when the metadata was computed.
+    /// Used as a fallback for cache entries written before file fingerprints
+    /// were recorded.
     pub timestamp: std::time::SystemTime,
 
     /// The outputs as reported by the build backend.

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -16,6 +16,7 @@ use crate::build::CanonicalSourceCodeLocation;
 use crate::input_hash::{
     BackendBinaryFingerprint, BackendSpecHash, ConfigurationHash, ProjectModelHash,
 };
+use crate::input_snapshot::InputSnapshot;
 use rattler_conda_types::PackageName;
 
 use crate::BuildEnvironment;
@@ -219,15 +220,14 @@ pub struct BuildBackendMetadataCacheEntry {
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub input_files: BTreeSet<pixi_path::AbsPathBuf>,
 
-    /// Content fingerprints for the input and variant files. The metadata
-    /// cache first compares size and mtime and only re-hashes files whose
-    /// mtime changed.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub(crate) file_fingerprints: BTreeMap<PathBuf, crate::file_fingerprint::FileFingerprint>,
+    /// Validation state for the input and variant files. Size and mtime are
+    /// compared first; contents are hashed only when the mtime moved.
+    #[serde(default, skip_serializing_if = "InputSnapshot::is_empty")]
+    pub(crate) input_file_states: InputSnapshot,
 
-    /// The timestamp of when the metadata was computed.
-    /// Used as a fallback for cache entries written before file fingerprints
-    /// were recorded.
+    /// The timestamp of when the metadata was computed. Files without a
+    /// recorded state (entries written before fingerprints existed) count as
+    /// unchanged while their mtime stays at or before this.
     pub timestamp: std::time::SystemTime,
 
     /// The outputs as reported by the build backend.

--- a/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
+++ b/crates/pixi_command_dispatcher/src/cache/backend_metadata.rs
@@ -244,10 +244,6 @@ impl VersionedCacheEntry<BuildBackendMetadataCache> for BuildBackendMetadataCach
     fn cache_version(&self) -> u64 {
         self.cache_version
     }
-
-    fn set_cache_version(&mut self, version: u64) {
-        self.cache_version = version;
-    }
 }
 
 impl BuildBackendMetadataCacheEntry {

--- a/crates/pixi_command_dispatcher/src/cache/common.rs
+++ b/crates/pixi_command_dispatcher/src/cache/common.rs
@@ -701,7 +701,7 @@ mod tests {
     /// A refresh must not overwrite contents it cannot parse: they are not
     /// the entry the refresh was computed from.
     #[tokio::test]
-    async fn try_refresh_does_not_clobber_unparseable_contents() {
+    async fn try_refresh_does_not_clobber_unparsable_contents() {
         let tmp = tempfile::TempDir::new().unwrap();
         let cache = DummyCache {
             root: tmp.path().to_path_buf(),

--- a/crates/pixi_command_dispatcher/src/cache/common.rs
+++ b/crates/pixi_command_dispatcher/src/cache/common.rs
@@ -125,6 +125,39 @@ pub trait MetadataCache: Clone + Sized {
     where
         Self::Entry: VersionedCacheEntry<Self>,
     {
+        self.write_at_version(input, metadata, expected_version, expected_version + 1)
+            .await
+    }
+
+    /// Like [`Self::try_write`] but keeps the version unchanged. Used to
+    /// persist refreshed bookkeeping for an entry that is otherwise
+    /// unchanged, without conflicting concurrent writers out of the version
+    /// CAS.
+    async fn try_refresh(
+        &self,
+        input: &Self::Key,
+        metadata: Self::Entry,
+        expected_version: u64,
+    ) -> Result<WriteResult<Self::Entry>, Self::Error>
+    where
+        Self::Entry: VersionedCacheEntry<Self>,
+    {
+        self.write_at_version(input, metadata, expected_version, expected_version)
+            .await
+    }
+
+    /// Writes `metadata` with `new_version` if the stored entry still has
+    /// `expected_version`.
+    async fn write_at_version(
+        &self,
+        input: &Self::Key,
+        metadata: Self::Entry,
+        expected_version: u64,
+        new_version: u64,
+    ) -> Result<WriteResult<Self::Entry>, Self::Error>
+    where
+        Self::Entry: VersionedCacheEntry<Self>,
+    {
         let cache_file_path = self.cache_file_path(input);
         if let Some(parent) = cache_file_path.parent() {
             tokio::fs::create_dir_all(&parent).await.map_err(|e| {
@@ -186,7 +219,7 @@ pub trait MetadataCache: Clone + Sized {
 
         // Version matches (or cache is empty), write new data
         let mut new_metadata = metadata;
-        new_metadata.set_cache_version(expected_version + 1);
+        new_metadata.set_cache_version(new_version);
 
         let bytes =
             serde_json::to_vec(&new_metadata).expect("serialization to JSON should not fail");

--- a/crates/pixi_command_dispatcher/src/cache/common.rs
+++ b/crates/pixi_command_dispatcher/src/cache/common.rs
@@ -114,155 +114,37 @@ pub trait MetadataCache: Clone + Sized {
     /// This method checks if the cache version matches the expected version
     /// before writing. If another process has updated the cache since it was
     /// read, this method returns `WriteResult::Conflict` with the newer metadata.
+    /// `metadata` must already carry `expected_version + 1`.
     ///
     /// The lock is held only during the version check and write operation.
     async fn try_write(
         &self,
         input: &Self::Key,
-        metadata: Self::Entry,
+        metadata: &Self::Entry,
         expected_version: u64,
     ) -> Result<WriteResult<Self::Entry>, Self::Error>
     where
         Self::Entry: VersionedCacheEntry<Self>,
     {
-        self.write_at_version(input, metadata, expected_version, expected_version + 1)
-            .await
+        debug_assert_eq!(metadata.cache_version(), expected_version + 1);
+        write_at_version(self, input, metadata, expected_version).await
     }
 
-    /// Like [`Self::try_write`] but keeps the version unchanged. Used to
-    /// persist refreshed bookkeeping for an entry that is otherwise
-    /// unchanged, without conflicting concurrent writers out of the version
-    /// CAS.
+    /// Like [`Self::try_write`] but keeps the version unchanged (`metadata`
+    /// must carry `expected_version`). Used to persist refreshed bookkeeping
+    /// for an entry that is otherwise unchanged, without conflicting
+    /// concurrent writers out of the version CAS.
     async fn try_refresh(
         &self,
         input: &Self::Key,
-        metadata: Self::Entry,
+        metadata: &Self::Entry,
         expected_version: u64,
     ) -> Result<WriteResult<Self::Entry>, Self::Error>
     where
         Self::Entry: VersionedCacheEntry<Self>,
     {
-        self.write_at_version(input, metadata, expected_version, expected_version)
-            .await
-    }
-
-    /// Writes `metadata` with `new_version` if the stored entry still has
-    /// `expected_version`.
-    async fn write_at_version(
-        &self,
-        input: &Self::Key,
-        metadata: Self::Entry,
-        expected_version: u64,
-        new_version: u64,
-    ) -> Result<WriteResult<Self::Entry>, Self::Error>
-    where
-        Self::Entry: VersionedCacheEntry<Self>,
-    {
-        let cache_file_path = self.cache_file_path(input);
-        if let Some(parent) = cache_file_path.parent() {
-            tokio::fs::create_dir_all(&parent).await.map_err(|e| {
-                Self::Error::from_io_error(
-                    "creating cache directory".to_string(),
-                    parent.to_path_buf(),
-                    e,
-                )
-            })?;
-        }
-
-        // Open or create the cache file
-        let cache_file = tokio::fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&cache_file_path)
-            .await
-            .map_err(|e| {
-                Self::Error::from_io_error(
-                    "opening cache file".to_string(),
-                    cache_file_path.clone(),
-                    e,
-                )
-            })?;
-
-        // Acquire lock
-        let mut locked_cache_file = cache_file.lock_write().await.map_err(|e| {
-            Self::Error::from_io_error(
-                "locking cache file".to_string(),
-                cache_file_path.clone(),
-                e.error,
-            )
-        })?;
-
-        // Check if cache was updated by another process
-        let mut current_contents = String::new();
-        locked_cache_file
-            .read_to_string(&mut current_contents)
-            .await
-            .map_err(|e| {
-                Self::Error::from_io_error(
-                    "reading cache file".to_string(),
-                    cache_file_path.clone(),
-                    e,
-                )
-            })?;
-
-        // If cache exists and has different version, return conflict
-        if !current_contents.is_empty()
-            && let Ok(current_metadata) = serde_json::from_str::<Self::Entry>(&current_contents)
-            && current_metadata.cache_version() != expected_version
-        {
-            // Cache was updated by another process
-            drop(locked_cache_file);
-            return Ok(WriteResult::Conflict(current_metadata));
-        }
-
-        // Version matches (or cache is empty), write new data
-        let mut new_metadata = metadata;
-        new_metadata.set_cache_version(new_version);
-
-        let bytes =
-            serde_json::to_vec(&new_metadata).expect("serialization to JSON should not fail");
-
-        // Write to file
-        locked_cache_file.rewind().await.map_err(|e| {
-            Self::Error::from_io_error(
-                "seeking to start of cache file".to_string(),
-                cache_file_path.clone(),
-                e,
-            )
-        })?;
-
-        locked_cache_file.write_all(&bytes).await.map_err(|e| {
-            Self::Error::from_io_error(
-                "writing metadata to cache file".to_string(),
-                cache_file_path.clone(),
-                e,
-            )
-        })?;
-
-        // Truncate file to new size
-        locked_cache_file
-            .inner_mut()
-            .set_len(bytes.len() as u64)
-            .await
-            .map_err(|e| {
-                Self::Error::from_io_error(
-                    "setting length of cache file".to_string(),
-                    cache_file_path.clone(),
-                    e,
-                )
-            })?;
-
-        // Flush to ensure data is written
-        locked_cache_file.flush().await.map_err(|e| {
-            Self::Error::from_io_error("flushing cache file".to_string(), cache_file_path, e)
-        })?;
-
-        // Release lock
-        drop(locked_cache_file);
-
-        Ok(WriteResult::Written)
+        debug_assert_eq!(metadata.cache_version(), expected_version);
+        write_at_version(self, input, metadata, expected_version).await
     }
 
     /// Returns the path to the cache entry with the given key.
@@ -273,6 +155,112 @@ pub trait MetadataCache: Clone + Sized {
         // truncate the file name.
         self.root().join(format!("{}.json", input.key()))
     }
+}
+
+/// Writes `metadata` if the stored entry still carries `expected_version`.
+/// The lock is held only for the version check and the write.
+async fn write_at_version<C: MetadataCache>(
+    cache: &C,
+    input: &C::Key,
+    metadata: &C::Entry,
+    expected_version: u64,
+) -> Result<WriteResult<C::Entry>, C::Error>
+where
+    C::Entry: VersionedCacheEntry<C>,
+{
+    let cache_file_path = cache.cache_file_path(input);
+    if let Some(parent) = cache_file_path.parent() {
+        tokio::fs::create_dir_all(&parent).await.map_err(|e| {
+            C::Error::from_io_error(
+                "creating cache directory".to_string(),
+                parent.to_path_buf(),
+                e,
+            )
+        })?;
+    }
+
+    // Open or create the cache file
+    let cache_file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&cache_file_path)
+        .await
+        .map_err(|e| {
+            C::Error::from_io_error("opening cache file".to_string(), cache_file_path.clone(), e)
+        })?;
+
+    // Acquire lock
+    let mut locked_cache_file = cache_file.lock_write().await.map_err(|e| {
+        C::Error::from_io_error(
+            "locking cache file".to_string(),
+            cache_file_path.clone(),
+            e.error,
+        )
+    })?;
+
+    // Check if cache was updated by another process
+    let mut current_contents = String::new();
+    locked_cache_file
+        .read_to_string(&mut current_contents)
+        .await
+        .map_err(|e| {
+            C::Error::from_io_error("reading cache file".to_string(), cache_file_path.clone(), e)
+        })?;
+
+    // If cache exists and has different version, return conflict
+    if !current_contents.is_empty()
+        && let Ok(current_metadata) = serde_json::from_str::<C::Entry>(&current_contents)
+        && current_metadata.cache_version() != expected_version
+    {
+        // Cache was updated by another process
+        drop(locked_cache_file);
+        return Ok(WriteResult::Conflict(current_metadata));
+    }
+
+    // Version matches (or cache is empty), write new data
+    let bytes = serde_json::to_vec(metadata).expect("serialization to JSON should not fail");
+
+    // Write to file
+    locked_cache_file.rewind().await.map_err(|e| {
+        C::Error::from_io_error(
+            "seeking to start of cache file".to_string(),
+            cache_file_path.clone(),
+            e,
+        )
+    })?;
+
+    locked_cache_file.write_all(&bytes).await.map_err(|e| {
+        C::Error::from_io_error(
+            "writing metadata to cache file".to_string(),
+            cache_file_path.clone(),
+            e,
+        )
+    })?;
+
+    // Truncate file to new size
+    locked_cache_file
+        .inner_mut()
+        .set_len(bytes.len() as u64)
+        .await
+        .map_err(|e| {
+            C::Error::from_io_error(
+                "setting length of cache file".to_string(),
+                cache_file_path.clone(),
+                e,
+            )
+        })?;
+
+    // Flush to ensure data is written
+    locked_cache_file.flush().await.map_err(|e| {
+        C::Error::from_io_error("flushing cache file".to_string(), cache_file_path, e)
+    })?;
+
+    // Release lock
+    drop(locked_cache_file);
+
+    Ok(WriteResult::Written)
 }
 
 /// Trait for cache keys that can produce a unique string used as the file name.
@@ -320,12 +308,9 @@ pub trait MetadataCacheEntry<C: MetadataCache>: Serialize + DeserializeOwned {
 /// concurrent processes), while the revision tracks *what content* is stored
 /// (for cross-cache staleness detection).
 pub trait VersionedCacheEntry<C: MetadataCache>: MetadataCacheEntry<C> {
-    /// Returns the current version counter.
+    /// Returns the version counter carried by the entry, which is what
+    /// [`MetadataCache::try_write`] persists.
     fn cache_version(&self) -> u64;
-
-    /// Sets the version counter. Called by [`MetadataCache::try_write`]
-    /// before persisting the entry.
-    fn set_cache_version(&mut self, version: u64);
 }
 
 /// The outcome of a [`MetadataCache::try_write`] call.
@@ -504,9 +489,6 @@ mod tests {
         fn cache_version(&self) -> u64 {
             self.version
         }
-        fn set_cache_version(&mut self, version: u64) {
-            self.version = version;
-        }
     }
 
     #[derive(Debug, thiserror::Error)]
@@ -558,10 +540,10 @@ mod tests {
         );
     }
 
-    fn entry() -> DummyMetadata {
+    fn entry(version: u64) -> DummyMetadata {
         DummyMetadata {
             revision: CacheRevision::new(),
-            version: 0,
+            version,
         }
     }
 
@@ -579,7 +561,7 @@ mod tests {
 
         // A rebuild writes the initial entry at version 0.
         assert!(matches!(
-            cache.try_write(&key, entry(), 0).await.unwrap(),
+            cache.try_write(&key, &entry(1), 0).await.unwrap(),
             WriteResult::Written
         ));
         let stored = cache.read(&key).await.unwrap().unwrap();
@@ -587,14 +569,14 @@ mod tests {
 
         // A read path refreshes it in place.
         assert!(matches!(
-            cache.try_refresh(&key, stored.clone(), 1).await.unwrap(),
+            cache.try_refresh(&key, &stored, 1).await.unwrap(),
             WriteResult::Written
         ));
         assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 1);
 
         // A writer holding the pre-refresh version still commits.
         assert!(matches!(
-            cache.try_write(&key, entry(), 1).await.unwrap(),
+            cache.try_write(&key, &entry(2), 1).await.unwrap(),
             WriteResult::Written
         ));
         assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
@@ -610,11 +592,11 @@ mod tests {
         };
         let key = DummyKey("entry".to_string());
 
-        cache.try_write(&key, entry(), 0).await.unwrap();
-        cache.try_write(&key, entry(), 1).await.unwrap();
+        cache.try_write(&key, &entry(1), 0).await.unwrap();
+        cache.try_write(&key, &entry(2), 1).await.unwrap();
         assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
 
-        let refreshed = cache.try_refresh(&key, entry(), 1).await.unwrap();
+        let refreshed = cache.try_refresh(&key, &entry(1), 1).await.unwrap();
         match refreshed {
             WriteResult::Conflict(current) => assert_eq!(current.cache_version(), 2),
             WriteResult::Written => panic!("a stale refresh must not overwrite a newer entry"),

--- a/crates/pixi_command_dispatcher/src/cache/common.rs
+++ b/crates/pixi_command_dispatcher/src/cache/common.rs
@@ -557,4 +557,68 @@ mod tests {
             PathBuf::from("/tmp/cache/source-dir/my-package-osx-arm64-HASH.json")
         );
     }
+
+    fn entry() -> DummyMetadata {
+        DummyMetadata {
+            revision: CacheRevision::new(),
+            version: 0,
+        }
+    }
+
+    /// `try_refresh` persists bookkeeping without consuming the version, so a
+    /// writer that read the entry before the refresh still wins its CAS. If
+    /// the refresh bumped the version instead, the rebuild would be forced to
+    /// conflict and throw away its work.
+    #[tokio::test]
+    async fn try_refresh_keeps_the_version_so_a_concurrent_writer_still_wins() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache = DummyCache {
+            root: tmp.path().to_path_buf(),
+        };
+        let key = DummyKey("entry".to_string());
+
+        // A rebuild writes the initial entry at version 0.
+        assert!(matches!(
+            cache.try_write(&key, entry(), 0).await.unwrap(),
+            WriteResult::Written
+        ));
+        let stored = cache.read(&key).await.unwrap().unwrap();
+        assert_eq!(stored.cache_version(), 1);
+
+        // A read path refreshes it in place.
+        assert!(matches!(
+            cache.try_refresh(&key, stored.clone(), 1).await.unwrap(),
+            WriteResult::Written
+        ));
+        assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 1);
+
+        // A writer holding the pre-refresh version still commits.
+        assert!(matches!(
+            cache.try_write(&key, entry(), 1).await.unwrap(),
+            WriteResult::Written
+        ));
+        assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
+    }
+
+    /// A refresh computed against a version that has since moved on must not
+    /// overwrite the newer entry.
+    #[tokio::test]
+    async fn try_refresh_conflicts_when_the_entry_moved_on() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache = DummyCache {
+            root: tmp.path().to_path_buf(),
+        };
+        let key = DummyKey("entry".to_string());
+
+        cache.try_write(&key, entry(), 0).await.unwrap();
+        cache.try_write(&key, entry(), 1).await.unwrap();
+        assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
+
+        let refreshed = cache.try_refresh(&key, entry(), 1).await.unwrap();
+        match refreshed {
+            WriteResult::Conflict(current) => assert_eq!(current.cache_version(), 2),
+            WriteResult::Written => panic!("a stale refresh must not overwrite a newer entry"),
+        }
+        assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
+    }
 }

--- a/crates/pixi_command_dispatcher/src/cache/common.rs
+++ b/crates/pixi_command_dispatcher/src/cache/common.rs
@@ -134,17 +134,22 @@ pub trait MetadataCache: Clone + Sized {
     /// must carry `expected_version`). Used to persist refreshed bookkeeping
     /// for an entry that is otherwise unchanged, without conflicting
     /// concurrent writers out of the version CAS.
+    ///
+    /// Unlike [`Self::try_write`] this never creates the cache file: an entry
+    /// that vanished (e.g. through a concurrent cache clean) or no longer
+    /// parses stays untouched, so the read path cannot resurrect or clobber
+    /// it.
     async fn try_refresh(
         &self,
         input: &Self::Key,
         metadata: &Self::Entry,
         expected_version: u64,
-    ) -> Result<WriteResult<Self::Entry>, Self::Error>
+    ) -> Result<RefreshResult<Self::Entry>, Self::Error>
     where
         Self::Entry: VersionedCacheEntry<Self>,
     {
         debug_assert_eq!(metadata.cache_version(), expected_version);
-        write_at_version(self, input, metadata, expected_version).await
+        refresh_at_version(self, input, metadata, expected_version).await
     }
 
     /// Returns the path to the cache entry with the given key.
@@ -220,13 +225,89 @@ where
     }
 
     // Version matches (or cache is empty), write new data
+    overwrite_locked_file::<C>(&mut locked_cache_file, metadata, &cache_file_path).await?;
+
+    // Release lock
+    drop(locked_cache_file);
+
+    Ok(WriteResult::Written)
+}
+
+/// Writes `metadata` back over the entry it was read from, if that entry
+/// still carries `expected_version`. Never creates the cache file; see
+/// [`MetadataCache::try_refresh`].
+async fn refresh_at_version<C: MetadataCache>(
+    cache: &C,
+    input: &C::Key,
+    metadata: &C::Entry,
+    expected_version: u64,
+) -> Result<RefreshResult<C::Entry>, C::Error>
+where
+    C::Entry: VersionedCacheEntry<C>,
+{
+    let cache_file_path = cache.cache_file_path(input);
+    let cache_file = match tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&cache_file_path)
+        .await
+    {
+        Ok(file) => file,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(RefreshResult::Skipped(None));
+        }
+        Err(e) => {
+            return Err(C::Error::from_io_error(
+                "opening cache file".to_string(),
+                cache_file_path,
+                e,
+            ));
+        }
+    };
+
+    let mut locked_cache_file = cache_file.lock_write().await.map_err(|e| {
+        C::Error::from_io_error(
+            "locking cache file".to_string(),
+            cache_file_path.clone(),
+            e.error,
+        )
+    })?;
+
+    let mut current_contents = String::new();
+    locked_cache_file
+        .read_to_string(&mut current_contents)
+        .await
+        .map_err(|e| {
+            C::Error::from_io_error("reading cache file".to_string(), cache_file_path.clone(), e)
+        })?;
+
+    // A refresh only rewrites the exact entry it was computed from. Contents
+    // that no longer parse (a truncated write, a foreign format) are not
+    // that entry.
+    let Ok(current_metadata) = serde_json::from_str::<C::Entry>(&current_contents) else {
+        return Ok(RefreshResult::Skipped(None));
+    };
+    if current_metadata.cache_version() != expected_version {
+        return Ok(RefreshResult::Skipped(Some(current_metadata)));
+    }
+
+    overwrite_locked_file::<C>(&mut locked_cache_file, metadata, &cache_file_path).await?;
+    Ok(RefreshResult::Written)
+}
+
+/// Serializes `metadata` and replaces the contents of the locked cache file.
+async fn overwrite_locked_file<C: MetadataCache>(
+    locked_cache_file: &mut async_fd_lock::RwLockWriteGuard<tokio::fs::File>,
+    metadata: &C::Entry,
+    cache_file_path: &Path,
+) -> Result<(), C::Error> {
     let bytes = serde_json::to_vec(metadata).expect("serialization to JSON should not fail");
 
     // Write to file
     locked_cache_file.rewind().await.map_err(|e| {
         C::Error::from_io_error(
             "seeking to start of cache file".to_string(),
-            cache_file_path.clone(),
+            cache_file_path.to_path_buf(),
             e,
         )
     })?;
@@ -234,7 +315,7 @@ where
     locked_cache_file.write_all(&bytes).await.map_err(|e| {
         C::Error::from_io_error(
             "writing metadata to cache file".to_string(),
-            cache_file_path.clone(),
+            cache_file_path.to_path_buf(),
             e,
         )
     })?;
@@ -247,20 +328,19 @@ where
         .map_err(|e| {
             C::Error::from_io_error(
                 "setting length of cache file".to_string(),
-                cache_file_path.clone(),
+                cache_file_path.to_path_buf(),
                 e,
             )
         })?;
 
     // Flush to ensure data is written
     locked_cache_file.flush().await.map_err(|e| {
-        C::Error::from_io_error("flushing cache file".to_string(), cache_file_path, e)
-    })?;
-
-    // Release lock
-    drop(locked_cache_file);
-
-    Ok(WriteResult::Written)
+        C::Error::from_io_error(
+            "flushing cache file".to_string(),
+            cache_file_path.to_path_buf(),
+            e,
+        )
+    })
 }
 
 /// Trait for cache keys that can produce a unique string used as the file name.
@@ -321,6 +401,17 @@ pub enum WriteResult<M> {
     /// Another process updated the cache file between our read and write.
     /// Contains the entry that was written by the other process.
     Conflict(M),
+}
+
+/// The outcome of a [`MetadataCache::try_refresh`] call.
+#[derive(Debug)]
+pub enum RefreshResult<M> {
+    /// The refreshed entry replaced the version it was read at.
+    Written,
+    /// The stored entry is no longer the one the refresh was computed from:
+    /// it moved to a different version (carried here when parseable),
+    /// vanished, or no longer parses. Nothing was written.
+    Skipped(Option<M>),
 }
 
 /// An opaque identifier representing a specific revision of a cache entry.
@@ -570,7 +661,7 @@ mod tests {
         // A read path refreshes it in place.
         assert!(matches!(
             cache.try_refresh(&key, &stored, 1).await.unwrap(),
-            WriteResult::Written
+            RefreshResult::Written
         ));
         assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 1);
 
@@ -580,6 +671,55 @@ mod tests {
             WriteResult::Written
         ));
         assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
+    }
+
+    /// A refresh computed before a concurrent clean removed the entry must
+    /// not write it back: the read path would otherwise undo an explicit
+    /// invalidation.
+    #[tokio::test]
+    async fn try_refresh_does_not_resurrect_a_deleted_entry() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache = DummyCache {
+            root: tmp.path().to_path_buf(),
+        };
+        let key = DummyKey("entry".to_string());
+
+        cache.try_write(&key, &entry(1), 0).await.unwrap();
+        let stored = cache.read(&key).await.unwrap().unwrap();
+        fs_err::remove_file(cache.cache_file_path(&key)).unwrap();
+
+        assert!(matches!(
+            cache.try_refresh(&key, &stored, 1).await.unwrap(),
+            RefreshResult::Skipped(None)
+        ));
+        assert!(
+            !cache.cache_file_path(&key).exists(),
+            "a refresh must not recreate an entry removed by a concurrent clean",
+        );
+    }
+
+    /// A refresh must not overwrite contents it cannot parse: they are not
+    /// the entry the refresh was computed from.
+    #[tokio::test]
+    async fn try_refresh_does_not_clobber_unparseable_contents() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cache = DummyCache {
+            root: tmp.path().to_path_buf(),
+        };
+        let key = DummyKey("entry".to_string());
+
+        cache.try_write(&key, &entry(1), 0).await.unwrap();
+        let stored = cache.read(&key).await.unwrap().unwrap();
+        fs_err::write(cache.cache_file_path(&key), b"garbage").unwrap();
+
+        assert!(matches!(
+            cache.try_refresh(&key, &stored, 1).await.unwrap(),
+            RefreshResult::Skipped(None)
+        ));
+        assert_eq!(
+            fs_err::read(cache.cache_file_path(&key)).unwrap(),
+            b"garbage"
+        );
     }
 
     /// A refresh computed against a version that has since moved on must not
@@ -598,8 +738,9 @@ mod tests {
 
         let refreshed = cache.try_refresh(&key, &entry(1), 1).await.unwrap();
         match refreshed {
-            WriteResult::Conflict(current) => assert_eq!(current.cache_version(), 2),
-            WriteResult::Written => panic!("a stale refresh must not overwrite a newer entry"),
+            RefreshResult::Skipped(Some(current)) => assert_eq!(current.cache_version(), 2),
+            RefreshResult::Written => panic!("a stale refresh must not overwrite a newer entry"),
+            RefreshResult::Skipped(None) => panic!("the newer entry must be returned"),
         }
         assert_eq!(cache.read(&key).await.unwrap().unwrap().cache_version(), 2);
     }

--- a/crates/pixi_command_dispatcher/src/cache/mod.rs
+++ b/crates/pixi_command_dispatcher/src/cache/mod.rs
@@ -27,7 +27,7 @@ pub use backend_metadata::{
 };
 pub use common::{
     CacheEntry, CacheError, CacheKey, CacheKeyString, CacheRevision, MetadataCache,
-    MetadataCacheEntry, MetadataCacheKey, VersionedCacheEntry, WriteResult,
+    MetadataCacheEntry, MetadataCacheKey, RefreshResult, VersionedCacheEntry, WriteResult,
 };
 pub use pixi_compute_cache_dirs::CacheDirs;
 pub use workspace::{WorkspaceCache, WorkspaceGuard, WorkspaceKey, compute_workspace_key};

--- a/crates/pixi_command_dispatcher/src/compute_data.rs
+++ b/crates/pixi_command_dispatcher/src/compute_data.rs
@@ -227,14 +227,14 @@ impl HasCondaSolveSemaphore for DataStore {
 }
 
 /// Newtype around the semaphore that bounds concurrent filesystem
-/// operations during package installation. Enforces the
-/// `max_io_concurrency` limit from [`crate::Limits`]. A single semaphore is
-/// shared across all installs so installing many environments at once cannot
+/// operations such as package installation and source fingerprinting.
+/// Enforces the `max_io_concurrency` limit from [`crate::Limits`]. A single
+/// semaphore is shared across dispatcher work so concurrent operations cannot
 /// exhaust the file descriptor limit.
 #[derive(Clone)]
 pub struct IoConcurrencySemaphore(pub Arc<Semaphore>);
 
-/// Access the semaphore bounding concurrent install filesystem operations.
+/// Access the semaphore bounding concurrent filesystem operations.
 /// Returns `None` when no semaphore was registered, treated as unbounded.
 pub trait HasIoConcurrencySemaphore {
     fn io_concurrency_semaphore(&self) -> Option<&Arc<Semaphore>>;

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -79,9 +79,6 @@ pub enum SourceBuildError {
     #[error("failed to calculate sha256 hash of {}", .0.display())]
     CalculateSha256(std::path::PathBuf, #[source] Arc<std::io::Error>),
 
-    #[error("failed to fingerprint input file at {}", .0.display())]
-    FingerprintInput(std::path::PathBuf, #[source] Arc<std::io::Error>),
-
     #[error("the package does not contain a valid subdir")]
     ConvertSubdir(#[source] Arc<ConvertSubdirError>),
 

--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -79,6 +79,9 @@ pub enum SourceBuildError {
     #[error("failed to calculate sha256 hash of {}", .0.display())]
     CalculateSha256(std::path::PathBuf, #[source] Arc<std::io::Error>),
 
+    #[error("failed to fingerprint input file at {}", .0.display())]
+    FingerprintInput(std::path::PathBuf, #[source] Arc<std::io::Error>),
+
     #[error("the package does not contain a valid subdir")]
     ConvertSubdir(#[source] Arc<ConvertSubdirError>),
 

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -4,7 +4,7 @@
 
 use std::{
     fs::File,
-    io::{BufReader, Read},
+    io::Read,
     path::{Path, PathBuf},
     sync::Arc,
     time::SystemTime,
@@ -51,47 +51,32 @@ pub(crate) struct FileFingerprint {
     pub(crate) hash: u64,
 }
 
+/// Persists filesystem timestamps through `chrono`, which round-trips
+/// pre-epoch instants and nanosecond precision.
 pub(crate) mod system_time_serde {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::SystemTime;
 
-    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
-
-    #[derive(Serialize, Deserialize)]
-    #[serde(untagged)]
-    enum SystemTimeRepr {
-        AfterEpoch {
-            secs_since_epoch: u64,
-            nanos_since_epoch: u32,
-        },
-        BeforeEpoch {
-            secs_before_epoch: u64,
-            nanos_before_epoch: u32,
-        },
-    }
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     pub fn serialize<S>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let repr = match time.duration_since(UNIX_EPOCH) {
-            Ok(duration) => SystemTimeRepr::AfterEpoch {
-                secs_since_epoch: duration.as_secs(),
-                nanos_since_epoch: duration.subsec_nanos(),
-            },
-            Err(err) => {
-                let duration = err.duration();
-                SystemTimeRepr::BeforeEpoch {
-                    secs_before_epoch: duration.as_secs(),
-                    nanos_before_epoch: duration.subsec_nanos(),
-                }
-            }
-        };
-        repr.serialize(serializer)
+        DateTime::<Utc>::from(*time).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        DateTime::<Utc>::deserialize(deserializer).map(SystemTime::from)
     }
 
     pub(crate) mod optional {
         use std::time::SystemTime;
 
+        use chrono::{DateTime, Utc};
         use serde::{Deserialize, Deserializer, Serializer};
 
         pub fn serialize<S>(time: &Option<SystemTime>, serializer: S) -> Result<S::Ok, S::Error>
@@ -108,42 +93,7 @@ pub(crate) mod system_time_serde {
         where
             D: Deserializer<'de>,
         {
-            #[derive(Deserialize)]
-            struct Wrapper(#[serde(with = "super")] SystemTime);
-            Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|wrapper| wrapper.0))
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let (before_epoch, seconds, nanoseconds) = match SystemTimeRepr::deserialize(deserializer)?
-        {
-            SystemTimeRepr::AfterEpoch {
-                secs_since_epoch,
-                nanos_since_epoch,
-            } => (false, secs_since_epoch, nanos_since_epoch),
-            SystemTimeRepr::BeforeEpoch {
-                secs_before_epoch,
-                nanos_before_epoch,
-            } => (true, secs_before_epoch, nanos_before_epoch),
-        };
-        if nanoseconds >= 1_000_000_000 {
-            return Err(de::Error::custom(
-                "system timestamp nanoseconds must be below one billion",
-            ));
-        }
-
-        let duration = Duration::new(seconds, nanoseconds);
-        if before_epoch {
-            UNIX_EPOCH
-                .checked_sub(duration)
-                .ok_or_else(|| de::Error::custom("system timestamp is out of range"))
-        } else {
-            UNIX_EPOCH
-                .checked_add(duration)
-                .ok_or_else(|| de::Error::custom("system timestamp is out of range"))
+            Ok(Option::<DateTime<Utc>>::deserialize(deserializer)?.map(SystemTime::from))
         }
     }
 }
@@ -151,80 +101,59 @@ pub(crate) mod system_time_serde {
 /// Hashes a single regular file, retrying once when it changes mid-read so a
 /// hash of an inconsistent read is never paired with the final metadata.
 pub(crate) fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError> {
+    fingerprint_file_inner(path).map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))
+}
+
+fn fingerprint_file_inner(path: &Path) -> std::io::Result<FileFingerprint> {
+    fn not_a_regular_file() -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "not a regular file")
+    }
+
     // Opening a special file can block indefinitely (e.g. a FIFO without a
     // writer), so check the file type from a stat before opening.
-    let file_type = fs_err::metadata(path)
-        .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?
-        .file_type();
-    if !file_type.is_file() {
-        return Err(FileFingerprintError::new(
-            path.to_path_buf(),
-            std::io::Error::new(std::io::ErrorKind::InvalidInput, "not a regular file"),
-        ));
+    if !fs_err::metadata(path)?.file_type().is_file() {
+        return Err(not_a_regular_file());
     }
 
     for _ in 0..2 {
-        let file =
-            File::open(path).map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        let handle = Handle::from_file(file)
-            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        let before = handle
-            .as_file()
-            .metadata()
-            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let handle = Handle::from_file(File::open(path)?)?;
+        let before = handle.as_file().metadata()?;
         if !before.file_type().is_file() {
-            return Err(FileFingerprintError::new(
-                path.to_path_buf(),
-                std::io::Error::new(std::io::ErrorKind::InvalidInput, "not a regular file"),
-            ));
+            return Err(not_a_regular_file());
         }
-        let modified = before
-            .modified()
-            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let modified = before.modified()?;
 
-        let mut reader = BufReader::new(handle.as_file());
-        let mut hasher = Xxh3::new();
-        let mut buffer = [0u8; 64 * 1024];
-        loop {
-            let read = reader
-                .read(&mut buffer)
-                .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-        drop(reader);
+        let hash = hash_file_contents(handle.as_file())?;
 
-        let after = handle
-            .as_file()
-            .metadata()
-            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        let after_modified = after
-            .modified()
-            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        let path_unchanged = path_matches_handle(path, &handle)
-            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        if path_unchanged && before.len() == after.len() && modified == after_modified {
+        let after = handle.as_file().metadata()?;
+        let path_unchanged = handle == Handle::from_path(path)?;
+        if path_unchanged && before.len() == after.len() && modified == after.modified()? {
             return Ok(FileFingerprint {
-                modified: after_modified,
+                modified,
                 size: after.len(),
-                hash: hasher.digest(),
+                hash,
             });
         }
     }
 
-    Err(FileFingerprintError::new(
-        path.to_path_buf(),
-        std::io::Error::new(
-            std::io::ErrorKind::Interrupted,
-            "file changed while computing its fingerprint",
-        ),
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Interrupted,
+        "file changed while computing its fingerprint",
     ))
 }
 
-fn path_matches_handle(path: &Path, handle: &Handle) -> std::io::Result<bool> {
-    Ok(*handle == Handle::from_path(path)?)
+/// XXH3-64 over everything `reader` yields.
+pub(crate) fn hash_file_contents(mut reader: impl Read) -> std::io::Result<u64> {
+    let mut hasher = Xxh3::new();
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hasher.digest())
 }
 
 #[derive(Debug, Clone, Error)]
@@ -245,17 +174,10 @@ impl FileFingerprintError {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::{
-        fs::OpenOptions,
-        time::{Duration, UNIX_EPOCH},
-    };
+pub(crate) mod test_helpers {
+    use std::{fs::OpenOptions, path::Path, time::SystemTime};
 
-    use tempfile::TempDir;
-
-    use super::*;
-
-    fn set_modified(path: &Path, modified: SystemTime) {
+    pub(crate) fn set_modified(path: &Path, modified: SystemTime) {
         OpenOptions::new()
             .write(true)
             .open(path)
@@ -263,6 +185,19 @@ mod tests {
             .set_modified(modified)
             .unwrap();
     }
+
+    pub(crate) fn mtime(path: &Path) -> SystemTime {
+        fs_err::metadata(path).unwrap().modified().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use tempfile::TempDir;
+
+    use super::{test_helpers::set_modified, *};
 
     #[test]
     fn content_hash_is_stable_when_only_mtime_changes() {
@@ -347,7 +282,7 @@ mod tests {
         };
 
         let json = serde_json::to_string(&fingerprint).unwrap();
-        assert!(json.contains("secs_before_epoch"));
+        assert!(json.contains("1969-12-31T23:59:58.500"), "got {json}");
         assert_eq!(
             serde_json::from_str::<FileFingerprint>(&json).unwrap(),
             fingerprint
@@ -355,18 +290,18 @@ mod tests {
     }
 
     #[test]
-    fn existing_positive_system_time_json_remains_readable() {
-        let json = r#"{
-            "modified": {
-                "secs_since_epoch": 1,
-                "nanos_since_epoch": 2
-            },
-            "size": 3,
-            "hash": 42
-        }"#;
+    fn mtime_serde_keeps_nanosecond_precision() {
+        let fingerprint = FileFingerprint {
+            modified: UNIX_EPOCH + Duration::new(1_700_000_000, 123_456_789),
+            size: 3,
+            hash: 42,
+        };
 
-        let fingerprint = serde_json::from_str::<FileFingerprint>(json).unwrap();
-        assert_eq!(fingerprint.modified, UNIX_EPOCH + Duration::new(1, 2));
+        let json = serde_json::to_string(&fingerprint).unwrap();
+        assert_eq!(
+            serde_json::from_str::<FileFingerprint>(&json).unwrap(),
+            fingerprint
+        );
     }
 
     #[test]
@@ -380,6 +315,6 @@ mod tests {
         fs_err::rename(&path, moved).unwrap();
         fs_err::write(&path, b"new").unwrap();
 
-        assert!(!path_matches_handle(&path, &handle).unwrap());
+        assert_ne!(Handle::from_path(&path).unwrap(), handle);
     }
 }

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -89,6 +89,31 @@ pub(crate) mod system_time_serde {
         repr.serialize(serializer)
     }
 
+    pub(crate) mod optional {
+        use std::time::SystemTime;
+
+        use serde::{Deserialize, Deserializer, Serializer};
+
+        pub fn serialize<S>(time: &Option<SystemTime>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match time {
+                Some(time) => super::serialize(time, serializer),
+                None => serializer.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<SystemTime>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct Wrapper(#[serde(with = "super")] SystemTime);
+            Ok(Option::<Wrapper>::deserialize(deserializer)?.map(|wrapper| wrapper.0))
+        }
+    }
+
     pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
     where
         D: Deserializer<'de>,

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -1,10 +1,13 @@
+//! Content fingerprinting of single files: the [`FileFingerprint`] data type
+//! and the blocking hash primitive used by
+//! [`crate::input_snapshot::InputSnapshot`].
+
 use std::{
-    collections::{BTreeMap, BTreeSet},
     fs::File,
     io::{BufReader, Read},
     path::{Path, PathBuf},
     sync::Arc,
-    time::{Instant, SystemTime},
+    time::SystemTime,
 };
 
 use same_file::Handle;
@@ -12,8 +15,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Semaphore;
 use xxhash_rust::xxh3::Xxh3;
-
-use futures::{StreamExt, TryStreamExt};
 
 /// Runs blocking filesystem work while holding a permit from the dispatcher's
 /// shared I/O budget.
@@ -40,7 +41,8 @@ where
     .await
 }
 
-/// A snapshot of a file used to validate source-build caches.
+/// A content snapshot of a file: size and mtime for cheap comparisons, an
+/// XXH3-64 hash to prove contents unchanged when only the mtime moved.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct FileFingerprint {
     #[serde(with = "system_time_serde")]
@@ -49,7 +51,7 @@ pub(crate) struct FileFingerprint {
     pub(crate) hash: u64,
 }
 
-mod system_time_serde {
+pub(crate) mod system_time_serde {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -121,160 +123,9 @@ mod system_time_serde {
     }
 }
 
-impl FileFingerprint {
-    /// Returns whether the metadata is identical, requires a content check, or
-    /// already proves that the file changed.
-    pub(crate) fn compare_metadata(
-        &self,
-        metadata: &std::fs::Metadata,
-    ) -> Result<MetadataComparison, std::io::Error> {
-        if metadata.len() != self.size {
-            return Ok(MetadataComparison::Changed);
-        }
-
-        if metadata.modified()? == self.modified {
-            Ok(MetadataComparison::Unchanged)
-        } else {
-            Ok(MetadataComparison::HashRequired)
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub(crate) enum MetadataComparison {
-    Unchanged,
-    HashRequired,
-    Changed,
-}
-
-/// Computes fingerprints for all provided paths without blocking the async
-/// executor.
-pub(crate) async fn fingerprint_files(
-    paths: impl IntoIterator<Item = PathBuf>,
-    io_semaphore: Option<Arc<Semaphore>>,
-) -> Result<BTreeMap<PathBuf, FileFingerprint>, FileFingerprintError> {
-    let paths = paths.into_iter().collect::<BTreeSet<_>>();
-    let file_count = paths.len();
-    let started = Instant::now();
-    // A permit represents one file read. This allows other users of the
-    // dispatcher's shared I/O budget to make progress between files.
-    let fingerprints = futures::stream::iter(paths)
-        .map(|path| {
-            let io_semaphore = io_semaphore.clone();
-            async move {
-                spawn_blocking_with_io_permit(io_semaphore, move || {
-                    fingerprint_file(&path).map(|fingerprint| (path, fingerprint))
-                })
-                .await
-                .expect("file fingerprint task panicked")
-            }
-        })
-        .buffer_unordered(fingerprint_worker_count(file_count))
-        .try_collect::<BTreeMap<_, _>>()
-        .await?;
-    log_fingerprint_stats(&fingerprints, file_count, started);
-    Ok(fingerprints)
-}
-
-/// The result of fingerprinting a set of files while tolerating per-file
-/// failures.
-#[derive(Debug, Default)]
-pub(crate) struct LenientFingerprints {
-    /// Files that were hashed successfully.
-    pub(crate) fingerprints: BTreeMap<PathBuf, FileFingerprint>,
-    /// Files that could not be hashed but could still be stat'ed. These keep
-    /// timestamp-based cache validation.
-    pub(crate) mtime_only: BTreeMap<PathBuf, SystemTime>,
-}
-
-/// Computes fingerprints like [`fingerprint_files`] but never fails: a file
-/// that cannot be hashed falls back to its mtime, and a file that cannot even
-/// be stat'ed (e.g. deleted mid-build) is dropped entirely.
-pub(crate) async fn fingerprint_files_lenient(
-    paths: impl IntoIterator<Item = PathBuf>,
-    io_semaphore: Option<Arc<Semaphore>>,
-) -> LenientFingerprints {
-    let paths = paths.into_iter().collect::<BTreeSet<_>>();
-    let file_count = paths.len();
-    let started = Instant::now();
-    let outcomes = futures::stream::iter(paths)
-        .map(|path| {
-            let io_semaphore = io_semaphore.clone();
-            async move {
-                spawn_blocking_with_io_permit(io_semaphore, move || {
-                    let outcome = match fingerprint_file(&path) {
-                        Ok(fingerprint) => Ok(fingerprint),
-                        Err(err) => {
-                            let mtime =
-                                fs_err::metadata(&path).and_then(|m| m.modified()).ok();
-                            Err((err, mtime))
-                        }
-                    };
-                    (path, outcome)
-                })
-                .await
-                .expect("file fingerprint task panicked")
-            }
-        })
-        .buffer_unordered(fingerprint_worker_count(file_count))
-        .collect::<Vec<_>>()
-        .await;
-
-    let mut result = LenientFingerprints::default();
-    for (path, outcome) in outcomes {
-        match outcome {
-            Ok(fingerprint) => {
-                result.fingerprints.insert(path, fingerprint);
-            }
-            Err((err, Some(mtime))) => {
-                tracing::debug!(
-                    path = %path.display(),
-                    error = %err,
-                    "could not hash source input file; keeping timestamp-based validation"
-                );
-                result.mtime_only.insert(path, mtime);
-            }
-            Err((err, None)) => {
-                tracing::debug!(
-                    path = %path.display(),
-                    error = %err,
-                    "could not stat source input file; dropping it from the cache record"
-                );
-            }
-        }
-    }
-    log_fingerprint_stats(&result.fingerprints, file_count, started);
-    result
-}
-
-fn fingerprint_worker_count(file_count: usize) -> usize {
-    file_count
-        .min(
-            std::thread::available_parallelism()
-                .map(usize::from)
-                .unwrap_or(1),
-        )
-        .max(1)
-}
-
-fn log_fingerprint_stats(
-    fingerprints: &BTreeMap<PathBuf, FileFingerprint>,
-    file_count: usize,
-    started: Instant,
-) {
-    let total_bytes = fingerprints
-        .values()
-        .map(|fingerprint| fingerprint.size)
-        .sum::<u64>();
-    tracing::debug!(
-        file_count,
-        total_bytes,
-        elapsed_ms = started.elapsed().as_millis() as u64,
-        "fingerprinted source-build input files"
-    );
-}
-
-fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError> {
+/// Hashes a single regular file, retrying once when it changes mid-read so a
+/// hash of an inconsistent read is never paired with the final metadata.
+pub(crate) fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError> {
     // Opening a special file can block indefinitely (e.g. a FIFO without a
     // writer), so check the file type from a stat before opening.
     let file_type = fs_err::metadata(path)
@@ -287,8 +138,6 @@ fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError
         ));
     }
 
-    // Retry once when a file changes while it is being read. This prevents
-    // associating a hash of an inconsistent read with the final metadata.
     for _ in 0..2 {
         let file =
             File::open(path).map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
@@ -390,74 +239,78 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
-    async fn empty_input_produces_no_fingerprints() {
-        let fingerprints = fingerprint_files([], Some(Arc::new(Semaphore::new(1))))
-            .await
-            .unwrap();
-        assert!(fingerprints.is_empty());
-    }
-
-    #[tokio::test]
-    async fn fingerprints_multiple_files_with_io_limit() {
-        let temp = TempDir::new().unwrap();
-        let paths = (0..20)
-            .map(|index| {
-                let path = temp.path().join(format!("{index}.txt"));
-                fs_err::write(&path, index.to_string()).unwrap();
-                path
-            })
-            .collect::<Vec<_>>();
-
-        let fingerprints = fingerprint_files(paths, Some(Arc::new(Semaphore::new(2))))
-            .await
-            .unwrap();
-        assert_eq!(fingerprints.len(), 20);
-    }
-
-    #[tokio::test]
-    async fn content_hash_is_stable_when_only_mtime_changes() {
+    #[test]
+    fn content_hash_is_stable_when_only_mtime_changes() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("input.txt");
         fs_err::write(&path, b"same contents").unwrap();
 
-        let first = fingerprint_files([path.clone()], None)
-            .await
-            .unwrap()
-            .remove(&path)
-            .unwrap();
+        let first = fingerprint_file(&path).unwrap();
         set_modified(&path, first.modified + Duration::from_secs(1));
-        let second = fingerprint_files([path.clone()], None)
-            .await
-            .unwrap()
-            .remove(&path)
-            .unwrap();
+        let second = fingerprint_file(&path).unwrap();
 
         assert_ne!(first.modified, second.modified);
         assert_eq!(first.size, second.size);
         assert_eq!(first.hash, second.hash);
     }
 
-    #[tokio::test]
-    async fn content_hash_changes_for_same_size_edit() {
+    #[test]
+    fn content_hash_changes_for_same_size_edit() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("input.txt");
         fs_err::write(&path, b"old").unwrap();
-        let first = fingerprint_files([path.clone()], None)
-            .await
-            .unwrap()
-            .remove(&path)
-            .unwrap();
+        let first = fingerprint_file(&path).unwrap();
 
         fs_err::write(&path, b"new").unwrap();
-        let second = fingerprint_files([path.clone()], None)
-            .await
-            .unwrap()
-            .remove(&path)
-            .unwrap();
+        let second = fingerprint_file(&path).unwrap();
 
         assert_eq!(first.size, second.size);
         assert_ne!(first.hash, second.hash);
+    }
+
+    /// Two empty files hash identically; only size and path separate them.
+    /// Confirms the hasher handles a zero-length read loop.
+    #[test]
+    fn empty_files_hash_consistently() {
+        let temp = TempDir::new().unwrap();
+        let a = temp.path().join("a.txt");
+        let b = temp.path().join("b.txt");
+        fs_err::write(&a, b"").unwrap();
+        fs_err::write(&b, b"").unwrap();
+
+        let first = fingerprint_file(&a).unwrap();
+        let second = fingerprint_file(&b).unwrap();
+        assert_eq!(first.size, 0);
+        assert_eq!(first.hash, second.hash);
+    }
+
+    /// A directory matched by an input glob must be rejected from the stat
+    /// alone, before anything is opened.
+    #[test]
+    fn directories_are_rejected_without_opening() {
+        let temp = TempDir::new().unwrap();
+        let err = fingerprint_file(temp.path()).unwrap_err();
+        assert_eq!(err.source.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    /// A FIFO would block forever if opened without a writer, so the file
+    /// type check must reject it from the stat alone.
+    #[cfg(unix)]
+    #[test]
+    fn fifos_are_rejected_without_opening_them() {
+        use std::os::unix::fs::FileTypeExt;
+
+        let temp = TempDir::new().unwrap();
+        let fifo = temp.path().join("pipe");
+        let status = std::process::Command::new("mkfifo").arg(&fifo).status();
+        let Ok(status) = status else { return };
+        if !status.success() {
+            return;
+        }
+        assert!(fs_err::metadata(&fifo).unwrap().file_type().is_fifo());
+
+        let err = fingerprint_file(&fifo).unwrap_err();
+        assert_eq!(err.source.kind(), std::io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -7,6 +7,7 @@ use std::{
     time::{Instant, SystemTime},
 };
 
+use same_file::Handle;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::Semaphore;
@@ -42,9 +43,82 @@ where
 /// A snapshot of a file used to validate source-build caches.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct FileFingerprint {
+    #[serde(with = "system_time_serde")]
     pub(crate) modified: SystemTime,
     pub(crate) size: u64,
     pub(crate) hash: u64,
+}
+
+mod system_time_serde {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    #[derive(Serialize, Deserialize)]
+    #[serde(untagged)]
+    enum SystemTimeRepr {
+        AfterEpoch {
+            secs_since_epoch: u64,
+            nanos_since_epoch: u32,
+        },
+        BeforeEpoch {
+            secs_before_epoch: u64,
+            nanos_before_epoch: u32,
+        },
+    }
+
+    pub fn serialize<S>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let repr = match time.duration_since(UNIX_EPOCH) {
+            Ok(duration) => SystemTimeRepr::AfterEpoch {
+                secs_since_epoch: duration.as_secs(),
+                nanos_since_epoch: duration.subsec_nanos(),
+            },
+            Err(err) => {
+                let duration = err.duration();
+                SystemTimeRepr::BeforeEpoch {
+                    secs_before_epoch: duration.as_secs(),
+                    nanos_before_epoch: duration.subsec_nanos(),
+                }
+            }
+        };
+        repr.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (before_epoch, seconds, nanoseconds) = match SystemTimeRepr::deserialize(deserializer)?
+        {
+            SystemTimeRepr::AfterEpoch {
+                secs_since_epoch,
+                nanos_since_epoch,
+            } => (false, secs_since_epoch, nanos_since_epoch),
+            SystemTimeRepr::BeforeEpoch {
+                secs_before_epoch,
+                nanos_before_epoch,
+            } => (true, secs_before_epoch, nanos_before_epoch),
+        };
+        if nanoseconds >= 1_000_000_000 {
+            return Err(de::Error::custom(
+                "system timestamp nanoseconds must be below one billion",
+            ));
+        }
+
+        let duration = Duration::new(seconds, nanoseconds);
+        if before_epoch {
+            UNIX_EPOCH
+                .checked_sub(duration)
+                .ok_or_else(|| de::Error::custom("system timestamp is out of range"))
+        } else {
+            UNIX_EPOCH
+                .checked_add(duration)
+                .ok_or_else(|| de::Error::custom("system timestamp is out of range"))
+        }
+    }
 }
 
 impl FileFingerprint {
@@ -88,9 +162,16 @@ pub(crate) async fn fingerprint_files(
             .unwrap_or(1),
     );
     // Keep a few batches queued per worker for load balancing without
-    // creating one blocking task per file. A batch holds one global I/O
-    // permit while it is processed.
-    let batch_count = file_count.min(worker_count.saturating_mul(4));
+    // creating one blocking task per file. Cap batches at 32 files so a
+    // fingerprint pass cannot monopolize a scarce global I/O permit for an
+    // arbitrarily large input set.
+    const MAX_FILES_PER_BATCH: usize = 32;
+    let batch_count = if file_count == 0 {
+        0
+    } else {
+        let batches_for_fairness = file_count.div_ceil(MAX_FILES_PER_BATCH);
+        file_count.min(worker_count.saturating_mul(4).max(batches_for_fairness))
+    };
     let mut batches = (0..batch_count)
         .map(|_| Vec::new())
         .collect::<Vec<Vec<PathBuf>>>();
@@ -135,15 +216,19 @@ fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError
     // Retry once when a file changes while it is being read. This prevents
     // associating a hash of an inconsistent read with the final metadata.
     for _ in 0..2 {
-        let before = fs_err::metadata(path)
+        let file =
+            File::open(path).map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let handle = Handle::from_file(file)
+            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let before = handle
+            .as_file()
+            .metadata()
             .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
         let modified = before
             .modified()
             .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
 
-        let file =
-            File::open(path).map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        let mut reader = BufReader::new(file);
+        let mut reader = BufReader::new(handle.as_file());
         let mut hasher = Xxh3::new();
         let mut buffer = [0u8; 64 * 1024];
         loop {
@@ -155,13 +240,18 @@ fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError
             }
             hasher.update(&buffer[..read]);
         }
+        drop(reader);
 
-        let after = fs_err::metadata(path)
+        let after = handle
+            .as_file()
+            .metadata()
             .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
         let after_modified = after
             .modified()
             .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
-        if before.len() == after.len() && modified == after_modified {
+        let path_unchanged = path_matches_handle(path, &handle)
+            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        if path_unchanged && before.len() == after.len() && modified == after_modified {
             return Ok(FileFingerprint {
                 modified: after_modified,
                 size: after.len(),
@@ -177,6 +267,10 @@ fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError
             "file changed while computing its fingerprint",
         ),
     ))
+}
+
+fn path_matches_handle(path: &Path, handle: &Handle) -> std::io::Result<bool> {
+    Ok(*handle == Handle::from_path(path)?)
 }
 
 #[derive(Debug, Clone, Error)]
@@ -198,11 +292,23 @@ impl FileFingerprintError {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{
+        fs::OpenOptions,
+        time::{Duration, UNIX_EPOCH},
+    };
 
     use tempfile::TempDir;
 
     use super::*;
+
+    fn set_modified(path: &Path, modified: SystemTime) {
+        OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(modified)
+            .unwrap();
+    }
 
     #[tokio::test]
     async fn empty_input_produces_no_fingerprints() {
@@ -240,10 +346,7 @@ mod tests {
             .unwrap()
             .remove(&path)
             .unwrap();
-        File::open(&path)
-            .unwrap()
-            .set_modified(first.modified + Duration::from_secs(1))
-            .unwrap();
+        set_modified(&path, first.modified + Duration::from_secs(1));
         let second = fingerprint_files([path.clone()], None)
             .await
             .unwrap()
@@ -275,5 +378,50 @@ mod tests {
 
         assert_eq!(first.size, second.size);
         assert_ne!(first.hash, second.hash);
+    }
+
+    #[test]
+    fn pre_epoch_mtime_round_trips_through_json() {
+        let fingerprint = FileFingerprint {
+            modified: UNIX_EPOCH - Duration::from_millis(1_500),
+            size: 3,
+            hash: 42,
+        };
+
+        let json = serde_json::to_string(&fingerprint).unwrap();
+        assert!(json.contains("secs_before_epoch"));
+        assert_eq!(
+            serde_json::from_str::<FileFingerprint>(&json).unwrap(),
+            fingerprint
+        );
+    }
+
+    #[test]
+    fn existing_positive_system_time_json_remains_readable() {
+        let json = r#"{
+            "modified": {
+                "secs_since_epoch": 1,
+                "nanos_since_epoch": 2
+            },
+            "size": 3,
+            "hash": 42
+        }"#;
+
+        let fingerprint = serde_json::from_str::<FileFingerprint>(json).unwrap();
+        assert_eq!(fingerprint.modified, UNIX_EPOCH + Duration::new(1, 2));
+    }
+
+    #[test]
+    fn replacing_a_path_changes_its_file_identity() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("input.txt");
+        let moved = temp.path().join("old-input.txt");
+        fs_err::write(&path, b"old").unwrap();
+
+        let handle = Handle::from_file(File::open(&path).unwrap()).unwrap();
+        fs_err::rename(&path, moved).unwrap();
+        fs_err::write(&path, b"new").unwrap();
+
+        assert!(!path_matches_handle(&path, &handle).unwrap());
     }
 }

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -9,7 +9,35 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::sync::Semaphore;
 use xxhash_rust::xxh3::Xxh3;
+
+use futures::{StreamExt, TryStreamExt};
+
+/// Runs blocking filesystem work while holding a permit from the dispatcher's
+/// shared I/O budget.
+pub(crate) async fn spawn_blocking_with_io_permit<T>(
+    io_semaphore: Option<Arc<Semaphore>>,
+    task: impl FnOnce() -> T + Send + 'static,
+) -> Result<T, tokio::task::JoinError>
+where
+    T: Send + 'static,
+{
+    let permit = match io_semaphore {
+        Some(semaphore) => Some(
+            semaphore
+                .acquire_owned()
+                .await
+                .expect("I/O concurrency semaphore is never closed"),
+        ),
+        None => None,
+    };
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        task()
+    })
+    .await
+}
 
 /// A snapshot of a file used to validate source-build caches.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
@@ -49,18 +77,47 @@ pub(crate) enum MetadataComparison {
 /// executor.
 pub(crate) async fn fingerprint_files(
     paths: impl IntoIterator<Item = PathBuf>,
+    io_semaphore: Option<Arc<Semaphore>>,
 ) -> Result<BTreeMap<PathBuf, FileFingerprint>, FileFingerprintError> {
     let paths = paths.into_iter().collect::<BTreeSet<_>>();
     let file_count = paths.len();
     let started = Instant::now();
-    let fingerprints: BTreeMap<PathBuf, FileFingerprint> = tokio::task::spawn_blocking(move || {
-        paths
-            .into_iter()
-            .map(|path| fingerprint_file(&path).map(|fingerprint| (path, fingerprint)))
-            .collect::<Result<BTreeMap<_, _>, _>>()
-    })
-    .await
-    .expect("file fingerprint task panicked")?;
+    let worker_count = file_count.min(
+        std::thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1),
+    );
+    // Keep a few batches queued per worker for load balancing without
+    // creating one blocking task per file. A batch holds one global I/O
+    // permit while it is processed.
+    let batch_count = file_count.min(worker_count.saturating_mul(4));
+    let mut batches = (0..batch_count)
+        .map(|_| Vec::new())
+        .collect::<Vec<Vec<PathBuf>>>();
+    for (index, path) in paths.into_iter().enumerate() {
+        batches[index % batch_count].push(path);
+    }
+
+    let fingerprints = futures::stream::iter(batches)
+        .map(|paths| {
+            let io_semaphore = io_semaphore.clone();
+            async move {
+                spawn_blocking_with_io_permit(io_semaphore, move || {
+                    paths
+                        .into_iter()
+                        .map(|path| fingerprint_file(&path).map(|fingerprint| (path, fingerprint)))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .await
+                .expect("file fingerprint task panicked")
+            }
+        })
+        .buffer_unordered(worker_count.max(1))
+        .try_collect::<Vec<Vec<_>>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect::<BTreeMap<_, _>>();
     let total_bytes = fingerprints
         .values()
         .map(|fingerprint| fingerprint.size)
@@ -148,12 +205,37 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn empty_input_produces_no_fingerprints() {
+        let fingerprints = fingerprint_files([], Some(Arc::new(Semaphore::new(1))))
+            .await
+            .unwrap();
+        assert!(fingerprints.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fingerprints_multiple_files_with_io_limit() {
+        let temp = TempDir::new().unwrap();
+        let paths = (0..20)
+            .map(|index| {
+                let path = temp.path().join(format!("{index}.txt"));
+                fs_err::write(&path, index.to_string()).unwrap();
+                path
+            })
+            .collect::<Vec<_>>();
+
+        let fingerprints = fingerprint_files(paths, Some(Arc::new(Semaphore::new(2))))
+            .await
+            .unwrap();
+        assert_eq!(fingerprints.len(), 20);
+    }
+
+    #[tokio::test]
     async fn content_hash_is_stable_when_only_mtime_changes() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("input.txt");
         fs_err::write(&path, b"same contents").unwrap();
 
-        let first = fingerprint_files([path.clone()])
+        let first = fingerprint_files([path.clone()], None)
             .await
             .unwrap()
             .remove(&path)
@@ -162,7 +244,7 @@ mod tests {
             .unwrap()
             .set_modified(first.modified + Duration::from_secs(1))
             .unwrap();
-        let second = fingerprint_files([path.clone()])
+        let second = fingerprint_files([path.clone()], None)
             .await
             .unwrap()
             .remove(&path)
@@ -178,14 +260,14 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("input.txt");
         fs_err::write(&path, b"old").unwrap();
-        let first = fingerprint_files([path.clone()])
+        let first = fingerprint_files([path.clone()], None)
             .await
             .unwrap()
             .remove(&path)
             .unwrap();
 
         fs_err::write(&path, b"new").unwrap();
-        let second = fingerprint_files([path.clone()])
+        let second = fingerprint_files([path.clone()], None)
             .await
             .unwrap()
             .remove(&path)

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -156,11 +156,6 @@ pub(crate) async fn fingerprint_files(
     let paths = paths.into_iter().collect::<BTreeSet<_>>();
     let file_count = paths.len();
     let started = Instant::now();
-    let worker_count = file_count.min(
-        std::thread::available_parallelism()
-            .map(usize::from)
-            .unwrap_or(1),
-    );
     // A permit represents one file read. This allows other users of the
     // dispatcher's shared I/O budget to make progress between files.
     let fingerprints = futures::stream::iter(paths)
@@ -174,9 +169,99 @@ pub(crate) async fn fingerprint_files(
                 .expect("file fingerprint task panicked")
             }
         })
-        .buffer_unordered(worker_count.max(1))
+        .buffer_unordered(fingerprint_worker_count(file_count))
         .try_collect::<BTreeMap<_, _>>()
         .await?;
+    log_fingerprint_stats(&fingerprints, file_count, started);
+    Ok(fingerprints)
+}
+
+/// The result of fingerprinting a set of files while tolerating per-file
+/// failures.
+#[derive(Debug, Default)]
+pub(crate) struct LenientFingerprints {
+    /// Files that were hashed successfully.
+    pub(crate) fingerprints: BTreeMap<PathBuf, FileFingerprint>,
+    /// Files that could not be hashed but could still be stat'ed. These keep
+    /// timestamp-based cache validation.
+    pub(crate) mtime_only: BTreeMap<PathBuf, SystemTime>,
+}
+
+/// Computes fingerprints like [`fingerprint_files`] but never fails: a file
+/// that cannot be hashed falls back to its mtime, and a file that cannot even
+/// be stat'ed (e.g. deleted mid-build) is dropped entirely.
+pub(crate) async fn fingerprint_files_lenient(
+    paths: impl IntoIterator<Item = PathBuf>,
+    io_semaphore: Option<Arc<Semaphore>>,
+) -> LenientFingerprints {
+    let paths = paths.into_iter().collect::<BTreeSet<_>>();
+    let file_count = paths.len();
+    let started = Instant::now();
+    let outcomes = futures::stream::iter(paths)
+        .map(|path| {
+            let io_semaphore = io_semaphore.clone();
+            async move {
+                spawn_blocking_with_io_permit(io_semaphore, move || {
+                    let outcome = match fingerprint_file(&path) {
+                        Ok(fingerprint) => Ok(fingerprint),
+                        Err(err) => {
+                            let mtime =
+                                fs_err::metadata(&path).and_then(|m| m.modified()).ok();
+                            Err((err, mtime))
+                        }
+                    };
+                    (path, outcome)
+                })
+                .await
+                .expect("file fingerprint task panicked")
+            }
+        })
+        .buffer_unordered(fingerprint_worker_count(file_count))
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut result = LenientFingerprints::default();
+    for (path, outcome) in outcomes {
+        match outcome {
+            Ok(fingerprint) => {
+                result.fingerprints.insert(path, fingerprint);
+            }
+            Err((err, Some(mtime))) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "could not hash source input file; keeping timestamp-based validation"
+                );
+                result.mtime_only.insert(path, mtime);
+            }
+            Err((err, None)) => {
+                tracing::debug!(
+                    path = %path.display(),
+                    error = %err,
+                    "could not stat source input file; dropping it from the cache record"
+                );
+            }
+        }
+    }
+    log_fingerprint_stats(&result.fingerprints, file_count, started);
+    result
+}
+
+fn fingerprint_worker_count(file_count: usize) -> usize {
+    file_count
+        .min(
+            std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1),
+        )
+        .max(1)
+}
+
+fn log_fingerprint_stats(
+    fingerprints: &BTreeMap<PathBuf, FileFingerprint>,
+    file_count: usize,
+    started: Instant,
+) {
     let total_bytes = fingerprints
         .values()
         .map(|fingerprint| fingerprint.size)
@@ -187,10 +272,21 @@ pub(crate) async fn fingerprint_files(
         elapsed_ms = started.elapsed().as_millis() as u64,
         "fingerprinted source-build input files"
     );
-    Ok(fingerprints)
 }
 
 fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError> {
+    // Opening a special file can block indefinitely (e.g. a FIFO without a
+    // writer), so check the file type from a stat before opening.
+    let file_type = fs_err::metadata(path)
+        .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?
+        .file_type();
+    if !file_type.is_file() {
+        return Err(FileFingerprintError::new(
+            path.to_path_buf(),
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "not a regular file"),
+        ));
+    }
+
     // Retry once when a file changes while it is being read. This prevents
     // associating a hash of an inconsistent read with the final metadata.
     for _ in 0..2 {
@@ -202,6 +298,12 @@ fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError
             .as_file()
             .metadata()
             .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        if !before.file_type().is_file() {
+            return Err(FileFingerprintError::new(
+                path.to_path_buf(),
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "not a regular file"),
+            ));
+        }
         let modified = before
             .modified()
             .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -1,0 +1,197 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::File,
+    io::{BufReader, Read},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Instant, SystemTime},
+};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use xxhash_rust::xxh3::Xxh3;
+
+/// A snapshot of a file used to validate source-build caches.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) struct FileFingerprint {
+    pub(crate) modified: SystemTime,
+    pub(crate) size: u64,
+    pub(crate) hash: u64,
+}
+
+impl FileFingerprint {
+    /// Returns whether the metadata is identical, requires a content check, or
+    /// already proves that the file changed.
+    pub(crate) fn compare_metadata(
+        &self,
+        metadata: &std::fs::Metadata,
+    ) -> Result<MetadataComparison, std::io::Error> {
+        if metadata.len() != self.size {
+            return Ok(MetadataComparison::Changed);
+        }
+
+        if metadata.modified()? == self.modified {
+            Ok(MetadataComparison::Unchanged)
+        } else {
+            Ok(MetadataComparison::HashRequired)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum MetadataComparison {
+    Unchanged,
+    HashRequired,
+    Changed,
+}
+
+/// Computes fingerprints for all provided paths without blocking the async
+/// executor.
+pub(crate) async fn fingerprint_files(
+    paths: impl IntoIterator<Item = PathBuf>,
+) -> Result<BTreeMap<PathBuf, FileFingerprint>, FileFingerprintError> {
+    let paths = paths.into_iter().collect::<BTreeSet<_>>();
+    let file_count = paths.len();
+    let started = Instant::now();
+    let fingerprints: BTreeMap<PathBuf, FileFingerprint> = tokio::task::spawn_blocking(move || {
+        paths
+            .into_iter()
+            .map(|path| fingerprint_file(&path).map(|fingerprint| (path, fingerprint)))
+            .collect::<Result<BTreeMap<_, _>, _>>()
+    })
+    .await
+    .expect("file fingerprint task panicked")?;
+    let total_bytes = fingerprints
+        .values()
+        .map(|fingerprint| fingerprint.size)
+        .sum::<u64>();
+    tracing::debug!(
+        file_count,
+        total_bytes,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "fingerprinted source-build input files"
+    );
+    Ok(fingerprints)
+}
+
+fn fingerprint_file(path: &Path) -> Result<FileFingerprint, FileFingerprintError> {
+    // Retry once when a file changes while it is being read. This prevents
+    // associating a hash of an inconsistent read with the final metadata.
+    for _ in 0..2 {
+        let before = fs_err::metadata(path)
+            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let modified = before
+            .modified()
+            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+
+        let file =
+            File::open(path).map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let mut reader = BufReader::new(file);
+        let mut hasher = Xxh3::new();
+        let mut buffer = [0u8; 64 * 1024];
+        loop {
+            let read = reader
+                .read(&mut buffer)
+                .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+
+        let after = fs_err::metadata(path)
+            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        let after_modified = after
+            .modified()
+            .map_err(|err| FileFingerprintError::new(path.to_path_buf(), err))?;
+        if before.len() == after.len() && modified == after_modified {
+            return Ok(FileFingerprint {
+                modified: after_modified,
+                size: after.len(),
+                hash: hasher.digest(),
+            });
+        }
+    }
+
+    Err(FileFingerprintError::new(
+        path.to_path_buf(),
+        std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            "file changed while computing its fingerprint",
+        ),
+    ))
+}
+
+#[derive(Debug, Clone, Error)]
+#[error("failed to fingerprint '{}'", path.display())]
+pub(crate) struct FileFingerprintError {
+    pub(crate) path: PathBuf,
+    #[source]
+    pub(crate) source: Arc<std::io::Error>,
+}
+
+impl FileFingerprintError {
+    fn new(path: PathBuf, source: std::io::Error) -> Self {
+        Self {
+            path,
+            source: Arc::new(source),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn content_hash_is_stable_when_only_mtime_changes() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("input.txt");
+        fs_err::write(&path, b"same contents").unwrap();
+
+        let first = fingerprint_files([path.clone()])
+            .await
+            .unwrap()
+            .remove(&path)
+            .unwrap();
+        File::open(&path)
+            .unwrap()
+            .set_modified(first.modified + Duration::from_secs(1))
+            .unwrap();
+        let second = fingerprint_files([path.clone()])
+            .await
+            .unwrap()
+            .remove(&path)
+            .unwrap();
+
+        assert_ne!(first.modified, second.modified);
+        assert_eq!(first.size, second.size);
+        assert_eq!(first.hash, second.hash);
+    }
+
+    #[tokio::test]
+    async fn content_hash_changes_for_same_size_edit() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("input.txt");
+        fs_err::write(&path, b"old").unwrap();
+        let first = fingerprint_files([path.clone()])
+            .await
+            .unwrap()
+            .remove(&path)
+            .unwrap();
+
+        fs_err::write(&path, b"new").unwrap();
+        let second = fingerprint_files([path.clone()])
+            .await
+            .unwrap()
+            .remove(&path)
+            .unwrap();
+
+        assert_eq!(first.size, second.size);
+        assert_ne!(first.hash, second.hash);
+    }
+}

--- a/crates/pixi_command_dispatcher/src/file_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/file_fingerprint.rs
@@ -161,44 +161,22 @@ pub(crate) async fn fingerprint_files(
             .map(usize::from)
             .unwrap_or(1),
     );
-    // Keep a few batches queued per worker for load balancing without
-    // creating one blocking task per file. Cap batches at 32 files so a
-    // fingerprint pass cannot monopolize a scarce global I/O permit for an
-    // arbitrarily large input set.
-    const MAX_FILES_PER_BATCH: usize = 32;
-    let batch_count = if file_count == 0 {
-        0
-    } else {
-        let batches_for_fairness = file_count.div_ceil(MAX_FILES_PER_BATCH);
-        file_count.min(worker_count.saturating_mul(4).max(batches_for_fairness))
-    };
-    let mut batches = (0..batch_count)
-        .map(|_| Vec::new())
-        .collect::<Vec<Vec<PathBuf>>>();
-    for (index, path) in paths.into_iter().enumerate() {
-        batches[index % batch_count].push(path);
-    }
-
-    let fingerprints = futures::stream::iter(batches)
-        .map(|paths| {
+    // A permit represents one file read. This allows other users of the
+    // dispatcher's shared I/O budget to make progress between files.
+    let fingerprints = futures::stream::iter(paths)
+        .map(|path| {
             let io_semaphore = io_semaphore.clone();
             async move {
                 spawn_blocking_with_io_permit(io_semaphore, move || {
-                    paths
-                        .into_iter()
-                        .map(|path| fingerprint_file(&path).map(|fingerprint| (path, fingerprint)))
-                        .collect::<Result<Vec<_>, _>>()
+                    fingerprint_file(&path).map(|fingerprint| (path, fingerprint))
                 })
                 .await
                 .expect("file fingerprint task panicked")
             }
         })
         .buffer_unordered(worker_count.max(1))
-        .try_collect::<Vec<Vec<_>>>()
-        .await?
-        .into_iter()
-        .flatten()
-        .collect::<BTreeMap<_, _>>();
+        .try_collect::<BTreeMap<_, _>>()
+        .await?;
     let total_bytes = fingerprints
         .values()
         .map(|fingerprint| fingerprint.size)

--- a/crates/pixi_command_dispatcher/src/input_snapshot.rs
+++ b/crates/pixi_command_dispatcher/src/input_snapshot.rs
@@ -5,8 +5,9 @@
 //! filesystem when the entry is probed. Size and mtime are the fast path;
 //! contents are hashed only when the mtime moved.
 
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::SystemTime};
+use std::{collections::BTreeMap, path::Path, sync::Arc, time::SystemTime};
 
+use pixi_path::AbsPathBuf;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Semaphore;
 
@@ -96,7 +97,7 @@ enum StateComparison {
 /// The recorded validation state of every input file of a cache entry.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct InputSnapshot {
-    files: BTreeMap<PathBuf, InputFileState>,
+    files: BTreeMap<AbsPathBuf, InputFileState>,
 
     /// When the states were observed. An unconfirmed fingerprint in this
     /// snapshot may only confirm a later capture whose build started after
@@ -115,9 +116,10 @@ pub(crate) struct InputSnapshot {
 pub(crate) enum SnapshotFreshness {
     /// Every file matches its recorded state.
     Fresh,
-    /// Contents match but at least one mtime moved. Persisting the refreshed
-    /// snapshot (best-effort) avoids rehashing on the next probe.
-    Refreshed(InputSnapshot),
+    /// These files' contents match but their mtime moved. Recording them
+    /// (best-effort) via [`InputSnapshot::apply_refresh`] avoids rehashing
+    /// on the next probe.
+    Refreshed(Vec<(AbsPathBuf, FileFingerprint)>),
     /// The file provably changed, vanished, or could not be verified.
     Stale(StaleFile),
 }
@@ -126,7 +128,7 @@ pub(crate) enum SnapshotFreshness {
 /// reporting.
 #[derive(Debug)]
 pub(crate) struct StaleFile {
-    pub(crate) path: PathBuf,
+    pub(crate) path: AbsPathBuf,
     pub(crate) reason: StaleFileReason,
 }
 
@@ -146,14 +148,14 @@ pub(crate) enum StaleFileReason {
 }
 
 impl StaleFile {
-    fn removed(path: PathBuf) -> Self {
+    fn removed(path: AbsPathBuf) -> Self {
         Self {
             path,
             reason: StaleFileReason::Removed,
         }
     }
 
-    fn modified(path: PathBuf, recorded: SystemTime, observed: SystemTime) -> Self {
+    fn modified(path: AbsPathBuf, recorded: SystemTime, observed: SystemTime) -> Self {
         Self {
             path,
             reason: StaleFileReason::Modified { recorded, observed },
@@ -167,17 +169,32 @@ impl InputSnapshot {
     }
 
     #[cfg(test)]
-    pub(crate) fn get(&self, path: &std::path::Path) -> Option<&InputFileState> {
-        self.files.get(path)
+    pub(crate) fn get(&self, path: &Path) -> Option<&InputFileState> {
+        self.files
+            .iter()
+            .find(|(recorded, _)| recorded.as_std_path() == path)
+            .map(|(_, state)| state)
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&PathBuf, &InputFileState)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&AbsPathBuf, &InputFileState)> {
         self.files.iter()
     }
 
     /// Inserts `state` for `path` unless a state is already recorded.
-    pub(crate) fn insert_fallback(&mut self, path: PathBuf, state: InputFileState) {
+    pub(crate) fn insert_fallback(&mut self, path: AbsPathBuf, state: InputFileState) {
         self.files.entry(path).or_insert(state);
+    }
+
+    /// Records freshly verified fingerprints from a
+    /// [`SnapshotFreshness::Refreshed`] result.
+    pub(crate) fn apply_refresh(
+        &mut self,
+        refreshed: impl IntoIterator<Item = (AbsPathBuf, FileFingerprint)>,
+    ) {
+        for (path, fingerprint) in refreshed {
+            self.files
+                .insert(path, InputFileState::Fingerprint(fingerprint));
+        }
     }
 
     /// Captures the current state of `paths`. Never fails: an unhashable
@@ -198,14 +215,14 @@ impl InputSnapshot {
     /// An mtime-only file past the cutoff keeps its mtime: it cannot be
     /// confirmed by a second observation, but it must stay tracked.
     pub(crate) async fn capture(
-        paths: impl IntoIterator<Item = PathBuf>,
+        paths: impl IntoIterator<Item = AbsPathBuf>,
         cutoff: Option<SystemTime>,
         previous: Option<&InputSnapshot>,
         io_semaphore: Option<Arc<Semaphore>>,
     ) -> Self {
         let started = std::time::Instant::now();
-        let outcomes = run_fingerprint_tasks(paths, io_semaphore, |path| {
-            let state = match fingerprint_file(&path) {
+        let outcomes =
+            run_fingerprint_tasks(paths, io_semaphore, |path| match fingerprint_file(path) {
                 Ok(fingerprint) => Some(InputFileState::Fingerprint(fingerprint)),
                 Err(err) => {
                     tracing::debug!(
@@ -213,62 +230,33 @@ impl InputSnapshot {
                         error = %err,
                         "could not hash source input file; keeping mtime-only validation"
                     );
-                    fs_err::metadata(&path)
+                    fs_err::metadata(path)
                         .and_then(|metadata| metadata.modified())
                         .ok()
                         .map(InputFileState::MtimeOnly)
                 }
-            };
-            (path, state)
-        })
-        .await;
+            })
+            .await;
 
         let files: BTreeMap<_, _> = outcomes
             .into_iter()
             .filter_map(|(path, state)| {
-                let state = state?;
-                let state = match cutoff {
-                    Some(cutoff) if state.modified() > cutoff => match state {
-                        InputFileState::Fingerprint(fingerprint) => {
-                            // Content equality across the two captures is
-                            // what matters; the mtime may move (e.g. a build
-                            // regenerating the file with identical bytes).
-                            // The previous observation must predate this
-                            // build (the cutoff) or it cannot bracket the
-                            // build's reads.
-                            let confirmed = previous
-                                .filter(|previous| {
-                                    previous
-                                        .captured_at
-                                        .is_some_and(|observed| observed <= cutoff)
-                                })
-                                .and_then(|previous| previous.files.get(&path))
-                                .and_then(InputFileState::fingerprint)
-                                .is_some_and(|prev| {
-                                    prev.hash == fingerprint.hash && prev.size == fingerprint.size
-                                });
-                            if confirmed {
-                                InputFileState::Fingerprint(fingerprint)
-                            } else {
-                                InputFileState::Unconfirmed(fingerprint)
-                            }
-                        }
-                        // An mtime cannot be confirmed by a second
-                        // observation, but dropping it would untrack the
-                        // file; keep it validated by its mtime.
-                        InputFileState::Unconfirmed(_) | InputFileState::MtimeOnly(_) => state,
-                    },
-                    _ => state,
+                let state = match (cutoff, state?) {
+                    (Some(cutoff), InputFileState::Fingerprint(fingerprint))
+                        if fingerprint.modified > cutoff
+                            && !confirmed_by_previous(previous, cutoff, &path, &fingerprint) =>
+                    {
+                        InputFileState::Unconfirmed(fingerprint)
+                    }
+                    // An mtime past the cutoff cannot be confirmed by a
+                    // second observation, but the file must stay tracked.
+                    (_, state) => state,
                 };
                 Some((path, state))
             })
             .collect();
         log_hash_stats(
-            files.values().map(|state| {
-                state
-                    .fingerprint()
-                    .map_or(0, |fingerprint| fingerprint.size)
-            }),
+            files.values().filter_map(InputFileState::fingerprint),
             started,
         );
         Self {
@@ -286,98 +274,142 @@ impl InputSnapshot {
     /// with nothing to compare against, a content hash proves nothing.
     pub(crate) async fn verify(
         &self,
-        files: impl IntoIterator<Item = PathBuf>,
+        files: impl IntoIterator<Item = AbsPathBuf>,
         fallback_cutoff: Option<SystemTime>,
         io_semaphore: Option<Arc<Semaphore>>,
     ) -> SnapshotFreshness {
-        let mut to_hash = Vec::new();
-        for path in files {
-            let Ok(metadata) = fs_err::metadata(&path) else {
-                return SnapshotFreshness::Stale(StaleFile::removed(path));
-            };
-            let observed = metadata.modified().ok();
-            match self.files.get(&path) {
-                Some(state) => match state.compare_metadata(&metadata) {
-                    StateComparison::Unchanged => {}
-                    StateComparison::HashRequired => to_hash.push(path),
-                    StateComparison::Changed => {
-                        if matches!(state, InputFileState::Unconfirmed(_)) {
-                            return SnapshotFreshness::Stale(StaleFile {
-                                path,
-                                reason: StaleFileReason::Unconfirmed,
-                            });
-                        }
-                        let recorded = state.modified();
-                        return SnapshotFreshness::Stale(match observed {
-                            Some(observed) => StaleFile::modified(path, recorded, observed),
-                            None => StaleFile::removed(path),
-                        });
-                    }
-                },
-                None => {
-                    let unchanged = fallback_cutoff
-                        .is_some_and(|cutoff| observed.is_some_and(|modified| modified <= cutoff));
-                    if !unchanged {
-                        let Some(observed) = observed else {
-                            return SnapshotFreshness::Stale(StaleFile::removed(path));
-                        };
-                        // With no recorded state the cutoff is the baseline.
-                        let recorded = fallback_cutoff.unwrap_or(observed);
-                        return SnapshotFreshness::Stale(StaleFile::modified(
-                            path, recorded, observed,
-                        ));
-                    }
-                }
-            }
-        }
+        // One blocking task for the whole stat pass: it keeps the syscalls
+        // off the async worker and yields immediately, so work joined with
+        // this future (the glob walk) genuinely runs concurrently.
+        let states: Vec<(AbsPathBuf, Option<InputFileState>)> = files
+            .into_iter()
+            .map(|path| {
+                let state = self.files.get(&path).copied();
+                (path, state)
+            })
+            .collect();
+        let to_hash =
+            spawn_blocking_with_io_permit(None, move || classify_files(states, fallback_cutoff))
+                .await
+                .expect("file stat task panicked");
+        let to_hash = match to_hash {
+            Ok(to_hash) => to_hash,
+            Err(stale) => return SnapshotFreshness::Stale(stale),
+        };
 
         if to_hash.is_empty() {
             return SnapshotFreshness::Fresh;
         }
 
         let started = std::time::Instant::now();
-        let hashed = run_fingerprint_tasks(to_hash, io_semaphore, |path| {
-            let fingerprint = fingerprint_file(&path);
-            (path, fingerprint)
-        })
+        let hashed = run_fingerprint_tasks(
+            to_hash.keys().cloned().collect::<Vec<_>>(),
+            io_semaphore,
+            fingerprint_file,
+        )
         .await;
         log_hash_stats(
             hashed
                 .iter()
-                .filter_map(|(_, fingerprint)| fingerprint.as_ref().ok())
-                .map(|fingerprint| fingerprint.size),
+                .filter_map(|(_, fingerprint)| fingerprint.as_ref().ok()),
             started,
         );
 
-        let mut refreshed = self.clone();
+        let mut refreshed = Vec::with_capacity(hashed.len());
         for (path, current) in hashed {
             let Ok(current) = current else {
                 return SnapshotFreshness::Stale(StaleFile::removed(path));
             };
-            match self.files.get(&path) {
-                Some(InputFileState::Fingerprint(expected)) if expected.hash == current.hash => {
-                    refreshed
-                        .files
-                        .insert(path, InputFileState::Fingerprint(current));
-                }
-                // Only files with a recorded fingerprint are queued for
-                // hashing.
-                Some(state) => {
-                    return SnapshotFreshness::Stale(StaleFile::modified(
-                        path,
-                        state.modified(),
-                        current.modified,
-                    ));
-                }
-                None => return SnapshotFreshness::Stale(StaleFile::removed(path)),
+            let expected = to_hash[&path];
+            if expected.hash != current.hash {
+                return SnapshotFreshness::Stale(StaleFile::modified(
+                    path,
+                    expected.modified,
+                    current.modified,
+                ));
             }
+            refreshed.push((path, current));
         }
         SnapshotFreshness::Refreshed(refreshed)
     }
 }
 
-impl FromIterator<(PathBuf, InputFileState)> for InputSnapshot {
-    fn from_iter<T: IntoIterator<Item = (PathBuf, InputFileState)>>(iter: T) -> Self {
+/// Whether `previous` proves that `fingerprint`'s content was stable while
+/// the build ran: it must have observed the same content, and must have
+/// observed it before the build started (the cutoff).
+fn confirmed_by_previous(
+    previous: Option<&InputSnapshot>,
+    cutoff: SystemTime,
+    path: &AbsPathBuf,
+    fingerprint: &FileFingerprint,
+) -> bool {
+    previous
+        .filter(|previous| {
+            previous
+                .captured_at
+                .is_some_and(|observed| observed <= cutoff)
+        })
+        .and_then(|previous| previous.files.get(path))
+        .and_then(InputFileState::fingerprint)
+        .is_some_and(|prev| prev.hash == fingerprint.hash && prev.size == fingerprint.size)
+}
+
+/// The stat pass of [`InputSnapshot::verify`]: compares every file against
+/// its recorded state and returns the fingerprints that need a content hash
+/// to decide.
+fn classify_files(
+    states: Vec<(AbsPathBuf, Option<InputFileState>)>,
+    fallback_cutoff: Option<SystemTime>,
+) -> Result<BTreeMap<AbsPathBuf, FileFingerprint>, StaleFile> {
+    let mut to_hash = BTreeMap::new();
+    for (path, state) in states {
+        let Ok(metadata) = fs_err::metadata(path.as_std_path()) else {
+            return Err(StaleFile::removed(path));
+        };
+        let observed = metadata.modified().ok();
+        match state {
+            Some(state) => match state.compare_metadata(&metadata) {
+                StateComparison::Unchanged => {}
+                StateComparison::HashRequired => {
+                    let fingerprint = *state
+                        .fingerprint()
+                        .expect("only fingerprints can require a hash");
+                    to_hash.insert(path, fingerprint);
+                }
+                StateComparison::Changed => {
+                    if matches!(state, InputFileState::Unconfirmed(_)) {
+                        return Err(StaleFile {
+                            path,
+                            reason: StaleFileReason::Unconfirmed,
+                        });
+                    }
+                    let recorded = state.modified();
+                    return Err(match observed {
+                        Some(observed) => StaleFile::modified(path, recorded, observed),
+                        None => StaleFile::removed(path),
+                    });
+                }
+            },
+            None => {
+                let unchanged = fallback_cutoff
+                    .is_some_and(|cutoff| observed.is_some_and(|modified| modified <= cutoff));
+                if !unchanged {
+                    let Some(observed) = observed else {
+                        return Err(StaleFile::removed(path));
+                    };
+                    // With no recorded state the cutoff is the baseline.
+                    let recorded = fallback_cutoff.unwrap_or(observed);
+                    return Err(StaleFile::modified(path, recorded, observed));
+                }
+            }
+        }
+    }
+    Ok(to_hash)
+}
+
+#[cfg(test)]
+impl FromIterator<(AbsPathBuf, InputFileState)> for InputSnapshot {
+    fn from_iter<T: IntoIterator<Item = (AbsPathBuf, InputFileState)>>(iter: T) -> Self {
         Self {
             files: iter.into_iter().collect(),
             captured_at: None,
@@ -385,8 +417,14 @@ impl FromIterator<(PathBuf, InputFileState)> for InputSnapshot {
     }
 }
 
-fn log_hash_stats(sizes: impl Iterator<Item = u64>, started: std::time::Instant) {
-    let (file_count, total_bytes) = sizes.fold((0u64, 0u64), |(n, b), size| (n + 1, b + size));
+fn log_hash_stats<'a>(
+    fingerprints: impl Iterator<Item = &'a FileFingerprint>,
+    started: std::time::Instant,
+) {
+    let (file_count, total_bytes) = fingerprints
+        .fold((0u64, 0u64), |(count, bytes), fingerprint| {
+            (count + 1, bytes + fingerprint.size)
+        });
     tracing::debug!(
         file_count,
         total_bytes,
@@ -399,10 +437,10 @@ fn log_hash_stats(sizes: impl Iterator<Item = u64>, started: std::time::Instant)
 /// permit from the dispatcher's shared I/O budget. A permit covers one file
 /// read, so other users of the budget can make progress between files.
 async fn run_fingerprint_tasks<T: Send + 'static>(
-    paths: impl IntoIterator<Item = PathBuf>,
+    paths: impl IntoIterator<Item = AbsPathBuf>,
     io_semaphore: Option<Arc<Semaphore>>,
-    task: impl Fn(PathBuf) -> T + Clone + Send + 'static,
-) -> Vec<T> {
+    task: impl Fn(&Path) -> T + Clone + Send + 'static,
+) -> Vec<(AbsPathBuf, T)> {
     use futures::StreamExt;
 
     let paths = paths.into_iter().collect::<std::collections::BTreeSet<_>>();
@@ -419,9 +457,12 @@ async fn run_fingerprint_tasks<T: Send + 'static>(
             let io_semaphore = io_semaphore.clone();
             let task = task.clone();
             async move {
-                spawn_blocking_with_io_permit(io_semaphore, move || task(path))
-                    .await
-                    .expect("file fingerprint task panicked")
+                spawn_blocking_with_io_permit(io_semaphore, move || {
+                    let outcome = task(path.as_std_path());
+                    (path, outcome)
+                })
+                .await
+                .expect("file fingerprint task panicked")
             }
         })
         .buffer_unordered(worker_count)
@@ -431,23 +472,21 @@ async fn run_fingerprint_tasks<T: Send + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::OpenOptions, time::Duration};
+    use std::time::Duration;
 
     use tempfile::TempDir;
 
     use super::*;
+    use crate::file_fingerprint::test_helpers::{mtime, set_modified};
 
-    fn set_modified(path: &std::path::Path, modified: SystemTime) {
-        OpenOptions::new()
-            .write(true)
-            .open(path)
-            .unwrap()
-            .set_modified(modified)
-            .unwrap();
+    fn abs(path: &Path) -> AbsPathBuf {
+        AbsPathBuf::new(path.to_path_buf()).unwrap()
     }
 
-    fn mtime(path: &std::path::Path) -> SystemTime {
-        fs_err::metadata(path).unwrap().modified().unwrap()
+    /// Dates the file ahead of the clock, so it lands past any cutoff taken
+    /// "now" (a skewed mount, a restored snapshot).
+    fn set_future_mtime(path: &Path) {
+        set_modified(path, SystemTime::now() + Duration::from_secs(3600));
     }
 
     #[tokio::test]
@@ -456,7 +495,7 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], None, None, None).await;
         assert!(matches!(
             snapshot.get(&file),
             Some(InputFileState::Fingerprint(_))
@@ -469,7 +508,7 @@ mod tests {
         let dir = temp.path().join("assets");
         fs_err::create_dir_all(&dir).unwrap();
 
-        let snapshot = InputSnapshot::capture([dir.clone()], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&dir)], None, None, None).await;
         assert!(matches!(
             snapshot.get(&dir),
             Some(InputFileState::MtimeOnly(_))
@@ -481,7 +520,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let missing = temp.path().join("gone.py");
 
-        let snapshot = InputSnapshot::capture([missing], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&missing)], None, None, None).await;
         assert!(snapshot.is_empty());
     }
 
@@ -492,7 +531,7 @@ mod tests {
         fs_err::write(&file, b"body").unwrap();
 
         let cutoff = mtime(&file) - Duration::from_secs(10);
-        let snapshot = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], Some(cutoff), None, None).await;
         assert!(matches!(
             snapshot.get(&file),
             Some(InputFileState::Unconfirmed(_))
@@ -500,15 +539,9 @@ mod tests {
 
         // An unconfirmed state cannot vouch for the cached outputs.
         assert!(matches!(
-            snapshot.verify([file], Some(cutoff), None).await,
+            snapshot.verify([abs(&file)], Some(cutoff), None).await,
             SnapshotFreshness::Stale(_)
         ));
-    }
-
-    /// Dates the file ahead of the clock, so it lands past any cutoff taken
-    /// "now" (a skewed mount, a restored snapshot).
-    fn set_future_mtime(path: &std::path::Path) {
-        set_modified(path, SystemTime::now() + Duration::from_secs(3600));
     }
 
     /// The two-observation promotion: content observed before this build
@@ -520,22 +553,20 @@ mod tests {
         fs_err::write(&file, b"body").unwrap();
         set_future_mtime(&file);
 
-        let first =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), None, None).await;
+        let first = InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), None, None).await;
         assert!(matches!(
             first.get(&file),
             Some(InputFileState::Unconfirmed(_))
         ));
 
         let second =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&first), None)
-                .await;
+            InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), Some(&first), None).await;
         assert!(matches!(
             second.get(&file),
             Some(InputFileState::Fingerprint(_))
         ));
         assert!(matches!(
-            second.verify([file], None, None).await,
+            second.verify([abs(&file)], None, None).await,
             SnapshotFreshness::Fresh
         ));
     }
@@ -547,13 +578,11 @@ mod tests {
         fs_err::write(&file, b"old").unwrap();
         set_future_mtime(&file);
 
-        let first =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), None, None).await;
+        let first = InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), None, None).await;
         fs_err::write(&file, b"new").unwrap();
         set_future_mtime(&file);
         let second =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&first), None)
-                .await;
+            InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), Some(&first), None).await;
 
         assert!(matches!(
             second.get(&file),
@@ -573,9 +602,9 @@ mod tests {
 
         let build_started = SystemTime::now();
         let concurrent =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), None, None).await;
+            InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), None, None).await;
         let captured =
-            InputSnapshot::capture([file.clone()], Some(build_started), Some(&concurrent), None)
+            InputSnapshot::capture([abs(&file)], Some(build_started), Some(&concurrent), None)
                 .await;
 
         assert!(
@@ -590,9 +619,9 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], None, None, None).await;
         assert!(matches!(
-            snapshot.verify([file], None, None).await,
+            snapshot.verify([abs(&file)], None, None).await,
             SnapshotFreshness::Fresh
         ));
     }
@@ -603,13 +632,14 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
+        let mut snapshot = InputSnapshot::capture([abs(&file)], None, None, None).await;
         let touched = mtime(&file) + Duration::from_secs(1);
         set_modified(&file, touched);
 
-        match snapshot.verify([file.clone()], None, None).await {
+        match snapshot.verify([abs(&file)], None, None).await {
             SnapshotFreshness::Refreshed(refreshed) => {
-                assert_eq!(refreshed.get(&file).unwrap().modified(), touched);
+                snapshot.apply_refresh(refreshed);
+                assert_eq!(snapshot.get(&file).unwrap().modified(), touched);
             }
             other => panic!("expected a refresh, got {other:?}"),
         }
@@ -621,13 +651,13 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"old").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], None, None, None).await;
         let touched = mtime(&file) + Duration::from_secs(1);
         fs_err::write(&file, b"new").unwrap();
         set_modified(&file, touched);
 
         assert!(matches!(
-            snapshot.verify([file], None, None).await,
+            snapshot.verify([abs(&file)], None, None).await,
             SnapshotFreshness::Stale(_)
         ));
     }
@@ -638,11 +668,11 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], None, None, None).await;
         fs_err::remove_file(&file).unwrap();
 
         assert!(matches!(
-            snapshot.verify([file], None, None).await,
+            snapshot.verify([abs(&file)], None, None).await,
             SnapshotFreshness::Stale(_)
         ));
     }
@@ -653,18 +683,18 @@ mod tests {
         let dir = temp.path().join("assets");
         fs_err::create_dir_all(&dir).unwrap();
 
-        let snapshot = InputSnapshot::capture([dir.clone()], None, None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&dir)], None, None, None).await;
         assert!(matches!(
-            snapshot.verify([dir.clone()], None, None).await,
+            snapshot.verify([abs(&dir)], None, None).await,
             SnapshotFreshness::Fresh
         ));
 
         // A recorded mtime that no longer matches must invalidate; an
         // mtime-only file can never be re-verified through a hash.
         let touched = InputFileState::MtimeOnly(mtime(&dir) + Duration::from_secs(1));
-        let snapshot = InputSnapshot::from_iter([(dir.clone(), touched)]);
+        let snapshot = InputSnapshot::from_iter([(abs(&dir), touched)]);
         assert!(matches!(
-            snapshot.verify([dir], None, None).await,
+            snapshot.verify([abs(&dir)], None, None).await,
             SnapshotFreshness::Stale(_)
         ));
     }
@@ -681,18 +711,18 @@ mod tests {
 
         let cutoff = mtime(&file) + Duration::from_secs(10);
         assert!(matches!(
-            snapshot.verify([file.clone()], Some(cutoff), None).await,
+            snapshot.verify([abs(&file)], Some(cutoff), None).await,
             SnapshotFreshness::Fresh
         ));
 
         assert!(matches!(
-            snapshot.verify([file.clone()], None, None).await,
+            snapshot.verify([abs(&file)], None, None).await,
             SnapshotFreshness::Stale(_)
         ));
 
         set_modified(&file, cutoff + Duration::from_secs(10));
         assert!(matches!(
-            snapshot.verify([file], Some(cutoff), None).await,
+            snapshot.verify([abs(&file)], Some(cutoff), None).await,
             SnapshotFreshness::Stale(_)
         ));
     }
@@ -708,15 +738,14 @@ mod tests {
         fs_err::write(&file, b"body").unwrap();
         set_future_mtime(&file);
 
-        let first = InputSnapshot::capture([file.clone()], None, None, None).await;
+        let first = InputSnapshot::capture([abs(&file)], None, None, None).await;
         assert!(matches!(
             first.get(&file),
             Some(InputFileState::Fingerprint(_))
         ));
 
         let second =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&first), None)
-                .await;
+            InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), Some(&first), None).await;
         assert!(
             matches!(second.get(&file), Some(InputFileState::Fingerprint(_))),
             "a trusted previous observation of the same content must promote",
@@ -724,7 +753,7 @@ mod tests {
 
         // And the trust survives further captures that keep seeing it.
         let third =
-            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&second), None)
+            InputSnapshot::capture([abs(&file)], Some(SystemTime::now()), Some(&second), None)
                 .await;
         assert!(matches!(
             third.get(&file),
@@ -741,7 +770,7 @@ mod tests {
         let path = temp.path().join("assets");
         fs_err::create_dir_all(&path).unwrap();
 
-        let first = InputSnapshot::capture([path.clone()], None, None, None).await;
+        let first = InputSnapshot::capture([abs(&path)], None, None, None).await;
         assert!(matches!(
             first.get(&path),
             Some(InputFileState::MtimeOnly(_))
@@ -749,9 +778,10 @@ mod tests {
 
         fs_err::remove_dir(&path).unwrap();
         fs_err::write(&path, b"body").unwrap();
-        let cutoff = mtime(&path) - Duration::from_secs(10);
+        set_future_mtime(&path);
 
-        let second = InputSnapshot::capture([path.clone()], Some(cutoff), Some(&first), None).await;
+        let second =
+            InputSnapshot::capture([abs(&path)], Some(SystemTime::now()), Some(&first), None).await;
         assert!(
             matches!(second.get(&path), Some(InputFileState::Unconfirmed(_))),
             "an mtime-only predecessor cannot vouch for any content",
@@ -771,9 +801,9 @@ mod tests {
         set_future_mtime(&seen);
         set_future_mtime(&fresh);
 
-        let previous = InputSnapshot::capture([seen.clone()], None, None, None).await;
+        let previous = InputSnapshot::capture([abs(&seen)], None, None, None).await;
         let captured = InputSnapshot::capture(
-            [seen.clone(), fresh.clone()],
+            [abs(&seen), abs(&fresh)],
             Some(SystemTime::now()),
             Some(&previous),
             None,
@@ -799,14 +829,14 @@ mod tests {
         fs_err::write(&file, b"body").unwrap();
 
         let cutoff = mtime(&file);
-        let snapshot = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], Some(cutoff), None, None).await;
         assert!(matches!(
             snapshot.get(&file),
             Some(InputFileState::Fingerprint(_))
         ));
 
         set_modified(&file, cutoff + Duration::from_secs(1));
-        let snapshot = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&file)], Some(cutoff), None, None).await;
         assert!(matches!(
             snapshot.get(&file),
             Some(InputFileState::Unconfirmed(_))
@@ -824,7 +854,7 @@ mod tests {
         fs_err::create_dir_all(&dir).unwrap();
         let cutoff = mtime(&dir) - Duration::from_secs(10);
 
-        let snapshot = InputSnapshot::capture([dir.clone()], Some(cutoff), None, None).await;
+        let snapshot = InputSnapshot::capture([abs(&dir)], Some(cutoff), None, None).await;
         assert!(
             matches!(snapshot.get(&dir), Some(InputFileState::MtimeOnly(_))),
             "dropping the input leaves it unvalidated forever, which is weaker \

--- a/crates/pixi_command_dispatcher/src/input_snapshot.rs
+++ b/crates/pixi_command_dispatcher/src/input_snapshot.rs
@@ -1,0 +1,520 @@
+//! The validation state of a cache entry's source input files, shared by the
+//! build-backend metadata cache and the artifact cache.
+//!
+//! A snapshot is captured when an entry is stored and verified against the
+//! filesystem when the entry is probed. Size and mtime are the fast path;
+//! contents are hashed only when the mtime moved.
+
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::SystemTime};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+
+use crate::file_fingerprint::{
+    FileFingerprint, fingerprint_file, spawn_blocking_with_io_permit, system_time_serde,
+};
+
+/// Validation state recorded for one input file.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InputFileState {
+    /// Content hash plus the size and mtime observed when it was computed.
+    Fingerprint(FileFingerprint),
+    /// Only an mtime: the file could not be hashed when the entry was stored
+    /// (unreadable or not a regular file). Any mtime change counts as a
+    /// content change.
+    MtimeOnly(#[serde(with = "system_time_serde")] SystemTime),
+}
+
+impl InputFileState {
+    /// The mtime recorded for the file.
+    pub(crate) fn modified(&self) -> SystemTime {
+        match self {
+            InputFileState::Fingerprint(fingerprint) => fingerprint.modified,
+            InputFileState::MtimeOnly(modified) => *modified,
+        }
+    }
+
+    /// Compares the recorded state against fresh stat data. `Unchanged` and
+    /// `Changed` are final; `HashRequired` means the contents must be hashed
+    /// to decide.
+    fn compare_metadata(&self, metadata: &std::fs::Metadata) -> StateComparison {
+        let Ok(modified) = metadata.modified() else {
+            return StateComparison::Changed;
+        };
+        match self {
+            InputFileState::Fingerprint(fingerprint) => {
+                if metadata.len() != fingerprint.size {
+                    StateComparison::Changed
+                } else if modified == fingerprint.modified {
+                    StateComparison::Unchanged
+                } else if metadata.is_file() {
+                    StateComparison::HashRequired
+                } else {
+                    // A special file cannot be hashed to prove its contents.
+                    StateComparison::Changed
+                }
+            }
+            InputFileState::MtimeOnly(expected) => {
+                if modified == *expected {
+                    StateComparison::Unchanged
+                } else {
+                    StateComparison::Changed
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum StateComparison {
+    Unchanged,
+    HashRequired,
+    Changed,
+}
+
+/// The recorded validation state of every input file of a cache entry.
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct InputSnapshot {
+    files: BTreeMap<PathBuf, InputFileState>,
+}
+
+/// Result of [`InputSnapshot::verify`].
+#[derive(Debug)]
+pub(crate) enum SnapshotFreshness {
+    /// Every file matches its recorded state.
+    Fresh,
+    /// Contents match but at least one mtime moved. Persisting the refreshed
+    /// snapshot (best-effort) avoids rehashing on the next probe.
+    Refreshed(InputSnapshot),
+    /// The file provably changed, vanished, or could not be verified.
+    Stale(StaleFile),
+}
+
+/// A file that failed verification, with the evidence for cache miss
+/// reporting.
+#[derive(Debug)]
+pub(crate) struct StaleFile {
+    pub(crate) path: PathBuf,
+    pub(crate) reason: StaleFileReason,
+}
+
+/// Why verification rejected the file.
+#[derive(Debug)]
+pub(crate) enum StaleFileReason {
+    /// The file can no longer be stat'ed or read.
+    Removed,
+    /// The recorded state no longer matches the file.
+    Modified {
+        recorded: SystemTime,
+        observed: SystemTime,
+    },
+}
+
+impl StaleFile {
+    fn removed(path: PathBuf) -> Self {
+        Self {
+            path,
+            reason: StaleFileReason::Removed,
+        }
+    }
+
+    fn modified(path: PathBuf, recorded: SystemTime, observed: SystemTime) -> Self {
+        Self {
+            path,
+            reason: StaleFileReason::Modified { recorded, observed },
+        }
+    }
+}
+
+impl InputSnapshot {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get(&self, path: &std::path::Path) -> Option<&InputFileState> {
+        self.files.get(path)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&PathBuf, &InputFileState)> {
+        self.files.iter()
+    }
+
+    /// Inserts `state` for `path` unless a state is already recorded.
+    pub(crate) fn insert_fallback(&mut self, path: PathBuf, state: InputFileState) {
+        self.files.entry(path).or_insert(state);
+    }
+
+    /// Captures the current state of `paths`. Never fails: an unhashable
+    /// file is recorded mtime-only and a file that cannot be stat'ed is
+    /// dropped. A file modified after `cutoff` is dropped as well; its
+    /// contents may not match what the entry was built from. This means a
+    /// file whose mtime is ahead of the clock (skewed mount, restored
+    /// snapshot) never gets a state and rebuilds on every run. Promoting its
+    /// hash would need a second build to confirm the content is stable.
+    pub(crate) async fn capture(
+        paths: impl IntoIterator<Item = PathBuf>,
+        cutoff: Option<SystemTime>,
+        io_semaphore: Option<Arc<Semaphore>>,
+    ) -> Self {
+        let started = std::time::Instant::now();
+        let outcomes = run_fingerprint_tasks(paths, io_semaphore, |path| {
+            let state = match fingerprint_file(&path) {
+                Ok(fingerprint) => Some(InputFileState::Fingerprint(fingerprint)),
+                Err(err) => {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %err,
+                        "could not hash source input file; keeping mtime-only validation"
+                    );
+                    fs_err::metadata(&path)
+                        .and_then(|metadata| metadata.modified())
+                        .ok()
+                        .map(InputFileState::MtimeOnly)
+                }
+            };
+            (path, state)
+        })
+        .await;
+
+        let files: BTreeMap<_, _> = outcomes
+            .into_iter()
+            .filter_map(|(path, state)| Some((path, state?)))
+            .filter(|(_, state)| cutoff.is_none_or(|cutoff| state.modified() <= cutoff))
+            .collect();
+        log_hash_stats(
+            files.values().map(|state| match state {
+                InputFileState::Fingerprint(fingerprint) => fingerprint.size,
+                InputFileState::MtimeOnly(_) => 0,
+            }),
+            started,
+        );
+        Self { files }
+    }
+
+    /// Verifies `files` against their recorded state.
+    ///
+    /// A file without a recorded state passes when its mtime is at or before
+    /// `fallback_cutoff` (entries written before fingerprints existed);
+    /// without a cutoff it counts as changed. Such files are never hashed:
+    /// with nothing to compare against, a content hash proves nothing.
+    pub(crate) async fn verify(
+        &self,
+        files: impl IntoIterator<Item = PathBuf>,
+        fallback_cutoff: Option<SystemTime>,
+        io_semaphore: Option<Arc<Semaphore>>,
+    ) -> SnapshotFreshness {
+        let mut to_hash = Vec::new();
+        for path in files {
+            let Ok(metadata) = fs_err::metadata(&path) else {
+                return SnapshotFreshness::Stale(StaleFile::removed(path));
+            };
+            let observed = metadata.modified().ok();
+            match self.files.get(&path) {
+                Some(state) => match state.compare_metadata(&metadata) {
+                    StateComparison::Unchanged => {}
+                    StateComparison::HashRequired => to_hash.push(path),
+                    StateComparison::Changed => {
+                        let recorded = state.modified();
+                        return SnapshotFreshness::Stale(match observed {
+                            Some(observed) => StaleFile::modified(path, recorded, observed),
+                            None => StaleFile::removed(path),
+                        });
+                    }
+                },
+                None => {
+                    let unchanged = fallback_cutoff
+                        .is_some_and(|cutoff| observed.is_some_and(|modified| modified <= cutoff));
+                    if !unchanged {
+                        let Some(observed) = observed else {
+                            return SnapshotFreshness::Stale(StaleFile::removed(path));
+                        };
+                        // With no recorded state the cutoff is the baseline.
+                        let recorded = fallback_cutoff.unwrap_or(observed);
+                        return SnapshotFreshness::Stale(StaleFile::modified(
+                            path, recorded, observed,
+                        ));
+                    }
+                }
+            }
+        }
+
+        if to_hash.is_empty() {
+            return SnapshotFreshness::Fresh;
+        }
+
+        let started = std::time::Instant::now();
+        let hashed = run_fingerprint_tasks(to_hash, io_semaphore, |path| {
+            let fingerprint = fingerprint_file(&path);
+            (path, fingerprint)
+        })
+        .await;
+        log_hash_stats(
+            hashed
+                .iter()
+                .filter_map(|(_, fingerprint)| fingerprint.as_ref().ok())
+                .map(|fingerprint| fingerprint.size),
+            started,
+        );
+
+        let mut refreshed = self.clone();
+        for (path, current) in hashed {
+            let Ok(current) = current else {
+                return SnapshotFreshness::Stale(StaleFile::removed(path));
+            };
+            match self.files.get(&path) {
+                Some(InputFileState::Fingerprint(expected)) if expected.hash == current.hash => {
+                    refreshed
+                        .files
+                        .insert(path, InputFileState::Fingerprint(current));
+                }
+                // Only files with a recorded fingerprint are queued for
+                // hashing.
+                Some(state) => {
+                    return SnapshotFreshness::Stale(StaleFile::modified(
+                        path,
+                        state.modified(),
+                        current.modified,
+                    ));
+                }
+                None => return SnapshotFreshness::Stale(StaleFile::removed(path)),
+            }
+        }
+        SnapshotFreshness::Refreshed(refreshed)
+    }
+}
+
+impl FromIterator<(PathBuf, InputFileState)> for InputSnapshot {
+    fn from_iter<T: IntoIterator<Item = (PathBuf, InputFileState)>>(iter: T) -> Self {
+        Self {
+            files: iter.into_iter().collect(),
+        }
+    }
+}
+
+fn log_hash_stats(sizes: impl Iterator<Item = u64>, started: std::time::Instant) {
+    let (file_count, total_bytes) = sizes.fold((0u64, 0u64), |(n, b), size| (n + 1, b + size));
+    tracing::debug!(
+        file_count,
+        total_bytes,
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        "fingerprinted source-build input files"
+    );
+}
+
+/// Runs `task` for each path on the blocking pool, each run holding one
+/// permit from the dispatcher's shared I/O budget. A permit covers one file
+/// read, so other users of the budget can make progress between files.
+async fn run_fingerprint_tasks<T: Send + 'static>(
+    paths: impl IntoIterator<Item = PathBuf>,
+    io_semaphore: Option<Arc<Semaphore>>,
+    task: impl Fn(PathBuf) -> T + Clone + Send + 'static,
+) -> Vec<T> {
+    use futures::StreamExt;
+
+    let paths = paths.into_iter().collect::<std::collections::BTreeSet<_>>();
+    let worker_count = paths
+        .len()
+        .min(
+            std::thread::available_parallelism()
+                .map(usize::from)
+                .unwrap_or(1),
+        )
+        .max(1);
+    futures::stream::iter(paths)
+        .map(|path| {
+            let io_semaphore = io_semaphore.clone();
+            let task = task.clone();
+            async move {
+                spawn_blocking_with_io_permit(io_semaphore, move || task(path))
+                    .await
+                    .expect("file fingerprint task panicked")
+            }
+        })
+        .buffer_unordered(worker_count)
+        .collect()
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::OpenOptions, time::Duration};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn set_modified(path: &std::path::Path, modified: SystemTime) {
+        OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(modified)
+            .unwrap();
+    }
+
+    fn mtime(path: &std::path::Path) -> SystemTime {
+        fs_err::metadata(path).unwrap().modified().unwrap()
+    }
+
+    #[tokio::test]
+    async fn capture_records_fingerprints_for_regular_files() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        assert!(matches!(
+            snapshot.get(&file),
+            Some(InputFileState::Fingerprint(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn capture_falls_back_to_mtime_for_unhashable_files() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("assets");
+        fs_err::create_dir_all(&dir).unwrap();
+
+        let snapshot = InputSnapshot::capture([dir.clone()], None, None).await;
+        assert!(matches!(
+            snapshot.get(&dir),
+            Some(InputFileState::MtimeOnly(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn capture_drops_missing_files() {
+        let temp = TempDir::new().unwrap();
+        let missing = temp.path().join("gone.py");
+
+        let snapshot = InputSnapshot::capture([missing], None, None).await;
+        assert!(snapshot.is_empty());
+    }
+
+    #[tokio::test]
+    async fn capture_drops_files_modified_after_the_cutoff() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let cutoff = mtime(&file) - Duration::from_secs(10);
+        let snapshot = InputSnapshot::capture([file], Some(cutoff), None).await;
+        assert!(snapshot.is_empty());
+    }
+
+    #[tokio::test]
+    async fn verify_is_fresh_for_unchanged_files() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        assert!(matches!(
+            snapshot.verify([file], None, None).await,
+            SnapshotFreshness::Fresh
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_refreshes_a_touched_but_unchanged_file() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let touched = mtime(&file) + Duration::from_secs(1);
+        set_modified(&file, touched);
+
+        match snapshot.verify([file.clone()], None, None).await {
+            SnapshotFreshness::Refreshed(refreshed) => {
+                assert_eq!(refreshed.get(&file).unwrap().modified(), touched);
+            }
+            other => panic!("expected a refresh, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_is_stale_for_a_same_size_edit() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"old").unwrap();
+
+        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let touched = mtime(&file) + Duration::from_secs(1);
+        fs_err::write(&file, b"new").unwrap();
+        set_modified(&file, touched);
+
+        assert!(matches!(
+            snapshot.verify([file], None, None).await,
+            SnapshotFreshness::Stale(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_is_stale_for_a_deleted_file() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        fs_err::remove_file(&file).unwrap();
+
+        assert!(matches!(
+            snapshot.verify([file], None, None).await,
+            SnapshotFreshness::Stale(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_is_stale_when_an_mtime_only_file_is_touched() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("assets");
+        fs_err::create_dir_all(&dir).unwrap();
+
+        let snapshot = InputSnapshot::capture([dir.clone()], None, None).await;
+        assert!(matches!(
+            snapshot.verify([dir.clone()], None, None).await,
+            SnapshotFreshness::Fresh
+        ));
+
+        // A recorded mtime that no longer matches must invalidate; an
+        // mtime-only file can never be re-verified through a hash.
+        let touched = InputFileState::MtimeOnly(mtime(&dir) + Duration::from_secs(1));
+        let snapshot = InputSnapshot::from_iter([(dir.clone(), touched)]);
+        assert!(matches!(
+            snapshot.verify([dir], None, None).await,
+            SnapshotFreshness::Stale(_)
+        ));
+    }
+
+    /// Files without a recorded state (entries written before fingerprints
+    /// existed) pass the cutoff check but never gain a hash: with nothing to
+    /// compare against, a hash of the current contents proves nothing.
+    #[tokio::test]
+    async fn verify_uses_the_cutoff_for_unrecorded_files_and_never_hashes_them() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+        let snapshot = InputSnapshot::default();
+
+        let cutoff = mtime(&file) + Duration::from_secs(10);
+        assert!(matches!(
+            snapshot.verify([file.clone()], Some(cutoff), None).await,
+            SnapshotFreshness::Fresh
+        ));
+
+        assert!(matches!(
+            snapshot.verify([file.clone()], None, None).await,
+            SnapshotFreshness::Stale(_)
+        ));
+
+        set_modified(&file, cutoff + Duration::from_secs(10));
+        assert!(matches!(
+            snapshot.verify([file], Some(cutoff), None).await,
+            SnapshotFreshness::Stale(_)
+        ));
+    }
+}

--- a/crates/pixi_command_dispatcher/src/input_snapshot.rs
+++ b/crates/pixi_command_dispatcher/src/input_snapshot.rs
@@ -328,6 +328,12 @@ impl InputSnapshot {
                     current.modified,
                 ));
             }
+            tracing::debug!(
+                path = %path,
+                recorded_mtime = %chrono::DateTime::<chrono::Utc>::from(expected.modified),
+                observed_mtime = %chrono::DateTime::<chrono::Utc>::from(current.modified),
+                "input file mtime moved but its contents are unchanged; keeping the cache hit"
+            );
             refreshed.push((path, current));
         }
         SnapshotFreshness::Refreshed(refreshed)

--- a/crates/pixi_command_dispatcher/src/input_snapshot.rs
+++ b/crates/pixi_command_dispatcher/src/input_snapshot.rs
@@ -95,9 +95,19 @@ enum StateComparison {
 
 /// The recorded validation state of every input file of a cache entry.
 #[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(transparent)]
 pub(crate) struct InputSnapshot {
     files: BTreeMap<PathBuf, InputFileState>,
+
+    /// When the states were observed. An unconfirmed fingerprint in this
+    /// snapshot may only confirm a later capture whose build started after
+    /// this; otherwise the two observations do not bracket that build's
+    /// reads. Absent for snapshots that never ran a capture.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "system_time_serde::optional"
+    )]
+    captured_at: Option<SystemTime>,
 }
 
 /// Result of [`InputSnapshot::verify`].
@@ -178,11 +188,14 @@ impl InputSnapshot {
     /// the build itself rewrote) may not match what the build read, so its
     /// hash is recorded as [`InputFileState::Unconfirmed`] and the entry
     /// rebuilds once more. When `previous` (the entry this one replaces)
-    /// observed the same content, it was stable across both builds and the
-    /// state is promoted to a trusted fingerprint. An edit in between changes
-    /// the hash and breaks the promotion; an excursion that ends at the old
-    /// content is the race the fast path already accepts everywhere. An
-    /// mtime-only file past the cutoff keeps its mtime: it cannot be
+    /// observed the same content *before this build started*, the content
+    /// was stable while the build read it and the state is promoted to a
+    /// trusted fingerprint. Both halves matter: without the time bound, a
+    /// concurrent build that read older content could have its artifact
+    /// vouched for by another process's observation. An edit in between
+    /// changes the hash and breaks the promotion; an excursion that ends at
+    /// the old content is the race the fast path already accepts everywhere.
+    /// An mtime-only file past the cutoff keeps its mtime: it cannot be
     /// confirmed by a second observation, but it must stay tracked.
     pub(crate) async fn capture(
         paths: impl IntoIterator<Item = PathBuf>,
@@ -220,7 +233,15 @@ impl InputSnapshot {
                             // Content equality across the two captures is
                             // what matters; the mtime may move (e.g. a build
                             // regenerating the file with identical bytes).
+                            // The previous observation must predate this
+                            // build (the cutoff) or it cannot bracket the
+                            // build's reads.
                             let confirmed = previous
+                                .filter(|previous| {
+                                    previous
+                                        .captured_at
+                                        .is_some_and(|observed| observed <= cutoff)
+                                })
                                 .and_then(|previous| previous.files.get(&path))
                                 .and_then(InputFileState::fingerprint)
                                 .is_some_and(|prev| {
@@ -250,7 +271,11 @@ impl InputSnapshot {
             }),
             started,
         );
-        Self { files }
+        Self {
+            files,
+            // Taken after all hashing: every observation predates it.
+            captured_at: Some(SystemTime::now()),
+        }
     }
 
     /// Verifies `files` against their recorded state.
@@ -355,6 +380,7 @@ impl FromIterator<(PathBuf, InputFileState)> for InputSnapshot {
     fn from_iter<T: IntoIterator<Item = (PathBuf, InputFileState)>>(iter: T) -> Self {
         Self {
             files: iter.into_iter().collect(),
+            captured_at: None,
         }
     }
 }
@@ -479,26 +505,37 @@ mod tests {
         ));
     }
 
-    /// The two-observation promotion: content that is stable across two
-    /// captures is what the second build read, even when the mtime stays
-    /// past the cutoff or moves between the builds.
+    /// Dates the file ahead of the clock, so it lands past any cutoff taken
+    /// "now" (a skewed mount, a restored snapshot).
+    fn set_future_mtime(path: &std::path::Path) {
+        set_modified(path, SystemTime::now() + Duration::from_secs(3600));
+    }
+
+    /// The two-observation promotion: content observed before this build
+    /// started and unchanged at its capture is what the build read.
     #[tokio::test]
     async fn capture_promotes_an_unconfirmed_fingerprint_seen_twice() {
         let temp = TempDir::new().unwrap();
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
-        let cutoff = mtime(&file) - Duration::from_secs(10);
+        set_future_mtime(&file);
 
-        let first = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
-        set_modified(&file, mtime(&file) + Duration::from_secs(1));
-        let second = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&first), None).await;
+        let first =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), None, None).await;
+        assert!(matches!(
+            first.get(&file),
+            Some(InputFileState::Unconfirmed(_))
+        ));
 
+        let second =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&first), None)
+                .await;
         assert!(matches!(
             second.get(&file),
             Some(InputFileState::Fingerprint(_))
         ));
         assert!(matches!(
-            second.verify([file], Some(cutoff), None).await,
+            second.verify([file], None, None).await,
             SnapshotFreshness::Fresh
         ));
     }
@@ -508,17 +545,43 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"old").unwrap();
-        let cutoff = mtime(&file) - Duration::from_secs(10);
+        set_future_mtime(&file);
 
-        let first = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        let first =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), None, None).await;
         fs_err::write(&file, b"new").unwrap();
-        set_modified(&file, mtime(&file) + Duration::from_secs(1));
-        let second = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&first), None).await;
+        set_future_mtime(&file);
+        let second =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&first), None)
+                .await;
 
         assert!(matches!(
             second.get(&file),
             Some(InputFileState::Unconfirmed(_))
         ));
+    }
+
+    /// A previous observation taken after this build started cannot bracket
+    /// the build's reads: another process's capture must not confirm content
+    /// this build may never have seen.
+    #[tokio::test]
+    async fn capture_does_not_promote_an_observation_from_during_the_build() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+        set_future_mtime(&file);
+
+        let build_started = SystemTime::now();
+        let concurrent =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), None, None).await;
+        let captured =
+            InputSnapshot::capture([file.clone()], Some(build_started), Some(&concurrent), None)
+                .await;
+
+        assert!(
+            matches!(captured.get(&file), Some(InputFileState::Unconfirmed(_))),
+            "an observation from during the build must not promote",
+        );
     }
 
     #[tokio::test]
@@ -643,7 +706,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
-        let cutoff = mtime(&file) - Duration::from_secs(10);
+        set_future_mtime(&file);
 
         let first = InputSnapshot::capture([file.clone()], None, None, None).await;
         assert!(matches!(
@@ -651,14 +714,18 @@ mod tests {
             Some(InputFileState::Fingerprint(_))
         ));
 
-        let second = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&first), None).await;
+        let second =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&first), None)
+                .await;
         assert!(
             matches!(second.get(&file), Some(InputFileState::Fingerprint(_))),
             "a trusted previous observation of the same content must promote",
         );
 
         // And the trust survives further captures that keep seeing it.
-        let third = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&second), None).await;
+        let third =
+            InputSnapshot::capture([file.clone()], Some(SystemTime::now()), Some(&second), None)
+                .await;
         assert!(matches!(
             third.get(&file),
             Some(InputFileState::Fingerprint(_))
@@ -701,12 +768,13 @@ mod tests {
         let fresh = temp.path().join("fresh.py");
         fs_err::write(&seen, b"").unwrap();
         fs_err::write(&fresh, b"").unwrap();
-        let cutoff = mtime(&seen).min(mtime(&fresh)) - Duration::from_secs(10);
+        set_future_mtime(&seen);
+        set_future_mtime(&fresh);
 
         let previous = InputSnapshot::capture([seen.clone()], None, None, None).await;
         let captured = InputSnapshot::capture(
             [seen.clone(), fresh.clone()],
-            Some(cutoff),
+            Some(SystemTime::now()),
             Some(&previous),
             None,
         )

--- a/crates/pixi_command_dispatcher/src/input_snapshot.rs
+++ b/crates/pixi_command_dispatcher/src/input_snapshot.rs
@@ -20,6 +20,12 @@ use crate::file_fingerprint::{
 pub(crate) enum InputFileState {
     /// Content hash plus the size and mtime observed when it was computed.
     Fingerprint(FileFingerprint),
+    /// Hashed after the build's cutoff (e.g. an mtime ahead of the clock),
+    /// so the hash may not describe what the build read. Counts as changed
+    /// until a later capture observes the identical fingerprint and promotes
+    /// it: content that is stable across two builds is what the second build
+    /// read.
+    Unconfirmed(FileFingerprint),
     /// Only an mtime: the file could not be hashed when the entry was stored
     /// (unreadable or not a regular file). Any mtime change counts as a
     /// content change.
@@ -30,8 +36,20 @@ impl InputFileState {
     /// The mtime recorded for the file.
     pub(crate) fn modified(&self) -> SystemTime {
         match self {
-            InputFileState::Fingerprint(fingerprint) => fingerprint.modified,
+            InputFileState::Fingerprint(fingerprint) | InputFileState::Unconfirmed(fingerprint) => {
+                fingerprint.modified
+            }
             InputFileState::MtimeOnly(modified) => *modified,
+        }
+    }
+
+    /// The recorded fingerprint, if the file was hashed.
+    fn fingerprint(&self) -> Option<&FileFingerprint> {
+        match self {
+            InputFileState::Fingerprint(fingerprint) | InputFileState::Unconfirmed(fingerprint) => {
+                Some(fingerprint)
+            }
+            InputFileState::MtimeOnly(_) => None,
         }
     }
 
@@ -55,6 +73,8 @@ impl InputFileState {
                     StateComparison::Changed
                 }
             }
+            // The hash cannot be trusted until a second capture confirms it.
+            InputFileState::Unconfirmed(_) => StateComparison::Changed,
             InputFileState::MtimeOnly(expected) => {
                 if modified == *expected {
                     StateComparison::Unchanged
@@ -110,6 +130,9 @@ pub(crate) enum StaleFileReason {
         recorded: SystemTime,
         observed: SystemTime,
     },
+    /// The file was modified while the entry was being built; only a rebuild
+    /// can confirm its contents.
+    Unconfirmed,
 }
 
 impl StaleFile {
@@ -149,14 +172,22 @@ impl InputSnapshot {
 
     /// Captures the current state of `paths`. Never fails: an unhashable
     /// file is recorded mtime-only and a file that cannot be stat'ed is
-    /// dropped. A file modified after `cutoff` is dropped as well; its
-    /// contents may not match what the entry was built from. This means a
-    /// file whose mtime is ahead of the clock (skewed mount, restored
-    /// snapshot) never gets a state and rebuilds on every run. Promoting its
-    /// hash would need a second build to confirm the content is stable.
+    /// dropped.
+    ///
+    /// A file modified after `cutoff` (an mtime ahead of the clock, or a file
+    /// the build itself rewrote) may not match what the build read, so its
+    /// hash is recorded as [`InputFileState::Unconfirmed`] and the entry
+    /// rebuilds once more. When `previous` (the entry this one replaces)
+    /// observed the same content, it was stable across both builds and the
+    /// state is promoted to a trusted fingerprint. An edit in between changes
+    /// the hash and breaks the promotion; an excursion that ends at the old
+    /// content is the race the fast path already accepts everywhere. An
+    /// mtime-only file past the cutoff keeps its mtime: it cannot be
+    /// confirmed by a second observation, but it must stay tracked.
     pub(crate) async fn capture(
         paths: impl IntoIterator<Item = PathBuf>,
         cutoff: Option<SystemTime>,
+        previous: Option<&InputSnapshot>,
         io_semaphore: Option<Arc<Semaphore>>,
     ) -> Self {
         let started = std::time::Instant::now();
@@ -181,13 +212,41 @@ impl InputSnapshot {
 
         let files: BTreeMap<_, _> = outcomes
             .into_iter()
-            .filter_map(|(path, state)| Some((path, state?)))
-            .filter(|(_, state)| cutoff.is_none_or(|cutoff| state.modified() <= cutoff))
+            .filter_map(|(path, state)| {
+                let state = state?;
+                let state = match cutoff {
+                    Some(cutoff) if state.modified() > cutoff => match state {
+                        InputFileState::Fingerprint(fingerprint) => {
+                            // Content equality across the two captures is
+                            // what matters; the mtime may move (e.g. a build
+                            // regenerating the file with identical bytes).
+                            let confirmed = previous
+                                .and_then(|previous| previous.files.get(&path))
+                                .and_then(InputFileState::fingerprint)
+                                .is_some_and(|prev| {
+                                    prev.hash == fingerprint.hash && prev.size == fingerprint.size
+                                });
+                            if confirmed {
+                                InputFileState::Fingerprint(fingerprint)
+                            } else {
+                                InputFileState::Unconfirmed(fingerprint)
+                            }
+                        }
+                        // An mtime cannot be confirmed by a second
+                        // observation, but dropping it would untrack the
+                        // file; keep it validated by its mtime.
+                        InputFileState::Unconfirmed(_) | InputFileState::MtimeOnly(_) => state,
+                    },
+                    _ => state,
+                };
+                Some((path, state))
+            })
             .collect();
         log_hash_stats(
-            files.values().map(|state| match state {
-                InputFileState::Fingerprint(fingerprint) => fingerprint.size,
-                InputFileState::MtimeOnly(_) => 0,
+            files.values().map(|state| {
+                state
+                    .fingerprint()
+                    .map_or(0, |fingerprint| fingerprint.size)
             }),
             started,
         );
@@ -217,6 +276,12 @@ impl InputSnapshot {
                     StateComparison::Unchanged => {}
                     StateComparison::HashRequired => to_hash.push(path),
                     StateComparison::Changed => {
+                        if matches!(state, InputFileState::Unconfirmed(_)) {
+                            return SnapshotFreshness::Stale(StaleFile {
+                                path,
+                                reason: StaleFileReason::Unconfirmed,
+                            });
+                        }
                         let recorded = state.modified();
                         return SnapshotFreshness::Stale(match observed {
                             Some(observed) => StaleFile::modified(path, recorded, observed),
@@ -365,7 +430,7 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
         assert!(matches!(
             snapshot.get(&file),
             Some(InputFileState::Fingerprint(_))
@@ -378,7 +443,7 @@ mod tests {
         let dir = temp.path().join("assets");
         fs_err::create_dir_all(&dir).unwrap();
 
-        let snapshot = InputSnapshot::capture([dir.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([dir.clone()], None, None, None).await;
         assert!(matches!(
             snapshot.get(&dir),
             Some(InputFileState::MtimeOnly(_))
@@ -390,19 +455,70 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let missing = temp.path().join("gone.py");
 
-        let snapshot = InputSnapshot::capture([missing], None, None).await;
+        let snapshot = InputSnapshot::capture([missing], None, None, None).await;
         assert!(snapshot.is_empty());
     }
 
     #[tokio::test]
-    async fn capture_drops_files_modified_after_the_cutoff() {
+    async fn capture_records_files_modified_after_the_cutoff_as_unconfirmed() {
         let temp = TempDir::new().unwrap();
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
         let cutoff = mtime(&file) - Duration::from_secs(10);
-        let snapshot = InputSnapshot::capture([file], Some(cutoff), None).await;
-        assert!(snapshot.is_empty());
+        let snapshot = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        assert!(matches!(
+            snapshot.get(&file),
+            Some(InputFileState::Unconfirmed(_))
+        ));
+
+        // An unconfirmed state cannot vouch for the cached outputs.
+        assert!(matches!(
+            snapshot.verify([file], Some(cutoff), None).await,
+            SnapshotFreshness::Stale(_)
+        ));
+    }
+
+    /// The two-observation promotion: content that is stable across two
+    /// captures is what the second build read, even when the mtime stays
+    /// past the cutoff or moves between the builds.
+    #[tokio::test]
+    async fn capture_promotes_an_unconfirmed_fingerprint_seen_twice() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+        let cutoff = mtime(&file) - Duration::from_secs(10);
+
+        let first = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        set_modified(&file, mtime(&file) + Duration::from_secs(1));
+        let second = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&first), None).await;
+
+        assert!(matches!(
+            second.get(&file),
+            Some(InputFileState::Fingerprint(_))
+        ));
+        assert!(matches!(
+            second.verify([file], Some(cutoff), None).await,
+            SnapshotFreshness::Fresh
+        ));
+    }
+
+    #[tokio::test]
+    async fn capture_does_not_promote_changed_content() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"old").unwrap();
+        let cutoff = mtime(&file) - Duration::from_secs(10);
+
+        let first = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        fs_err::write(&file, b"new").unwrap();
+        set_modified(&file, mtime(&file) + Duration::from_secs(1));
+        let second = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&first), None).await;
+
+        assert!(matches!(
+            second.get(&file),
+            Some(InputFileState::Unconfirmed(_))
+        ));
     }
 
     #[tokio::test]
@@ -411,7 +527,7 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
         assert!(matches!(
             snapshot.verify([file], None, None).await,
             SnapshotFreshness::Fresh
@@ -424,7 +540,7 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
         let touched = mtime(&file) + Duration::from_secs(1);
         set_modified(&file, touched);
 
@@ -442,7 +558,7 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"old").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
         let touched = mtime(&file) + Duration::from_secs(1);
         fs_err::write(&file, b"new").unwrap();
         set_modified(&file, touched);
@@ -459,7 +575,7 @@ mod tests {
         let file = temp.path().join("main.py");
         fs_err::write(&file, b"body").unwrap();
 
-        let snapshot = InputSnapshot::capture([file.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([file.clone()], None, None, None).await;
         fs_err::remove_file(&file).unwrap();
 
         assert!(matches!(
@@ -474,7 +590,7 @@ mod tests {
         let dir = temp.path().join("assets");
         fs_err::create_dir_all(&dir).unwrap();
 
-        let snapshot = InputSnapshot::capture([dir.clone()], None, None).await;
+        let snapshot = InputSnapshot::capture([dir.clone()], None, None, None).await;
         assert!(matches!(
             snapshot.verify([dir.clone()], None, None).await,
             SnapshotFreshness::Fresh
@@ -516,5 +632,135 @@ mod tests {
             snapshot.verify([file], Some(cutoff), None).await,
             SnapshotFreshness::Stale(_)
         ));
+    }
+
+    /// Promotion only asks whether the previous capture saw the same content;
+    /// it does not care whether that previous state was itself trusted. A file
+    /// whose mtime stays past the cutoff forever must therefore keep its
+    /// trusted fingerprint instead of falling back to unconfirmed.
+    #[tokio::test]
+    async fn capture_promotes_when_the_previous_state_is_a_trusted_fingerprint() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+        let cutoff = mtime(&file) - Duration::from_secs(10);
+
+        let first = InputSnapshot::capture([file.clone()], None, None, None).await;
+        assert!(matches!(
+            first.get(&file),
+            Some(InputFileState::Fingerprint(_))
+        ));
+
+        let second = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&first), None).await;
+        assert!(
+            matches!(second.get(&file), Some(InputFileState::Fingerprint(_))),
+            "a trusted previous observation of the same content must promote",
+        );
+
+        // And the trust survives further captures that keep seeing it.
+        let third = InputSnapshot::capture([file.clone()], Some(cutoff), Some(&second), None).await;
+        assert!(matches!(
+            third.get(&file),
+            Some(InputFileState::Fingerprint(_))
+        ));
+    }
+
+    /// A path that previously held something unhashable (a directory) carries
+    /// no fingerprint, so when a regular file takes its place past the cutoff
+    /// there is nothing to confirm it against.
+    #[tokio::test]
+    async fn capture_does_not_promote_a_path_that_was_previously_mtime_only() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("assets");
+        fs_err::create_dir_all(&path).unwrap();
+
+        let first = InputSnapshot::capture([path.clone()], None, None, None).await;
+        assert!(matches!(
+            first.get(&path),
+            Some(InputFileState::MtimeOnly(_))
+        ));
+
+        fs_err::remove_dir(&path).unwrap();
+        fs_err::write(&path, b"body").unwrap();
+        let cutoff = mtime(&path) - Duration::from_secs(10);
+
+        let second = InputSnapshot::capture([path.clone()], Some(cutoff), Some(&first), None).await;
+        assert!(
+            matches!(second.get(&path), Some(InputFileState::Unconfirmed(_))),
+            "an mtime-only predecessor cannot vouch for any content",
+        );
+    }
+
+    /// Every empty file shares one hash, so content equality alone would let
+    /// any empty input confirm any other. Promotion is keyed by path, which is
+    /// what keeps them apart.
+    #[tokio::test]
+    async fn capture_promotion_is_keyed_by_path_not_by_content() {
+        let temp = TempDir::new().unwrap();
+        let seen = temp.path().join("seen.py");
+        let fresh = temp.path().join("fresh.py");
+        fs_err::write(&seen, b"").unwrap();
+        fs_err::write(&fresh, b"").unwrap();
+        let cutoff = mtime(&seen).min(mtime(&fresh)) - Duration::from_secs(10);
+
+        let previous = InputSnapshot::capture([seen.clone()], None, None, None).await;
+        let captured = InputSnapshot::capture(
+            [seen.clone(), fresh.clone()],
+            Some(cutoff),
+            Some(&previous),
+            None,
+        )
+        .await;
+
+        assert!(
+            matches!(captured.get(&seen), Some(InputFileState::Fingerprint(_))),
+            "the path the previous capture recorded must be promoted",
+        );
+        assert!(
+            matches!(captured.get(&fresh), Some(InputFileState::Unconfirmed(_))),
+            "an identical-but-unseen path must not borrow another path's confirmation",
+        );
+    }
+
+    /// The cutoff is exclusive: a file whose mtime lands exactly on it was
+    /// not modified after the build started.
+    #[tokio::test]
+    async fn capture_treats_an_mtime_equal_to_the_cutoff_as_trusted() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let cutoff = mtime(&file);
+        let snapshot = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        assert!(matches!(
+            snapshot.get(&file),
+            Some(InputFileState::Fingerprint(_))
+        ));
+
+        set_modified(&file, cutoff + Duration::from_secs(1));
+        let snapshot = InputSnapshot::capture([file.clone()], Some(cutoff), None, None).await;
+        assert!(matches!(
+            snapshot.get(&file),
+            Some(InputFileState::Unconfirmed(_))
+        ));
+    }
+
+    /// An unhashable input (a directory) whose mtime is past the cutoff must
+    /// stay in the snapshot: dropping it would silently remove it from
+    /// validation. The recorded mtime is no less trustworthy than one
+    /// recorded before the cutoff.
+    #[tokio::test]
+    async fn capture_must_not_silently_untrack_an_mtime_only_file_past_the_cutoff() {
+        let temp = TempDir::new().unwrap();
+        let dir = temp.path().join("assets");
+        fs_err::create_dir_all(&dir).unwrap();
+        let cutoff = mtime(&dir) - Duration::from_secs(10);
+
+        let snapshot = InputSnapshot::capture([dir.clone()], Some(cutoff), None, None).await;
+        assert!(
+            matches!(snapshot.get(&dir), Some(InputFileState::MtimeOnly(_))),
+            "dropping the input leaves it unvalidated forever, which is weaker \
+             than any recorded state",
+        );
     }
 }

--- a/crates/pixi_command_dispatcher/src/input_snapshot.rs
+++ b/crates/pixi_command_dispatcher/src/input_snapshot.rs
@@ -135,13 +135,17 @@ pub(crate) struct StaleFile {
 /// Why verification rejected the file.
 #[derive(Debug)]
 pub(crate) enum StaleFileReason {
-    /// The file can no longer be stat'ed or read.
+    /// The file no longer exists.
     Removed,
+    /// The file exists but its contents or metadata could not be read.
+    Unreadable,
     /// The recorded state no longer matches the file.
     Modified {
         recorded: SystemTime,
         observed: SystemTime,
     },
+    /// The entry records no state for the file, so nothing can verify it.
+    Untracked,
     /// The file was modified while the entry was being built; only a rebuild
     /// can confirm its contents.
     Unconfirmed,
@@ -155,10 +159,34 @@ impl StaleFile {
         }
     }
 
+    fn unreadable(path: AbsPathBuf) -> Self {
+        Self {
+            path,
+            reason: StaleFileReason::Unreadable,
+        }
+    }
+
+    fn untracked(path: AbsPathBuf) -> Self {
+        Self {
+            path,
+            reason: StaleFileReason::Untracked,
+        }
+    }
+
     fn modified(path: AbsPathBuf, recorded: SystemTime, observed: SystemTime) -> Self {
         Self {
             path,
             reason: StaleFileReason::Modified { recorded, observed },
+        }
+    }
+
+    /// A missing file was removed; any other I/O failure means the file is
+    /// still there but cannot be verified.
+    fn from_io(path: AbsPathBuf, kind: std::io::ErrorKind) -> Self {
+        if kind == std::io::ErrorKind::NotFound {
+            Self::removed(path)
+        } else {
+            Self::unreadable(path)
         }
     }
 }
@@ -317,8 +345,11 @@ impl InputSnapshot {
 
         let mut refreshed = Vec::with_capacity(hashed.len());
         for (path, current) in hashed {
-            let Ok(current) = current else {
-                return SnapshotFreshness::Stale(StaleFile::removed(path));
+            let current = match current {
+                Ok(current) => current,
+                Err(err) => {
+                    return SnapshotFreshness::Stale(StaleFile::from_io(path, err.source.kind()));
+                }
             };
             let expected = to_hash[&path];
             if expected.hash != current.hash {
@@ -369,8 +400,9 @@ fn classify_files(
 ) -> Result<BTreeMap<AbsPathBuf, FileFingerprint>, StaleFile> {
     let mut to_hash = BTreeMap::new();
     for (path, state) in states {
-        let Ok(metadata) = fs_err::metadata(path.as_std_path()) else {
-            return Err(StaleFile::removed(path));
+        let metadata = match fs_err::metadata(path.as_std_path()) {
+            Ok(metadata) => metadata,
+            Err(err) => return Err(StaleFile::from_io(path, err.kind())),
         };
         let observed = metadata.modified().ok();
         match state {
@@ -392,7 +424,7 @@ fn classify_files(
                     let recorded = state.modified();
                     return Err(match observed {
                         Some(observed) => StaleFile::modified(path, recorded, observed),
-                        None => StaleFile::removed(path),
+                        None => StaleFile::unreadable(path),
                     });
                 }
             },
@@ -400,12 +432,14 @@ fn classify_files(
                 let unchanged = fallback_cutoff
                     .is_some_and(|cutoff| observed.is_some_and(|modified| modified <= cutoff));
                 if !unchanged {
-                    let Some(observed) = observed else {
-                        return Err(StaleFile::removed(path));
-                    };
-                    // With no recorded state the cutoff is the baseline.
-                    let recorded = fallback_cutoff.unwrap_or(observed);
-                    return Err(StaleFile::modified(path, recorded, observed));
+                    return Err(match (fallback_cutoff, observed) {
+                        // With no recorded state the cutoff is the baseline.
+                        (Some(cutoff), Some(observed)) => {
+                            StaleFile::modified(path, cutoff, observed)
+                        }
+                        (None, _) => StaleFile::untracked(path),
+                        (_, None) => StaleFile::unreadable(path),
+                    });
                 }
             }
         }
@@ -703,6 +737,51 @@ mod tests {
             snapshot.verify([abs(&dir)], None, None).await,
             SnapshotFreshness::Stale(_)
         ));
+    }
+
+    /// A file the snapshot has no state for and no cutoff to compare against
+    /// is reported as untracked, not as a modification from a time to itself.
+    #[tokio::test]
+    async fn verify_reports_a_stateless_file_without_cutoff_as_untracked() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        match InputSnapshot::default()
+            .verify([abs(&file)], None, None)
+            .await
+        {
+            SnapshotFreshness::Stale(stale) => {
+                assert!(matches!(stale.reason, StaleFileReason::Untracked))
+            }
+            other => panic!("expected a stale result, got {other:?}"),
+        }
+    }
+
+    /// A file that exists but cannot be hashed is unreadable, not removed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn verify_reports_a_permission_denied_file_as_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("main.py");
+        fs_err::write(&file, b"body").unwrap();
+
+        let snapshot = InputSnapshot::capture([abs(&file)], None, None, None).await;
+        set_modified(&file, mtime(&file) + Duration::from_secs(1));
+        fs_err::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if fs_err::File::open(&file).is_ok() {
+            // Running as root; the permission bits cannot deny anything.
+            return;
+        }
+
+        match snapshot.verify([abs(&file)], None, None).await {
+            SnapshotFreshness::Stale(stale) => {
+                assert!(matches!(stale.reason, StaleFileReason::Unreadable))
+            }
+            other => panic!("expected a stale result, got {other:?}"),
+        }
     }
 
     /// Files without a recorded state (entries written before fingerprints

--- a/crates/pixi_command_dispatcher/src/keys/backend_binary_fingerprint.rs
+++ b/crates/pixi_command_dispatcher/src/keys/backend_binary_fingerprint.rs
@@ -7,17 +7,11 @@
 //! [`crate::cache::backend_metadata::BuildBackendMetadataCacheEntry`] and
 //! compared on cache probe.
 
-use std::{
-    fs::File,
-    io::{BufReader, Read},
-    path::PathBuf,
-    sync::Arc,
-};
+use std::{fs::File, path::PathBuf, sync::Arc};
 
 use derive_more::Display;
 use pixi_compute_engine::{ComputeCtx, Key};
 use thiserror::Error;
-use xxhash_rust::xxh3::Xxh3;
 
 use crate::input_hash::BackendBinaryFingerprint;
 
@@ -42,21 +36,10 @@ impl Key for BackendBinaryFingerprintKey {
     async fn compute(&self, _ctx: &mut ComputeCtx) -> Self::Value {
         let path = self.0.path.clone();
         tokio::task::spawn_blocking(move || {
-            let file = File::open(&path)
-                .map_err(|err| BackendBinaryFingerprintError::new(path.clone(), err))?;
-            let mut reader = BufReader::new(file);
-            let mut hasher = Xxh3::new();
-            let mut buf = [0u8; 64 * 1024];
-            loop {
-                let n = reader
-                    .read(&mut buf)
-                    .map_err(|err| BackendBinaryFingerprintError::new(path.clone(), err))?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buf[..n]);
-            }
-            Ok(BackendBinaryFingerprint::new(hasher.digest()))
+            File::open(&path)
+                .and_then(crate::file_fingerprint::hash_file_contents)
+                .map(BackendBinaryFingerprint::new)
+                .map_err(|err| BackendBinaryFingerprintError::new(path, err))
         })
         .await
         .expect("spawn_blocking panicked while fingerprinting backend binary")

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -36,7 +36,7 @@ use crate::{
     InstallPixiEnvironmentExt, InstallPixiEnvironmentSpec, InstantiateBackendKey,
     ProjectModelOverrides, SourceBuildError,
     build::{Dependencies, PixiRunExports, convert_extra_dependencies},
-    compute_data::HasGateway,
+    compute_data::{HasGateway, HasIoConcurrencySemaphore},
 };
 use pixi_compute_cache_dirs::CacheDirsExt;
 use pixi_compute_sources::SourceCheckoutExt;
@@ -218,7 +218,8 @@ async fn compute_inner(
     // Force-rebuild is handled by wiping the cache entry before calling;
     // this body honors whatever state it finds on disk.
     let artifacts_dir = ctx.cache_dir::<SourceBuildArtifactsDir>().await;
-    let artifact_cache = ArtifactCache::new(artifacts_dir.as_std_path());
+    let artifact_cache = ArtifactCache::new(artifacts_dir.as_std_path())
+        .with_io_concurrency_semaphore(ctx.global_data().io_concurrency_semaphore().cloned());
     let source_dir = build_source_checkout
         .path
         .as_dir_or_file_parent()

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -819,6 +819,9 @@ fn map_cache_err(err: ArtifactCacheError) -> SourceBuildError {
         }
         ArtifactCacheError::Glob(err) => SourceBuildError::GlobSet(err),
         ArtifactCacheError::ArtifactFilename(path) => SourceBuildError::MissingOutputFile(path),
+        ArtifactCacheError::Fingerprint { path, source } => {
+            SourceBuildError::FingerprintInput(path, source)
+        }
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -834,9 +834,6 @@ fn map_cache_err(err: ArtifactCacheError) -> SourceBuildError {
         }
         ArtifactCacheError::Glob(err) => SourceBuildError::GlobSet(err),
         ArtifactCacheError::ArtifactFilename(path) => SourceBuildError::MissingOutputFile(path),
-        ArtifactCacheError::Fingerprint { path, source } => {
-            SourceBuildError::FingerprintInput(path, source)
-        }
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -833,6 +833,9 @@ fn map_cache_err(err: ArtifactCacheError) -> SourceBuildError {
         }
         ArtifactCacheError::Glob(err) => SourceBuildError::GlobSet(err),
         ArtifactCacheError::ArtifactFilename(path) => SourceBuildError::MissingOutputFile(path),
+        ArtifactCacheError::Fingerprint { path, source } => {
+            SourceBuildError::FingerprintInput(path, source)
+        }
     }
 }
 

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -447,6 +447,9 @@ async fn compute_inner(
 
     let editable =
         matches!(spec.build_profile, BuildProfile::Development) && spec.record.has_mutable_source();
+    // Anything the backend reads it reads after this point; a file modified
+    // later gets an unconfirmed fingerprint in the cache entry.
+    let build_started = std::time::SystemTime::now();
     let built = ctx
         .backend_source_build(BackendSourceBuildSpec {
             method: BackendSourceBuildMethod::BuildV1(BackendSourceBuildV1Method {
@@ -509,6 +512,7 @@ async fn compute_inner(
             &built.output_file,
             input_glob_sets,
             input_files,
+            build_started,
             record,
         )
         .await

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -37,7 +37,7 @@ use crate::{
     InstallPixiEnvironmentExt, InstallPixiEnvironmentSpec, InstantiateBackendKey,
     ProjectModelOverrides, SourceBuildError,
     build::{Dependencies, PixiRunExports, convert_extra_dependencies},
-    compute_data::HasGateway,
+    compute_data::{HasGateway, HasIoConcurrencySemaphore},
 };
 use pixi_compute_cache_dirs::CacheDirsExt;
 use pixi_compute_sources::SourceCheckoutExt;
@@ -219,7 +219,8 @@ async fn compute_inner(
     // Force-rebuild is handled by wiping the cache entry before calling;
     // this body honors whatever state it finds on disk.
     let artifacts_dir = ctx.cache_dir::<SourceBuildArtifactsDir>().await;
-    let artifact_cache = ArtifactCache::new(artifacts_dir.as_std_path());
+    let artifact_cache = ArtifactCache::new(artifacts_dir.as_std_path())
+        .with_io_concurrency_semaphore(ctx.global_data().io_concurrency_semaphore().cloned());
     let source_dir = build_source_checkout
         .path
         .as_dir_or_file_parent()

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -55,6 +55,7 @@ mod injected_config;
 mod inline_package;
 mod input_globs;
 mod input_hash;
+mod input_snapshot;
 mod install_binary;
 mod install_pixi;
 mod installed_source_hints;

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -50,6 +50,7 @@ mod discovered_backend;
 pub mod environment;
 mod ephemeral_env;
 mod errors;
+mod file_fingerprint;
 mod injected_config;
 mod inline_package;
 mod input_globs;

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -80,9 +81,7 @@ def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspac
 
 
 @pytest.mark.slow
-def test_recipe_change_trigger_metadata_invalidation(
-    pixi: Path, simple_workspace: Workspace
-) -> None:
+def test_touching_recipe_does_not_trigger_rebuild(pixi: Path, simple_workspace: Workspace) -> None:
     simple_workspace.write_files()
 
     verify_cli_command(
@@ -96,8 +95,12 @@ def test_recipe_change_trigger_metadata_invalidation(
         stderr_contains=BUILD_RUNNING_STRING,
     )
 
-    # Touch the recipe
-    simple_workspace.recipe_path.touch()
+    # Change only the recipe mtime.
+    stat = simple_workspace.recipe_path.stat()
+    os.utime(
+        simple_workspace.recipe_path,
+        ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000),
+    )
 
     verify_cli_command(
         [
@@ -107,7 +110,7 @@ def test_recipe_change_trigger_metadata_invalidation(
             "--manifest-path",
             simple_workspace.workspace_dir,
         ],
-        stderr_contains=BUILD_RUNNING_STRING,
+        stderr_excludes=BUILD_RUNNING_STRING,
     )
 
 

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -80,10 +79,12 @@ def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspac
     assert simple_workspace.find_debug_file("conda_build_v1_params.json") is None
 
 
-def bump_mtime(path: Path) -> None:
-    """Moves the mtime forward by one second without touching the contents."""
-    stat = path.stat()
-    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+def conda_artifact_mtimes(workspace: Workspace) -> dict[Path, int]:
+    """The mtimes of every `.conda` pixi built for this workspace, keyed by path."""
+    return {
+        path: path.stat().st_mtime_ns
+        for path in sorted(workspace.workspace_dir.joinpath(".pixi").rglob("*.conda"))
+    }
 
 
 def install(pixi: Path, workspace: Workspace, expect_build: bool) -> None:
@@ -104,10 +105,15 @@ def install(pixi: Path, workspace: Workspace, expect_build: bool) -> None:
 def test_touching_recipe_does_not_trigger_rebuild(pixi: Path, simple_workspace: Workspace) -> None:
     simple_workspace.write_files()
     install(pixi, simple_workspace, expect_build=True)
+    artifacts = conda_artifact_mtimes(simple_workspace)
+    assert artifacts, "the first install must have built a package"
 
-    bump_mtime(simple_workspace.recipe_path)
+    simple_workspace.recipe_path.touch()
 
     install(pixi, simple_workspace, expect_build=False)
+
+    # The cached artifacts are served as they are, not written again.
+    assert conda_artifact_mtimes(simple_workspace) == artifacts
 
 
 @pytest.mark.slow
@@ -124,7 +130,6 @@ def test_same_size_recipe_edit_triggers_rebuild(pixi: Path, simple_workspace: Wo
     edited = original.replace("version: 1.0.0", "version: 1.0.1")
     assert len(edited) == len(original), "the edit must not change the file size"
     simple_workspace.recipe_path.write_text(edited)
-    bump_mtime(simple_workspace.recipe_path)
 
     install(pixi, simple_workspace, expect_build=True)
 

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -115,6 +115,50 @@ def test_touching_recipe_does_not_trigger_rebuild(pixi: Path, simple_workspace: 
 
 
 @pytest.mark.slow
+def test_same_size_recipe_edit_triggers_rebuild(pixi: Path, simple_workspace: Workspace) -> None:
+    """The counterpart to touching the recipe. Both a touch and this edit
+    change only the mtime and leave the size alone, so the hash is the only
+    thing that separates them. A wrong hash wiring here would silently serve
+    the previous artifact."""
+    simple_workspace.write_files()
+
+    verify_cli_command(
+        [
+            pixi,
+            "install",
+            "-v",
+            "--manifest-path",
+            simple_workspace.workspace_dir,
+        ],
+        stderr_contains=BUILD_RUNNING_STRING,
+    )
+
+    original = simple_workspace.recipe_path.read_text()
+    assert "version: 1.0.0" in original
+    edited = original.replace("version: 1.0.0", "version: 1.0.1")
+    assert len(edited) == len(original), "the edit must not change the file size"
+    stat = simple_workspace.recipe_path.stat()
+    simple_workspace.recipe_path.write_text(edited)
+    # Move the mtime exactly the way the touch test does, so the two tests
+    # differ only in whether the bytes changed.
+    os.utime(
+        simple_workspace.recipe_path,
+        ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000),
+    )
+
+    verify_cli_command(
+        [
+            pixi,
+            "install",
+            "-v",
+            "--manifest-path",
+            simple_workspace.workspace_dir,
+        ],
+        stderr_contains=BUILD_RUNNING_STRING,
+    )
+
+
+@pytest.mark.slow
 def test_project_model_change_trigger_rebuild(pixi: Path, simple_workspace: Workspace) -> None:
     simple_workspace.write_files()
     verify_cli_command(

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -80,38 +80,34 @@ def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspac
     assert simple_workspace.find_debug_file("conda_build_v1_params.json") is None
 
 
+def bump_mtime(path: Path) -> None:
+    """Moves the mtime forward by one second without touching the contents."""
+    stat = path.stat()
+    os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+
+
+def install(pixi: Path, workspace: Workspace, expect_build: bool) -> None:
+    verify_cli_command(
+        [
+            pixi,
+            "install",
+            "-v",
+            "--manifest-path",
+            workspace.workspace_dir,
+        ],
+        stderr_contains=BUILD_RUNNING_STRING if expect_build else None,
+        stderr_excludes=None if expect_build else BUILD_RUNNING_STRING,
+    )
+
+
 @pytest.mark.slow
 def test_touching_recipe_does_not_trigger_rebuild(pixi: Path, simple_workspace: Workspace) -> None:
     simple_workspace.write_files()
+    install(pixi, simple_workspace, expect_build=True)
 
-    verify_cli_command(
-        [
-            pixi,
-            "install",
-            "-v",
-            "--manifest-path",
-            simple_workspace.workspace_dir,
-        ],
-        stderr_contains=BUILD_RUNNING_STRING,
-    )
+    bump_mtime(simple_workspace.recipe_path)
 
-    # Change only the recipe mtime.
-    stat = simple_workspace.recipe_path.stat()
-    os.utime(
-        simple_workspace.recipe_path,
-        ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000),
-    )
-
-    verify_cli_command(
-        [
-            pixi,
-            "install",
-            "-v",
-            "--manifest-path",
-            simple_workspace.workspace_dir,
-        ],
-        stderr_excludes=BUILD_RUNNING_STRING,
-    )
+    install(pixi, simple_workspace, expect_build=False)
 
 
 @pytest.mark.slow
@@ -121,41 +117,16 @@ def test_same_size_recipe_edit_triggers_rebuild(pixi: Path, simple_workspace: Wo
     thing that separates them. A wrong hash wiring here would silently serve
     the previous artifact."""
     simple_workspace.write_files()
-
-    verify_cli_command(
-        [
-            pixi,
-            "install",
-            "-v",
-            "--manifest-path",
-            simple_workspace.workspace_dir,
-        ],
-        stderr_contains=BUILD_RUNNING_STRING,
-    )
+    install(pixi, simple_workspace, expect_build=True)
 
     original = simple_workspace.recipe_path.read_text()
     assert "version: 1.0.0" in original
     edited = original.replace("version: 1.0.0", "version: 1.0.1")
     assert len(edited) == len(original), "the edit must not change the file size"
-    stat = simple_workspace.recipe_path.stat()
     simple_workspace.recipe_path.write_text(edited)
-    # Move the mtime exactly the way the touch test does, so the two tests
-    # differ only in whether the bytes changed.
-    os.utime(
-        simple_workspace.recipe_path,
-        ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000),
-    )
+    bump_mtime(simple_workspace.recipe_path)
 
-    verify_cli_command(
-        [
-            pixi,
-            "install",
-            "-v",
-            "--manifest-path",
-            simple_workspace.workspace_dir,
-        ],
-        stderr_contains=BUILD_RUNNING_STRING,
-    )
+    install(pixi, simple_workspace, expect_build=True)
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Editors, git operations, and copy tools constantly touch source files without changing them. For path-based source dependencies every such touch invalidates both the cached backend metadata and the built artifact, so a workspace with a few source packages keeps rebuilding them while nothing actually changed. That is the pain behind prefix-dev/pixi#5347.

The fix: when only a file's mtime moved, hash its contents and keep the cache hit if they are unchanged. Unchanged size + mtime stays the fast path with no hashing (the same tradeoff make and ninja make), and a real edit still invalidates. On a warm filesystem, hashing 10,000 small files costs about 24 ms over the stat pass, so this stays cheap even when a whole tree was touched.

The guiding rule throughout: a hash only counts when it provably describes what the build read. That is why entries written by older pixi versions are not upgraded in place (they cost one rebuild on their first touch instead of risking a permanently wrong hit), and why a file modified during the build, or carrying an mtime ahead of the clock, needs a second build to confirm its content before its hash is trusted. Wherever content cannot be proven, one extra rebuild wins over a stale artifact.

Both caches share one type, `InputSnapshot`, that captures and verifies the per-file state. A few artifact cache races (lookup vs. concurrent store, refresh vs. `pixi build --clean`) are closed along the way.

This plugs into the miss-reason logging from prefix-dev/pixi#6784, so a rebuild explains itself with the file and the evidence (`-v` shows the debug events):

```
DEBUG artifact cache miss, rebuilding package="foo" key=3xI9qA reason=input file modified: /work/foo/src/main.py (mtime at build time 2026-08-12 09:14:03 UTC, now 2026-08-12 10:02:41 UTC)
DEBUG artifact cache miss, rebuilding package="foo" key=3xI9qA reason=input file removed: /work/foo/src/gone.py
DEBUG artifact cache miss, rebuilding package="foo" key=3xI9qA reason=input file added: /work/foo/src/extra.py
DEBUG artifact cache miss, rebuilding package="foo" key=3xI9qA reason=entry changed while it was being validated
```

The first one now also covers content changes proven by the hash, and a touched-but-unchanged file produces no miss at all. The tests assert these reasons rather than a bare hit or miss.

Closes prefix-dev/pixi#5347.

## Testing

133 crate tests, including an adversarial suite (legacy sidecars, mtime restoration, special files, concurrent store/lookup), and clippy with `-D warnings`. The two integration tests (touch keeps the cache, same-size edit rebuilds) run in CI only; this checkout cannot build the backend binaries.