### PR TITLE
fix: honour `editable = true` in transitive `[tool.uv.sources]` at install time

### DIFF
--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -3720,7 +3720,7 @@ version = "0.1.0"
     }
 
     #[test]
-    fn test_editable_source_declarations_ignores_unparseable_manifest() {
+    fn test_editable_source_declarations_ignores_unparsable_manifest() {
         assert!(
             editable_source_declarations(
                 "[tool.uv.sources]\ncore = { path = \"../core\", branch = \"main\" }".to_string(),

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     future::{Future, ready},
     iter,
-    path::PathBuf,
+    path::{Path, PathBuf},
     pin::Pin,
     str::FromStr,
     sync::Arc,
@@ -999,10 +999,15 @@ impl<'p> LockFileDerivedData<'p> {
                 let resolver = self.resolver()?;
                 let pixi_records = locked_packages_to_unresolved_records(conda_packages, &resolver);
 
-                // Get the manifest's pypi dependencies for this environment to look up editability.
-                // The lock file always stores editable=false, so we apply the actual
-                // editability from the manifest at install time.
+                // The lock file never records editability, so it has to be decided here at
+                // install time. The manifest wins for packages it declares as path
+                // dependencies; everything else falls back to whatever the locked path
+                // packages declare in their own `[tool.uv.sources]`.
                 let manifest_pypi_deps = environment.pypi_dependencies(Some(platform));
+                let source_editable = editable_from_source_declarations(
+                    pypi_packages.iter().copied(),
+                    self.workspace.root(),
+                );
 
                 let pypi_records = pypi_packages
                     .into_iter()
@@ -1017,10 +1022,8 @@ impl<'p> LockFileDerivedData<'p> {
                         pixi_install_pypi::InstallablePypiRecord::from_locked(
                             &locked,
                             pixi_install_pypi::ManifestData {
-                                editable: is_editable_from_manifest(
-                                    &manifest_pypi_deps,
-                                    data.name(),
-                                ),
+                                editable: editable_from_manifest(&manifest_pypi_deps, data.name())
+                                    .unwrap_or_else(|| source_editable.contains(data.name())),
                             },
                         )
                     })
@@ -3474,14 +3477,85 @@ async fn spawn_solve_pypi_task<'p>(
 /// feature priority ordering (non-default features come first) while also
 /// handling the same-feature case where a registry spec from
 /// `project.dependencies` lacks an editable field.
-fn is_editable_from_manifest(
+///
+/// Returns `None` when the package is absent from the manifest or only named
+/// by specs that can't be editable, like versions or git refs. A path spec
+/// without an `editable` key counts as non-editable, matching uv.
+fn editable_from_manifest(
     manifest_pypi_deps: &pixi_manifest::PyPiDependencies,
     package_name: &pep508_rs::PackageName,
-) -> bool {
-    manifest_pypi_deps
-        .get(package_name)
-        .and_then(|specs| specs.iter().find_map(|spec| spec.editable()))
-        .unwrap_or(false)
+) -> Option<bool> {
+    let specs = manifest_pypi_deps.get(package_name)?;
+    specs.iter().find_map(|spec| spec.editable()).or_else(|| {
+        specs
+            .iter()
+            .any(|spec| spec.as_path().is_some())
+            .then_some(false)
+    })
+}
+
+/// The packages that the environment's locked path packages mark as editable
+/// in their own `[tool.uv.sources]`.
+///
+/// Editability isn't recorded in the lock file (see `as_uv_req`), it's derived
+//  from the manifest where possible and from these declarations otherwise.
+fn editable_from_source_declarations<'a>(
+    packages: impl IntoIterator<Item = &'a LockedPackage>,
+    lock_file_dir: &Path,
+) -> HashSet<pep508_rs::PackageName> {
+    packages
+        .into_iter()
+        .filter_map(LockedPackage::as_pypi)
+        .filter_map(|data| data.location().inner().as_path())
+        .flat_map(|source_tree| {
+            // Anchor relative paths exactly like the installer does, so the
+            // manifest we read is the same one the package installs from.
+            let source_tree = if source_tree.is_absolute() {
+                PathBuf::from(source_tree.as_str())
+            } else {
+                lock_file_dir.join(source_tree.as_str())
+            };
+            let manifest = source_tree.join(consts::PYPROJECT_MANIFEST);
+            fs_err::read_to_string(&manifest)
+                .map(|contents| editable_source_declarations(contents, &manifest))
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+/// The packages a `pyproject.toml` marks `editable = true` in its
+/// `[tool.uv.sources]`.
+fn editable_source_declarations(
+    contents: String,
+    manifest_path: &Path,
+) -> Vec<pep508_rs::PackageName> {
+    use uv_workspace::pyproject::{PyProjectToml, Source};
+
+    let Some(sources) = PyProjectToml::from_string(contents, manifest_path)
+        // Best-effort: installing from a lock skips resolution, so the file may
+        // have drifted. Fall back to non-editable if we can't parse it.
+        .inspect_err(|err| tracing::debug!("ignoring {}: {err}", manifest_path.display()))
+        .ok()
+        .and_then(|pyproject| pyproject.tool?.uv?.sources)
+    else {
+        return Vec::new();
+    };
+    sources
+        .inner()
+        .iter()
+        .filter(|(_, sources)| {
+            sources.iter().any(|source| {
+                matches!(
+                    source,
+                    Source::Path {
+                        editable: Some(true),
+                        ..
+                    }
+                )
+            })
+        })
+        .filter_map(|(name, _)| to_normalize(name).ok())
+        .collect()
 }
 
 #[cfg(test)]
@@ -3531,14 +3605,15 @@ mod tests {
         deps.insert(name.clone(), registry_spec);
 
         // The first explicit editable value (Some(true)) should win
-        assert!(
-            is_editable_from_manifest(&deps, &pep508_name),
+        assert_eq!(
+            editable_from_manifest(&deps, &pep508_name),
+            Some(true),
             "Package should be editable when an editable path spec exists alongside a registry spec"
         );
     }
 
     #[test]
-    fn test_not_editable_when_only_registry_spec() {
+    fn test_none_when_only_registry_spec() {
         let mut deps = PyPiDependencies::default();
         let name = pixi_pypi_spec::PypiPackageName::from_str("requests").unwrap();
         let pep508_name = pep508_rs::PackageName::new("requests".to_string()).unwrap();
@@ -3549,10 +3624,38 @@ mod tests {
             .unwrap();
         deps.insert(name.clone(), registry_spec);
 
-        assert!(
-            !is_editable_from_manifest(&deps, &pep508_name),
-            "Package should not be editable when no spec has editable=true"
+        assert_eq!(
+            editable_from_manifest(&deps, &pep508_name),
+            None,
+            "A registry spec can't be editable, so the manifest doesn't answer"
         );
+    }
+
+    #[test]
+    fn test_path_spec_without_editable_is_not_editable() {
+        let mut deps = PyPiDependencies::default();
+        let name = pixi_pypi_spec::PypiPackageName::from_str("requests").unwrap();
+        let pep508_name = pep508_rs::PackageName::new("requests".to_string()).unwrap();
+
+        let path_spec = PixiPypiSpec::new(pixi_pypi_spec::PixiPypiSource::Path {
+            path: std::path::PathBuf::from("./requests").into(),
+            editable: None,
+        });
+        deps.insert(name.clone(), path_spec);
+
+        assert_eq!(
+            editable_from_manifest(&deps, &pep508_name),
+            Some(false),
+            "A path spec without an editable key means non-editable"
+        );
+    }
+
+    #[test]
+    fn test_none_when_package_absent() {
+        let deps = PyPiDependencies::default();
+        let pep508_name = pep508_rs::PackageName::new("requests".to_string()).unwrap();
+
+        assert_eq!(editable_from_manifest(&deps, &pep508_name), None);
     }
 
     #[test]
@@ -3576,9 +3679,54 @@ mod tests {
         deps.insert(name.clone(), editable_spec);
 
         // The first explicit editable value (Some(false)) should win
-        assert!(
-            !is_editable_from_manifest(&deps, &pep508_name),
+        assert_eq!(
+            editable_from_manifest(&deps, &pep508_name),
+            Some(false),
             "Higher-priority feature's explicit editable=false should take precedence"
+        );
+    }
+
+    #[test]
+    fn test_editable_source_declarations() {
+        let contents = r#"
+[project]
+name = "middle"
+version = "0.1.0"
+dependencies = ["core", "helper", "requests"]
+
+[tool.uv.sources]
+core = { path = "../core", editable = true }
+helper = { path = "../helper" }
+requests = { git = "https://github.com/psf/requests" }
+"#;
+        assert_eq!(
+            editable_source_declarations(contents.to_string(), Path::new("middle/pyproject.toml")),
+            vec![pep508_rs::PackageName::new("core".to_string()).unwrap()],
+            "Only a path source with editable=true declares a package editable"
+        );
+    }
+
+    #[test]
+    fn test_editable_source_declarations_without_sources() {
+        let contents = r#"
+[project]
+name = "middle"
+version = "0.1.0"
+"#;
+        assert!(
+            editable_source_declarations(contents.to_string(), Path::new("middle/pyproject.toml"))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_editable_source_declarations_ignores_unparseable_manifest() {
+        assert!(
+            editable_source_declarations(
+                "[tool.uv.sources]\ncore = { path = \"../core\", branch = \"main\" }".to_string(),
+                Path::new("middle/pyproject.toml")
+            )
+            .is_empty()
         );
     }
 }

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -175,7 +175,7 @@ pub fn as_uv_req(
                 RequirementSource::Directory {
                     install_path: canonicalized.into_boxed_path(),
                     // Editability is applied at install time from the manifest
-                    // (`is_editable_from_manifest`). Leaving it unspecified
+                    // (`editable_from_manifest`). Leaving it unspecified
                     // avoids uv "conflicting URLs" errors across solve-group
                     // environments and transitive `[tool.uv.sources]` (#6121).
                     editable: None,

--- a/tests/integration_python/test_uv_sources.py
+++ b/tests/integration_python/test_uv_sources.py
@@ -50,9 +50,7 @@ def test_manifest_overrides_uv_sources_editable(
     `[tool.uv.sources]` entry of a dependency disagrees."""
     shutil.copytree(test_data / "uv-sources-non-root", tmp_pixi_workspace, dirs_exist_ok=True)
     manifest = tmp_pixi_workspace / "pyproject.toml"
-    manifest.write_text(
-        manifest.read_text() + 'local-library2 = { path = "./local-library2" }\n'
-    )
+    manifest.write_text(manifest.read_text() + 'local-library2 = { path = "./local-library2" }\n')
 
     verify_cli_command(
         [pixi, "install", "--manifest-path", tmp_pixi_workspace],

--- a/tests/integration_python/test_uv_sources.py
+++ b/tests/integration_python/test_uv_sources.py
@@ -1,9 +1,23 @@
+import json
 from pathlib import Path
 import pytest
 import shutil
 import sys
 
 from .common import verify_cli_command
+
+
+def site_packages(workspace: Path) -> Path:
+    if sys.platform.startswith("win"):
+        python_dir = ""
+    else:
+        python_dir = "python3.13"
+    return workspace / ".pixi" / "envs" / "default" / "lib" / python_dir / "site-packages"
+
+
+def is_editable(workspace: Path, package: str, version: str = "0.1.0") -> bool:
+    direct_url = site_packages(workspace) / f"{package}-{version}.dist-info" / "direct_url.json"
+    return json.loads(direct_url.read_text())["dir_info"].get("editable", False)
 
 
 @pytest.mark.slow
@@ -18,18 +32,31 @@ def test_install_with_uv_sources(
     )
     # Check if dist-info is available for local-library2
     #
-    if sys.platform.startswith("win"):
-        python_dir = ""
-    else:
-        python_dir = "python3.13"
+    assert (site_packages(tmp_pixi_workspace) / "local_library2-0.1.0.dist-info").exists()
 
-    assert (
-        tmp_pixi_workspace
-        / ".pixi"
-        / "envs"
-        / "default"
-        / "lib"
-        / python_dir
-        / "site-packages"
-        / "local_library2-0.1.0.dist-info"
-    ).exists()
+    # `local-library` declares `local-library2` editable in its `[tool.uv.sources]`,
+    # and the workspace manifest doesn't mention it, so it installs editable.
+    assert is_editable(tmp_pixi_workspace, "local_library")
+    assert is_editable(tmp_pixi_workspace, "local_library2")
+
+
+@pytest.mark.slow
+def test_manifest_overrides_uv_sources_editable(
+    pixi: Path,
+    tmp_pixi_workspace: Path,
+    test_data: Path,
+) -> None:
+    """A path dependency in the manifest decides editability, even when a
+    `[tool.uv.sources]` entry of a dependency disagrees."""
+    shutil.copytree(test_data / "uv-sources-non-root", tmp_pixi_workspace, dirs_exist_ok=True)
+    manifest = tmp_pixi_workspace / "pyproject.toml"
+    manifest.write_text(
+        manifest.read_text() + 'local-library2 = { path = "./local-library2" }\n'
+    )
+
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", tmp_pixi_workspace],
+    )
+
+    assert is_editable(tmp_pixi_workspace, "local_library")
+    assert not is_editable(tmp_pixi_workspace, "local_library2")


### PR DESCRIPTION
## What

`editable = true` on a path dependency's `[tool.uv.sources]` entry is now honoured when pixi installs the environment.

This is a follow-up to prefix-dev/pixi#6121: that fix resolves path dependencies with `editable: None` so a manifest declaration and a transitive `[tool.uv.sources]` entry can't conflict during the uv solve, and the lock file doesn't record editability at all. The side effect was that a transitive `editable = true` was silently dropped — uv honoured it while resolving, but the installed package was always non-editable unless the workspace manifest itself declared it editable.

## How

Editability stays an install-time property, derived from what's declared on disk at that moment:

1. The workspace manifest wins for packages it declares as path dependencies. A path spec without an `editable` key counts as non-editable, matching uv.
2. For packages the manifest doesn't declare, pixi reads the locked path packages' own `pyproject.toml`s and applies their `[tool.uv.sources]` `editable = true` declarations.

The lookup is best-effort: installing from a lock skips resolution, so a `pyproject.toml` that is missing, has drifted since the solve, or uses a `[tool.uv]` schema this version of uv doesn't know is skipped, and the package installs non-editable exactly as it did before.

## AI Disclosure

Written with Claude Opus + Fable, reviewed and edited by me.