### PR TITLE
fix: force reinstall with setuptools in ros backend

### DIFF
--- a/crates/pixi_build_ros/templates/bld_ament_python.bat
+++ b/crates/pixi_build_ros/templates/bld_ament_python.bat
@@ -15,11 +15,13 @@ set "PKG_NAME_SHORT=%PKG_NAME_SHORT:-=_%"
 findstr install[-_]scripts setup.cfg
 if "%errorlevel%" == "0" (
     %PYTHON% setup.py install --single-version-externally-managed --record="%RATTLER_BUILD_PACKAGE_FILES%" ^
+        --force ^
         --prefix=%LIBRARY_PREFIX% ^
         --install-lib=%SP_DIR% ^
          --install-scripts=%LIBRARY_PREFIX%\lib\%PKG_NAME_SHORT%
 ) else (
     %PYTHON% setup.py install --single-version-externally-managed --record="%RATTLER_BUILD_PACKAGE_FILES%" ^
+        --force ^
         --prefix=%LIBRARY_PREFIX% ^
         --install-lib=%SP_DIR% ^
         --install-scripts=%LIBRARY_PREFIX%\bin

--- a/crates/pixi_build_ros/templates/build_ament_python.sh
+++ b/crates/pixi_build_ros/templates/build_ament_python.sh
@@ -15,7 +15,7 @@ if [ -f setup.cfg ] && grep -q "install[-_]scripts" setup.cfg; then
     echo "WARNING: setup.cfg not set, will set INSTALL_SCRIPTS_ARG to: $INSTALL_SCRIPTS_ARG"
     # The prefix is reused, so record what this build installed instead of
     # letting rattler-build package the previous build's leftovers as well.
-    $PYTHON setup.py install --prefix="$PREFIX" --install-lib="$SP_DIR" $INSTALL_SCRIPTS_ARG --single-version-externally-managed --record="$RATTLER_BUILD_PACKAGE_FILES"
+    $PYTHON setup.py install --force --prefix="$PREFIX" --install-lib="$SP_DIR" $INSTALL_SCRIPTS_ARG --single-version-externally-managed --record="$RATTLER_BUILD_PACKAGE_FILES"
 
     # Remove build artifacts from setup.py install
     rm -rf *.egg-info 2>/dev/null || true


### PR DESCRIPTION
### Description

Fixes stale output where the MTIME of the source files are newer than the MTIME of the build cache. 

### How Has This Been Tested?

Tested with given reproducer

### AI Disclosure
AI was used to digest the issue the change was manual.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
