### PR TITLE
feat: Resolve GitHub Gist scripts

### DIFF
--- a/crates/pixi_cli/src/run_script.rs
+++ b/crates/pixi_cli/src/run_script.rs
@@ -7,6 +7,9 @@ use miette::{IntoDiagnostic, WrapErr};
 use pixi_config::Config;
 use pixi_manifest::script::ScriptManifest;
 use pixi_utils::reqwest::build_reqwest_clients;
+use reqwest::header::ACCEPT;
+use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
+use serde::Deserialize;
 use tempfile::NamedTempFile;
 use url::Url;
 
@@ -42,17 +45,18 @@ pub(crate) async fn prepare_remote_script(
 ) -> miette::Result<PreparedRemoteScript> {
     let safe_original_url = safe_url(&original_url);
     let (_, client) = build_reqwest_clients(Some(config), None)?;
-    let mut response = client.get(original_url.clone()).send().await.map_err(|_| {
-        miette::miette!("failed to download remote script from {safe_original_url}")
-    })?;
-    let final_url = response.url().clone();
-    let status = response.status();
-    if !status.is_success() {
-        return Err(miette::miette!(
-            "failed to download remote script from {safe_original_url}: server returned {status}"
-        ));
+    let mut response = send_success(
+        client.get(original_url.clone()),
+        &safe_original_url,
+        "download",
+    )
+    .await?;
+    if response.url().host_str() == Some("gist.github.com") {
+        let raw_url = resolve_gist(&client, response.url(), &safe_original_url).await?;
+        response = send_success(client.get(raw_url), &safe_original_url, "download").await?;
     }
 
+    let final_url = response.url().clone();
     let cache_name = friendly_name(&final_url);
     let mut file = tempfile::Builder::new()
         .prefix(&format!("{cache_name}-"))
@@ -99,6 +103,87 @@ pub(crate) async fn prepare_remote_script(
     })
 }
 
