### PR TITLE
fix(test): strip ANSI escapes from rendered diagnostics in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7268,6 +7268,7 @@ name = "pixi_test_utils"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "console",
  "fs-err",
  "itertools 0.15.0",
  "jiff",

--- a/crates/pixi_test_utils/Cargo.toml
+++ b/crates/pixi_test_utils/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.1.0"
 
 [dependencies]
 chrono = { workspace = true }
+console = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
 jiff = { workspace = true }

--- a/crates/pixi_test_utils/src/lib.rs
+++ b/crates/pixi_test_utils/src/lib.rs
@@ -32,6 +32,12 @@ pub fn format_diagnostic(error: &dyn Diagnostic) -> String {
         .with_theme(GraphicalTheme::unicode_nocolor());
     report_handler.render_report(&mut s, error).unwrap();
 
+    // Error messages can embed styled text (e.g. `fancy_display`), which emits
+    // ANSI escape sequences whenever `console` thinks the terminal supports
+    // colors. Strip them so snapshots don't depend on the environment the tests
+    // run in.
+    s = console::strip_ansi_codes(&s).into_owned();
+
     // Strip machine specific paths
     let cargo_root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .parent()


### PR DESCRIPTION
### Description

Fixes #6689

### How Has This Been Tested?

`cargo test --features rustls --no-default-features --no-fail-fast` in three configurations, all green (176 passed, 0 failed, 49 ignored):

- piped output — the CI-like case, which already passed
- `CLICOLOR_FORCE=1`
- under a real pty via `script -qec ... /dev/null`, closest to the portage environment in the issue

Reproduction was confirmed both ways: with the new strip line temporarily removed, `CLICOLOR_FORCE=1` reproduces exactly the failure from the issue, and only that test.


### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
fix all tests that you get when running the command in this issue: https://github.com/prefix-dev/pixi/issues/6689
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

