### PR TITLE
chore: bump backend versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-ros"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "pixi-build-ros"
 repository.workspace = true
-version = "0.6.5"
+version = "0.7.0"
 
 [package.metadata.dist]
 dist = false


### PR DESCRIPTION
Automated backend version bump.

Fixing that stale files in the `.pixi/bld` folder are wrapped in the resulting package that will be installed in the following environment.