+async fn send_success(
+    request: RequestBuilder,
+    safe_original_url: &str,
+    action: &str,
+) -> miette::Result<reqwest::Response> {
+    let response = request.send().await.map_err(|_| {
+        miette::miette!("failed to {action} remote script from {safe_original_url}")
+    })?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(miette::miette!(
+            "failed to {action} remote script from {safe_original_url}: server returned {status}"
+        ));
+    }
+    Ok(response)
+}
+
+#[derive(Debug, Deserialize)]
+struct Gist {
+    files: indexmap::IndexMap<String, GistFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GistFile {
+    filename: String,
+    raw_url: Url,
+}
+
+async fn resolve_gist(
+    client: &ClientWithMiddleware,
+    gist_url: &Url,
+    safe_original_url: &str,
+) -> miette::Result<Url> {
+    let gist_id = gist_id(gist_url).ok_or_else(|| {
+        miette::miette!(
+            "could not determine the Gist ID from {}",
+            safe_url(gist_url)
+        )
+    })?;
+    let api_url = Url::parse(&format!("https://api.github.com/gists/{gist_id}"))
+        .expect("the GitHub Gist API URL is valid");
+    resolve_gist_at(client, api_url, safe_original_url).await
+}
+
+async fn resolve_gist_at(
+    client: &ClientWithMiddleware,
+    api_url: Url,
+    safe_original_url: &str,
+) -> miette::Result<Url> {
+    let mut request = client
+        .get(api_url)
+        .header(ACCEPT, "application/vnd.github+json");
+    if let Ok(token) = std::env::var("PIXI_GITHUB_TOKEN") {
+        request = request.bearer_auth(token);
+    }
+    let response = send_success(request, safe_original_url, "resolve GitHub Gist").await?;
+    let body = response.bytes().await.map_err(|_| {
+        miette::miette!("failed to read the GitHub Gist response for {safe_original_url}")
+    })?;
+    let gist = serde_json::from_slice::<Gist>(&body).map_err(|_| {
+        miette::miette!("the GitHub API returned an invalid Gist response for {safe_original_url}")
+    })?;
+    select_gist_file(&gist).cloned().ok_or_else(|| {
+        miette::miette!("the GitHub Gist at {safe_original_url} does not contain any files")
+    })
+}
+
+fn gist_id(url: &Url) -> Option<&str> {
+    let mut segments = url.path_segments()?.filter(|segment| !segment.is_empty());
+    segments.next()?;
+    segments.next()
+}
+
+fn select_gist_file(gist: &Gist) -> Option<&Url> {
+    gist.files
+        .values()
+        .find(|file| file.filename.to_ascii_lowercase().ends_with(".py"))
+        .or_else(|| gist.files.values().next())
+        .map(|file| &file.raw_url)
+}
+
 pub(crate) fn safe_url(url: &Url) -> String {
     let mut safe = url.clone();
     if !safe.username().is_empty() {
@@ -136,9 +221,52 @@ fn friendly_name(url: &Url) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{RunScriptInput, friendly_name, safe_url};
-    use std::path::Path;
+    use super::{
+        Gist, RunScriptInput, friendly_name, gist_id, resolve_gist_at, safe_url, select_gist_file,
+    };
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        path::Path,
+        sync::mpsc,
+        thread,
+    };
     use url::Url;
+
+    fn serve_once(
+        status: &str,
+        body: &str,
+    ) -> (Url, mpsc::Receiver<String>, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (sender, receiver) = mpsc::channel();
+        let status = status.to_owned();
+        let body = body.to_owned();
+        let thread = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            loop {
+                let mut chunk = [0; 1024];
+                let length = stream.read(&mut chunk).unwrap();
+                request.extend_from_slice(&chunk[..length]);
+                if length == 0 || request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let _ = sender.send(String::from_utf8_lossy(&request).into_owned());
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .unwrap();
+        });
+        (
+            Url::parse(&format!("http://{address}/gists/abc123")).unwrap(),
+            receiver,
+            thread,
+        )
+    }
 
     #[test]
     fn classifies_only_http_urls_as_remote() {
@@ -182,5 +310,118 @@ mod tests {
             safe_url(&Url::parse("https://user:secret@example.com/script.py").unwrap()),
             "https://***:***@example.com/script.py"
         );
+    }
+
+    #[test]
+    fn extracts_gist_ids_from_normal_gist_urls() {
+        assert_eq!(
+            gist_id(&Url::parse("https://gist.github.com/user/abc123").unwrap()),
+            Some("abc123")
+        );
+        assert_eq!(
+            gist_id(&Url::parse("https://gist.github.com/abc123").unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn selects_the_first_python_file_from_a_gist() {
+        let gist: Gist = serde_json::from_str(
+            r#"{
+                "files": {
+                    "README.md": {
+                        "filename": "README.md",
+                        "raw_url": "https://example.com/readme"
+                    },
+                    "FIRST.PY": {
+                        "filename": "FIRST.PY",
+                        "raw_url": "https://example.com/first"
+                    },
+                    "second.py": {
+                        "filename": "second.py",
+                        "raw_url": "https://example.com/second"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            select_gist_file(&gist).unwrap().as_str(),
+            "https://example.com/first"
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_first_gist_file() {
+        let gist: Gist = serde_json::from_str(
+            r#"{
+                "files": {
+                    "README.md": {
+                        "filename": "README.md",
+                        "raw_url": "https://example.com/readme"
+                    },
+                    "script.rb": {
+                        "filename": "script.rb",
+                        "raw_url": "https://example.com/ruby"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            select_gist_file(&gist).unwrap().as_str(),
+            "https://example.com/readme"
+        );
+    }
+
+    #[tokio::test]
+    async fn authenticates_the_gist_api_request() {
+        let (api_url, request, server) = serve_once(
+            "200 OK",
+            r#"{
+                "files": {
+                    "script.py": {
+                        "filename": "script.py",
+                        "raw_url": "https://raw.example.com/script.py"
+                    }
+                }
+            }"#,
+        );
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build();
+        let raw_url = temp_env::async_with_vars(
+            [("PIXI_GITHUB_TOKEN", Some("gist-secret"))],
+            resolve_gist_at(&client, api_url, "https://gist.github.com/user/abc123"),
+        )
+        .await
+        .unwrap();
+        let request = request.recv().unwrap();
+        server.join().unwrap();
+
+        assert_eq!(raw_url.as_str(), "https://raw.example.com/script.py");
+        assert!(request.contains("authorization: Bearer gist-secret"));
+        assert!(request.contains("accept: application/vnd.github+json"));
+    }
+
+    #[test]
+    fn rejects_an_empty_gist() {
+        let gist: Gist = serde_json::from_str(r#"{"files": {}}"#).unwrap();
+        assert!(select_gist_file(&gist).is_none());
+    }
+
+    #[tokio::test]
+    async fn reports_gist_api_http_errors_at_the_api_boundary() {
+        let (api_url, _, server) = serve_once("403 Forbidden", "");
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build();
+        let error = temp_env::async_with_vars(
+            [("PIXI_GITHUB_TOKEN", None::<&str>)],
+            resolve_gist_at(&client, api_url, "https://gist.github.com/user/abc123"),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        let error = error.to_string();
+        assert!(error.contains("resolve GitHub Gist"));
+        assert!(error.contains("403 Forbidden"));
     }
 }

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -130,6 +130,7 @@ pixi run --script earthquakes.py
 
 ```console
 pixi run --script https://example.com/earthquakes.py
+pixi run --script https://gist.github.com/user/gist-id
 ```
 
 Remote scripts must already contain a PEP 723 metadata block. They are fetched
@@ -140,6 +141,12 @@ metadata resolve from the directory where Pixi was invoked.
 Remote inputs are execution-only: commands that edit, inspect, export, or lock
 a script continue to require a local path. A remote script has no adjacent lock
 file, so it cannot be run with `--locked` or `--frozen`.
+
+For a normal GitHub Gist page, Pixi selects the first filename ending in
+`.py`, case-insensitively, or the first file when the Gist contains no Python
+filename. Set `PIXI_GITHUB_TOKEN` to authenticate the Gist API request, for
+example when accessing a private Gist. Pixi sends this token only to
+`api.github.com`, never to the selected file's raw URL.
 
 > A remote script executes with your user permissions. Inspect the source or
 > trust its publisher before running it.


### PR DESCRIPTION
Follow up to #6728

Extend our remote script support with GitHub Gist page URLs. This follows the semantics of `uv run <GIST_URL>` from astral-sh/uv#15058, but with the explicit `--script` selector used by Pixi.

    pixi run --script https://gist.github.com/user/gist-id

Pixi resolves the page through the GitHub API and passes the selected raw file URL to the existing downloader. It prefers the first Python file and otherwise uses the first file. Set `PIXI_GITHUB_TOKEN` for authenticated API requests without sending the token to the raw file URL.
