### PR TITLE
chore: bump pixi-build-python to 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6065,7 +6065,7 @@ dependencies = [
 
 [[package]]
 name = "pixi-build-python"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "async-trait",
  "fs-err",

--- a/crates/pixi_build_python/Cargo.toml
+++ b/crates/pixi_build_python/Cargo.toml
@@ -2,7 +2,7 @@
 edition.workspace = true
 license.workspace = true
 name = "pixi-build-python"
-version = "0.8.3"
+version = "0.8.4"
 
 [package.metadata.dist]
 dist = false


### PR DESCRIPTION
Automated backend version bump.