### PR TITLE
fix(publish): resolve the target subdir to the declared workspace platform

### DIFF
--- a/crates/pixi_cli/src/publish/mod.rs
+++ b/crates/pixi_cli/src/publish/mod.rs
@@ -628,8 +628,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         )
         .finish();
 
-    let target_pixi_platform = pixi_manifest::PixiPlatform::from_subdir(args.target_platform);
-    let build_pixi_platform = pixi_manifest::PixiPlatform::from_subdir(args.build_platform);
+    // Resolve the CLI subdirs to the platforms the workspace declares for them,
+    // so a declared `glibc = "2.34"` (and any other system requirement) reaches
+    // the build variants and the build/host virtual packages.
+    let target_pixi_platform = workspace.pixi_platform_for_subdir(args.target_platform);
+    let build_pixi_platform = workspace.pixi_platform_for_subdir(args.build_platform);
     let VariantConfig {
         mut variant_configuration,
         mut variant_files,

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -41,9 +41,9 @@ use pixi_config::{Config, RunPostLinkScripts};
 use pixi_consts::consts;
 use pixi_diff::LockFileDiff;
 use pixi_manifest::{
-    AssociateProvenance, BuildVariantSource, EnvironmentName, Environments, HasWorkspaceManifest,
-    LoadManifestsError, ManifestProvenance, Manifests, PackageManifest, PixiPlatform,
-    PixiPlatformName, SpecType, WithProvenance, WithWarnings, WorkspaceManifest,
+    AssociateProvenance, BuildVariantSource, EnvironmentName, Environments, FeaturesExt,
+    HasWorkspaceManifest, LoadManifestsError, ManifestProvenance, Manifests, PackageManifest,
+    PixiPlatform, PixiPlatformName, SpecType, WithProvenance, WithWarnings, WorkspaceManifest,
 };
 use pixi_path::AbsPathBuf;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
@@ -714,6 +714,44 @@ impl Workspace {
                 workspace: self,
                 solve_group: group,
             })
+    }
+
+    /// Resolves a conda subdir to the workspace platform that targets it.
+    ///
+    /// Commands that take a bare subdir on the command line (`pixi publish
+    /// --target-platform linux-64`) need the declared platform behind it: the
+    /// system requirements that a build depends on (`glibc`, `macos`, `cuda`,
+    /// ...) live on the `[workspace] platforms` entries, which may carry a
+    /// synthesized name like `linux-64-glibc-2-34`. Reaching for
+    /// [`PixiPlatform::from_subdir`] instead picks up pixi's portable defaults
+    /// (`__glibc = 2.28`), so the declared requirements silently drop out of
+    /// both the derived `c_stdlib`/`c_stdlib_version` build variants and the
+    /// virtual packages the build environments solve against
+    /// (prefix-dev/pixi#6709).
+    ///
+    /// Candidates are the declared platforms for `subdir` in manifest order,
+    /// preferring one the default environment selects -- which is also the
+    /// entry the composition pass registers for the legacy
+    /// `[system-requirements]` shape. A subdir the workspace does not declare
+    /// (cross-building for `osx-arm64` from a linux-only workspace, say) falls
+    /// back to the subdir baseline.
+    pub fn pixi_platform_for_subdir(&self, subdir: Platform) -> PixiPlatform {
+        let candidates: Vec<&PixiPlatform> = self
+            .workspace
+            .value
+            .workspace
+            .platforms
+            .iter()
+            .filter(|platform| platform.subdir() == subdir)
+            .collect();
+
+        let environment_platforms = self.default_environment().platforms();
+        candidates
+            .iter()
+            .find(|platform| environment_platforms.contains(platform.name()))
+            .or(candidates.first())
+            .map(|platform| (*platform).clone())
+            .unwrap_or_else(|| PixiPlatform::from_subdir(subdir))
     }
 
     /// Returns the resolved variant configuration for a given platform.
