### PR TITLE
feat: Run PEP 723 scripts from standard input

### DIFF
--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -60,7 +60,9 @@ pub struct ScriptWorkspaceConfig {
     #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
-    /// The path to a Python script containing PEP 723 metadata
+    /// The path to a Python script containing PEP 723 metadata.
+    ///
+    /// `pixi run` also accepts an HTTP(S) URL or `-` to read the script from stdin.
     #[arg(long, short = 's', global = true, conflicts_with_all = ["manifest_path", "workspace"], help_heading = consts::CLAP_GLOBAL_OPTIONS)]
     pub script: Option<PathBuf>,
 }

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -2,6 +2,7 @@ use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     convert::identity,
     ffi::OsString,
+    io::Read,
     string::String,
 };
 
@@ -45,7 +46,10 @@ use crate::cli_config::{
     transient_script_lock_file_usage,
 };
 use crate::process_exit;
-use crate::run_script::{RunScriptInput, prepare_remote_script};
+use crate::run_script::{
+    RunScriptInput, STDIN_SCRIPT_COMMAND, StdinScriptCommand, prepare_remote_script,
+    prepare_stdin_script,
+};
 use crate::shared::install_platform::resolve_install_platform;
 
 /// Runs task in the pixi environment.
@@ -176,6 +180,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
     let global_config_source = args.config_source.source();
     let mut transient_lock_file_usage = None;
     let mut _remote_script_file = None;
+    let mut stdin_script_command = None;
     let workspace = match script_input {
         Some(RunScriptInput::Remote(url)) => {
             transient_lock_file_usage = Some(transient_script_lock_file_usage(
@@ -194,6 +199,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                 prepared.manifest,
                 config,
                 root,
+                prepared.file.path().to_owned(),
                 &prepared.cache_name,
                 &cache_key,
             )?;
@@ -201,6 +207,37 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                 tracing::warn!("{warning}");
             }
             _remote_script_file = Some(prepared.file);
+            workspace
+        }
+        Some(RunScriptInput::Stdin) => {
+            transient_lock_file_usage = Some(transient_script_lock_file_usage(
+                args.lock_and_install_config.lock_file_usage()?,
+            )?);
+            let root = std::env::current_dir().into_diagnostic()?;
+            let config = pixi_config::Config::load_with(&root, &global_config_source)
+                .merge_config(cli_config);
+            let mut contents = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut contents)
+                .into_diagnostic()?;
+            let prepared = prepare_stdin_script(contents, &root)?;
+            let mut cache_key = b"stdin\0".to_vec();
+            cache_key.extend_from_slice(prepared.manifest.metadata().as_bytes());
+            let WithWarnings {
+                value: workspace,
+                warnings,
+            } = Workspace::from_transient_script(
+                prepared.manifest,
+                config,
+                root,
+                "<stdin>".into(),
+                "stdin",
+                &cache_key,
+            )?;
+            for warning in warnings {
+                tracing::warn!("{warning}");
+            }
+            stdin_script_command = Some(prepared.command);
             workspace
         }
         Some(RunScriptInput::Local(path)) => WorkspaceLocator::for_cli()
@@ -215,7 +252,15 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             .locate()?,
     };
 
