### PR TITLE
fix: don't abort `workspace platform remove` when the host platform g…

### DIFF
--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -39,6 +39,40 @@ pub async fn get_workspace_platform(
         .cloned()
 }
 
+/// Whether this machine can still install the default environment.
+///
+/// A platform edit can drop -- or retarget -- the only platform the host is
+/// able to run. Both the manifest change and the lock-file refresh remain
+/// valid in that case; only materialising a prefix here is impossible.
+fn host_can_install(workspace: &Workspace) -> bool {
+    workspace
+        .default_environment()
+        .best_declared_platform()
+        .is_some()
+}
+
+/// Tell the user why nothing was installed after a platform change left the
+/// workspace without a platform this machine can run.
+async fn report_skipped_install<I: Interface>(interface: &I, workspace: &Workspace) {
+    let platforms = workspace
+        .workspace_manifest()
+        .workspace
+        .platforms
+        .iter()
+        .map(|p| p.name().as_str())
+        .collect::<Vec<_>>();
+    let message = if platforms.is_empty() {
+        "Skipped installing the environment. The workspace no longer declares any platform."
+            .to_string()
+    } else {
+        format!(
+            "Skipped installing the environment. This machine can't run any of the remaining platforms: {}.",
+            platforms.join(", ")
+        )
+    };
+    interface.warning(&message).await;
+}
+
 /// Apply an edit to an existing workspace platform identified by `name`.
 /// Updates the lockfile and saves the manifest.
 pub async fn edit<I: Interface>(
@@ -51,13 +85,17 @@ pub async fn edit<I: Interface>(
 ) -> miette::Result<()> {
     workspace.manifest().edit_workspace_platform(&name, edit)?;
 
+    // Failing here would strand the manifest edit while the refreshed lock
+    // file is already on disk, so skip the install rather than the edit.
+    let skipped_install = !no_install && !host_can_install(workspace.workspace());
+
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
         workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,
-            no_install,
+            no_install: no_install || skipped_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
             ..Default::default()
         },
@@ -65,9 +103,12 @@ pub async fn edit<I: Interface>(
         &InstallFilter::default(),
     )
     .await?;
-    workspace.save().await.into_diagnostic()?;
+    let workspace = workspace.save().await.into_diagnostic()?;
 
     interface.success(&format!("Updated platform {name}")).await;
+    if skipped_install {
+        report_skipped_install(interface, &workspace).await;
+    }
     Ok(())
 }
 
@@ -307,13 +348,17 @@ pub async fn remove<I: Interface>(
         .manifest()
         .remove_platforms(platforms.iter(), &feature_name)?;
 
+    // Failing here would strand the removal while the refreshed lock file is
+    // already on disk, so skip the install rather than the removal.
+    let skipped_install = !no_install && !host_can_install(workspace.workspace());
+
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
         workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,
-            no_install,
+            no_install: no_install || skipped_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
             ..Default::default()
         },
@@ -321,7 +366,7 @@ pub async fn remove<I: Interface>(
         &InstallFilter::default(),
     )
     .await?;
-    workspace.save().await.into_diagnostic()?;
+    let workspace = workspace.save().await.into_diagnostic()?;
 
     // Report back to the user
     for platform in platforms {
@@ -335,6 +380,9 @@ pub async fn remove<I: Interface>(
                 }
             ))
             .await;
+    }
+    if skipped_install {
+        report_skipped_install(interface, &workspace).await;
     }
 
     Ok(())

--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -39,6 +39,40 @@ pub async fn get_workspace_platform(
         .cloned()
 }
 
