### PR TITLE
feat(platforms): keep installed environments on their platform and report new ones

### DIFF
--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -529,6 +529,13 @@ impl InstallBuilder {
         self
     }
 
+    /// `--platform` with a workspace platform name, which -- unlike a bare
+    /// conda subdir -- can be a custom name from `[workspace] platforms`.
+    pub fn with_platform_name(mut self, name: &str) -> Self {
+        self.args.platform = Some(name.parse().expect("valid platform name"));
+        self
+    }
+
     pub fn with_environment(mut self, env: Vec<String>) -> Self {
         self.args.environment = Some(env);
         self

--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -535,6 +535,13 @@ impl InstallBuilder {
         self
     }
 
+    /// `--platform` with a workspace platform name, which -- unlike a bare
+    /// conda subdir -- can be a custom name from `[workspace] platforms`.
+    pub fn with_platform_name(mut self, name: &str) -> Self {
+        self.args.platform = Some(name.parse().expect("valid platform name"));
+        self
+    }
+
     pub fn with_environment(mut self, env: Vec<String>) -> Self {
         self.args.environment = Some(env);
         self

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -23,6 +23,9 @@ use pixi_core::{
     lock_file::{CondaPrefixUpdater, ReinstallPackages, UpdateMode},
     workspace::{HasWorkspaceRef, grouped_environment::GroupedEnvironment},
 };
+// Only used by the linux-gated `a_lapsed_pin_offers_no_alternatives` test below.
+#[cfg(target_os = "linux")]
+use pixi_core::workspace::platform_options::alternative_platforms;
 use pixi_manifest::{FeatureName, FeaturesExt};
 use pixi_record::PixiRecord;
 use rattler_conda_types::{Platform, RepoDataRecord};
@@ -2151,6 +2154,146 @@ no-deps = "*"
             .iter()
             .any(|vp| vp.name.as_normalized() == "__linux" && vp.version.to_string() == "5.4"),
         "resolved platform should declare __linux 5.4, got {virtual_packages:?}"
+    );
+}
+
+/// A platform that becomes runnable after an environment is installed must not
+/// take the prefix over: it stays put until asked with `--platform`.
+///
+/// `tuned` is declared *first*, so it would win on a fresh workspace -- the
+/// point is that an installed environment ignores that ordering. Both `__linux`
+/// versions sit below any realistic host kernel so both really run here.
+/// Linux-only: `__linux` only gates installs on linux hosts.
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_newly_runnable_platform_does_not_move_an_installed_environment() {
+    let channel_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/data/channels/channels/virtual_packages");
+    let channel_path = fs_err::canonicalize(channel_path).expect("canonicalize channel path");
+    let channel_url = Url::from_directory_path(&channel_path).expect("valid file url");
+
+    let manifest = |platforms: &str| {
+        format!(
+            r#"
+[workspace]
+name = "platform-pin"
+channels = ["{channel_url}"]
+platforms = [{platforms}]
+
+[dependencies]
+no-deps = "*"
+"#
+        )
+    };
+
+    // The `__linux` version recorded in `conda-meta/pixi` identifies which of
+    // the two platforms the prefix was installed for.
+    let recorded_linux_version = |pixi: &PixiControl| {
+        let marker_path = pixi
+            .default_env_path()
+            .unwrap()
+            .join(consts::CONDA_META_DIR)
+            .join(consts::ENVIRONMENT_FILE_NAME);
+        let marker: serde_json::Value =
+            serde_json::from_str(&fs_err::read_to_string(&marker_path).unwrap()).unwrap();
+        let virtual_packages: Vec<rattler_conda_types::GenericVirtualPackage> =
+            serde_json::from_value(marker["resolved_platform"]["virtual_packages"].clone())
+                .expect("resolved_platform should record virtual packages");
+        virtual_packages
+            .iter()
+            .find(|vp| vp.name.as_normalized() == "__linux")
+            .map(|vp| vp.version.to_string())
+            .expect("resolved platform should declare __linux")
+    };
+
+    // Install with only the plain `linux-64` platform available.
+    let pixi = PixiControl::from_manifest(&manifest(r#""linux-64""#)).unwrap();
+    pixi.install().await.unwrap();
+    let installed_for = recorded_linux_version(&pixi);
+
+    // A second platform shows up that also runs here, declared ahead of the
+    // installed one so platform selection would prefer it.
+    pixi.update_manifest(&manifest(
+        r#"{ name = "tuned", platform = "linux-64", linux = "5.4" }, "linux-64""#,
+    ))
+    .unwrap();
+    pixi.install().await.unwrap();
+    assert_eq!(
+        recorded_linux_version(&pixi),
+        installed_for,
+        "an installed environment must stay on its platform when another becomes runnable"
+    );
+
+    // Asking for the other platform switches, and the switch is recorded, so it
+    // survives later commands that pass no `--platform`.
+    pixi.install().with_platform_name("tuned").await.unwrap();
+    assert_eq!(
+        recorded_linux_version(&pixi),
+        "5.4",
+        "`--platform` must move the environment"
+    );
+    pixi.install().await.unwrap();
+    assert_eq!(
+        recorded_linux_version(&pixi),
+        "5.4",
+        "a later bare install must not undo the switch"
+    );
+}
+
+/// A machine that cannot run the platform its environment is installed for gets
+/// no alternatives offered: the pin has lapsed, so the environment is about to
+/// move whatever the user picks, and listing options would imply a choice.
+///
+/// `future` demands a kernel no host has, so it is installable only via
+/// `--platform` and never runnable. Linux-only: `__linux` only gates installs on
+/// linux hosts.
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_lapsed_pin_offers_no_alternatives() {
+    let channel_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/data/channels/channels/virtual_packages");
+    let channel_path = fs_err::canonicalize(channel_path).expect("canonicalize channel path");
+    let channel_url = Url::from_directory_path(&channel_path).expect("valid file url");
+
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+[workspace]
+name = "lapsed-pin"
+channels = ["{channel_url}"]
+platforms = [
+  {{ name = "low", platform = "linux-64", linux = "4.18" }},
+  {{ name = "future", platform = "linux-64", linux = "99.0" }},
+  "linux-64",
+]
+
+[dependencies]
+no-deps = "*"
+"#
+    ))
+    .unwrap();
+
+    // Installed for a runnable platform, the other runnable one is an option.
+    pixi.install().await.unwrap();
+    let workspace = pixi.workspace().unwrap();
+    let options = alternative_platforms(&workspace.default_environment())
+        .expect("a runnable pin with another runnable platform has alternatives");
+    assert_eq!(options.installed.name().as_str(), "low");
+    assert_eq!(
+        options
+            .alternatives
+            .iter()
+            .map(|platform| platform.name().as_str())
+            .collect::<Vec<_>>(),
+        ["linux-64"],
+        "`future` is declared but cannot run here, so it is not an option"
+    );
+
+    // Installed for a platform this machine can't run, nothing is offered.
+    pixi.install().with_platform_name("future").await.unwrap();
+    let workspace = pixi.workspace().unwrap();
+    assert!(
+        alternative_platforms(&workspace.default_environment()).is_none(),
+        "a lapsed pin must not be offered alternatives"
     );
 }
 

--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -23,6 +23,9 @@ use pixi_core::{
     lock_file::{CondaPrefixUpdater, ReinstallPackages, UpdateMode},
     workspace::{HasWorkspaceRef, grouped_environment::GroupedEnvironment},
 };
+// Only used by the linux-gated `a_lapsed_pin_offers_no_alternatives` test below.
+#[cfg(target_os = "linux")]
+use pixi_core::workspace::platform_options::alternative_platforms;
 use pixi_manifest::{FeatureName, FeaturesExt};
 use pixi_record::PixiRecord;
 use rattler_conda_types::{Platform, RepoDataRecord};
@@ -2154,6 +2157,146 @@ no-deps = "*"
             .iter()
             .any(|vp| vp.name.as_normalized() == "__linux" && vp.version.to_string() == "5.4"),
         "resolved platform should declare __linux 5.4, got {virtual_packages:?}"
+    );
+}
+
+/// A platform that becomes runnable after an environment is installed must not
+/// take the prefix over: it stays put until asked with `--platform`.
+///
+/// `tuned` is declared *first*, so it would win on a fresh workspace -- the
+/// point is that an installed environment ignores that ordering. Both `__linux`
+/// versions sit below any realistic host kernel so both really run here.
+/// Linux-only: `__linux` only gates installs on linux hosts.
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_newly_runnable_platform_does_not_move_an_installed_environment() {
+    let channel_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/data/channels/channels/virtual_packages");
+    let channel_path = fs_err::canonicalize(channel_path).expect("canonicalize channel path");
+    let channel_url = Url::from_directory_path(&channel_path).expect("valid file url");
+
+    let manifest = |platforms: &str| {
+        format!(
+            r#"
+[workspace]
+name = "platform-pin"
+channels = ["{channel_url}"]
+platforms = [{platforms}]
+
+[dependencies]
+no-deps = "*"
+"#
+        )
+    };
+
+    // The `__linux` version recorded in `conda-meta/pixi` identifies which of
+    // the two platforms the prefix was installed for.
+    let recorded_linux_version = |pixi: &PixiControl| {
+        let marker_path = pixi
+            .default_env_path()
+            .unwrap()
+            .join(consts::CONDA_META_DIR)
+            .join(consts::ENVIRONMENT_FILE_NAME);
+        let marker: serde_json::Value =
+            serde_json::from_str(&fs_err::read_to_string(&marker_path).unwrap()).unwrap();
+        let virtual_packages: Vec<rattler_conda_types::GenericVirtualPackage> =
+            serde_json::from_value(marker["resolved_platform"]["virtual_packages"].clone())
+                .expect("resolved_platform should record virtual packages");
+        virtual_packages
+            .iter()
+            .find(|vp| vp.name.as_normalized() == "__linux")
+            .map(|vp| vp.version.to_string())
+            .expect("resolved platform should declare __linux")
+    };
+
+    // Install with only the plain `linux-64` platform available.
+    let pixi = PixiControl::from_manifest(&manifest(r#""linux-64""#)).unwrap();
+    pixi.install().await.unwrap();
+    let installed_for = recorded_linux_version(&pixi);
+
+    // A second platform shows up that also runs here, declared ahead of the
+    // installed one so platform selection would prefer it.
+    pixi.update_manifest(&manifest(
+        r#"{ name = "tuned", platform = "linux-64", linux = "5.4" }, "linux-64""#,
+    ))
+    .unwrap();
+    pixi.install().await.unwrap();
+    assert_eq!(
+        recorded_linux_version(&pixi),
+        installed_for,
+        "an installed environment must stay on its platform when another becomes runnable"
+    );
+
+    // Asking for the other platform switches, and the switch is recorded, so it
+    // survives later commands that pass no `--platform`.
+    pixi.install().with_platform_name("tuned").await.unwrap();
+    assert_eq!(
+        recorded_linux_version(&pixi),
+        "5.4",
+        "`--platform` must move the environment"
+    );
+    pixi.install().await.unwrap();
+    assert_eq!(
+        recorded_linux_version(&pixi),
+        "5.4",
+        "a later bare install must not undo the switch"
+    );
+}
+
+/// A machine that cannot run the platform its environment is installed for gets
+/// no alternatives offered: the pin has lapsed, so the environment is about to
+/// move whatever the user picks, and listing options would imply a choice.
+///
+/// `future` demands a kernel no host has, so it is installable only via
+/// `--platform` and never runnable. Linux-only: `__linux` only gates installs on
+/// linux hosts.
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn a_lapsed_pin_offers_no_alternatives() {
+    let channel_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/data/channels/channels/virtual_packages");
+    let channel_path = fs_err::canonicalize(channel_path).expect("canonicalize channel path");
+    let channel_url = Url::from_directory_path(&channel_path).expect("valid file url");
+
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+[workspace]
+name = "lapsed-pin"
+channels = ["{channel_url}"]
+platforms = [
+  {{ name = "low", platform = "linux-64", linux = "4.18" }},
+  {{ name = "future", platform = "linux-64", linux = "99.0" }},
+  "linux-64",
+]
+
+[dependencies]
+no-deps = "*"
+"#
+    ))
+    .unwrap();
+
+    // Installed for a runnable platform, the other runnable one is an option.
+    pixi.install().await.unwrap();
+    let workspace = pixi.workspace().unwrap();
+    let options = alternative_platforms(&workspace.default_environment())
+        .expect("a runnable pin with another runnable platform has alternatives");
+    assert_eq!(options.installed.name().as_str(), "low");
+    assert_eq!(
+        options
+            .alternatives
+            .iter()
+            .map(|platform| platform.name().as_str())
+            .collect::<Vec<_>>(),
+        ["linux-64"],
+        "`future` is declared but cannot run here, so it is not an option"
+    );
+
+    // Installed for a platform this machine can't run, nothing is offered.
+    pixi.install().with_platform_name("future").await.unwrap();
+    let workspace = pixi.workspace().unwrap();
+    assert!(
+        alternative_platforms(&workspace.default_environment()).is_none(),
+        "a lapsed pin must not be offered alternatives"
     );
 }
 

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -8,6 +8,7 @@ use miette::IntoDiagnostic;
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_core::environment::{PlatformData, RequiredPlatform};
+use pixi_core::workspace::platform_options::alternative_platforms;
 use pixi_global::{BinDir, EnvRoot};
 use pixi_manifest::platform::subdir_default_virtual_packages;
 use pixi_manifest::toml::inline_virtual_package_specs;