@@ -1709,6 +1747,65 @@ mod tests {
         assert_eq!(
             variants.get("c_stdlib_version"),
             Some(&vec![VariantValue::String("2.28".to_string())])
+        );
+    }
+
+    /// Reproduces #6709: a subdir handed to `pixi publish`/`pixi build` must
+    /// resolve to the platform the workspace declares for it, so its system
+    /// requirements reach the build. Resolving to the subdir baseline instead
+    /// would pin `c_stdlib_version` to pixi's default `2.28` and hand the build
+    /// solve a `__glibc = 2.28`, making the declared `glibc = "2.34"`
+    /// unreachable from a recipe.
+    #[test]
+    fn subdir_resolves_to_declared_platform() {
+        let file_contents = r#"
+            [workspace]
+            name = "foo"
+            channels = ["conda-forge"]
+            platforms = [{ platform = "linux-64", glibc = "2.34" }]
+            "#;
+        let workspace = Workspace::from_str(Path::new("pixi.toml"), file_contents).unwrap();
+
+        let platform = workspace.pixi_platform_for_subdir(Platform::Linux64);
+        assert_eq!(
+            platform
+                .declared_virtual_packages()
+                .iter()
+                .find(|vp| vp.name.as_normalized() == "__glibc")
+                .map(|vp| vp.version.to_string()),
+            Some("2.34".to_string())
+        );
+
+        let variants = workspace.variants(&platform).unwrap().variant_configuration;
+        assert_eq!(
+            variants.get("c_stdlib_version"),
+            Some(&vec![VariantValue::String("2.34".to_string())])
+        );
+    }
+
+    /// A workspace that declares plain subdirs keeps the subdir baseline, and a
+    /// subdir it doesn't declare at all (cross-building) falls back to it too.
+    #[test]
+    fn subdir_without_declared_customisation_uses_baseline() {
+        let file_contents = r#"
+            [workspace]
+            name = "foo"
+            channels = ["conda-forge"]
+            platforms = ["linux-64"]
+            "#;
+        let workspace = Workspace::from_str(Path::new("pixi.toml"), file_contents).unwrap();
+
+        let declared = workspace.pixi_platform_for_subdir(Platform::Linux64);
+        assert_eq!(
+            declared.declared_virtual_packages(),
+            PixiPlatform::from_subdir(Platform::Linux64).declared_virtual_packages()
+        );
+
+        let undeclared = workspace.pixi_platform_for_subdir(Platform::OsxArm64);
+        assert_eq!(undeclared.name().as_str(), "osx-arm64");
+        assert_eq!(
+            undeclared.declared_virtual_packages(),
+            PixiPlatform::from_subdir(Platform::OsxArm64).declared_virtual_packages()
         );
     }
 


### PR DESCRIPTION
Fixes prefix-dev/pixi#6709.

### Problem

`pixi publish` — and `pixi build`, which delegates to it — turned the `--target-platform` / `--build-platform` subdirs into platforms with `PixiPlatform::from_subdir`:

```rust
let target_pixi_platform = PixiPlatform::from_subdir(args.target_platform);
```

That fabricates the *subdir baseline*, carrying pixi's portable defaults (`__glibc = 2.28`), and never consults `[workspace] platforms`. An entry like `{ platform = "linux-64", glibc = "2.34" }` parses into a rich platform with a synthesized name (`linux-64-glibc-2-34`), which such a lookup can never match, so the declared system requirements dropped out of both places a build needs them:

* `Workspace::variants()` derived `c_stdlib_version = 2.28` instead of `2.34`, so `stdlib('c')` expanded to `sysroot_linux-64 =2.28`;
* the build/host virtual packages carried `__glibc 2.28`, so pinning `sysroot_linux-64 2.34.*` by hand failed with `__glibc >=2.34, for which no candidates were found`.

Building the very same package as a *source dependency* was always correct: `lock_file::platform_setup` passes the environment's real (rich) platform. The two paths therefore also disagreed on the build hash for identical sources.

### Fix

Add `Workspace::pixi_platform_for_subdir()` and use it for both the target and the build platform. It resolves a subdir to the platform the workspace declares for it, preferring one the default environment selects — which is also the entry the composition pass registers for the legacy `[system-requirements]` shape — and falls back to the subdir baseline for subdirs the workspace does not declare, e.g. a cross-build target.

### Verification

Against the reporter's reproducer ([https://github.com/crusaderky/pixi-glibc-version-poc](<https://github.com/crusaderky/pixi-glibc-version-poc>)), which now builds; its self-evidencing block prints:

```
resolved c_stdlib_version ....... 2.34
resolved stdlib('c') ............ sysroot_linux-64 =2.34
sysroot glibc ................... 2.34
addchdir_np declared in sysroot . yes
```

<!-- linear:table-colwidths:266,266,266 -->
| case | before | after |
| -- | -- | -- |
| `platforms = [{ platform = "linux-64", glibc = "2.34" }]`, `pixi build` | `c_stdlib_version=2.28`, solve fails on `sysroot 2.34` | `sysroot_linux-64 =2.34` resolves, `__glibc >=2.34` run export |
| legacy `[system-requirements] libc = "2.34"` | `2.28` | `2.34` |
| bare `platforms = ["linux-64"]` | `2.28` | `2.28` (unchanged) |

Two unit tests cover the resolution and the baseline fallback.

### Not addressed here

A recipe's own `variants.yaml` still cannot set `c_stdlib_version`: `extend_with_input_variants` inserts pixi's variant configuration over anything loaded from variant files. Deferring to the recipe would desync pixi's own build/host solves, which take `__glibc` from the platform — the workspace platform has to stay the source of truth. What is worth a follow-up is that the override is *silent*; a warning when an injected variant replaces a differing value from a variant file would have made the original report a lot shorter. Likewise, `--target-platform` accepting a platform *name* would let workspaces with several rich platforms per subdir choose explicitly, instead of getting the first declared match.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)