### PR TITLE
chore: fix pre-commit during backends release script

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,8 +1,8 @@
-lefthook: pixi run --no-progress lefthook
+lefthook: pixi run --no-progress --environment=lefthook lefthook
 no_auto_install: true
 
 templates:
-  run: run --quiet --no-progress
+  run: run --environment=default --quiet --no-progress
 
 colors: true
 
@@ -21,13 +21,13 @@ pre-commit:
   parallel: true
   jobs:
     - name: actionlint
-      run: pixi {run} -e default actionlint
+      run: pixi {run} actionlint
     - name: zizmor
-      run: pixi {run} -e default zizmor --no-progress
+      run: pixi {run} zizmor --no-progress
     - name: cargo-fmt
       glob: "*.rs"
       stage_fixed: true
-      run: pixi {run} -e default cargo-fmt
+      run: pixi {run} cargo-fmt
     - name: ruff
       glob: "*.{py,pyi}"
       stage_fixed: true
@@ -35,46 +35,46 @@ pre-commit:
         piped: true
         jobs:
           - name: ruff lint
-            run: pixi {run} -e default ruff-lint {staged_files}
+            run: pixi {run} ruff-lint {staged_files}
           - name: ruff format
-            run: pixi {run} -e default ruff-fmt {staged_files}
+            run: pixi {run} ruff-fmt {staged_files}
     - name: cargo-shear
       glob: "*.rs,Cargo.toml"
       stage_fixed: true
-      run: pixi {run} -e default cargo-shear
+      run: pixi {run} cargo-shear
     - name: shell-format
       glob: "*.{sh, bash}"
-      run: pixi {run} -e default shell-fmt {staged_files}
+      run: pixi {run} shell-fmt {staged_files}
     - name: taplo
       stage_fixed: true
       glob: "*.toml"
       exclude:
         - schema/examples/invalid/*.toml
-      run: pixi {run} -e default toml-fmt {staged_files}
+      run: pixi {run} toml-fmt {staged_files}
     - name: dprint
       glob: "*.{yaml,yml}"
       group:
         jobs:
           - name: dprint check
-            run: pixi {run} -e default dprint-check {staged_files}
+            run: pixi {run} dprint-check {staged_files}
           - name: dprint fmt
-            run: pixi {run} -e default dprint-fmt {staged_files}
+            run: pixi {run} dprint-fmt {staged_files}
             stage_fixed: true
     - name: typos
       stage_fixed: true
-      run: pixi {run} -e default typos
+      run: pixi {run} typos
     - name: typecheck-python
       glob: "*.{py,pyi}"
-      run: pixi {run} -e default typecheck-python
+      run: pixi {run} typecheck-python
 
 pre-push:
   jobs:
     - name: cargo-clippy
       glob: "*.rs"
-      run: pixi {run} -e default cargo-clippy
+      run: pixi {run} cargo-clippy
     - name: cargo-deny
       glob: "Cargo.lock,Cargo.toml"
       stage_fixed: true
-      run: pixi {run} -e default cargo-deny
+      run: pixi {run} cargo-deny
     - name: check-openssl
-      run: pixi {run} -e default check-openssl
+      run: pixi {run} check-openssl


### PR DESCRIPTION
I must be the only one of us who uses the pre-commit hook and runs the `release-backends` task 😅

Adding `--environment=lefthook` on L1 avoids the error:

```console
$ git commit --all --message chore: bump backend versions
Error:   × the task 'lefthook' is not available in environment 'backends-release'
  help: The task is defined in environment(s): lefthook.

        Run it there with:

        	pixi run --environment lefthook lefthook
```

---

The rest of the diff is just a simplification of what you added in 8b6c901c27c77a41d857d5b83e75dea16bb33e6b @ruben-arts 