### PR TITLE
feat: Run PEP 723 scripts from URLs

### DIFF
--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -100,6 +100,22 @@ pub(crate) fn script_lock_file_usage(
     }
 }
 
+/// Select the lock-file policy for a transient script, which can never have an
+/// adjacent lock file.
+pub(crate) fn transient_script_lock_file_usage(
+    requested: LockFileUsage,
+) -> miette::Result<LockFileUsage> {
+    match requested {
+        LockFileUsage::Update | LockFileUsage::DryRun => Ok(LockFileUsage::DryRun),
+        LockFileUsage::Locked => Err(miette::miette!(
+            "transient scripts cannot be run with `--locked` because they do not have an adjacent lock file"
+        )),
+        LockFileUsage::Frozen => Err(miette::miette!(
+            "transient scripts cannot be run with `--frozen` because they do not have an adjacent lock file"
+        )),
+    }
+}
+
 /// Channel configuration
 #[derive(Parser, Debug, Default)]
 pub struct ChannelsConfig {
@@ -572,6 +588,7 @@ mod tests {
     use crate::cli_config::{
         DependencyConfig, GitRev, LockAndInstallConfig, LockFileUpdateConfig, NoInstallConfig,
         ScriptWorkspaceConfig, build_vcs_requirement, script_lock_file_usage,
+        transient_script_lock_file_usage,
     };
     use pixi_core::environment::LockFileUsage;
     use pixi_core::workspace::DiscoveryStart;
@@ -633,6 +650,12 @@ mod tests {
             script_lock_file_usage(LockFileUsage::Update, false, false).unwrap(),
             LockFileUsage::Update
         );
+        assert_eq!(
+            transient_script_lock_file_usage(LockFileUsage::Update).unwrap(),
+            LockFileUsage::DryRun
+        );
+        assert!(transient_script_lock_file_usage(LockFileUsage::Locked).is_err());
+        assert!(transient_script_lock_file_usage(LockFileUsage::Frozen).is_err());
     }
 
     #[test]

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -43,6 +43,7 @@ pub mod publish;
 pub mod reinstall;
 pub mod remove;
 pub mod run;
+mod run_script;
 pub mod search;
 pub mod self_update;
 mod shared;

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -29,7 +29,7 @@ use pixi_core::{
         },
     },
 };