-    if is_script {
+    let stdin_display_args = if stdin_script_command.is_some() {
+        Some(args.task.clone())
+    } else {
+        None
+    };
+    if stdin_script_command.is_some() {
+        args.task.insert(0, STDIN_SCRIPT_COMMAND.to_owned());
+        args.executable = true;
+    } else if is_script {
         let script_path = workspace.workspace.provenance.path.clone();
         let script_path = script_path.into_os_string().into_string().map_err(|_| {
             miette::miette!("the script path must contain only valid UTF-8 characters")
@@ -407,13 +452,23 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
         }
 
         // Showing which command is being run if the level and type allows it.
-        if tracing::enabled!(Level::WARN) && !executable_task.task().is_custom() {
+        if tracing::enabled!(Level::WARN)
+            && (!executable_task.task().is_custom() || stdin_script_command.is_some())
+        {
             if task_idx > 0 {
                 // Add a newline between task outputs
                 pixi_progress::println!();
             }
 
-            let display_command = executable_task.display_command().to_string();
+            let display_command = if let Some(forwarded_args) = &stdin_display_args {
+                if forwarded_args.is_empty() {
+                    "python -c <stdin>".to_owned()
+                } else {
+                    format!("python -c <stdin> {}", forwarded_args.iter().format(" "))
+                }
+            } else {
+                executable_task.display_command().to_string()
+            };
 
             pixi_progress::println!(
                 "{}{}{}{}{}{}{}",
@@ -552,7 +607,14 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
         // Execute the task itself within the command environment. If one of the tasks
         // failed with a non-zero exit code, we exit this parent process with
         // the same code.
-        match execute_task(&executable_task, &task_env, signal.clone()).await {
+        match execute_task(
+            &executable_task,
+            &task_env,
+            signal.clone(),
+            stdin_script_command.as_ref(),
+        )
+        .await
+        {
             Ok(_) => {
                 task_idx += 1;
             }
@@ -645,16 +707,20 @@ async fn execute_task(
     task: &ExecutableTask<'_>,
     command_env: &HashMap<OsString, OsString>,
     kill_signal: KillSignal,
+    stdin_script: Option<&StdinScriptCommand>,
 ) -> Result<(), TaskExecutionError> {
     let Some(script) = task.as_deno_script()? else {
         return Ok(());
     };
     let cwd = task.working_directory()?;
+    let custom_commands = stdin_script
+        .map(|command| HashMap::from([(STDIN_SCRIPT_COMMAND.to_owned(), command.shell_command())]))
+        .unwrap_or_default();
     let execute_future = deno_task_shell::execute(
         script,
         command_env.clone(),
         cwd,
-        Default::default(),
+        custom_commands,
         kill_signal.clone(),
     );
 

--- a/crates/pixi_cli/src/run_script.rs
+++ b/crates/pixi_cli/src/run_script.rs
@@ -1,8 +1,12 @@
 use std::{
+    ffi::OsString,
     io::Write,
     path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
 };
 
+use deno_task_shell::{ExecutableCommand, FutureExecuteResult, ShellCommand, ShellCommandContext};
 use miette::{IntoDiagnostic, WrapErr};
 use pixi_config::Config;
 use pixi_manifest::script::ScriptManifest;
@@ -14,10 +18,14 @@ use url::Url;
 pub(crate) enum RunScriptInput {
     Local(PathBuf),
     Remote(Url),
+    Stdin,
 }
 
 impl RunScriptInput {
     pub(crate) fn classify(input: &Path) -> Self {
+        if input == Path::new("-") {
+            return Self::Stdin;
+        }
         let Some(input) = input.to_str() else {
             return Self::Local(input.to_owned());
         };
@@ -26,6 +34,60 @@ impl RunScriptInput {
             _ => Self::Local(input.into()),
         }
     }
+}
+
+pub(crate) const STDIN_SCRIPT_COMMAND: &str = "__pixi_stdin_script__";
+
+#[derive(Clone)]
+pub(crate) struct StdinScriptCommand {
+    contents: Arc<str>,
+}
+
+impl StdinScriptCommand {
+    pub(crate) fn new(contents: String) -> Self {
+        Self {
+            contents: contents.into(),
+        }
+    }
+
+    pub(crate) fn shell_command(&self) -> Rc<dyn ShellCommand> {
+        Rc::new(self.clone())
+    }
+}
+
+impl ShellCommand for StdinScriptCommand {
+    fn execute(&self, mut context: ShellCommandContext) -> FutureExecuteResult {
+        context.args.splice(
+            0..0,
+            [OsString::from("-c"), OsString::from(self.contents.as_ref())],
+        );
+        ExecutableCommand::new("python".to_owned(), PathBuf::from("python")).execute(context)
+    }
+}
+
+pub(crate) struct PreparedStdinScript {
+    pub(crate) manifest: ScriptManifest,
+    pub(crate) command: StdinScriptCommand,
+}
+
+pub(crate) fn prepare_stdin_script(
+    contents: Vec<u8>,
+    root: &Path,
+) -> miette::Result<PreparedStdinScript> {
+    let manifest = ScriptManifest::from_source_with_context(
+        root.join("stdin.py"),
+        &contents,
+        "<stdin>",
+        root.to_owned(),
+        "stdin",
+    )?
+    .ok_or_else(|| miette::miette!("stdin does not contain a PEP 723 metadata block"))?;
+    let contents =
+        String::from_utf8(contents).expect("ScriptManifest validates the complete script as UTF-8");
+    Ok(PreparedStdinScript {
+        manifest,
+        command: StdinScriptCommand::new(contents),
+    })
 }
 
 pub(crate) struct PreparedRemoteScript {
@@ -157,6 +219,10 @@ mod tests {
         assert!(matches!(
             RunScriptInput::classify(Path::new("script.py")),
             RunScriptInput::Local(_)
+        ));
+        assert!(matches!(
+            RunScriptInput::classify(Path::new("-")),
+            RunScriptInput::Stdin
         ));
     }
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -535,10 +535,10 @@ impl Workspace {
         script: ScriptManifest,
         config: Config,
         root: PathBuf,
+        provenance_path: PathBuf,
         cache_name: &str,
         cache_key: &[u8],
     ) -> Result<WithWarnings<Self>, ScriptWorkspaceError> {
-        let script_path = script.path().to_owned();
         let script_manifest = script.clone();
         let script_config = script.workspace_config()?;
         let (mut manifest, warnings) = script.into_workspace_manifest()?;
@@ -577,8 +577,10 @@ impl Workspace {
             .cache_dir_for(CacheKind::ExecEnvironments)
             .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?
             .join(cache_name);
-        let workspace =
-            manifest.with_provenance(ManifestProvenance::new(script_path, ManifestKind::Pep723));
+        let workspace = manifest.with_provenance(ManifestProvenance::new(
+            provenance_path,
+            ManifestKind::Pep723,
+        ));
 
         Ok(WithWarnings::from(Self::from_parsed(
             workspace,

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -144,6 +144,23 @@ file, so it cannot be run with `--locked` or `--frozen`.
 > A remote script executes with your user permissions. Inspect the source or
 > trust its publisher before running it.
 
+Pass `-` as the script to read a PEP 723 script from standard input:
+
+```console
+pixi run --script - < analysis.py
+cat analysis.py | pixi run --script - input.csv --verbose
+```
+
+Pixi consumes standard input once, resolves the environment from its metadata,
+and executes the source with `python -c`. Consequently, `sys.argv[0]` is `-c`,
+`__file__` is not defined, and the script sees standard input at EOF. Relative
+metadata paths resolve from the directory where Pixi was invoked.
+
+Like URL inputs, stdin is execution-only, requires an existing PEP 723 metadata
+block, and cannot use `--locked` or `--frozen`. Its cached environment identity
+comes from the metadata block, so changing only the Python body reuses the same
+environment.
+
 Arguments after Pixi's options are forwarded to the script:
 
 ```console

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -67,6 +67,7 @@ def verify_cli_command(
     cwd: str | Path | None = None,
     reset_env: bool = False,
     strip_ansi: bool = False,
+    stdin: str | bytes | None = None,
 ) -> Output:
     if reset_env:
         base_env = {}
@@ -87,6 +88,7 @@ def verify_cli_command(
         capture_output=True,
         env=complete_env,
         cwd=cwd,
+        input=stdin.encode() if isinstance(stdin, str) else stdin,
     )
     # Decode stdout and stderr explicitly using UTF-8
     stdout = process.stdout.decode("utf-8", errors="replace")

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -162,6 +162,110 @@ def test_pixi_run_remote_script_reports_http_errors_and_rejects_locks(
     assert requests == ["/missing"]
 
 
+@pytest.mark.slow
+def test_pixi_run_stdin_script(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    exec_cache = tmp_pixi_workspace / "stdin-exec-cache"
+    env = {"PIXI_CACHE_EXEC_ENVIRONMENTS_DIR": str(exec_cache)}
+    source = f'''# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# ///
+import json
+import os
+import sys
+
+print(json.dumps({{
+    "argv": sys.argv,
+    "cwd": os.getcwd(),
+    "has_file": "__file__" in globals(),
+    "manifest": os.environ["PIXI_PROJECT_MANIFEST"],
+    "remaining_stdin": sys.stdin.read(),
+}}))
+'''
+    output = verify_cli_command(
+        [pixi, "run", "--script", "-", "first", "--second"],
+        cwd=tmp_pixi_workspace,
+        env=env,
+        stdin=source,
+    )
+
+    payload = json.loads(next(line for line in output.stdout.splitlines() if line.startswith("{")))
+    assert payload == {
+        "argv": ["-c", "first", "--second"],
+        "cwd": str(tmp_pixi_workspace),
+        "has_file": False,
+        "manifest": "<stdin>",
+        "remaining_stdin": "",
+    }
+
+    body_changed = source.replace("import json", "# changed body\nimport json")
+    verify_cli_command(
+        [pixi, "run", "--script", "-", "first", "--second"],
+        cwd=tmp_pixi_workspace,
+        env=env,
+        stdin=body_changed,
+    )
+    assert len(list(exec_cache.iterdir())) == 1
+
+    metadata_changed = source.replace(
+        "# ///\nimport json", "# # identity change\n# ///\nimport json"
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", "-", "first", "--second"],
+        cwd=tmp_pixi_workspace,
+        env=env,
+        stdin=metadata_changed,
+    )
+    assert len(list(exec_cache.iterdir())) == 2
+    assert_no_workspace_state_created(tmp_pixi_workspace)
+
+
+def test_pixi_run_stdin_script_errors_and_dry_run_are_source_safe(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    verify_cli_command(
+        [pixi, "run", "--script", "-"],
+        ExitCode.FAILURE,
+        stderr_contains="stdin does not contain a PEP 723 metadata block",
+        stdin="print('missing metadata')\n",
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", "-"],
+        ExitCode.FAILURE,
+        stderr_contains="<stdin>",
+        stderr_excludes="stdin.py",
+        stdin="# /// script\n# dependencies = [\n# ///\n",
+    )
+
+    secret_marker = "stdin-body-must-not-appear"
+    source = f'''# /// script
+# dependencies = []
+# ///
+print("{secret_marker}")
+    '''
+    verify_cli_command(
+        [pixi, "-vvv", "run", "--dry-run", "--script", "-"],
+        cwd=tmp_pixi_workspace,
+        stdin=source,
+        stdout_excludes=secret_marker,
+        stderr_contains="python -c <stdin>",
+        stderr_excludes=secret_marker,
+    )
+    verify_cli_command(
+        [pixi, "run", "--locked", "--script", "-"],
+        ExitCode.FAILURE,
+        stderr_contains=[
+            "transient scripts cannot be run with `--locked`",
+            "do not have an adjacent lock file",
+        ],
+        stdin=secret_marker,
+        stderr_excludes=secret_marker,
+    )
+
+
 def test_pixi_run_script_rejects_workspace_only_options(
     pixi: Path, tmp_pixi_workspace: Path
 ) -> None:


### PR DESCRIPTION
Follow up to #6728 

Extend our PEP 723 script support with standard input. This follows the semantics of `uv run -` from astral-sh/uv#8111, but with `pixi run --script -`.

    cat script.py | pixi run --script - input.csv --verbose

Pixi buffers the source once, parses its metadata directly, and executes it with `python -c`. Trailing arguments are forwarded to the script and its environment cache is keyed by the metadata. Standard input is execution-only and cannot be used with `--locked` or `--frozen`.