+/// Whether this machine can still install the default environment.
+///
+/// A platform edit can drop -- or retarget -- the only platform the host is
+/// able to run. Both the manifest change and the lock-file refresh remain
+/// valid in that case; only materialising a prefix here is impossible.
+fn host_can_install(workspace: &Workspace) -> bool {
+    workspace
+        .default_environment()
+        .best_declared_platform()
+        .is_some()
+}
+
+/// Tell the user why nothing was installed after a platform change left the
+/// workspace without a platform this machine can run.
+async fn report_skipped_install<I: Interface>(interface: &I, workspace: &Workspace) {
+    let platforms = workspace
+        .workspace_manifest()
+        .workspace
+        .platforms
+        .iter()
+        .map(|p| p.name().as_str())
+        .collect::<Vec<_>>();
+    let message = if platforms.is_empty() {
+        "Skipped installing the environment. The workspace no longer declares any platform."
+            .to_string()
+    } else {
+        format!(
+            "Skipped installing the environment. This machine can't run any of the remaining platforms: {}.",
+            platforms.join(", ")
+        )
+    };
+    interface.warning(&message).await;
+}
+
 /// Apply an edit to an existing workspace platform identified by `name`.
 /// Updates the lockfile and saves the manifest.
 pub async fn edit<I: Interface>(
@@ -50,13 +84,17 @@ pub async fn edit<I: Interface>(
 ) -> miette::Result<()> {
     workspace.manifest().edit_workspace_platform(&name, edit)?;
 
+    // Failing here would strand the manifest edit while the refreshed lock
+    // file is already on disk, so skip the install rather than the edit.
+    let skipped_install = !no_install && !host_can_install(workspace.workspace());
+
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
         None,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage: LockFileUsage::Update,
-            no_install,
+            no_install: no_install || skipped_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
             ..Default::default()
         },
@@ -64,9 +102,12 @@ pub async fn edit<I: Interface>(
         &InstallFilter::default(),
     )
     .await?;
-    workspace.save().await.into_diagnostic()?;
+    let workspace = workspace.save().await.into_diagnostic()?;
 
     interface.success(&format!("Updated platform {name}")).await;
+    if skipped_install {
+        report_skipped_install(interface, &workspace).await;
+    }
     Ok(())
 }
 
@@ -298,13 +339,17 @@ pub async fn remove<I: Interface>(
         .manifest()
         .remove_platforms(platforms.iter(), &feature_name)?;
 
+    // Failing here would strand the removal while the refreshed lock file is
+    // already on disk, so skip the install rather than the removal.
+    let skipped_install = !no_install && !host_can_install(workspace.workspace());
+
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
         None,
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage: LockFileUsage::Update,
-            no_install,
+            no_install: no_install || skipped_install,
             max_concurrent_solves: workspace.workspace().config().max_concurrent_solves(),
             ..Default::default()
         },
@@ -312,7 +357,7 @@ pub async fn remove<I: Interface>(
         &InstallFilter::default(),
     )
     .await?;
-    workspace.save().await.into_diagnostic()?;
+    let workspace = workspace.save().await.into_diagnostic()?;
 
     // Report back to the user
     for platform in platforms {
@@ -326,6 +371,9 @@ pub async fn remove<I: Interface>(
                 }
             ))
             .await;
+    }
+    if skipped_install {
+        report_skipped_install(interface, &workspace).await;
     }
 
     Ok(())

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -163,6 +163,7 @@ Adding a platform whose definition already exists under a *different* name is re
 - `pixi workspace platform remove <NAME>` drops an entry.
 
 The mutating subcommands keep `pixi.lock` in sync.
+If a change leaves no platform your machine can run, the manifest and `pixi.lock` are still updated, but the environment is not installed.
 
 ## Target specifier
 

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -184,6 +184,7 @@ Adding a platform whose definition already exists under a *different* name is re
 - `pixi workspace platform remove <NAME>` drops an entry.
 
 The mutating subcommands keep `pixi.lock` in sync.
+If a change leaves no platform your machine can run, the manifest and `pixi.lock` are still updated, but the environment is not installed.
 
 ## Target specifier
 

--- a/tests/integration_python/test_workspace_platform.py
+++ b/tests/integration_python/test_workspace_platform.py
@@ -11,8 +11,9 @@ commits. Heavy install/publish flows that don't fit pytest live in
 - lockfile invariants that are observable without a real solve (the platforms
   block at the top of `pixi.lock` is rewritten regardless of `--no-install`)
 