@@ -111,6 +112,21 @@ impl From<&RequiredPlatform> for PlatformInfo {
     }
 }
 
+/// The resolved platform, named after the declared platform `declared`
+/// recovered. The marker file records no name, so without this an environment
+/// installed for `gpu` reports as `linux-64 (cuda=13)` -- indistinguishable from
+/// the bare `linux-64` platform listed beside it.
+fn resolved_platform_info(
+    data: &PlatformData,
+    declared: Option<&pixi_manifest::PixiPlatform>,
+) -> PlatformInfo {
+    let mut info = PlatformInfo::from(data);
+    if let Some(declared) = declared {
+        info.name = declared.name().clone();
+    }
+    info
+}
+
 /// Human-readable representation of a platform entry in the `pixi info`
 /// output: bare name when it carries no customised VPs, otherwise
 /// `<name> (vp1, vp2, ...)` in friendly form.
@@ -133,6 +149,9 @@ pub struct EnvironmentInfo {
     platforms: Vec<PlatformInfo>,
     resolved_platform: Option<PlatformInfo>,
     minimum_supported_platform: Option<PlatformInfo>,
+    /// Declared platforms this machine can also run, besides the one the
+    /// environment is installed for. Empty unless it is installed.
+    alternative_platforms: Vec<PlatformInfo>,
     tasks: Vec<TaskName>,
     channels: Vec<String>,
     prefix: PathBuf,
@@ -240,6 +259,20 @@ impl Display for EnvironmentInfo {
             bold.apply_to("Minimum platform"),
             minimum
         )?;
+
+        if !self.alternative_platforms.is_empty() {
+            let alternatives = self
+                .alternative_platforms
+                .iter()
+                .map(format_platform)
+                .format(", ");
+            writeln!(
+                f,
+                "{:>WIDTH$}: {}",
+                bold.apply_to("Also runnable here"),
+                alternatives
+            )?;
+        }
 
         writeln!(
             f,
@@ -500,7 +533,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             ws.environments()
                 .iter()
                 .map(|env| {
-                    let best = env.best_declared_platform();
+                    // The platform in use, so the dependencies and tasks shown
+                    // are the ones this machine actually resolves against.
+                    let best = env.pinned_or_best_declared_platform();
                     let tasks = env
                         .tasks(best)
                         .ok()
@@ -543,10 +578,21 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                                     .map(PlatformInfo::from)
                             })
                             .collect(),
-                        resolved_platform: resolved_platform.as_ref().map(PlatformInfo::from),
+                        resolved_platform: resolved_platform.as_ref().map(|data| {
+                            resolved_platform_info(data, env.installed_resolved_platform())
+                        }),
                         minimum_supported_platform: minimum_supported_platform
                             .as_ref()
                             .map(PlatformInfo::from),
+                        alternative_platforms: alternative_platforms(env)
+                            .map(|options| {
+                                options
+                                    .alternatives
+                                    .into_iter()
+                                    .map(PlatformInfo::from)
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
                         channels: env.channels().into_iter().map(|c| c.to_string()).collect(),
                         prefix: env.dir(),
                         tasks,

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -8,6 +8,7 @@ use miette::IntoDiagnostic;
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_core::environment::PlatformData;
+use pixi_core::workspace::platform_options::alternative_platforms;
 use pixi_global::{BinDir, EnvRoot};
 use pixi_manifest::platform::subdir_default_virtual_packages;
 use pixi_manifest::toml::inline_virtual_package_specs;
@@ -102,6 +103,21 @@ impl From<&PlatformData> for PlatformInfo {
     }
 }
 
+/// The resolved platform, named after the declared platform `declared`
+/// recovered. The marker file records no name, so without this an environment
+/// installed for `gpu` reports as `linux-64 (cuda=13)` -- indistinguishable from
+/// the bare `linux-64` platform listed beside it.
+fn resolved_platform_info(
+    data: &PlatformData,
+    declared: Option<&pixi_manifest::PixiPlatform>,
+) -> PlatformInfo {
+    let mut info = PlatformInfo::from(data);
+    if let Some(declared) = declared {
+        info.name = declared.name().clone();
+    }
+    info
+}
+
 /// Human-readable representation of a platform entry in the `pixi info`
 /// output: bare name when it carries no customised VPs, otherwise
 /// `<name> (vp1, vp2, ...)` in friendly form.
@@ -124,6 +140,9 @@ pub struct EnvironmentInfo {
     platforms: Vec<PlatformInfo>,
     resolved_platform: Option<PlatformInfo>,
     minimum_supported_platform: Option<PlatformInfo>,
+    /// Declared platforms this machine can also run, besides the one the
+    /// environment is installed for. Empty unless it is installed.
+    alternative_platforms: Vec<PlatformInfo>,
     tasks: Vec<TaskName>,
     channels: Vec<String>,
     prefix: PathBuf,
@@ -231,6 +250,20 @@ impl Display for EnvironmentInfo {
             bold.apply_to("Minimum platform"),
             minimum
         )?;
+
+        if !self.alternative_platforms.is_empty() {
+            let alternatives = self
+                .alternative_platforms
+                .iter()
+                .map(format_platform)
+                .format(", ");
+            writeln!(
+                f,
+                "{:>WIDTH$}: {}",
+                bold.apply_to("Also runnable here"),
+                alternatives
+            )?;
+        }
 
         writeln!(
             f,
@@ -491,7 +524,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             ws.environments()
                 .iter()
                 .map(|env| {
-                    let best = env.best_declared_platform();
+                    // The platform in use, so the dependencies and tasks shown
+                    // are the ones this machine actually resolves against.
+                    let best = env.pinned_or_best_declared_platform();
                     let tasks = env
                         .tasks(best)
                         .ok()
@@ -534,10 +569,21 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                                     .map(PlatformInfo::from)
                             })
                             .collect(),
-                        resolved_platform: resolved_platform.as_ref().map(PlatformInfo::from),
+                        resolved_platform: resolved_platform.as_ref().map(|data| {
+                            resolved_platform_info(data, env.installed_resolved_platform())
+                        }),
                         minimum_supported_platform: minimum_supported_platform
                             .as_ref()
                             .map(PlatformInfo::from),
+                        alternative_platforms: alternative_platforms(env)
+                            .map(|options| {
+                                options
+                                    .alternatives
+                                    .into_iter()
+                                    .map(PlatformInfo::from)
+                                    .collect()
+                            })
+                            .unwrap_or_default(),
                         channels: env.channels().into_iter().map(|c| c.to_string()).collect(),
                         prefix: env.dir(),
                         tasks,

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -183,7 +183,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             // not runnable on the current host (e.g. a cross-target install).
             let host_platform = host_baseline();
             let platform = environment
-                .named_or_best_declared_platform(target_platform.as_ref())
+                .named_or_pinned_platform(target_platform.as_ref())
                 .unwrap_or(&host_platform);
             let locked_env = lock_file
                 .environment(environment.name().as_str())

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -186,7 +186,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 PlatformOverrides::EnvironmentVariableOverrides,
             );
             let platform = environment
-                .named_or_best_declared_platform(target_platform.as_ref())
+                .named_or_pinned_platform(target_platform.as_ref())
                 .unwrap_or(&host_platform);
             let locked_env = lock_file
                 .environment(environment.name().as_str())

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -166,16 +166,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Sanity check of prefix location
     sanity_check_workspace(&workspace).await?;
 
-    // `--platform` pins which declared platform the environment is installed
-    // and activated for. Without it we auto-upgrade to the platform the
-    // environment was last installed for (so users need not repeat
-    // `--platform`), falling back to the host-aware best match when the
-    // environment isn't installed yet.
+    // `--platform` pins which declared platform to install and activate for;
+    // without it the environment stays on the one it was last installed for.
     let user_platform = resolve_install_platform(&workspace, args.platform.as_ref())?;
-    let run_platform = user_platform
-        .clone()
-        .or_else(|| environment.installed_resolved_platform_name());
-    let best_declared_platform = environment.named_or_best_declared_platform(run_platform.as_ref());
+    let best_declared_platform = environment.named_or_pinned_platform(user_platform.as_ref());
 
     // A `--platform` the environment doesn't list is a membership error. With
     // no platform requested, defer to the install path's minimum fallback.
@@ -192,6 +186,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     if args.lock_and_install_config.allow_installs() {
         environment.emit_emulation_warning();
+        // Also reported on the install path, but a `pixi run` that finds an
+        // up-to-date prefix never gets there.
+        pixi_core::workspace::platform_options::report_new_platform_options(&environment);
     }
 
     // Top-level progress, kept here so we can clear it between phases.
@@ -211,9 +208,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .0;
 
-    // Only an explicit `--platform` pins the global target; the implicit
-    // auto-upgrade is resolved per-environment in the loop below, since a
-    // global pin broke sibling environments with a different platform.
+    // Only an explicit `--platform` sets a global target; a global pin broke
+    // sibling environments whose own platform differs.
     lock_file.target_platform = user_platform.clone();
 
     // Spawn a task that listens for ctrl+c and resets the cursor.
@@ -382,14 +378,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             Entry::Vacant(entry) => {
                 // Report the platform per environment: a bare `pixi run` may
                 // span environments that declare different platforms.
-                let assumed_platform = user_platform.clone().or_else(|| {
-                    executable_task
-                        .run_environment
-                        .installed_resolved_platform_name()
-                });
                 if let Some(platform) = executable_task
                     .run_environment
-                    .named_or_best_declared_platform(assumed_platform.as_ref())
+                    .named_or_pinned_platform(user_platform.as_ref())
                 {
                     tracing::info!(
                         "Running tasks in environment '{}' assuming platform '{}'",
@@ -400,14 +391,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
                 // Check if we allow installs
                 if args.lock_and_install_config.allow_installs() {
-                    // No `--platform`: pin to the platform this environment was
-                    // last installed for, not a sibling's bare subdir.
-                    if user_platform.is_none() {
-                        lock_file.target_platform = executable_task
-                            .run_environment
-                            .installed_resolved_platform_name();
-                    }
-
                     // Ensure there is a valid prefix
                     lock_file
                         .prefix(

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -295,16 +295,10 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
     // Sanity check of prefix location
     sanity_check_workspace(&workspace).await?;
 
-    // `--platform` pins which declared platform the environment is installed
-    // and activated for. Without it we auto-upgrade to the platform the
-    // environment was last installed for (so users need not repeat
-    // `--platform`), falling back to the host-aware best match when the
-    // environment isn't installed yet.
+    // `--platform` pins which declared platform to install and activate for;
+    // without it the environment stays on the one it was last installed for.
     let user_platform = resolve_install_platform(&workspace, args.platform.as_ref())?;
-    let run_platform = user_platform
-        .clone()
-        .or_else(|| environment.installed_resolved_platform_name());
-    let best_declared_platform = environment.named_or_best_declared_platform(run_platform.as_ref());
+    let best_declared_platform = environment.named_or_pinned_platform(user_platform.as_ref());
 
     // A `--platform` the environment doesn't list is a membership error. With
     // no platform requested, defer to the install path's minimum fallback.
@@ -321,6 +315,9 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
 
     if args.lock_and_install_config.allow_installs() {
         environment.emit_emulation_warning();
+        // Also reported on the install path, but a `pixi run` that finds an
+        // up-to-date prefix never gets there.
+        pixi_core::workspace::platform_options::report_new_platform_options(&environment);
     }
 
     // Top-level progress, kept here so we can clear it between phases.
@@ -340,9 +337,8 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
         .await?
         .0;
 
-    // Only an explicit `--platform` pins the global target; the implicit
-    // auto-upgrade is resolved per-environment in the loop below, since a
-    // global pin broke sibling environments with a different platform.
+    // Only an explicit `--platform` sets a global target; a global pin broke
+    // sibling environments whose own platform differs.
     lock_file.target_platform = user_platform.clone();
 
     // Spawn a task that listens for ctrl+c and resets the cursor.
@@ -538,14 +534,6 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                 if args.lock_and_install_config.allow_installs()
                     && runnability != Some(EnvironmentRunnability::NoDependencies)
                 {
-                    // No `--platform`: pin to the platform this environment was
-                    // last installed for, not a sibling's bare subdir.
-                    if user_platform.is_none() {
-                        lock_file.target_platform = executable_task
-                            .run_environment
-                            .installed_resolved_platform_name();
-                    }
-
                     // Ensure there is a valid prefix
                     lock_file
                         .prefix(

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::str::FromStr;
 
@@ -725,9 +725,10 @@ async fn execute_list(
         let mut platforms: Vec<serde_json::Value> =
             Vec::with_capacity(workspace_platforms.len() + 1);
         platforms.push(autodetected_to_json());
+        let installed = installed_environments_by_platform(workspace);
         for p in &workspace_platforms {
             let users = environments_and_features_using(workspace, p);
-            platforms.push(show_to_json(p, &users));
+            platforms.push(show_to_json(p, &users, installed_for(&installed, p)));
         }
 
         let value = serde_json::json!({
@@ -765,6 +766,7 @@ fn format_workspace_platform_rows(
     machine: &HostMachine,
 ) -> String {
     let reachability = MachineReachability::compute(workspace, machine);
+    let installed = installed_environments_by_platform(workspace);
     let multiple_environments = workspace.environments().len() > 1;
     workspace
         .workspace_manifest()
@@ -773,9 +775,46 @@ fn format_workspace_platform_rows(
         .iter()
         .map(|p| {
             let users = environments_and_features_using(workspace, p);
-            format_workspace_platform_row(p, machine, &users, &reachability, multiple_environments)
+            format_workspace_platform_row(
+                p,
+                machine,
+                &users,
+                &reachability,
+                installed_for(&installed, p),
+                multiple_environments,
+            )
         })
         .collect()
+}
+
+/// The environments [`installed_environments_by_platform`] recorded for
+/// `platform`, or an empty slice.
+fn installed_for<'a>(
+    installed: &'a HashMap<String, Vec<String>>,
+    platform: &PixiPlatform,
+) -> &'a [String] {
+    installed
+        .get(platform.name().as_str())
+        .map_or(&[][..], Vec::as_slice)
+}
+
+/// Environment names currently installed for each workspace platform, keyed by
+/// platform name. Read from each environment's `conda-meta/pixi`, so it says
+/// what is on disk rather than what the manifest permits -- the distinction
+/// between a platform in use and one that merely runs here.
+fn installed_environments_by_platform(
+    workspace: &pixi_core::Workspace,
+) -> HashMap<String, Vec<String>> {
+    let mut installed: HashMap<String, Vec<String>> = HashMap::new();
+    for environment in workspace.environments() {
+        if let Some(platform) = environment.installed_resolved_platform() {
+            installed
+                .entry(platform.name().as_str().to_string())
+                .or_default()
+                .push(environment.name().to_string());
+        }
+    }
+    installed
 }
 
 async fn execute_remove(
@@ -1009,6 +1048,7 @@ fn format_workspace_platform_row(
     machine: &HostMachine,
     users: &PlatformUsers,
     reachability: &MachineReachability,
+    installed_environments: &[String],
     multiple_environments: bool,
 ) -> String {
     let subdir = platform.subdir();
@@ -1061,6 +1101,14 @@ fn format_workspace_platform_row(
         row.push_str(&format!(
             "    Used in environments: {}\n",
             format_user_names(&users.environments, &reachability.unreachable_environments),
+        ));
+    }
+    // What is on disk, which the rest of the row can't show: several platforms
+    // may be supported here while only one is the one an environment uses.
+    if !installed_environments.is_empty() {
+        row.push_str(&format!(
+            "    Installed for       : {}\n",
+            installed_environments.join(", "),
         ));
     }
     if !users.features.is_empty() {
@@ -1124,7 +1172,11 @@ fn render_friendly(
         .collect()
 }
 
-fn show_to_json(platform: &PixiPlatform, users: &PlatformUsers) -> serde_json::Value {
+fn show_to_json(
+    platform: &PixiPlatform,
+    users: &PlatformUsers,
+    installed_environments: &[String],
+) -> serde_json::Value {
     let detected: Vec<String> = match platform.virtual_packages() {
         Ok(detected) => render_friendly(
             &detected.into_generic_virtual_packages().collect::<Vec<_>>(),
@@ -1143,6 +1195,7 @@ fn show_to_json(platform: &PixiPlatform, users: &PlatformUsers) -> serde_json::V
         "features": users.features,
         "declared_inline_in_environments": users.inline_environments,
         "environments": users.environments,
+        "installed_for_environments": installed_environments,
     })
 }
 
@@ -1163,6 +1216,7 @@ fn autodetected_to_json() -> serde_json::Value {
         "features": Vec::<String>::new(),
         "declared_inline_in_environments": Vec::<String>::new(),
         "environments": Vec::<String>::new(),
+        "installed_for_environments": Vec::<String>::new(),
         "is_current": true,
         "is_autodetected": true,
     })
@@ -1232,7 +1286,7 @@ mod tests {
             .next()
             .expect("manifest declares one platform");
         let users = environments_and_features_using(&workspace, platform);
-        let json = show_to_json(platform, &users);
+        let json = show_to_json(platform, &users, &[]);
         assert_eq!(json["features"], serde_json::json!(["cuda"]));
         assert_eq!(
             json["declared_inline_in_environments"],

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -781,12 +781,18 @@ async fn execute_list(
         // Probe each distinct subdir once. Detecting per row repeats the work,
         // and repeats the warning when a `CONDA_OVERRIDE_*` value is unusable.
         let mut probed: HashMap<Platform, Vec<GenericVirtualPackage>> = HashMap::new();
+        let installed = installed_environments_by_platform(workspace);
         for p in &workspace_platforms {
             probed
                 .entry(p.subdir())
                 .or_insert_with(|| machine_virtual_packages(p.subdir()));
             let users = environments_and_features_using(workspace, p);
-            platforms.push(show_to_json(p, &users, &probed[&p.subdir()]));
+            platforms.push(show_to_json(
+                p,
+                &users,
+                &probed[&p.subdir()],
+                installed_for(&installed, p),
+            ));
         }
 
         let value = serde_json::json!({
@@ -824,6 +830,7 @@ fn format_workspace_platform_rows(
     machine: &HostMachine,
 ) -> String {
     let reachability = MachineReachability::compute(workspace, machine);
+    let installed = installed_environments_by_platform(workspace);
     let multiple_environments = workspace.environments().len() > 1;
     workspace
         .workspace_manifest()
@@ -832,9 +839,46 @@ fn format_workspace_platform_rows(
         .iter()
         .map(|p| {
             let users = environments_and_features_using(workspace, p);
-            format_workspace_platform_row(p, machine, &users, &reachability, multiple_environments)
+            format_workspace_platform_row(
+                p,
+                machine,
+                &users,
+                &reachability,
+                installed_for(&installed, p),
+                multiple_environments,
+            )
         })
         .collect()
+}
+
+/// The environments [`installed_environments_by_platform`] recorded for
+/// `platform`, or an empty slice.
+fn installed_for<'a>(
+    installed: &'a HashMap<String, Vec<String>>,
+    platform: &PixiPlatform,
+) -> &'a [String] {
+    installed
+        .get(platform.name().as_str())
+        .map_or(&[][..], Vec::as_slice)
+}
+
+/// Environment names currently installed for each workspace platform, keyed by
+/// platform name. Read from each environment's `conda-meta/pixi`, so it says
+/// what is on disk rather than what the manifest permits -- the distinction
+/// between a platform in use and one that merely runs here.
+fn installed_environments_by_platform(
+    workspace: &pixi_core::Workspace,
+) -> HashMap<String, Vec<String>> {
+    let mut installed: HashMap<String, Vec<String>> = HashMap::new();
+    for environment in workspace.environments() {
+        if let Some(platform) = environment.installed_resolved_platform() {
+            installed
+                .entry(platform.name().as_str().to_string())
+                .or_default()
+                .push(environment.name().to_string());
+        }
+    }
+    installed
 }
 
 async fn execute_remove(
@@ -1047,6 +1091,7 @@ fn format_workspace_platform_row(
     machine: &HostMachine,
     users: &PlatformUsers,
     reachability: &MachineReachability,
+    installed_environments: &[String],
     multiple_environments: bool,
 ) -> String {
     let subdir = platform.subdir();
@@ -1099,6 +1144,14 @@ fn format_workspace_platform_row(
         row.push_str(&format!(
             "    Used in environments: {}\n",
             format_user_names(&users.environments, &reachability.unreachable_environments),
+        ));
+    }
+    // What is on disk, which the rest of the row can't show: several platforms
+    // may be supported here while only one is the one an environment uses.
+    if !installed_environments.is_empty() {
+        row.push_str(&format!(
+            "    Installed for       : {}\n",
+            installed_environments.join(", "),
         ));
     }
     if !users.features.is_empty() {
@@ -1169,6 +1222,7 @@ fn show_to_json(
     platform: &PixiPlatform,
     users: &PlatformUsers,
     detected: &[GenericVirtualPackage],
+    installed_environments: &[String],
 ) -> serde_json::Value {
     let detected: Vec<String> = render_friendly(detected, None);
     serde_json::json!({
@@ -1182,6 +1236,7 @@ fn show_to_json(
         "features": users.features,
         "declared_inline_in_environments": users.inline_environments,
         "environments": users.environments,
+        "installed_for_environments": installed_environments,
     })
 }
 
@@ -1198,6 +1253,7 @@ fn autodetected_to_json(machine: &HostMachine) -> serde_json::Value {
         "features": Vec::<String>::new(),
         "declared_inline_in_environments": Vec::<String>::new(),
         "environments": Vec::<String>::new(),
+        "installed_for_environments": Vec::<String>::new(),
         "is_current": true,
         "is_autodetected": true,
     })
@@ -1268,7 +1324,7 @@ mod tests {
             .next()
             .expect("manifest declares one platform");
         let users = environments_and_features_using(&workspace, platform);
-        let json = show_to_json(platform, &users, &[]);
+        let json = show_to_json(platform, &users, &[], &[]);
         assert_eq!(json["features"], serde_json::json!(["cuda"]));
         assert_eq!(
             json["declared_inline_in_environments"],

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -8,17 +8,14 @@ use miette::{Context, IntoDiagnostic};
 use pixi_consts::consts;
 use pixi_git::credentials::store_credentials_from_url;
 pub use pixi_install_pypi::{ContinuePyPIPrefixUpdate, on_python_interpreter_change};
-use pixi_manifest::{FeaturesExt, PixiPlatform, PixiPlatformName, platform::candidate_subdirs};
+use pixi_manifest::{FeaturesExt, HasWorkspaceManifest, PixiPlatform, PixiPlatformName};
 use pixi_progress::await_in_progress;
 use pixi_pypi_spec::PixiPypiSource;
 pub use pixi_python_status::PythonStatus;
 use pixi_spec::{GitSpec, PixiSpec};
 use pixi_utils::EnvironmentFingerprint;
 use pixi_utils::{prefix::Prefix, rlimit::try_increase_rlimit_to_sensible};
-use rattler_conda_types::{
-    GenericVirtualPackage, MatchSpec, PackageNameMatcher, ParseStrictness, Platform, StringMatcher,
-    Version, VersionSpec, version_spec::RangeOperator,
-};
+use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_lock::{LockFile, LockedPackage};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -120,7 +117,7 @@ impl EnvironmentHash {
     /// Used for **task** caching: a task's cached result is keyed on
     /// inputs the user can change without going through an install
     /// (manifest, lock file, env vars, activation scripts), so this
-    /// flavor folds locked package URLs into the hash directly.
+    /// flavour folds locked package URLs into the hash directly.
     ///
     /// The activation cache uses [`Self::for_activation`] instead --
     /// see the docs there for why URL-based hashing is too coarse for
@@ -129,19 +126,14 @@ impl EnvironmentHash {
         run_environment: &workspace::Environment<'_>,
         input_environment_variables: &HashMap<String, Option<String>>,
         lock_file: &LockFile,
-        platform: &PixiPlatform,
     ) -> Self {
         let mut hasher = Xxh3::new();
-        Self::hash_common_inputs(
-            &mut hasher,
-            run_environment,
-            input_environment_variables,
-            platform,
-        );
+        Self::hash_common_inputs(&mut hasher, run_environment, input_environment_variables);
 
-        // Hash the packages of the platform this run targets.
+        // Hash the packages
         let mut urls = Vec::new();
         if let Some(env) = lock_file.environment(run_environment.name().as_str())
+            && let Some(platform) = run_environment.pinned_or_best_declared_platform()
             && let Some(lock_platform) = resolve_lock_platform_for(lock_file, platform)
             && let Some(packages) = env.packages(lock_platform)
         {
@@ -179,15 +171,9 @@ impl EnvironmentHash {
         run_environment: &workspace::Environment<'_>,
         input_environment_variables: &HashMap<String, Option<String>>,
         installed_fingerprint: &EnvironmentFingerprint,
-        platform: &PixiPlatform,
     ) -> Self {
         let mut hasher = Xxh3::new();
-        Self::hash_common_inputs(
-            &mut hasher,
-            run_environment,
-            input_environment_variables,
-            platform,
-        );
+        Self::hash_common_inputs(&mut hasher, run_environment, input_environment_variables);
         installed_fingerprint.as_str().hash(&mut hasher);
         EnvironmentHash(format!("{:x}", hasher.finish()))
     }
@@ -195,13 +181,11 @@ impl EnvironmentHash {
     /// Fold every input shared by both hash flavours into `hasher`:
     /// the shell input env vars (sorted by key for determinism),
     /// the activation scripts in declaration order, and the project
-    /// activation env (sorted by key). `platform` picks which `[target.*]`
-    /// applies and is hashed itself, so two platforms never share a key.
+    /// activation env (sorted by key).
     fn hash_common_inputs(
         hasher: &mut Xxh3,
         run_environment: &workspace::Environment<'_>,
         input_environment_variables: &HashMap<String, Option<String>>,
-        platform: &PixiPlatform,
     ) {
         let mut sorted_input_environment_variables: Vec<_> =
             input_environment_variables.iter().collect();
@@ -211,14 +195,14 @@ impl EnvironmentHash {
             value.hash(hasher);
         }
 
-        platform.name().as_str().hash(hasher);
-
-        let activation_scripts = run_environment.activation_scripts(Some(platform));
+        let activation_scripts =
+            run_environment.activation_scripts(run_environment.best_declared_platform());
         for script in activation_scripts {
             script.hash(hasher);
         }
 
-        let project_activation_env = run_environment.activation_env(Some(platform));
+        let project_activation_env =
+            run_environment.activation_env(run_environment.best_declared_platform());
         let mut env_vars: Vec<_> = project_activation_env.iter().collect();
         env_vars.sort_by_key(|(key, _)| *key);
         for (key, value) in env_vars {
@@ -359,136 +343,17 @@ impl From<&PixiPlatform> for PlatformData {
 
 impl Display for PlatformData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write_platform(f, self.subdir, &self.virtual_packages)
-    }
-}
-
-/// Render a platform as `<subdir>` or `<subdir> [entry, entry]`.
-fn write_platform(
-    f: &mut Formatter<'_>,
-    subdir: Platform,
-    entries: &[impl Display],
-) -> std::fmt::Result {
-    write!(f, "{subdir}")?;
-    if !entries.is_empty() {
-        let entries = entries
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(", ");
-        write!(f, " [{entries}]")?;
-    }
-    Ok(())
-}
-
-/// The requirements the installed packages place on the machine: the conda
-/// subdir plus the virtual-package specs some resolved dependency depends on.
-#[derive(Serialize, Deserialize)]
-#[serde(from = "RequiredPlatformRaw", into = "RequiredPlatformRaw")]
-#[derive(Clone)]
-pub struct RequiredPlatform {
-    subdir: Platform,
-    requirements: Vec<MatchSpec>,
-}
-
-impl RequiredPlatform {
-    /// A requirement set from a subdir and the specs resolved dependencies
-    pub fn new(subdir: Platform, requirements: Vec<MatchSpec>) -> Self {
-        Self {
-            subdir,
-            requirements,
+        write!(f, "{}", self.subdir)?;
+        if !self.virtual_packages.is_empty() {
+            let packages = self
+                .virtual_packages
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            write!(f, " [{packages}]")?;
         }
-    }
-
-    /// The conda subdir these requirements were resolved for.
-    pub fn subdir(&self) -> Platform {
-        self.subdir
-    }
-
-    /// The virtual-package specs resolved dependencies require.
-    pub fn requirements(&self) -> &[MatchSpec] {
-        &self.requirements
-    }
-
-    /// The requirements as conda match-spec strings: how they are written to the
-    /// marker file and shown by `pixi info`, and the only form that round-trips.
-    pub fn requirement_strings(&self) -> Vec<String> {
-        self.requirements.iter().map(ToString::to_string).collect()
-    }
-}
-
-impl Display for RequiredPlatform {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write_platform(f, self.subdir, &self.requirements)
-    }
-}
-
-/// On-disk representation of [`RequiredPlatform`]. Specs are stored as conda match-spec
-/// strings, matching how [`GenericVirtualPackage`] renders itself in this file
-#[derive(Serialize, Deserialize)]
-struct RequiredPlatformRaw {
-    subdir: Platform,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    requirements: Vec<String>,
-    /// Written by pixi versions that recorded requirements as concrete virtual
-    /// packages. Read for migration, never written.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    virtual_packages: Vec<String>,
-}
-
-impl From<RequiredPlatform> for RequiredPlatformRaw {
-    fn from(platform: RequiredPlatform) -> Self {
-        Self {
-            subdir: platform.subdir,
-            requirements: platform.requirement_strings(),
-            virtual_packages: Vec::new(),
-        }
-    }
-}
-
-impl From<RequiredPlatformRaw> for RequiredPlatform {
-    /// Read what can be read and drop the rest, loudly.
-    fn from(raw: RequiredPlatformRaw) -> Self {
-        let mut requirements: Vec<MatchSpec> = raw
-            .requirements
-            .iter()
-            .filter_map(|spec| {
-                MatchSpec::from_str(spec, ParseStrictness::Lenient)
-                    .inspect_err(|error| {
-                        tracing::warn!(
-                            "Ignoring unreadable requirement '{spec}' recorded in {}: {error}",
-                            consts::ENVIRONMENT_FILE_NAME
-                        );
-                    })
-                    .ok()
-            })
-            .collect();
-        // Migrate a marker written before requirements were specs.
-        requirements.extend(raw.virtual_packages.iter().filter_map(|entry| {
-            let package = pixi_manifest::platform::parse_locked_virtual_package(entry);
-            if package.is_none() {
-                tracing::warn!(
-                    "Ignoring unreadable virtual package '{entry}' recorded in {}",
-                    consts::ENVIRONMENT_FILE_NAME
-                );
-            }
-            package.as_ref().map(legacy_requirement)
-        }));
-        Self::new(raw.subdir, requirements)
-    }
-}
-
-/// Reinterpret a legacy marker's concrete virtual package as the requirement it
-/// stood for: at least this version, with version 0 meaning "any version".
-fn legacy_requirement(package: &GenericVirtualPackage) -> MatchSpec {
-    let version = (package.version != Version::major(0))
-        .then(|| VersionSpec::Range(RangeOperator::GreaterEquals, package.version.clone()));
-    MatchSpec {
-        name: PackageNameMatcher::Exact(package.name.clone()),
-        version,
-        build: (!package.build_string.is_empty())
-            .then(|| StringMatcher::Exact(package.build_string.clone())),
-        ..MatchSpec::default()
+        Ok(())
     }
 }
 
@@ -512,15 +377,15 @@ pub struct EnvironmentFile {
     /// file, so they record [`LockedEnvironmentHash::invalid`] here.
     pub environment_lock_file_hash: LockedEnvironmentHash,
     /// The platform the environment was resolved with (subdir + the virtual
-    /// packages the workspace declared for it). `None` for older pixi versions.
+    /// packages the workspace declared for it). `None` on environments written
+    /// by an older pixi, or when no declared platform runs on this machine.
     #[serde(default)]
     pub resolved_platform: Option<PlatformData>,
-    /// The minimum the installed packages actually require (the subdir plus
-    /// only the virtual-package specs some resolved dependency depends on). Can
-    /// be weaker than [`Self::resolved_platform`]. `None` for older pixi
-    /// versions.
+    /// The minimum platform the installed packages actually require (the subdir
+    /// plus only the virtual packages some resolved dependency depends on). Can
+    /// be weaker than [`Self::resolved_platform`]. `None` as above.
     #[serde(default)]
-    pub minimum_supported_platform: Option<RequiredPlatform>,
+    pub minimum_supported_platform: Option<PlatformData>,
     /// Fingerprints of the manifest's source dependencies at install time,
     /// keyed by package name: a hash of the source spec plus any inline
     /// package definition. Only written by `pixi global`, which has no lock
@@ -898,9 +763,7 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
         // A `--platform` the environment doesn't list is a membership error.
         // With no platform requested, defer to the install path's minimum fallback.
         if !no_install
-            && env
-                .named_or_best_declared_platform(target_platform)
-                .is_none()
+            && env.named_or_pinned_platform(target_platform).is_none()
             && let Some(name) = target_platform
         {
             return Err(miette::miette!(
@@ -911,6 +774,7 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
         }
         if !no_install {
             env.emit_emulation_warning();
+            workspace::platform_options::report_new_platform_options(env);
         }
     }
 
@@ -919,11 +783,16 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
     // now -- after the clear membership error, never before it.
     if !no_install
         && target_platform.is_some()
-        && let Some(platform) = environments[0].named_or_best_declared_platform(target_platform)
+        && let Some(platform) = environments[0].named_or_pinned_platform(target_platform)
     {
         let current = Platform::current();
         let subdir = platform.subdir();
-        if !candidate_subdirs(current).contains(&subdir) {
+        if !workspace
+            .workspace_manifest()
+            .workspace
+            .candidate_subdirs(current)
+            .contains(&subdir)
+        {
             tracing::warn!(
                 "installing for platform '{}' (subdir '{subdir}'), which this \
                  machine ('{current}') can not run -- packages will be downloaded \
@@ -932,10 +801,6 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
             );
         }
     }
-
-    // Held across the solve and install so the caller's summary output is not
-    // written over bars that have finished but are still rendered.
-    let _clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(progress.as_ref());
 
     // Make sure the project is in a sane state
     sanity_check_workspace(workspace).await?;
@@ -1117,194 +982,5 @@ mod tests {
         let restored: PlatformData = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.subdir, Platform::Linux64);
         assert!(restored.virtual_packages.contains(&cuda));
-    }
-
-    #[test]
-    fn required_platform_round_trips_pattern_requirements() {
-        let archspec = "__archspec[version='1.*', build='^(x86_64_v3|haswell|skylake)$']";
-        let requirements = vec![
-            MatchSpec::from_str(archspec, ParseStrictness::Lenient).unwrap(),
-            MatchSpec::from_str("__glibc >=2.17", ParseStrictness::Lenient).unwrap(),
-        ];
-        let platform = RequiredPlatform::new(Platform::Linux64, requirements);
-
-        let json = serde_json::to_string(&platform).unwrap();
-        // Stored as strings, like the concrete virtual packages beside them,
-        // rather than serde's field-wise form for a match spec.
-        assert!(json.contains("x86_64_v3|haswell|skylake"), "{json}");
-        assert!(!json.contains("\"build\":{"), "{json}");
-
-        let restored: RequiredPlatform = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.subdir(), Platform::Linux64);
-        let archspec_spec = restored
-            .requirements()
-            .iter()
-            .find(|spec| {
-                spec.name
-                    .as_exact()
-                    .is_some_and(|name| name.as_normalized() == "__archspec")
-            })
-            .expect("__archspec requirement");
-        // The build matcher survives as a regex, not as a literal name.
-        assert!(
-            matches!(archspec_spec.build, Some(StringMatcher::Regex(_))),
-            "{:?}",
-            archspec_spec.build
-        );
-    }
-
-    #[test]
-    fn legacy_marker_requirements_migrate_to_match_specs() {
-        let legacy = r#"{
-            "subdir": "linux-64",
-            "virtual_packages": ["__glibc=2.17", "__cuda=0"]
-        }"#;
-        let restored: RequiredPlatform = serde_json::from_str(legacy).unwrap();
-        assert_eq!(restored.subdir(), Platform::Linux64);
-        // A recorded version becomes a lower bound; version 0 meant "any".
-        assert_eq!(
-            restored
-                .requirements()
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
-            vec!["__glibc >=2.17", "__cuda"]
-        );
-
-        // Re-serializing writes the modern field and drops the legacy one.
-        let json = serde_json::to_string(&restored).unwrap();
-        assert!(json.contains("requirements"), "{json}");
-        assert!(!json.contains("virtual_packages"), "{json}");
-    }
-
-    #[test]
-    fn required_platform_reads_modern_and_legacy_keys_together() {
-        let both = r#"{
-            "subdir": "linux-64",
-            "requirements": ["__glibc >=2.28"],
-            "virtual_packages": ["__cuda=99"]
-        }"#;
-        let restored: RequiredPlatform = serde_json::from_str(both).unwrap();
-        assert_eq!(
-            restored
-                .requirements()
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
-            vec!["__glibc >=2.28", "__cuda >=99"]
-        );
-    }
-
-    #[test]
-    fn malformed_required_platform_markers_are_rejected_not_misread() {
-        // An entry pixi cannot read costs that entry and nothing more, in
-        // either the modern or the legacy field.
-        let unreadable: RequiredPlatform = serde_json::from_str(
-            r#"{"subdir": "linux-64", "requirements": ["@@@ not a spec @@@"]}"#,
-        )
-        .expect("one unreadable requirement must not reject the platform");
-        assert!(unreadable.requirements().is_empty());
-        let unreadable: RequiredPlatform =
-            serde_json::from_str(r#"{"subdir": "linux-64", "virtual_packages": ["not a vp"]}"#)
-                .expect("one unreadable legacy entry must not reject the platform");
-        assert!(unreadable.requirements().is_empty());
-
-        // A structurally wrong file is still a rejection.
-        assert!(
-            serde_json::from_str::<RequiredPlatform>(
-                r#"{"subdir": "linux-64", "requirements": "__cuda >=12"}"#
-            )
-            .is_err()
-        );
-        assert!(
-            serde_json::from_str::<RequiredPlatform>(r#"{"requirements": ["__cuda >=12"]}"#)
-                .is_err()
-        );
-
-        // These are tolerated: no requirements at all is a real state
-        let empty: RequiredPlatform =
-            serde_json::from_str(r#"{"subdir": "linux-64"}"#).expect("no requirements is valid");
-        assert!(empty.requirements().is_empty());
-        // An empty list round-trips to the same thing, and omits the key.
-        let json = serde_json::to_string(&empty).unwrap();
-        assert!(!json.contains("requirements"), "{json}");
-        assert!(
-            serde_json::from_str::<RequiredPlatform>(
-                r#"{"subdir": "linux-64", "requirements": [], "future_key": 3}"#
-            )
-            .is_ok()
-        );
-    }
-
-    #[test]
-    fn requirement_specs_survive_the_marker_round_trip() {
-        for raw in [
-            "__cuda >=12",
-            "__cuda",
-            "__glibc >=2.17,<3.0.a0",
-            "__unix",
-            "__archspec 1 x86_64",
-            "__archspec 1.* ^(x86_64_v3|haswell|skylake)$",
-        ] {
-            let spec = MatchSpec::from_str(raw, ParseStrictness::Lenient).unwrap();
-            let platform = RequiredPlatform::new(Platform::Linux64, vec![spec.clone()]);
-            let json = serde_json::to_string(&platform).unwrap();
-            let restored: RequiredPlatform = serde_json::from_str(&json)
-                .unwrap_or_else(|e| panic!("'{raw}' did not survive the round trip: {e}"));
-            assert_eq!(
-                restored.requirements(),
-                &[spec],
-                "'{raw}' changed meaning through the marker"
-            );
-        }
-    }
-
-    /// A version literal too large to represent.
-    const UNPARSABLE_REQUIREMENT: &str = "__cuda >=99999999999999999999";
-
-    #[test]
-    fn the_unparsable_requirement_fixture_really_is_unparsable() {
-        assert!(MatchSpec::from_str(UNPARSABLE_REQUIREMENT, ParseStrictness::Lenient).is_err());
-    }
-
-    #[test]
-    fn one_unparsable_requirement_does_not_discard_the_readable_ones() {
-        let json = format!(
-            r#"{{"subdir": "linux-64", "requirements": ["__cuda >=12", "{UNPARSABLE_REQUIREMENT}"]}}"#
-        );
-        let restored: RequiredPlatform = serde_json::from_str(&json)
-            .expect("a requirement pixi cannot read must not void the ones it can");
-        assert!(
-            restored
-                .requirements()
-                .iter()
-                .any(|spec| spec.to_string() == "__cuda >=12"),
-            "the readable requirement was dropped: {:?}",
-            restored.requirements()
-        );
-    }
-
-    #[test]
-    fn an_unparsable_requirement_does_not_void_the_whole_environment_file() {
-        let json = format!(
-            r#"{{
-                "manifest_path": "/ws/pixi.toml",
-                "environment_name": "default",
-                "pixi_version": "0.1.0",
-                "environment_lock_file_hash": "deadbeef",
-                "source_fingerprints": {{"some-source-package": 42}},
-                "minimum_supported_platform": {{
-                    "subdir": "linux-64",
-                    "requirements": ["{UNPARSABLE_REQUIREMENT}"]
-                }}
-            }}"#
-        );
-        let parsed: EnvironmentFile = serde_json::from_str(&json)
-            .expect("an unreadable minimum must not invalidate the rest of the marker");
-        assert_eq!(
-            parsed.source_fingerprints.get("some-source-package"),
-            Some(&42),
-            "the rest of the marker was lost with the unreadable requirement"
-        );
     }
 }

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -133,8 +133,8 @@ impl EnvironmentHash {
         // Hash the packages
         let mut urls = Vec::new();
         if let Some(env) = lock_file.environment(run_environment.name().as_str())
-            && let Some(best) = run_environment.best_declared_platform()
-            && let Some(lock_platform) = resolve_lock_platform_for(lock_file, best)
+            && let Some(platform) = run_environment.pinned_or_best_declared_platform()
+            && let Some(lock_platform) = resolve_lock_platform_for(lock_file, platform)
             && let Some(packages) = env.packages(lock_platform)
         {
             for package in packages {
@@ -763,9 +763,7 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
         // A `--platform` the environment doesn't list is a membership error.
         // With no platform requested, defer to the install path's minimum fallback.
         if !no_install
-            && env
-                .named_or_best_declared_platform(target_platform)
-                .is_none()
+            && env.named_or_pinned_platform(target_platform).is_none()
             && let Some(name) = target_platform
         {
             return Err(miette::miette!(
@@ -776,6 +774,7 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
         }
         if !no_install {
             env.emit_emulation_warning();
+            workspace::platform_options::report_new_platform_options(env);
         }
     }
 
@@ -784,7 +783,7 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
     // now -- after the clear membership error, never before it.
     if !no_install
         && target_platform.is_some()
-        && let Some(platform) = environments[0].named_or_best_declared_platform(target_platform)
+        && let Some(platform) = environments[0].named_or_pinned_platform(target_platform)
     {
         let current = Platform::current();
         let subdir = platform.subdir();

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -864,18 +864,19 @@ impl<'p> LockFileDerivedData<'p> {
             .ok_or_else(|| UpdateError::LockFileMissingEnv(environment.name().clone()))?;
         Ok(LockedEnvironmentHash::from_environment(
             locked_environment,
-            environment.named_or_best_declared_platform(self.target_platform.as_ref()),
+            environment.named_or_pinned_platform(self.target_platform.as_ref()),
         ))
     }
 
     /// The declared platform install targets for `environment`: the explicit
-    /// `--platform` override or the best declared platform; when neither
-    /// matches this machine, a declared platform whose lock-resolved minimum
-    /// requirements the machine meets (running "by accident").
+    /// `--platform` override, else the platform it is already installed for,
+    /// else the best declared platform; when none of those matches this
+    /// machine, a declared platform whose lock-resolved minimum requirements
+    /// the machine meets (running "by accident").
     fn install_platform(&self, environment: &Environment<'p>) -> Option<&'p PixiPlatform> {
         let target_override = self.target_platform.as_ref();
         environment
-            .named_or_best_declared_platform(target_override)
+            .named_or_pinned_platform(target_override)
             .or_else(|| {
                 if target_override.is_some() {
                     return None;
@@ -885,7 +886,7 @@ impl<'p> LockFileDerivedData<'p> {
                 if let Some(platform) = fallback {
                     tracing::debug!(
                         "no declared platform of environment '{}' matches this machine; \
-                         installing minimum-compatible platform '{}'",
+                     installing minimum-compatible platform '{}'",
                         environment.name(),
                         platform.name(),
                     );

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -734,18 +734,19 @@ impl<'p> LockFileDerivedData<'p> {
             .ok_or_else(|| UpdateError::LockFileMissingEnv(environment.name().clone()))?;
         Ok(LockedEnvironmentHash::from_environment(
             locked_environment,
-            environment.named_or_best_declared_platform(self.target_platform.as_ref()),
+            environment.named_or_pinned_platform(self.target_platform.as_ref()),
         ))
     }
 
     /// The declared platform install targets for `environment`: the explicit
-    /// `--platform` override or the best declared platform; when neither
-    /// matches this machine, a declared platform whose lock-resolved minimum
-    /// requirements the machine meets (running "by accident").
+    /// `--platform` override, else the platform it is already installed for,
+    /// else the best declared platform; when none of those matches this
+    /// machine, a declared platform whose lock-resolved minimum requirements
+    /// the machine meets (running "by accident").
     fn install_platform(&self, environment: &Environment<'p>) -> Option<&'p PixiPlatform> {
         let target_override = self.target_platform.as_ref();
         environment
-            .named_or_best_declared_platform(target_override)
+            .named_or_pinned_platform(target_override)
             .or_else(|| {
                 if target_override.is_some() {
                     return None;
@@ -755,7 +756,7 @@ impl<'p> LockFileDerivedData<'p> {
                 if let Some(platform) = fallback {
                     tracing::debug!(
                         "no declared platform of environment '{}' matches this machine; \
-                         installing minimum-compatible platform '{}'",
+                     installing minimum-compatible platform '{}'",
                         environment.name(),
                         platform.name(),
                     );

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -120,19 +120,10 @@ impl<'p> Environment<'p> {
         }
     }
 
-    /// The name of the workspace platform this environment was last installed
-    /// for, recovered by matching the resolved platform in `conda-meta/pixi`
-    /// (subdir + virtual packages) against the declared platforms. Lets `pixi
-    /// run` default to what the user installed for without a repeated
-    /// `--platform`. `None` when the environment isn't installed or its
-    /// resolved platform is no longer declared.
-    pub fn installed_resolved_platform_name(&self) -> Option<PixiPlatformName> {
-        self.installed_resolved_platform()
-            .map(|platform| platform.name().clone())
-    }
-
-    /// The declared platform [`Self::installed_resolved_platform_name`] refers
-    /// to, returned by reference to avoid a second name-based lookup.
+    /// The workspace platform this environment was last installed for, recovered
+    /// by matching the resolved platform in `conda-meta/pixi` (subdir + virtual
+    /// packages) against the declared platforms. `None` when it isn't installed
+    /// or that platform is no longer declared.
     pub fn installed_resolved_platform(&self) -> Option<&'p PixiPlatform> {
         let (resolved, _) = self.installed_platforms();
         let resolved = resolved?;
@@ -163,19 +154,20 @@ impl<'p> Environment<'p> {
             .join(self.activation_cache_name())
     }
 
-    /// Returns the platform that pixi will install/activate this environment
-    /// for on the current system, or `None` if none of the platforms supported
-    /// by this environment can run here.
+    /// The platforms this environment declares that can run on the current
+    /// system, ordered from most to least preferred.
     ///
     /// The candidate list comes from
     /// [`manifest::Workspace::possible_pixi_platforms`], which applies the current
     /// system's subdir (honoring `PIXI_OVERRIDE_PLATFORM`), the standard
     /// architecture fallbacks (osx-arm64 → osx-64, win-arm64 → win-64,
     /// win-64 → win-32, single-WASM workspace), and virtual-package
-    /// compatibility with this machine. We then keep only those candidates
-    /// the environment itself declares support for, and return the most
-    /// preferred one.
-    pub fn best_declared_platform(&self) -> Option<&'p PixiPlatform> {
+    /// compatibility with this machine. We then keep only those candidates the
+    /// environment itself declares support for.
+    ///
+    /// The order only decides where a not-yet-installed environment lands; it
+    /// makes no claim that an earlier platform suits the user better.
+    pub fn runnable_declared_platforms(&self) -> Vec<&'p PixiPlatform> {
         let current = self
             .workspace
             .host_platform(
@@ -193,25 +185,23 @@ impl<'p> Environment<'p> {
             .to_vec();
         let env_platforms = self.platforms();
 
-        // The candidates are the workspace platforms whose subdir matches this
-        // host and whose declared virtual packages the host satisfies; the
-        // selection is the first that the environment itself declares.
         let candidates = self
             .workspace_manifest()
             .workspace
             .possible_pixi_platforms(current, &system_virtual_packages);
-        let selected = candidates
+        let runnable: Vec<&'p PixiPlatform> = candidates
             .iter()
             .copied()
-            .find(|p| env_platforms.contains(p.name()));
+            .filter(|p| env_platforms.contains(p.name()))
+            .collect();
 
         if tracing::enabled!(tracing::Level::DEBUG) {
             let mut declared: Vec<&str> = env_platforms.iter().map(|p| p.as_str()).collect();
             declared.sort_unstable();
             tracing::debug!(
-                "selecting best platform for environment '{}' on host subdir '{}' \
+                "host-runnable platforms for environment '{}' on host subdir '{}' \
                  (host virtual packages: [{}]); environment declares [{}]; \
-                 host-runnable candidates [{}]; selected {}",
+                 workspace candidates [{}]; runnable here [{}]",
                 self.name(),
                 current,
                 system_virtual_packages
@@ -220,29 +210,54 @@ impl<'p> Environment<'p> {
                     .format(", "),
                 declared.iter().format(", "),
                 candidates.iter().map(|p| p.name().as_str()).format(", "),
-                match selected {
-                    Some(p) => format!("'{}'", p.name().as_str()),
-                    None => "<none>: no host-runnable candidate is declared by this environment"
-                        .to_string(),
-                },
+                runnable.iter().map(|p| p.name().as_str()).format(", "),
             );
         }
 
-        selected
+        runnable
+    }
+
+    /// Returns the platform that pixi will install/activate this environment
+    /// for on the current system when it isn't installed yet, or `None` if none
+    /// of the platforms supported by this environment can run here: the most
+    /// preferred entry of [`Self::runnable_declared_platforms`].
+    pub fn best_declared_platform(&self) -> Option<&'p PixiPlatform> {
+        self.runnable_declared_platforms().first().copied()
+    }
+
+    /// The platform to target when the caller pinned none: the one recorded in
+    /// `conda-meta/pixi` while this environment still declares it and it still
+    /// runs here, else [`Self::best_declared_platform`].
+    ///
+    /// This is what stops a platform that only just became runnable from taking
+    /// over an installed environment. `--platform` rewrites the record, and so
+    /// moves the pin.
+    pub fn pinned_or_best_declared_platform(&self) -> Option<&'p PixiPlatform> {
+        let runnable = self.runnable_declared_platforms();
+        if let Some(installed) = self.installed_resolved_platform()
+            && runnable.contains(&installed)
+        {
+            return Some(installed);
+        }
+        runnable.first().copied()
     }
 
     /// Picks the workspace platform install/solve should target, with
-    /// `override_platform` skipping [`Self::best_declared_platform`]'s host-VP
-    /// filter so `pixi install --platform <name>` can target a subdir
+    /// `override_platform` skipping [`Self::runnable_declared_platforms`]'s
+    /// host-VP filter so `pixi install --platform <name>` can target a subdir
     /// the local machine can't satisfy. Returns `None` if the override
     /// names a platform the environment doesn't list; falls through to
-    /// [`Self::best_declared_platform`] when the override is `None`.
-    pub fn named_or_best_declared_platform(
+    /// [`Self::pinned_or_best_declared_platform`] when the override is `None`.
+    ///
+    /// The prefix hash and the install must resolve the same platform here, or
+    /// a hash for one would never match a prefix for another and every
+    /// invocation would reinstall.
+    pub fn named_or_pinned_platform(
         &self,
         override_platform: Option<&PixiPlatformName>,
     ) -> Option<&'p PixiPlatform> {
         let Some(name) = override_platform else {
-            return self.best_declared_platform();
+            return self.pinned_or_best_declared_platform();
         };
         let env_platforms = self.platforms();
         if !env_platforms.is_empty() && !env_platforms.contains(name) {

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -116,19 +116,10 @@ impl<'p> Environment<'p> {
         }
     }
 
-    /// The name of the workspace platform this environment was last installed
-    /// for, recovered by matching the resolved platform in `conda-meta/pixi`
-    /// (subdir + virtual packages) against the declared platforms. Lets `pixi
-    /// run` default to what the user installed for without a repeated
-    /// `--platform`. `None` when the environment isn't installed or its
-    /// resolved platform is no longer declared.
-    pub fn installed_resolved_platform_name(&self) -> Option<PixiPlatformName> {
-        self.installed_resolved_platform()
-            .map(|platform| platform.name().clone())
-    }
-
-    /// The declared platform [`Self::installed_resolved_platform_name`] refers
-    /// to, returned by reference to avoid a second name-based lookup.
+    /// The workspace platform this environment was last installed for, recovered
+    /// by matching the resolved platform in `conda-meta/pixi` (subdir + virtual
+    /// packages) against the declared platforms. `None` when it isn't installed
+    /// or that platform is no longer declared.
     pub fn installed_resolved_platform(&self) -> Option<&'p PixiPlatform> {
         let (resolved, _) = self.installed_platforms();
         let resolved = resolved?;
@@ -159,42 +150,41 @@ impl<'p> Environment<'p> {
             .join(self.activation_cache_name())
     }
 
-    /// Returns the platform that pixi will install/activate this environment
-    /// for on the current system, or `None` if none of the platforms supported
-    /// by this environment can run here.
+    /// The platforms this environment declares that can run on the current
+    /// system, ordered from most to least preferred.
     ///
     /// The candidate list comes from
     /// [`manifest::Workspace::possible_pixi_platforms`], which applies the current
     /// system's subdir (honoring `PIXI_OVERRIDE_PLATFORM`), the standard
     /// architecture fallbacks (osx-arm64 → osx-64, win-arm64 → win-64,
     /// win-64 → win-32, single-WASM workspace), and virtual-package
-    /// compatibility with this machine. We then keep only those candidates
-    /// the environment itself declares support for, and return the most
-    /// preferred one.
-    pub fn best_declared_platform(&self) -> Option<&'p PixiPlatform> {
+    /// compatibility with this machine. We then keep only those candidates the
+    /// environment itself declares support for.
+    ///
+    /// The order only decides where a not-yet-installed environment lands; it
+    /// makes no claim that an earlier platform suits the user better.
+    pub fn runnable_declared_platforms(&self) -> Vec<&'p PixiPlatform> {
         let current = host_subdir();
         let system_virtual_packages = host_capabilities();
         let env_platforms = self.platforms();
 
-        // The candidates are the workspace platforms whose subdir matches this
-        // host and whose declared virtual packages the host satisfies; the
-        // selection is the first that the environment itself declares.
         let candidates = self
             .workspace_manifest()
             .workspace
             .possible_pixi_platforms(current, &system_virtual_packages);
-        let selected = candidates
+        let runnable: Vec<&'p PixiPlatform> = candidates
             .iter()
             .copied()
-            .find(|p| env_platforms.contains(p.name()));
+            .filter(|p| env_platforms.contains(p.name()))
+            .collect();
 
         if tracing::enabled!(tracing::Level::DEBUG) {
             let mut declared: Vec<&str> = env_platforms.iter().map(|p| p.as_str()).collect();
             declared.sort_unstable();
             tracing::debug!(
-                "selecting best platform for environment '{}' on host subdir '{}' \
+                "host-runnable platforms for environment '{}' on host subdir '{}' \
                  (host virtual packages: [{}]); environment declares [{}]; \
-                 host-runnable candidates [{}]; selected {}",
+                 workspace candidates [{}]; runnable here [{}]",
                 self.name(),
                 current,
                 system_virtual_packages
@@ -205,29 +195,54 @@ impl<'p> Environment<'p> {
                     .format(", "),
                 declared.iter().format(", "),
                 candidates.iter().map(|p| p.name().as_str()).format(", "),
-                match selected {
-                    Some(p) => format!("'{}'", p.name().as_str()),
-                    None => "<none>: no host-runnable candidate is declared by this environment"
-                        .to_string(),
-                },
+                runnable.iter().map(|p| p.name().as_str()).format(", "),
             );
         }
 
-        selected
+        runnable
+    }
+
+    /// Returns the platform that pixi will install/activate this environment
+    /// for on the current system when it isn't installed yet, or `None` if none
+    /// of the platforms supported by this environment can run here: the most
+    /// preferred entry of [`Self::runnable_declared_platforms`].
+    pub fn best_declared_platform(&self) -> Option<&'p PixiPlatform> {
+        self.runnable_declared_platforms().first().copied()
+    }
+
+    /// The platform to target when the caller pinned none: the one recorded in
+    /// `conda-meta/pixi` while this environment still declares it and it still
+    /// runs here, else [`Self::best_declared_platform`].
+    ///
+    /// This is what stops a platform that only just became runnable from taking
+    /// over an installed environment. `--platform` rewrites the record, and so
+    /// moves the pin.
+    pub fn pinned_or_best_declared_platform(&self) -> Option<&'p PixiPlatform> {
+        let runnable = self.runnable_declared_platforms();
+        if let Some(installed) = self.installed_resolved_platform()
+            && runnable.contains(&installed)
+        {
+            return Some(installed);
+        }
+        runnable.first().copied()
     }
 
     /// Picks the workspace platform install/solve should target, with
-    /// `override_platform` skipping [`Self::best_declared_platform`]'s host-VP
-    /// filter so `pixi install --platform <name>` can target a subdir
+    /// `override_platform` skipping [`Self::runnable_declared_platforms`]'s
+    /// host-VP filter so `pixi install --platform <name>` can target a subdir
     /// the local machine can't satisfy. Returns `None` if the override
     /// names a platform the environment doesn't list; falls through to
-    /// [`Self::best_declared_platform`] when the override is `None`.
-    pub fn named_or_best_declared_platform(
+    /// [`Self::pinned_or_best_declared_platform`] when the override is `None`.
+    ///
+    /// The prefix hash and the install must resolve the same platform here, or
+    /// a hash for one would never match a prefix for another and every
+    /// invocation would reinstall.
+    pub fn named_or_pinned_platform(
         &self,
         override_platform: Option<&PixiPlatformName>,
     ) -> Option<&'p PixiPlatform> {
         let Some(name) = override_platform else {
-            return self.best_declared_platform();
+            return self.pinned_or_best_declared_platform();
         };
         let env_platforms = self.platforms();
         if !env_platforms.is_empty() && !env_platforms.contains(name) {

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -4,6 +4,7 @@ mod environment;
 pub mod errors;
 pub mod grouped_environment;
 mod has_project_ref;
+pub mod platform_options;
 pub mod registry;
 mod repodata;
 mod solve_group;

--- a/crates/pixi_core/src/workspace/platform_options.rs
+++ b/crates/pixi_core/src/workspace/platform_options.rs
@@ -1,0 +1,284 @@
+//! Telling the user which other platforms an installed environment could use.
+//!
+//! The set of platforms that run on a machine grows over time: a teammate adds
+//! one to the manifest, or the machine gains a capability such as a CUDA driver.
+//! [`Environment::pinned_or_best_declared_platform`] keeps an installed
+//! environment where it is, so those options go unnoticed unless we say so.
+//!
+//! We name each platform at most once per environment, and never rank them --
+//! which platform suits the user is not something pixi can know.
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::{LazyLock, Mutex},
+};
+
+use itertools::Itertools;
+use pixi_consts::consts;
+use pixi_manifest::PixiPlatform;
+use serde::{Deserialize, Serialize};
+
+use crate::workspace::{Environment, HasWorkspaceRef};
+
+/// The platforms an environment could be installed for on this machine,
+/// relative to the one it is installed for now.
+#[derive(Debug)]
+pub struct AlternativePlatforms<'p> {
+    /// The platform the environment is installed for, as recorded in
+    /// `conda-meta/pixi`.
+    pub installed: &'p PixiPlatform,
+
+    /// Platforms that run here and that the environment declares, excluding
+    /// `installed`, in [`Environment::runnable_declared_platforms`] order --
+    /// an order of consideration, not a recommendation.
+    pub alternatives: Vec<&'p PixiPlatform>,
+}
+
+/// The platforms `environment` could be installed for besides the one it is
+/// installed for now.
+///
+/// `None` when it isn't installed, when the platform it was installed for is no
+/// longer declared or no longer runs here, or when nothing else runs here.
+pub fn alternative_platforms<'p>(
+    environment: &Environment<'p>,
+) -> Option<AlternativePlatforms<'p>> {
+    let installed = environment.installed_resolved_platform()?;
+    let runnable = environment.runnable_declared_platforms();
+
+    // A lapsed pin means the environment is about to move whatever the user
+    // wants, so offering alternatives would imply it still has a choice.
+    if !runnable.contains(&installed) {
+        return None;
+    }
+
+    let alternatives: Vec<&'p PixiPlatform> = runnable
+        .into_iter()
+        .filter(|platform| *platform != installed)
+        .collect();
+
+    (!alternatives.is_empty()).then_some(AlternativePlatforms {
+        installed,
+        alternatives,
+    })
+}
+
+/// Which alternative platforms we have already told the user about for one
+/// environment of one workspace.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ReportedPlatformOptions {
+    /// The platform installed when we last looked. Informational, so the file
+    /// explains itself to whoever asks why a message did or didn't appear.
+    installed: String,
+
+    /// Every platform this environment's user has been shown or has used. A
+    /// platform in here is never mentioned again.
+    known: Vec<String>,
+}
+
+impl ReportedPlatformOptions {
+    /// The alternatives the user hasn't met yet, in the order given, plus the
+    /// state to persist. An empty first element means stay quiet.
+    ///
+    /// `known` only ever grows and counts the installed platform, so a platform
+    /// that comes and goes, or that a `--platform` switch moved away from, is
+    /// named once and not again.
+    fn plan_report(
+        stored: Option<Self>,
+        installed: &str,
+        alternatives: &[&str],
+    ) -> (Vec<String>, Self) {
+        let mut state = stored.unwrap_or_default();
+        state.installed = installed.to_string();
+
+        let unreported: Vec<String> = alternatives
+            .iter()
+            .filter(|name| !state.known.iter().any(|seen| seen == *name))
+            .map(ToString::to_string)
+            .collect();
+
+        // The platform in use is known by definition; without this, switching
+        // would make the platform left behind look like a fresh discovery.
+        state.known.push(installed.to_string());
+        state.known.extend(unreported.iter().cloned());
+        state.known.sort_unstable();
+        state.known.dedup();
+        (unreported, state)
+    }
+}
+
+/// State files we have already handled in this process, so a multi-task
+/// `pixi run` reports at most once. Mirrors the dedup in
+/// [`crate::workspace::virtual_packages`].
+static REPORTED_IN_PROCESS: LazyLock<Mutex<HashSet<PathBuf>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Report that this machine can run platforms other than the one `environment`
+/// is installed for, at most once per process and once per platform per
+/// workspace.
+///
+/// Best-effort: an unreadable state file counts as nothing reported yet, and one
+/// we cannot write only means the message may repeat.
+pub fn report_new_platform_options(environment: &Environment<'_>) {
+    let state_path = state_file_path(environment);
+
+    let Ok(mut handled) = REPORTED_IN_PROCESS.lock() else {
+        return;
+    };
+    if !handled.insert(state_path.clone()) {
+        return;
+    }
+    drop(handled);
+
+    let Some(options) = alternative_platforms(environment) else {
+        return;
+    };
+
+    let installed = options.installed.name().as_str();
+    let alternatives: Vec<&str> = options
+        .alternatives
+        .iter()
+        .map(|platform| platform.name().as_str())
+        .collect();
+    let stored = read_state(&state_path);
+    let (unreported, state) =
+        ReportedPlatformOptions::plan_report(stored.clone(), installed, &alternatives);
+
+    // Persist on any change, not just when reporting, so the file keeps saying
+    // what we last observed. The common case -- no change -- writes nothing.
+    if stored.as_ref() != Some(&state) {
+        write_state(&state_path, &state);
+    }
+
+    if unreported.is_empty() {
+        return;
+    }
+
+    // Naming one platform would read as a recommendation, so only do it when
+    // there is nothing to choose between.
+    let switch_target = match unreported.as_slice() {
+        [only] => only.as_str(),
+        _ => "<name>",
+    };
+    tracing::warn!(
+        "Environment {} is installed for platform {}. This machine can also run {}. \
+         pixi keeps using {} until you switch it: `pixi install -e {} --platform {}`. \
+         Run `pixi workspace platform list` to see what each platform declares.",
+        consts::ENVIRONMENT_STYLE.apply_to(environment.name().as_str()),
+        consts::PLATFORM_STYLE.apply_to(installed),
+        unreported
+            .iter()
+            .map(|name| consts::PLATFORM_STYLE.apply_to(name.as_str()).to_string())
+            .format(", "),
+        consts::PLATFORM_STYLE.apply_to(installed),
+        environment.name().as_str(),
+        switch_target,
+    );
+}
+
+/// Where the reported-options state for `environment` lives, alongside the
+/// workspace's other one-time messages. `pixi clean` removes `.pixi/envs` but
+/// not this directory, so a reinstall re-announces nothing; delete the file to
+/// hear the message again.
+fn state_file_path(environment: &Environment<'_>) -> PathBuf {
+    environment
+        .workspace()
+        .pixi_dir()
+        .join(consts::ONE_TIME_MESSAGES_DIR)
+        .join(format!("platform-options-{}.json", environment.name()))
+}
+
+/// `None` when the file is absent or unreadable; a corrupt file is discarded so
+/// a stale format can't silence the message forever.
+fn read_state(path: &Path) -> Option<ReportedPlatformOptions> {
+    let contents = fs_err::read_to_string(path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
+fn write_state(path: &Path, state: &ReportedPlatformOptions) {
+    let Ok(contents) = serde_json::to_string_pretty(state) else {
+        return;
+    };
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if let Err(err) = fs_err::create_dir_all(parent)
+        .and_then(|()| pixi_utils::atomic_write::atomic_write_sync(path, contents))
+    {
+        tracing::debug!(
+            "failed to record reported platform options in '{}': {err}",
+            path.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drives the sequence a user actually sees: a new option is announced,
+    /// repeats stay quiet, a later option is announced on its own, and an
+    /// option that disappears and returns is not announced again.
+    #[test]
+    fn each_option_is_reported_once() {
+        let (reported, state) =
+            ReportedPlatformOptions::plan_report(None, "linux-64", &["x86-cuda13"]);
+        assert_eq!(reported, ["x86-cuda13"]);
+
+        let (reported, state) =
+            ReportedPlatformOptions::plan_report(Some(state), "linux-64", &["x86-cuda13"]);
+        assert!(reported.is_empty(), "a repeat run must stay quiet");
+
+        let (reported, state) = ReportedPlatformOptions::plan_report(
+            Some(state),
+            "linux-64",
+            &["x86-cuda13", "x86-v3"],
+        );
+        assert_eq!(reported, ["x86-v3"], "only the option that is new");
+
+        // The machine loses CUDA, then regains it.
+        let (reported, state) =
+            ReportedPlatformOptions::plan_report(Some(state), "linux-64", &["x86-v3"]);
+        assert!(reported.is_empty());
+        let (reported, _) = ReportedPlatformOptions::plan_report(
+            Some(state),
+            "linux-64",
+            &["x86-cuda13", "x86-v3"],
+        );
+        assert!(
+            reported.is_empty(),
+            "an option the user already saw must not come back"
+        );
+    }
+
+    /// Switching to one of the alternatives says nothing new: the user has been
+    /// told which platforms run here, and hearing the same set from the other
+    /// side is the nagging the once-per-option rule exists to prevent.
+    #[test]
+    fn switching_the_installed_platform_is_not_news() {
+        let (reported, state) =
+            ReportedPlatformOptions::plan_report(None, "linux-64", &["x86-cuda13", "x86-v3"]);
+        assert_eq!(reported, ["x86-cuda13", "x86-v3"]);
+
+        // The user switches to x86-cuda13; the alternatives are now linux-64
+        // (where they came from) and x86-v3 (already announced above).
+        let (reported, state) = ReportedPlatformOptions::plan_report(
+            Some(state),
+            "x86-cuda13",
+            &["linux-64", "x86-v3"],
+        );
+        assert!(
+            reported.is_empty(),
+            "no platform in this workspace is still unannounced"
+        );
+        assert_eq!(state.installed, "x86-cuda13", "the pin is still tracked");
+
+        // A genuinely new platform is still announced after a switch.
+        let (reported, _) = ReportedPlatformOptions::plan_report(
+            Some(state),
+            "x86-cuda13",
+            &["linux-64", "x86-v3", "x86-v4"],
+        );
+        assert_eq!(reported, ["x86-v4"]);
+    }
+}

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -446,7 +446,7 @@ pub fn verify_run_platform(
     let (base_subdirs, base_capabilities, base_name) = match target_platform {
         // Explicit `--platform`: trust the named platform's declared capabilities.
         Some(name) => {
-            let Some(platform) = environment.named_or_best_declared_platform(Some(name)) else {
+            let Some(platform) = environment.named_or_pinned_platform(Some(name)) else {
                 // Not a platform this environment lists; the caller reported it.
                 return Ok(());
             };

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -399,7 +399,7 @@ pub fn verify_run_platform(
     let (base_subdirs, base_capabilities, base_name, base_subdir) = match target_platform {
         // Explicit `--platform`: trust the named platform's declared capabilities.
         Some(name) => {
-            let Some(platform) = environment.named_or_best_declared_platform(Some(name)) else {
+            let Some(platform) = environment.named_or_pinned_platform(Some(name)) else {
                 // Not a platform this environment lists; the caller reported it.
                 return Ok(());
             };

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -130,7 +130,7 @@ pub(crate) fn environments_defining_task(
 /// machine-incompatible environments are still found -- the first declared
 /// platform.
 pub(crate) fn default_search_platform<'p>(env: &Environment<'p>) -> Option<&'p PixiPlatform> {
-    env.installed_or_best_declared_platform().or_else(|| {
+    env.pinned_or_best_declared_platform().or_else(|| {
         let env_platform_names = env.platforms();
         env.workspace_manifest()
             .workspace

--- a/crates/pixi_task/src/task_environment.rs
+++ b/crates/pixi_task/src/task_environment.rs
@@ -130,15 +130,7 @@ pub(crate) fn environments_defining_task(
 /// machine-incompatible environments are still found -- the first declared
 /// platform.
 fn default_search_platform<'p>(env: &Environment<'p>) -> Option<&'p PixiPlatform> {
-    if let Some(platform) = env.installed_resolved_platform() {
-        // Mirror `named_or_best_declared_platform`'s guard: only use the
-        // installed platform when the environment actually declares it.
-        let env_platforms = env.platforms();
-        if env_platforms.is_empty() || env_platforms.contains(platform.name()) {
-            return Some(platform);
-        }
-    }
-    env.best_declared_platform().or_else(|| {
+    env.pinned_or_best_declared_platform().or_else(|| {
         let env_platform_names = env.platforms();
         env.workspace_manifest()
             .workspace

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -152,7 +152,8 @@ pixi workspace platform add --auto-detect
 ```
 
 With `--auto-detect`, Pixi resolves the current subdir and the virtual packages it detects on the host (macOS version, glibc, archspec, CUDA, ...) into a concrete platform entry.
-It inserts this platform **first** in `platforms`, so it wins [platform selection](#platform-definition) on this machine.
+It inserts this platform **first** in `platforms`, so it wins [platform selection](#platform-definition) for environments that are not installed yet.
+Environments you have already installed stay on the platform they were installed for and report the new option instead; see [Switching an installed environment](#switching-an-installed-environment).
 Because it writes a normal entry to `pixi.toml`, the result is checked in and shared with everyone using the workspace.
 
 ```shell
@@ -170,6 +171,37 @@ Adding a platform whose definition already exists under a *different* name is re
     Auto-detection captures your machine exactly, which is usually more specific than your packages actually need.
     After installing, `pixi info` reports each environment's **Minimum platform** (the virtual-package requirements some resolved dependency really places on the machine), so you can see which ones are safe to drop with `pixi workspace platform edit`.
 
+### Switching an installed environment
+
+Platform selection order only decides where a *new* environment lands.
+Once an environment is installed, Pixi records the platform in `.pixi/envs/<name>/conda-meta/pixi` and keeps using it, even if another declared platform would now sort ahead of it.
+Which platform that is can change without you touching the manifest: a teammate adds one, or your machine gains a capability such as a CUDA driver, making a `cuda` entry satisfiable for the first time.
+Re-resolving an environment onto different binaries is not something Pixi does on your behalf.
+
+When Pixi notices that this machine can run a platform other than the installed one, it says so once:
+
+```shell
+❯ pixi run build
+ WARN Environment default is installed for platform linux-64. This machine can also run tuned.
+      pixi keeps using linux-64 until you switch it: `pixi install -e default --platform tuned`.
+      Run `pixi workspace platform list` to see what each platform declares.
+```
+
+Each option is announced once per workspace; a further option appearing later is announced on its own.
+Pixi does not rank the alternatives, because which platform suits you is not something it can know: a CUDA-enabled platform is the right choice for some workspaces and needless rebuilding for others.
+
+To switch, name the platform:
+
+```shell
+pixi install --platform tuned
+```
+
+That records `tuned` as the platform for that environment, so subsequent commands need no `--platform`.
+Two commands show the current state: `pixi info` lists the environment's **Resolved platform** and, below it, **Also runnable here**; `pixi workspace platform list` marks each platform with the environments **Installed for** it.
+
+!!! note "Going back to automatic selection"
+    There is no flag meaning "pick for me again". Name the platform you want with `pixi install --platform <name>`, or remove the environment (`pixi clean`) and let the next install choose.
+
 ### Managing platforms from the CLI
 
 [`pixi workspace platform`](../reference/cli/pixi/workspace/platform/index.md) is the CLI surface for these entries:
@@ -179,7 +211,7 @@ Adding a platform whose definition already exists under a *different* name is re
   `--auto-detect`, see above). `--cuda-arch` requires `--cuda` (or
   an existing `__cuda`) and serializes as `cuda = { driver, arch }`.
 - `pixi workspace platform edit <NAME> [--cuda 12.1] [--remove-virtual-package __glibc]` mutates a custom platform's declared virtual packages.
-- `pixi workspace platform move <NAME> --to-top | --to-bottom | --before <NAME> | --after <NAME>` reorders an entry; since order is selection priority, this is how you promote or demote a platform.
+- `pixi workspace platform move <NAME> --to-top | --to-bottom | --before <NAME> | --after <NAME>` reorders an entry; since order is selection priority for environments that are not installed yet, this is how you promote or demote a platform. Use `pixi install --platform <name>` to move an environment that is already installed.
 - `pixi workspace platform list` inspects what is declared.
 - `pixi workspace platform remove <NAME>` drops an entry.
 

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -140,7 +140,8 @@ pixi workspace platform add --auto-detect
 ```
 
 With `--auto-detect`, Pixi resolves the current subdir and the virtual packages it detects on the host (macOS version, glibc, archspec, CUDA, ...) into a concrete platform entry.
-It inserts this platform **first** in `platforms`, so it wins [platform selection](#platform-definition) on this machine.
+It inserts this platform **first** in `platforms`, so it wins [platform selection](#platform-definition) for environments that are not installed yet.
+Environments you have already installed stay on the platform they were installed for and report the new option instead; see [Switching an installed environment](#switching-an-installed-environment).
 Because it writes a normal entry to `pixi.toml`, the result is checked in and shared with everyone using the workspace.
 
 ```shell
@@ -158,6 +159,37 @@ Adding a platform whose definition already exists under a *different* name is re
     Auto-detection captures your machine exactly, which is usually more specific than your packages actually need.
     After installing, `pixi info` reports each environment's **Minimum platform** (the virtual packages some resolved dependency really requires), so you can see which ones are safe to drop with `pixi workspace platform edit`.
 
+### Switching an installed environment
+
+Platform selection order only decides where a *new* environment lands.
+Once an environment is installed, Pixi records the platform in `.pixi/envs/<name>/conda-meta/pixi` and keeps using it, even if another declared platform would now sort ahead of it.
+Which platform that is can change without you touching the manifest: a teammate adds one, or your machine gains a capability such as a CUDA driver, making a `cuda` entry satisfiable for the first time.
+Re-resolving an environment onto different binaries is not something Pixi does on your behalf.
+
+When Pixi notices that this machine can run a platform other than the installed one, it says so once:
+
+```shell
+❯ pixi run build
+ WARN Environment default is installed for platform linux-64. This machine can also run tuned.
+      pixi keeps using linux-64 until you switch it: `pixi install -e default --platform tuned`.
+      Run `pixi workspace platform list` to see what each platform declares.
+```
+
+Each option is announced once per workspace; a further option appearing later is announced on its own.
+Pixi does not rank the alternatives, because which platform suits you is not something it can know: a CUDA-enabled platform is the right choice for some workspaces and needless rebuilding for others.
+
+To switch, name the platform:
+
+```shell
+pixi install --platform tuned
+```
+
+That records `tuned` as the platform for that environment, so subsequent commands need no `--platform`.
+Two commands show the current state: `pixi info` lists the environment's **Resolved platform** and, below it, **Also runnable here**; `pixi workspace platform list` marks each platform with the environments **Installed for** it.
+
+!!! note "Going back to automatic selection"
+    There is no flag meaning "pick for me again". Name the platform you want with `pixi install --platform <name>`, or remove the environment (`pixi clean`) and let the next install choose.
+
 ### Managing platforms from the CLI
 
 [`pixi workspace platform`](../reference/cli/pixi/workspace/platform.md) is the CLI surface for these entries:
@@ -167,7 +199,7 @@ Adding a platform whose definition already exists under a *different* name is re
   `--auto-detect`, see above). `--cuda-arch` requires `--cuda` (or
   an existing `__cuda`) and serializes as `cuda = { driver, arch }`.
 - `pixi workspace platform edit <NAME> [--cuda 12.1] [--remove-virtual-package __glibc]` mutates a custom platform's declared virtual packages.
-- `pixi workspace platform move <NAME> --to-top | --to-bottom | --before <NAME> | --after <NAME>` reorders an entry; since order is selection priority, this is how you promote or demote a platform.
+- `pixi workspace platform move <NAME> --to-top | --to-bottom | --before <NAME> | --after <NAME>` reorders an entry; since order is selection priority for environments that are not installed yet, this is how you promote or demote a platform. Use `pixi install --platform <name>` to move an environment that is already installed.
 - `pixi workspace platform list` inspects what is declared.
 - `pixi workspace platform remove <NAME>` drops an entry.
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1219,6 +1219,9 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
                     "platforms": IsAnyList,
                     "resolved_platform": IsPlatformInfo,
                     "minimum_supported_platform": IsPlatformInfo,
+                    # Host-dependent like the two above: an osx-arm64 host also
+                    # runs the declared osx-64 platform, a linux-64 host doesn't.
+                    "alternative_platforms": IsAnyList,
                     "tasks": [],
                     "channels": ["conda-forge"],
                     "prefix": IsStr,
@@ -1233,6 +1236,9 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
                     "platforms": IsAnyList,
                     "resolved_platform": IsPlatformInfo,
                     "minimum_supported_platform": IsPlatformInfo,
+                    # Host-dependent like the two above: an osx-arm64 host also
+                    # runs the declared osx-64 platform, a linux-64 host doesn't.
+                    "alternative_platforms": IsAnyList,
                     "tasks": [],
                     "channels": ["conda-forge"],
                     "prefix": IsStr,

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -1485,6 +1485,9 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
                     "platforms": IsAnyList,
                     "resolved_platform": IsPlatformInfo,
                     "minimum_supported_platform": IsPlatformInfo,
+                    # Host-dependent like the two above: an osx-arm64 host also
+                    # runs the declared osx-64 platform, a linux-64 host doesn't.
+                    "alternative_platforms": IsAnyList,
                     "tasks": [],
                     "channels": ["conda-forge"],
                     "prefix": IsStr,
@@ -1499,6 +1502,9 @@ def test_info_output_extended(pixi: Path, tmp_pixi_workspace: Path) -> None:
                     "platforms": IsAnyList,
                     "resolved_platform": IsPlatformInfo,
                     "minimum_supported_platform": IsPlatformInfo,
+                    # Host-dependent like the two above: an osx-arm64 host also
+                    # runs the declared osx-64 platform, a linux-64 host doesn't.
+                    "alternative_platforms": IsAnyList,
                     "tasks": [],
                     "channels": ["conda-forge"],
                     "prefix": IsStr,

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -271,3 +271,91 @@ restricted = {{ features = ["x86-only"] }}
         [pixi, "lock", "--check", "--dry-run", "--manifest-path", manifest],
         ExitCode.SUCCESS,
     )
+
+
+def _platform_options_workspace(tmp_pixi_workspace: Path, channel: str) -> Path:
+    """A workspace whose `gpu` platform demands a CUDA driver no host reports,
+    so it only becomes runnable under `CONDA_OVERRIDE_CUDA`."""
+    return _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "platform-options"
+channels = ["{channel}"]
+platforms = [
+  {{ name = "gpu", platform = "{CURRENT_PLATFORM}", cuda = "999" }},
+  "{CURRENT_PLATFORM}",
+]
+
+[dependencies]
+no-deps = "*"
+""",
+    )
+
+
+def test_new_platform_option_is_announced_once(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """A platform that becomes runnable after an install is reported, with the
+    command that switches, and is not reported a second time."""
+    manifest = _platform_options_workspace(tmp_pixi_workspace, virtual_packages_channel)
+    with_cuda = {"CONDA_OVERRIDE_CUDA": "999"}
+
+    # No driver: `gpu` cannot run, so the environment installs for the subdir.
+    verify_cli_command([pixi, "install", "--manifest-path", manifest], ExitCode.SUCCESS)
+
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env=with_cuda,
+        stderr_contains=["is installed for platform", "can also run", "--platform gpu"],
+        strip_ansi=True,
+    )
+
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env=with_cuda,
+        stderr_excludes="can also run",
+        strip_ansi=True,
+    )
+
+
+def test_info_names_the_installed_rich_platform(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """`pixi info` reports the resolved platform under its declared name, not the
+    bare subdir it targets, and lists the platforms that also run here."""
+    manifest = _platform_options_workspace(tmp_pixi_workspace, virtual_packages_channel)
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest, "--platform", "gpu"],
+        ExitCode.SUCCESS,
+    )
+
+    verify_cli_command(
+        [pixi, "info", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "999"},
+        stdout_contains=["Resolved platform: gpu", f"Also runnable here: {CURRENT_PLATFORM}"],
+        strip_ansi=True,
+    )
+
+
+def test_platform_list_marks_the_installed_platform(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """`pixi workspace platform list` distinguishes the platform an environment
+    is installed for from those that merely run here."""
+    manifest = _platform_options_workspace(tmp_pixi_workspace, virtual_packages_channel)
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest, "--platform", "gpu"],
+        ExitCode.SUCCESS,
+    )
+
+    verify_cli_command(
+        [pixi, "workspace", "platform", "list", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "999"},
+        stdout_contains=["gpu:", "Installed for", "default"],
+        strip_ansi=True,
+    )

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -405,6 +405,90 @@ restricted = {{ features = ["x86-only"] }}
     )
 
 
+
+def _platform_options_workspace(tmp_pixi_workspace: Path, channel: str) -> Path:
+    """A workspace whose `gpu` platform demands a CUDA driver no host reports,
+    so it only becomes runnable under `CONDA_OVERRIDE_CUDA`."""
+    return _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "platform-options"
+channels = ["{channel}"]
+platforms = [
+  {{ name = "gpu", platform = "{CURRENT_PLATFORM}", cuda = "999" }},
+  "{CURRENT_PLATFORM}",
+]
+
+[dependencies]
+no-deps = "*"
+""",
+    )
+
+
+def test_new_platform_option_is_announced_once(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """A platform that becomes runnable after an install is reported, with the
+    command that switches, and is not reported a second time."""
+    manifest = _platform_options_workspace(tmp_pixi_workspace, virtual_packages_channel)
+    with_cuda = {"CONDA_OVERRIDE_CUDA": "999"}
+
+    verify_cli_command([pixi, "install", "--manifest-path", manifest], ExitCode.SUCCESS)
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env=with_cuda,
+        stderr_contains=["is installed for platform", "can also run", "--platform gpu"],
+        strip_ansi=True,
+    )
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env=with_cuda,
+        stderr_excludes="can also run",
+        strip_ansi=True,
+    )
+
+
+def test_info_names_the_installed_rich_platform(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """`pixi info` reports the resolved platform under its declared name, not the
+    bare subdir it targets, and lists the platforms that also run here."""
+    manifest = _platform_options_workspace(tmp_pixi_workspace, virtual_packages_channel)
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest, "--platform", "gpu"],
+        ExitCode.SUCCESS,
+    )
+    verify_cli_command(
+        [pixi, "info", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "999"},
+        stdout_contains=["Resolved platform: gpu", f"Also runnable here: {CURRENT_PLATFORM}"],
+        strip_ansi=True,
+    )
+
+
+def test_platform_list_marks_the_installed_platform(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """`pixi workspace platform list` distinguishes the platform an environment
+    is installed for from those that merely run here."""
+    manifest = _platform_options_workspace(tmp_pixi_workspace, virtual_packages_channel)
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest, "--platform", "gpu"],
+        ExitCode.SUCCESS,
+    )
+    verify_cli_command(
+        [pixi, "workspace", "platform", "list", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "999"},
+        stdout_contains=["gpu:", "Installed for", "default"],
+        strip_ansi=True,
+    )
+
+
 def test_unreadable_requirement_costs_only_that_requirement(
     pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
 ) -> None:


### PR DESCRIPTION
An environment was installed for whichever declared platform sorted first among those the host could run. That set grows on its own: a teammate adds a platform to the manifest, or the machine gains a capability and a `cuda` entry becomes satisfiable. When it grew, the environment hash changed and the next bare `pixi run` silently reinstalled the prefix onto the new platform. The same gap made the obvious remedy useless, since `pixi install --platform X` recorded X but the next bare command recomputed the best platform and reverted it.

The platform recorded in `conda-meta/pixi` is now a pin: `named_or_pinned_platform` keeps an installed environment there while it is still declared and still runs on the machine, and `--platform` moves the pin durably. Selection order now only decides where a not-yet-installed environment lands. `pixi run` and `task_environment` each carried their own partial version of this, one of which routed the installed name through the explicit-override path and so skipped the host check; both now delegate.

Newly runnable platforms are reported instead, once per platform per environment, tracked in `.pixi/one-time-messages/platform-options-<env>.json`. The message lists the alternatives and the command that switches, and names a single platform only when there is nothing to choose between -- naming one of several would read as a recommendation, and which platform suits a user is not something pixi can determine. `pixi info` gains "Also runnable here" and `pixi workspace platform list` an "Installed for" line, both unthrottled.

`pixi info` also now names the resolved platform after its declared entry. The marker records a composition and no name, so an environment installed for a rich platform was reported under its bare subdir, indistinguishable from the plain subdir platform listed beside it.

Known gap: a pin that stops being runnable still moves the environment without a message. The reinstall rewrites the marker before `verify_run_platform` reads it, so the existing check sees a consistent state and stays quiet.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.