-use pixi_manifest::{HasWorkspaceManifest, PixiPlatformName, TaskName};
+use pixi_manifest::{HasWorkspaceManifest, PixiPlatformName, TaskName, WithWarnings};
 use pixi_progress::global_multi_progress;
 use pixi_task::{
     AmbiguousTask, CanSkip, ExecutableTask, FailedToParseShellScript, InvalidWorkingDirectory,
@@ -40,8 +40,12 @@ use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use tracing::Level;
 
-use crate::cli_config::{LockAndInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage};
+use crate::cli_config::{
+    LockAndInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage,
+    transient_script_lock_file_usage,
+};
 use crate::process_exit;
+use crate::run_script::{RunScriptInput, prepare_remote_script};
 use crate::shared::install_platform::resolve_install_platform;
 
 /// Runs task in the pixi environment.
@@ -164,11 +168,52 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
         .merge_config(args.config.clone().into());
 
     let is_script = args.workspace_config.script.is_some();
-    let workspace_locator = WorkspaceLocator::for_cli()
-        .with_global_config_source(args.config_source.source())
-        .with_search_start(args.workspace_config.workspace_locator_start())
-        .with_cli_config(cli_config);
-    let workspace = workspace_locator.locate()?;
+    let script_input = args
+        .workspace_config
+        .script
+        .as_deref()
+        .map(RunScriptInput::classify);
+    let global_config_source = args.config_source.source();
+    let mut transient_lock_file_usage = None;
+    let mut _remote_script_file = None;
+    let workspace = match script_input {
+        Some(RunScriptInput::Remote(url)) => {
+            transient_lock_file_usage = Some(transient_script_lock_file_usage(
+                args.lock_and_install_config.lock_file_usage()?,
+            )?);
+            let root = std::env::current_dir().into_diagnostic()?;
+            let config = pixi_config::Config::load_with(&root, &global_config_source)
+                .merge_config(cli_config);
+            let prepared = prepare_remote_script(url, &config, &root).await?;
+            let mut cache_key = b"remote\0".to_vec();
+            cache_key.extend_from_slice(prepared.original_url.as_str().as_bytes());
+            let WithWarnings {
+                value: workspace,
+                warnings,
+            } = Workspace::from_transient_script(
+                prepared.manifest,
+                config,
+                root,
+                &prepared.cache_name,
+                &cache_key,
+            )?;
+            for warning in warnings {
+                tracing::warn!("{warning}");
+            }
+            _remote_script_file = Some(prepared.file);
+            workspace
+        }
+        Some(RunScriptInput::Local(path)) => WorkspaceLocator::for_cli()
+            .with_global_config_source(global_config_source)
+            .with_search_start(pixi_core::workspace::DiscoveryStart::Script(path))
+            .with_cli_config(cli_config)
+            .locate()?,
+        None => WorkspaceLocator::for_cli()
+            .with_global_config_source(global_config_source)
+            .with_search_start(args.workspace_config.workspace_locator_start())
+            .with_cli_config(cli_config)
+            .locate()?,
+    };
 
     if is_script {
         let script_path = workspace.workspace.provenance.path.clone();
@@ -242,11 +287,16 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
     let progress = pixi_reporters::TopLevelProgress::from_global();
 
     // Ensure that the lock file is up-to-date.
-    let lock_file_usage = script_lock_file_usage(
-        args.lock_and_install_config.lock_file_usage()?,
-        is_script,
-        workspace.lock_file_path().is_file(),
-    )?;
+    let lock_file_usage = match transient_lock_file_usage {
+        Some(lock_file_usage) => lock_file_usage,
+        None => script_lock_file_usage(
+            args.lock_and_install_config.lock_file_usage()?,
+            is_script,
+            workspace
+                .persistent_lock_file_path()
+                .is_some_and(|path| path.is_file()),
+        )?,
+    };
     let mut lock_file = workspace
         .update_lock_file(
             Some(progress.clone()),

--- a/crates/pixi_cli/src/run_script.rs
+++ b/crates/pixi_cli/src/run_script.rs
@@ -1,0 +1,186 @@
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use miette::{IntoDiagnostic, WrapErr};
+use pixi_config::Config;
+use pixi_manifest::script::ScriptManifest;
+use pixi_utils::reqwest::build_reqwest_clients;
+use tempfile::NamedTempFile;
+use url::Url;
+
+#[derive(Debug)]
+pub(crate) enum RunScriptInput {
+    Local(PathBuf),
+    Remote(Url),
+}
+
+impl RunScriptInput {
+    pub(crate) fn classify(input: &Path) -> Self {
+        let Some(input) = input.to_str() else {
+            return Self::Local(input.to_owned());
+        };
+        match Url::parse(input) {
+            Ok(url) if matches!(url.scheme(), "http" | "https") => Self::Remote(url),
+            _ => Self::Local(input.into()),
+        }
+    }
+}
+
+pub(crate) struct PreparedRemoteScript {
+    pub(crate) file: NamedTempFile,
+    pub(crate) manifest: ScriptManifest,
+    pub(crate) original_url: Url,
+    pub(crate) cache_name: String,
+}
+
+pub(crate) async fn prepare_remote_script(
+    original_url: Url,
+    config: &Config,
+    root: &Path,
+) -> miette::Result<PreparedRemoteScript> {
+    let safe_original_url = safe_url(&original_url);
+    let (_, client) = build_reqwest_clients(Some(config), None)?;
+    let mut response = client.get(original_url.clone()).send().await.map_err(|_| {
+        miette::miette!("failed to download remote script from {safe_original_url}")
+    })?;
+    let final_url = response.url().clone();
+    let status = response.status();
+    if !status.is_success() {
+        return Err(miette::miette!(
+            "failed to download remote script from {safe_original_url}: server returned {status}"
+        ));
+    }
+
+    let cache_name = friendly_name(&final_url);
+    let mut file = tempfile::Builder::new()
+        .prefix(&format!("{cache_name}-"))
+        .suffix(".py")
+        .tempfile()
+        .into_diagnostic()
+        .wrap_err("failed to create a temporary file for the remote script")?;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| miette::miette!("failed to download remote script from {safe_original_url}"))?
+    {
+        file.write_all(&chunk)
+            .into_diagnostic()
+            .wrap_err("failed to write the downloaded script to its temporary file")?;
+    }
+    file.flush()
+        .into_diagnostic()
+        .wrap_err("failed to flush the downloaded script")?;
+
+    let contents = fs_err::read(file.path())
+        .into_diagnostic()
+        .wrap_err("failed to read the downloaded script")?;
+    let manifest = ScriptManifest::from_source_with_context(
+        file.path().to_owned(),
+        &contents,
+        safe_original_url.clone(),
+        root.to_owned(),
+        cache_name.clone(),
+    )?
+    .ok_or_else(|| {
+        miette::miette!(
+            help =
+                "Download the script and initialize it locally with `pixi init --script <PATH>`.",
+            "the remote script at {safe_original_url} does not contain a PEP 723 metadata block"
+        )
+    })?;
+
+    Ok(PreparedRemoteScript {
+        file,
+        manifest,
+        original_url,
+        cache_name,
+    })
+}
+
+pub(crate) fn safe_url(url: &Url) -> String {
+    let mut safe = url.clone();
+    if !safe.username().is_empty() {
+        let _ = safe.set_username("***");
+    }
+    if safe.password().is_some() {
+        let _ = safe.set_password(Some("***"));
+    }
+    safe.to_string()
+}
+
+fn friendly_name(url: &Url) -> String {
+    let name = url
+        .path_segments()
+        .and_then(|mut segments| segments.rfind(|segment| !segment.is_empty()))
+        .unwrap_or("script");
+    let name = name.strip_suffix(".py").unwrap_or(name);
+    let name = name
+        .bytes()
+        .map(|byte| {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_') {
+                byte as char
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let name = name.trim_matches('-');
+    if name.is_empty() {
+        "script".to_owned()
+    } else {
+        name.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RunScriptInput, friendly_name, safe_url};
+    use std::path::Path;
+    use url::Url;
+
+    #[test]
+    fn classifies_only_http_urls_as_remote() {
+        assert!(matches!(
+            RunScriptInput::classify(Path::new("https://example.com/script")),
+            RunScriptInput::Remote(_)
+        ));
+        assert!(matches!(
+            RunScriptInput::classify(Path::new("http://example.com/script.py")),
+            RunScriptInput::Remote(_)
+        ));
+        assert!(matches!(
+            RunScriptInput::classify(Path::new("file:///tmp/script.py")),
+            RunScriptInput::Local(_)
+        ));
+        assert!(matches!(
+            RunScriptInput::classify(Path::new("script.py")),
+            RunScriptInput::Local(_)
+        ));
+    }
+
+    #[test]
+    fn derives_safe_friendly_names() {
+        assert_eq!(
+            friendly_name(&Url::parse("https://example.com/path/example.py").unwrap()),
+            "example"
+        );
+        assert_eq!(
+            friendly_name(&Url::parse("https://example.com/path/no%20spaces").unwrap()),
+            "no-20spaces"
+        );
+        assert_eq!(
+            friendly_name(&Url::parse("https://example.com/").unwrap()),
+            "script"
+        );
+    }
+
+    #[test]
+    fn redacts_url_credentials() {
+        assert_eq!(
+            safe_url(&Url::parse("https://user:secret@example.com/script.py").unwrap()),
+            "https://***:***@example.com/script.py"
+        );
+    }
+}

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -424,7 +424,9 @@ impl Workspace {
     /// - `.into_lock_file_or_empty()` - silent fallback to empty
     /// - `.into_lock_file_or_empty_with_warning()` - displays warning and continues
     pub async fn load_lock_file(&self) -> miette::Result<LockFileLoadResult> {
-        let lock_file_path = self.lock_file_path();
+        let Some(lock_file_path) = self.persistent_lock_file_path() else {
+            return Ok(LockFileLoadResult::Loaded(LockFile::default()));
+        };
         let manifest = self.workspace_manifest().clone();
         let workspace_root = self.root().to_path_buf();
         if lock_file_path.is_file() {
@@ -697,7 +699,9 @@ impl<'p> LockFileDerivedData<'p> {
             }
         }
 
-        let lock_file_path = self.workspace.lock_file_path();
+        let lock_file_path = self.workspace.persistent_lock_file_path().ok_or_else(|| {
+            miette::miette!("transient script workspaces cannot write lock files")
+        })?;
         // Shorten rich platform names to `p1`, `p2`, ... on disk; the load-time
         // pass restores the manifest names by identity.
         let lock_file = crate::lock_file::platform_rename::shorten_platform_names(

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -198,7 +198,7 @@ enum WorkspaceStorage {
     Script {
         manifest: Box<ScriptManifest>,
         pixi_dir: PathBuf,
-        lock_file_path: PathBuf,
+        lock_file_path: Option<PathBuf>,
     },
 }
 
@@ -524,7 +524,71 @@ impl Workspace {
             WorkspaceStorage::Script {
                 manifest: Box::new(script_manifest),
                 pixi_dir,
-                lock_file_path,
+                lock_file_path: Some(lock_file_path),
+            },
+        ))
+        .with_warnings(warnings))
+    }
+
+    /// Construct an isolated workspace for a transient PEP 723 script.
+    pub fn from_transient_script(
+        script: ScriptManifest,
+        config: Config,
+        root: PathBuf,
+        cache_name: &str,
+        cache_key: &[u8],
+    ) -> Result<WithWarnings<Self>, ScriptWorkspaceError> {
+        let script_path = script.path().to_owned();
+        let script_manifest = script.clone();
+        let script_config = script.workspace_config()?;
+        let (mut manifest, warnings) = script.into_workspace_manifest()?;
+
+        if !script_config.channels_explicit {
+            manifest.workspace.channels = config
+                .default_channels()
+                .into_iter()
+                .map(PrioritizedChannel::from)
+                .collect();
+        }
+        if !script_config.platforms_explicit {
+            manifest.workspace.platforms =
+                IndexSet::from([PixiPlatform::from_subdir(Platform::current())]);
+        }
+
+        let digest = format!("{:016x}", xxh3_64(cache_key));
+        let cache_name = cache_name
+            .bytes()
+            .take(100)
+            .map(|byte| {
+                if byte.is_ascii_alphanumeric() {
+                    byte.to_ascii_lowercase() as char
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>();
+        let cache_name = cache_name.trim_matches('-');
+        let cache_name = if cache_name.is_empty() {
+            digest
+        } else {
+            format!("{cache_name}-{digest}")
+        };
+        let pixi_dir = config
+            .cache_dir_for(CacheKind::ExecEnvironments)
+            .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?
+            .join(cache_name);
+        let workspace =
+            manifest.with_provenance(ManifestProvenance::new(script_path, ManifestKind::Pep723));
+
+        Ok(WithWarnings::from(Self::from_parsed(
+            workspace,
+            None,
+            root,
+            config,
+            WorkspaceStorage::Script {
+                manifest: Box::new(script_manifest),
+                pixi_dir,
+                lock_file_path: None,
             },
         ))
         .with_warnings(warnings))
@@ -777,6 +841,21 @@ impl Workspace {
     pub fn lock_file_path(&self) -> PathBuf {
         match &self.storage {
             WorkspaceStorage::Project => self.root.join(consts::PROJECT_LOCK_FILE),
+            WorkspaceStorage::Script {
+                lock_file_path: Some(lock_file_path),
+                ..
+            } => lock_file_path.clone(),
+            WorkspaceStorage::Script {
+                lock_file_path: None,
+                ..
+            } => panic!("transient script workspaces do not have a lock file path"),
+        }
+    }
+
+    /// Returns the lock file path when this workspace can persist a lock file.
+    pub fn persistent_lock_file_path(&self) -> Option<PathBuf> {
+        match &self.storage {
+            WorkspaceStorage::Project => Some(self.root.join(consts::PROJECT_LOCK_FILE)),
             WorkspaceStorage::Script { lock_file_path, .. } => lock_file_path.clone(),
         }
     }

--- a/crates/pixi_manifest/src/script.rs
+++ b/crates/pixi_manifest/src/script.rs
@@ -20,11 +20,19 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct ScriptManifest {
     path: PathBuf,
+    context: Box<ScriptManifestContext>,
     metadata: String,
     prelude: String,
     postlude: String,
     line_ending: LineEnding,
     source_map: ScriptSourceMap,
+}
+
+#[derive(Debug, Clone)]
+struct ScriptManifestContext {
+    source_name: String,
+    root_directory: PathBuf,
+    project_name: String,
 }
 
 #[derive(Debug, Clone)]
@@ -249,17 +257,38 @@ impl ScriptManifest {
         contents: &[u8],
     ) -> Result<Option<Self>, ScriptManifestError> {
         validate_script_extension(path.as_ref())?;
+        let path = std::path::absolute(path)?;
+        let source_name = path.to_string_lossy().into_owned();
+        let root_directory = path
+            .parent()
+            .expect("an absolute script path always has a parent")
+            .to_owned();
+        let project_name = script_name(&path)?.to_owned();
+        Self::from_source_with_context(path, contents, source_name, root_directory, project_name)
+    }
+
+    /// Parse a PEP 723 metadata block for a script whose logical source is not
+    /// the file used to execute it.
+    ///
+    /// Transient run inputs use this to keep diagnostics and relative metadata
+    /// resolution independent from their temporary execution file.
+    pub fn from_source_with_context(
+        path: impl Into<PathBuf>,
+        contents: &[u8],
+        source_name: impl Into<String>,
+        root_directory: impl Into<PathBuf>,
+        project_name: impl Into<String>,
+    ) -> Result<Option<Self>, ScriptManifestError> {
+        let path = path.into();
+        validate_script_extension(&path)?;
         let Some(block) = ScriptBlock::parse(contents)? else {
             return Ok(None);
         };
-        let path = std::path::absolute(path)?;
+        let source_name = source_name.into();
         block.metadata.parse::<DocumentMut>().map_err(|error| {
             ScriptManifestError::Metadata(Box::new(ScriptMetadataError {
                 error: error.into(),
-                source: NamedSource::new(
-                    path.to_string_lossy(),
-                    Arc::clone(&block.source_map.source),
-                ),
+                source: NamedSource::new(source_name.clone(), Arc::clone(&block.source_map.source)),
                 source_map: block.source_map.clone(),
                 synthetic_prefix: 0,
             }))
@@ -267,6 +296,11 @@ impl ScriptManifest {
 
         Ok(Some(Self {
             path,
+            context: Box::new(ScriptManifestContext {
+                source_name,
+                root_directory: root_directory.into(),
+                project_name: project_name.into(),
+            }),
             metadata: block.metadata,
             prelude: block.prelude,
             postlude: block.postlude,
@@ -291,7 +325,7 @@ impl ScriptManifest {
 
     /// Present the script metadata as a synthetic pyproject document for Pixi's editors.
     pub fn pyproject_document(&self) -> Result<DocumentMut, ScriptManifestError> {
-        Ok(inline_pyproject(self, script_name(&self.path)?)?.document)
+        Ok(inline_pyproject(self, &self.context.project_name)?.document)
     }
 
     pub fn workspace_config(&self) -> Result<ScriptWorkspaceConfig, ScriptManifestError> {
@@ -312,16 +346,11 @@ impl ScriptManifest {
     pub fn into_workspace_manifest(
         self,
     ) -> Result<(WorkspaceManifest, Vec<Warning>), ScriptManifestError> {
-        let root_directory = self
-            .path
-            .parent()
-            .expect("an absolute script path always has a parent");
-        let project_name = script_name(&self.path)?;
-        let pyproject = inline_pyproject(&self, project_name)?;
+        let pyproject = inline_pyproject(&self, &self.context.project_name)?;
         let pyproject_manifest = PyProjectManifest::from_toml_str(&pyproject.document.to_string())
             .map_err(|error| self.metadata_error(error, pyproject.metadata_offset))?;
         let (workspace, package, warnings) = pyproject_manifest
-            .into_workspace_manifest(root_directory)
+            .into_workspace_manifest(&self.context.root_directory)
             .map_err(|error| self.metadata_error(error, pyproject.metadata_offset))?;
 
         debug_assert!(package.is_none(), "script manifests cannot define packages");
@@ -332,7 +361,7 @@ impl ScriptManifest {
         ScriptManifestError::Metadata(Box::new(ScriptMetadataError {
             error,
             source: NamedSource::new(
-                self.path.to_string_lossy(),
+                &self.context.source_name,
                 Arc::clone(&self.source_map.source),
             ),
             source_map: self.source_map.clone(),

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -125,6 +125,25 @@ file with its declared Python and dependencies:
 pixi run --script earthquakes.py
 ```
 
+`run` also accepts a direct HTTP or HTTPS URL, including URLs without a
+`.py` suffix:
+
+```console
+pixi run --script https://example.com/earthquakes.py
+```
+
+Remote scripts must already contain a PEP 723 metadata block. They are fetched
+on every invocation and executed from a secure temporary `.py` file, while
+their environment is reused from Pixi's cache. Relative paths in remote
+metadata resolve from the directory where Pixi was invoked.
+
+Remote inputs are execution-only: commands that edit, inspect, export, or lock
+a script continue to require a local path. A remote script has no adjacent lock
+file, so it cannot be run with `--locked` or `--frozen`.
+
+> A remote script executes with your user permissions. Inspect the source or
+> trust its publisher before running it.
+
 Arguments after Pixi's options are forwarded to the script:
 
 ```console

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -1,5 +1,9 @@
 import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Iterator
 
 import pytest
 from inline_snapshot import snapshot
@@ -9,6 +13,45 @@ from .common import CONDA_FORGE_CHANNEL, CURRENT_PLATFORM, ExitCode, verify_cli_
 
 def assert_no_workspace_state_created(workspace: Path) -> None:
     assert {path.name for path in (workspace / ".pixi").iterdir()} == {"config.toml"}
+
+
+@contextmanager
+def remote_script_server(source: str) -> Iterator[tuple[str, list[str]]]:
+    requests: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            requests.append(self.path)
+            if self.path == "/redirect":
+                self.send_response(302)
+                self.send_header(
+                    "Location",
+                    f"http://127.0.0.1:{server.server_port}/extensionless",
+                )
+                self.end_headers()
+                return
+            if self.path == "/extensionless":
+                body = source.encode()
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", requests
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
 
 
 def test_pixi_init_script(pixi: Path, tmp_pixi_workspace: Path) -> None:
@@ -56,6 +99,67 @@ def test_pixi_run_script_requires_inline_metadata(pixi: Path, tmp_pixi_workspace
         ],
     )
     assert script.read_text() == "print('hello')\n"
+
+
+@pytest.mark.slow
+def test_pixi_run_remote_script(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    source = f'''# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# ///
+import json
+import os
+import sys
+
+print(json.dumps({{
+    "argv": sys.argv[1:],
+    "cwd": os.getcwd(),
+    "file": __file__,
+}}))
+'''
+    with remote_script_server(source) as (base_url, requests):
+        output = verify_cli_command(
+            [
+                pixi,
+                "run",
+                "--script",
+                f"{base_url}/redirect",
+                "first",
+                "--second",
+            ],
+            cwd=tmp_pixi_workspace,
+        )
+
+    payload = json.loads(next(line for line in output.stdout.splitlines() if line.startswith("{")))
+    assert payload["argv"] == ["first", "--second"]
+    assert payload["cwd"] == str(tmp_pixi_workspace)
+    assert payload["file"].endswith(".py")
+    assert not Path(payload["file"]).exists()
+    assert requests == ["/redirect", "/extensionless"]
+    assert_no_workspace_state_created(tmp_pixi_workspace)
+
+
+def test_pixi_run_remote_script_reports_http_errors_and_rejects_locks(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    with remote_script_server("") as (base_url, requests):
+        verify_cli_command(
+            [pixi, "run", "--script", f"{base_url}/missing"],
+            ExitCode.FAILURE,
+            stderr_contains=["server returned 404", f"{base_url}/missing"],
+        )
+        verify_cli_command(
+            [pixi, "run", "--frozen", "--script", f"{base_url}/extensionless"],
+            ExitCode.FAILURE,
+            stderr_contains=[
+                "transient scripts cannot be run with `--frozen`",
+                "do not have an adjacent lock file",
+            ],
+        )
+    assert requests == ["/missing"]
 
 
 def test_pixi_run_script_rejects_workspace_only_options(


### PR DESCRIPTION
Closes prefix-dev/pixi#6725

Follow the semantics of `uv run <URL>` from [astral-sh/uv#6375](<https://github.com/astral-sh/uv/issues/6375>), but with the explicit `--script` selector used by Pixi. Pixi downloads an HTTP(S) source to a secure temporary `.py` file and runs it through the existing PEP 723 path.

```
pixi run --script https://example.com/script.py
```

Remote scripts use transient workspaces without local lockfiles or `.pixi` directories. Stable cache keys reuse their environments while credentials and query parameters stay out of user-facing output.