-To keep the suite fast everything uses `--no-install` and a manifest with no
-channels/dependencies so no network is involved.
+To keep the suite fast everything uses a manifest with no channels/dependencies
+so no network is involved, and `--no-install` wherever the install step isn't
+what's under test.
 """
 
 from __future__ import annotations
@@ -779,6 +780,36 @@ def test_edit_set_subdir(pixi: Path, tmp_pixi_workspace: Path) -> None:
     assert entry["cuda"] == "11.0"
 
 
+def test_edit_subdir_away_from_host_installs_nothing_but_still_edits(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """`edit` shares `remove`'s skip: retargeting the last platform this machine
+    can run leaves nothing to install, but the edit itself still has to land."""
+    other = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "osx-arm64"
+    manifest = tmp_pixi_workspace / "pixi.toml"
+    manifest.write_text(
+        f"""\
+[workspace]
+name = "platform-test"
+channels = []
+platforms = [{{ name = "host", platform = "{CURRENT_PLATFORM}" }}]
+"""
+    )
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "edit",
+        "host",
+        "--subdir",
+        other,
+        stderr_contains=[
+            "Updated platform host",
+            "can't run any of the remaining platforms",
+        ],
+    )
+    assert [_subdir(p) for p in _platforms_from_toml(manifest)] == [other]
+
+
 def test_edit_noop_rejected(pixi: Path, tmp_pixi_workspace: Path) -> None:
     _seed_with_rich_platform(tmp_pixi_workspace, pixi)
     _run_platform(
@@ -1165,6 +1196,68 @@ def test_remove_custom_platform_drops_vps(pixi: Path, tmp_pixi_workspace: Path) 
         for p in _platforms_from_toml(tmp_pixi_workspace / "pixi.toml")
     ]
     assert "gpu-linux" not in names
+
+
+def test_remove_current_platform_installs_nothing_but_still_edits(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """Removing the platform this machine runs must still edit the manifest.
+
+    The install that follows the edit has no runnable platform left to target.
+    That used to abort the command, leaving the manifest untouched while the
+    already-rewritten lockfile stayed on disk. Now the install is skipped with
+    a warning instead.
+    """
+    other = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "osx-arm64"
+    manifest = _seed_workspace(tmp_pixi_workspace, [CURRENT_PLATFORM, other])
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "remove",
+        CURRENT_PLATFORM,
+        stderr_contains=[
+            f"Removed {CURRENT_PLATFORM}",
+            f"can't run any of the remaining platforms: {other}",
+        ],
+    )
+    assert _platforms_from_toml(manifest) == [other]
+    lock_names = [
+        p if isinstance(p, str) else p["name"] for p in _lockfile_platforms(tmp_pixi_workspace)
+    ]
+    assert lock_names == [other]
+
+
+def test_remove_last_platform_installs_nothing_but_still_edits(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """Emptying the platform list is the degenerate case of the above: there is
+    nothing left to install, but the removal itself still has to land."""
+    manifest = _seed_workspace(tmp_pixi_workspace, [CURRENT_PLATFORM])
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "remove",
+        CURRENT_PLATFORM,
+        stderr_contains="The workspace no longer declares any platform",
+    )
+    assert _platforms_from_toml(manifest) == []
+    assert _lockfile_platforms(tmp_pixi_workspace) == []
+
+
+def test_remove_non_current_platform_still_installs(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """The skip is narrow: as long as a runnable platform survives the removal,
+    the environment is installed and no warning is emitted."""
+    other = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "osx-arm64"
+    _seed_workspace(tmp_pixi_workspace, [CURRENT_PLATFORM, other])
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "remove",
+        other,
+        stderr_contains=f"Removed {other}",
+        stderr_excludes="Skipped installing the environment",
+    )
+    assert (tmp_pixi_workspace / ".pixi" / "envs" / "default").is_dir()
 
 
 # ----------------------------------------------------------------------------

--- a/tests/integration_python/test_workspace_platform.py
+++ b/tests/integration_python/test_workspace_platform.py
@@ -11,10 +11,11 @@ commits. Heavy install/publish flows that don't fit pytest live in
 - lockfile invariants that are observable without a real solve (the platforms
   block at the top of `pixi.lock` is rewritten regardless of `--no-install`)
 
-To keep the suite fast everything uses `--no-install` and a manifest with no
-channels/dependencies so no network is involved. The one exception is the
-`--locked` legacy-alias test, which installs an empty environment (still
-offline) because `--locked` satisfiability is exactly what it verifies.
+To keep the suite fast everything uses a manifest with no channels/dependencies
+so no network is involved, and `--no-install` wherever the install step isn't
+what's under test. The one exception is the `--locked` legacy-alias test, which
+installs an empty environment (still offline) because `--locked` satisfiability
+is exactly what it verifies.
 """
 
 from __future__ import annotations
@@ -877,6 +878,36 @@ def test_edit_set_subdir(pixi: Path, tmp_pixi_workspace: Path) -> None:
     assert entry["cuda"] == "11.0"
 
 
+def test_edit_subdir_away_from_host_installs_nothing_but_still_edits(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """`edit` shares `remove`'s skip: retargeting the last platform this machine
+    can run leaves nothing to install, but the edit itself still has to land."""
+    other = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "osx-arm64"
+    manifest = tmp_pixi_workspace / "pixi.toml"
+    manifest.write_text(
+        f"""\
+[workspace]
+name = "platform-test"
+channels = []
+platforms = [{{ name = "host", platform = "{CURRENT_PLATFORM}" }}]
+"""
+    )
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "edit",
+        "host",
+        "--subdir",
+        other,
+        stderr_contains=[
+            "Updated platform host",
+            "can't run any of the remaining platforms",
+        ],
+    )
+    assert [_subdir(p) for p in _platforms_from_toml(manifest)] == [other]
+
+
 def test_edit_noop_rejected(pixi: Path, tmp_pixi_workspace: Path) -> None:
     _seed_with_rich_platform(tmp_pixi_workspace, pixi)
     _run_platform(
@@ -1361,6 +1392,68 @@ def test_remove_custom_platform_drops_vps(pixi: Path, tmp_pixi_workspace: Path) 
         for p in _platforms_from_toml(tmp_pixi_workspace / "pixi.toml")
     ]
     assert "gpu-linux" not in names
+
+
+def test_remove_current_platform_installs_nothing_but_still_edits(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """Removing the platform this machine runs must still edit the manifest.
+
+    The install that follows the edit has no runnable platform left to target.
+    That used to abort the command, leaving the manifest untouched while the
+    already-rewritten lockfile stayed on disk. Now the install is skipped with
+    a warning instead.
+    """
+    other = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "osx-arm64"
+    manifest = _seed_workspace(tmp_pixi_workspace, [CURRENT_PLATFORM, other])
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "remove",
+        CURRENT_PLATFORM,
+        stderr_contains=[
+            f"Removed {CURRENT_PLATFORM}",
+            f"can't run any of the remaining platforms: {other}",
+        ],
+    )
+    assert _platforms_from_toml(manifest) == [other]
+    lock_names = [
+        p if isinstance(p, str) else p["name"] for p in _lockfile_platforms(tmp_pixi_workspace)
+    ]
+    assert lock_names == [other]
+
+
+def test_remove_last_platform_installs_nothing_but_still_edits(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """Emptying the platform list is the degenerate case of the above: there is
+    nothing left to install, but the removal itself still has to land."""
+    manifest = _seed_workspace(tmp_pixi_workspace, [CURRENT_PLATFORM])
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "remove",
+        CURRENT_PLATFORM,
+        stderr_contains="The workspace no longer declares any platform",
+    )
+    assert _platforms_from_toml(manifest) == []
+    assert _lockfile_platforms(tmp_pixi_workspace) == []
+
+
+def test_remove_non_current_platform_still_installs(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """The skip is narrow: as long as a runnable platform survives the removal,
+    the environment is installed and no warning is emitted."""
+    other = "linux-aarch64" if CURRENT_PLATFORM != "linux-aarch64" else "osx-arm64"
+    _seed_workspace(tmp_pixi_workspace, [CURRENT_PLATFORM, other])
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "remove",
+        other,
+        stderr_contains=f"Removed {other}",
+        stderr_excludes="Skipped installing the environment",
+    )
+    assert (tmp_pixi_workspace / ".pixi" / "envs" / "default").is_dir()
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
…oes away

Removing the platform the current machine runs made the command fail: the manifest edit is applied in memory, the lock file is refreshed and written, and only then is `pixi.toml` saved. The install between those steps has no runnable platform left, so it errored out -- leaving the removal unsaved while the rewritten `pixi.lock` was already on disk.

The manifest edit and the lock-file refresh are both valid in that state; only materialising a prefix is impossible. Skip the install and warn instead of failing the whole command. `platform edit` gets the same treatment, since `--subdir` can retarget the last host-runnable platform the same way.

Fixes prefix-dev/pixi#6612

### How Has This Been Tested?

New unit tests

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.