### PR TITLE
feat(remove): resolve unqualified dependencies across manifest locations

### DIFF
--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -18,7 +18,7 @@ use crate::common::{
     builders::{HasDependencyConfig, HasLockFileUpdateConfig, HasNoInstallConfig},
 };
 use crate::setup_tracing;
-use pixi_test_utils::{GitRepoFixture, MockRepoData, Package};
+use pixi_test_utils::{GitRepoFixture, MockRepoData, Package, format_diagnostic};
 
 /// Test add functionality for different types of packages.
 /// Run, dev, build
@@ -83,6 +83,124 @@ async fn add_functionality() {
         Platform::current(),
         "rattler==1"
     ));
+}
+
+#[tokio::test]
+async fn remove_unqualified_dependencies_from_mixed_locations() {
+    setup_tracing();
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "test-remove-mixed"
+channels = []
+platforms = ["linux-64"]
+
+[dependencies]
+numpy = "*"
+
+[pypi-dependencies]
+black = "*"
+
+[feature.test.dependencies]
+pytest = "*"
+
+[target.linux.dependencies]
+bla = "*"
+"#,
+    )
+    .unwrap();
+
+    pixi.remove("numpy")
+        .with_spec("black")
+        .with_spec("pytest")
+        .with_spec("bla")
+        .with_frozen(true)
+        .await
+        .unwrap();
+
+    let manifest = fs_err::read_to_string(pixi.manifest_path()).unwrap();
+    for name in ["numpy", "black", "pytest", "bla"] {
+        assert!(!manifest.contains(&format!("{name} =")));
+    }
+}
+
+#[tokio::test]
+async fn remove_with_explicit_type_stays_scoped() {
+    setup_tracing();
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "test-remove-explicit"
+channels = []
+platforms = ["linux-64"]
+
+[pypi-dependencies]
+black = "*"
+
+[host-dependencies]
+cmake = "*"
+"#,
+    )
+    .unwrap();
+
+    let err = pixi
+        .remove("black")
+        .set_type(DependencyType::CondaDependency(SpecType::Host))
+        .with_frozen(true)
+        .await
+        .unwrap_err();
+
+    assert!(
+        format_diagnostic(&*err).contains("not found in host-dependencies"),
+        "{}",
+        format_diagnostic(&*err)
+    );
+    assert!(
+        fs_err::read_to_string(pixi.manifest_path())
+            .unwrap()
+            .contains("black =")
+    );
+}
+
+#[tokio::test]
+async fn remove_with_explicit_default_feature_stays_scoped() {
+    setup_tracing();
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "test-remove-explicit-default-feature"
+channels = []
+platforms = ["linux-64"]
+
+[dependencies]
+numpy = "*"
+
+[pypi-dependencies]
+black = "*"
+"#,
+    )
+    .unwrap();
+
+    let err = pixi
+        .remove("black")
+        .with_feature("default")
+        .with_frozen(true)
+        .await
+        .unwrap_err();
+
+    assert!(
+        format_diagnostic(&*err).contains("not found in dependencies"),
+        "{}",
+        format_diagnostic(&*err)
+    );
+    assert!(
+        fs_err::read_to_string(pixi.manifest_path())
+            .unwrap()
+            .contains("black =")
+    );
 }
 
 /// Test adding a package with a specific channel

--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -224,7 +224,7 @@ impl AddBuilder {
     }
 
     pub fn with_feature(mut self, feature: impl ToString) -> Self {
-        self.args.dependency_config.feature = FeatureName::from(feature.to_string());
+        self.args.dependency_config.feature = Some(FeatureName::from(feature.to_string()));
         self
     }
 
@@ -329,6 +329,19 @@ impl HasDependencyConfig for RemoveBuilder {
 impl HasNoInstallConfig for RemoveBuilder {
     fn no_install_config(&mut self) -> &mut NoInstallConfig {
         &mut self.args.no_install_config
+    }
+}
+
+impl RemoveBuilder {
+    pub fn with_feature(mut self, feature: impl ToString) -> Self {
+        self.args.dependency_config.feature = Some(FeatureName::from(feature.to_string()));
+        self
+    }
+}
+
+impl HasLockFileUpdateConfig for RemoveBuilder {
+    fn lock_file_update_config(&mut self) -> &mut LockFileUpdateConfig {
+        &mut self.args.lock_file_update_config
     }
 }
 

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -385,6 +385,20 @@ impl<I: Interface> WorkspaceContext<I> {
         .await
     }
 
+    pub async fn remove_deps_unqualified(
+        &self,
+        specs: Vec<String>,
+        options: DependencyOptions,
+    ) -> Result<(), RemoveError> {
+        let workspace_mut = self.workspace.clone().modify()?;
+        Box::pin(crate::workspace::remove::remove_deps_unqualified(
+            workspace_mut,
+            specs,
+            options,
+        ))
+        .await
+    }
+
     pub async fn reinstall(
         &self,
         options: ReinstallOptions,

--- a/crates/pixi_api/src/workspace/remove/mod.rs
+++ b/crates/pixi_api/src/workspace/remove/mod.rs
@@ -1,5 +1,8 @@
+use std::path::Path;
+
 use indexmap::IndexMap;
 use miette::Diagnostic;
+use pep508_rs::Requirement;
 use pixi_core::{
     InstallFilter, UpdateLockFileOptions,
     environment::{LockFileUsage, get_update_lock_file_and_prefix},
@@ -7,8 +10,10 @@ use pixi_core::{
     workspace::{PypiDeps, WorkspaceMut},
 };
 use pixi_manifest::{
-    DependencyError, FeaturesExt, LoadManifestsError, RemoveDependencyError, SpecType,
+    DependencyError, FeatureName, FeaturesExt, LoadManifestsError, RemoveDependencyError, SpecType,
+    TargetSelector, WorkspaceManifest,
 };
+use pixi_pypi_spec::PypiPackageName;
 use rattler_conda_types::{MatchSpec, PackageName};
 use thiserror::Error;
 
@@ -18,6 +23,18 @@ use crate::workspace::DependencyOptions;
 pub enum RemoveError {
     #[error("dependency `{name}` was not found")]
     NotFound { name: String },
+
+    #[error(
+        "dependency `{name}` exists in multiple locations: {}",
+        .locations.join(", ")
+    )]
+    Ambiguous {
+        name: String,
+        locations: Vec<String>,
+    },
+
+    #[error("`{spec}` is not a valid Conda or PyPI dependency")]
+    InvalidSpec { spec: String },
 
     #[error(
         "Cannot remove Python while PyPI dependencies exist. Please remove these PyPI dependencies first: {}",
@@ -40,6 +57,119 @@ pub enum RemoveError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     LockFileUpdate(Box<dyn Diagnostic + Send + Sync + 'static>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DependencyLocation {
+    Conda {
+        name: PackageName,
+        spec_type: SpecType,
+        feature: FeatureName,
+        target: Option<TargetSelector>,
+    },
+    Pypi {
+        name: PypiPackageName,
+        feature: FeatureName,
+        target: Option<TargetSelector>,
+    },
+}
+
+impl DependencyLocation {
+    fn describe(&self) -> String {
+        let (table, feature, target) = match self {
+            DependencyLocation::Conda {
+                spec_type,
+                feature,
+                target,
+                ..
+            } => (spec_type.name(), feature, target),
+            DependencyLocation::Pypi {
+                feature, target, ..
+            } => ("pypi-dependencies", feature, target),
+        };
+
+        let feature = if feature.is_default() {
+            "the default feature".to_string()
+        } else {
+            format!("feature `{feature}`")
+        };
+        match target {
+            Some(target) => format!("{table} for target `{target}` in {feature}"),
+            None => format!("{table} in {feature}"),
+        }
+    }
+}
+
+struct RequestedDependency {
+    name: String,
+    conda: Option<PackageName>,
+    pypi: Option<PypiPackageName>,
+}
+
+fn parse_requested_dependency(
+    spec: &str,
+    workspace_root: &Path,
+) -> Result<RequestedDependency, RemoveError> {
+    let conda = MatchSpec::from_str(
+        spec,
+        rattler_conda_types::ParseMatchSpecOptions::lenient()
+            .with_repodata_revision(rattler_conda_types::RepodataRevision::V3),
+    )
+    .ok()
+    .and_then(|spec| spec.name.as_exact().cloned());
+    let pypi = Requirement::<pep508_rs::VerbatimUrl>::parse(spec, workspace_root)
+        .ok()
+        .map(|requirement| PypiPackageName::from_normalized(requirement.name));
+
+    if conda.is_none() && pypi.is_none() {
+        return Err(RemoveError::InvalidSpec {
+            spec: spec.to_string(),
+        });
+    }
+
+    let name = conda
+        .as_ref()
+        .map(|name| name.as_source().to_string())
+        .or_else(|| pypi.as_ref().map(|name| name.as_source().to_string()))
+        .expect("at least one dependency parser succeeded");
+    Ok(RequestedDependency { name, conda, pypi })
+}
+
+fn find_dependency_locations(
+    manifest: &WorkspaceManifest,
+    requested: &RequestedDependency,
+) -> Vec<DependencyLocation> {
+    let mut locations = Vec::new();
+    for (feature_name, feature) in &manifest.features {
+        for (target, selector) in feature.targets.iter() {
+            if let Some(requested_name) = &requested.conda {
+                for spec_type in SpecType::all() {
+                    if let Some(name) = target.dependencies(spec_type).and_then(|dependencies| {
+                        dependencies.names().find(|name| *name == requested_name)
+                    }) {
+                        locations.push(DependencyLocation::Conda {
+                            name: name.clone(),
+                            spec_type,
+                            feature: feature_name.clone(),
+                            target: selector.cloned(),
+                        });
+                    }
+                }
+            }
+            if let Some(requested_name) = &requested.pypi
+                && let Some(name) = target.pypi_dependencies.as_ref().and_then(|dependencies| {
+                    dependencies.names().find(|name| *name == requested_name)
+                })
+            {
+                locations.push(DependencyLocation::Pypi {
+                    name: name.clone(),
+                    feature: feature_name.clone(),
+                    target: selector.cloned(),
+                });
+            }
+        }
+    }
+    locations
 }
 
 impl From<RemoveDependencyError> for RemoveError {
@@ -85,29 +215,7 @@ pub async fn remove_conda_deps(
             &options.feature,
         )?;
     }
-    let workspace = workspace.save().await.map_err(RemoveError::Save)?;
-
-    // TODO: update all environments touched by this feature defined.
-    // updating prefix after removing from toml
-    if options.lock_file_usage == LockFileUsage::Update {
-        get_update_lock_file_and_prefix(
-            &workspace.default_environment(),
-            None,
-            UpdateMode::Revalidate,
-            UpdateLockFileOptions {
-                lock_file_usage: options.lock_file_usage,
-                no_install: options.no_install,
-                max_concurrent_solves: workspace.config().max_concurrent_solves(),
-                ..Default::default()
-            },
-            ReinstallPackages::default(),
-            &InstallFilter::default(),
-        )
-        .await
-        .map_err(|e| RemoveError::LockFileUpdate(e.into()))?;
-    }
-
-    Ok(())
+    save_and_update(workspace, options).await
 }
 
 pub async fn remove_pypi_deps(
@@ -121,6 +229,100 @@ pub async fn remove_pypi_deps(
             .remove_pypi_dependency(name, &options.platforms, &options.feature)?;
     }
 
+    save_and_update(workspace, options).await
+}
+
+/// Removes unqualified dependency names by resolving each one across every
+/// dependency table, feature, and target in the manifest.
+pub async fn remove_deps_unqualified(
+    mut workspace: WorkspaceMut,
+    specs: Vec<String>,
+    options: DependencyOptions,
+) -> Result<(), RemoveError> {
+    let requested = specs
+        .iter()
+        .map(|spec| parse_requested_dependency(spec, workspace.workspace().root()))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Resolve every input before mutating anything so ambiguity or a missing
+    // package cannot leave a partially edited manifest.
+    let mut resolved = Vec::new();
+    for requested in requested {
+        let locations =
+            find_dependency_locations(&workspace.workspace().workspace.value, &requested);
+        match locations.as_slice() {
+            [] => {
+                return Err(RemoveError::NotFound {
+                    name: requested.name,
+                });
+            }
+            [location] => {
+                if !resolved.contains(location) {
+                    resolved.push(location.clone());
+                }
+            }
+            locations => {
+                return Err(RemoveError::Ambiguous {
+                    name: requested.name,
+                    locations: locations.iter().map(DependencyLocation::describe).collect(),
+                });
+            }
+        }
+    }
+
+    if resolved.iter().any(|location| {
+        matches!(
+            location,
+            DependencyLocation::Conda { name, .. } if name.as_source() == "python"
+        )
+    }) {
+        let pypi_deps = workspace
+            .workspace()
+            .default_environment()
+            .pypi_dependencies(None);
+        if !pypi_deps.is_empty() {
+            return Err(RemoveError::PythonHasPypiDependencies {
+                pypi_deps: pypi_deps
+                    .iter()
+                    .map(|(name, _)| name.as_source().to_string())
+                    .collect(),
+            });
+        }
+    }
+
+    {
+        let mut manifest = workspace.manifest();
+        for location in resolved {
+            match location {
+                DependencyLocation::Conda {
+                    name,
+                    spec_type,
+                    feature,
+                    target,
+                } => manifest.remove_dependency_from_target(
+                    &name,
+                    spec_type,
+                    target.as_ref(),
+                    &feature,
+                )?,
+                DependencyLocation::Pypi {
+                    name,
+                    feature,
+                    target,
+                } => {
+                    manifest.remove_pypi_dependency_from_target(&name, target.as_ref(), &feature)?
+                }
+            }
+        }
+    }
+
+    save_and_update(workspace, options).await
+}
+
+async fn save_and_update(
+    workspace: WorkspaceMut,
+    options: DependencyOptions,
+) -> Result<(), RemoveError> {
     let workspace = workspace.save().await.map_err(RemoveError::Save)?;
 
     // TODO: update all environments touched by this feature defined.
@@ -161,6 +363,13 @@ mod tests {
         // intentionally leaked for the duration of the test.
         let tmp = tempfile::TempDir::new().unwrap().keep();
         let path = tmp.join("pixi.toml");
+        fs_err::write(&path, toml).unwrap();
+        Workspace::from_path(&path).expect("failed to load workspace")
+    }
+
+    fn workspace_from_pyproject(toml: &str) -> Workspace {
+        let tmp = tempfile::TempDir::new().unwrap().keep();
+        let path = tmp.join("pyproject.toml");
         fs_err::write(&path, toml).unwrap();
         Workspace::from_path(&path).expect("failed to load workspace")
     }
@@ -243,5 +452,169 @@ ruff = "*"
             @"  × dependency `fizzbuzz` was not found"
         );
         assert!(matches!(err, RemoveError::NotFound { name } if name == "fizzbuzz"));
+    }
+
+    #[tokio::test]
+    async fn removes_unambiguous_dependencies_across_all_locations() {
+        let workspace = workspace_from(
+            r#"
+[workspace]
+name = "test"
+channels = []
+platforms = ["linux-64"]
+
+[dependencies]
+numpy = "*"
+
+[pypi-dependencies]
+black = "*"
+
+[feature.test.dependencies]
+pytest = "*"
+
+[target.linux.dependencies]
+bla = "*"
+"#,
+        );
+        let manifest_path = workspace.workspace.provenance.path.clone();
+
+        remove_deps_unqualified(
+            workspace.modify().unwrap(),
+            ["numpy", "black", "pytest", "bla"]
+                .map(str::to_string)
+                .to_vec(),
+            options(),
+        )
+        .await
+        .unwrap();
+
+        let manifest = fs_err::read_to_string(manifest_path).unwrap();
+        for name in ["numpy", "black", "pytest", "bla"] {
+            assert!(!manifest.contains(&format!("{name} =")));
+        }
+    }
+
+    #[tokio::test]
+    async fn ambiguous_dependency_reports_locations_without_editing() {
+        let workspace = workspace_from(
+            r#"
+[workspace]
+name = "test"
+channels = []
+platforms = ["linux-64"]
+
+[dependencies]
+ruff = "*"
+
+[feature.dev.pypi-dependencies]
+ruff = "*"
+"#,
+        );
+        let manifest_path = workspace.workspace.provenance.path.clone();
+        let original = fs_err::read_to_string(&manifest_path).unwrap();
+
+        let err = remove_deps_unqualified(
+            workspace.modify().unwrap(),
+            vec!["ruff".to_string()],
+            options(),
+        )
+        .await
+        .unwrap_err();
+
+        insta::assert_snapshot!(
+            format_diagnostic(&err),
+            @"  × dependency `ruff` exists in multiple locations: dependencies in the default feature, pypi-dependencies in feature `dev`"
+        );
+        assert_eq!(fs_err::read_to_string(manifest_path).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn missing_dependency_does_not_partially_edit_manifest() {
+        let workspace = workspace_from(
+            r#"
+[workspace]
+name = "test"
+channels = []
+platforms = ["linux-64"]
+
+[dependencies]
+numpy = "*"
+"#,
+        );
+        let manifest_path = workspace.workspace.provenance.path.clone();
+        let original = fs_err::read_to_string(&manifest_path).unwrap();
+
+        let err = remove_deps_unqualified(
+            workspace.modify().unwrap(),
+            vec!["numpy".to_string(), "missing".to_string()],
+            options(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, RemoveError::NotFound { name } if name == "missing"));
+        assert_eq!(fs_err::read_to_string(manifest_path).unwrap(), original);
+    }
+
+    #[tokio::test]
+    async fn pypi_names_are_matched_but_removed_with_source_spelling() {
+        let workspace = workspace_from(
+            r#"
+[workspace]
+name = "test"
+channels = []
+platforms = ["linux-64"]
+
+[pypi-dependencies]
+foo_bar = "*"
+"#,
+        );
+        let manifest_path = workspace.workspace.provenance.path.clone();
+
+        remove_deps_unqualified(
+            workspace.modify().unwrap(),
+            vec!["Foo-Bar".to_string()],
+            options(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !fs_err::read_to_string(manifest_path)
+                .unwrap()
+                .contains("foo_bar")
+        );
+    }
+
+    #[tokio::test]
+    async fn removes_native_pyproject_dependency() {
+        let workspace = workspace_from_pyproject(
+            r#"
+[project]
+name = "test"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["Requests>=2"]
+
+[tool.pixi.workspace]
+channels = []
+platforms = ["linux-64"]
+"#,
+        );
+        let manifest_path = workspace.workspace.provenance.path.clone();
+
+        remove_deps_unqualified(
+            workspace.modify().unwrap(),
+            vec!["requests".to_string()],
+            options(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !fs_err::read_to_string(manifest_path)
+                .unwrap()
+                .contains("Requests>=2")
+        );
     }
 }

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -113,7 +113,7 @@ impl TryFrom<&Args> for DependencyOptions {
 
     fn try_from(args: &Args) -> miette::Result<Self> {
         Ok(DependencyOptions {
-            feature: args.dependency_config.feature.clone(),
+            feature: args.dependency_config.feature(),
             platforms: args.dependency_config.platforms.clone(),
             no_install: args.no_install_config.no_install,
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -301,8 +301,8 @@ pub struct DependencyConfig {
     pub platforms: Vec<PixiPlatformName>,
 
     /// The feature for which the dependency should be modified.
-    #[clap(long, short, default_value_t)]
-    pub feature: FeatureName,
+    #[clap(long, short)]
+    pub feature: Option<FeatureName>,
 
     /// The git url to use when adding a git dependency
     #[clap(long, short, help_heading = consts::CLAP_GIT_OPTIONS)]
@@ -318,6 +318,14 @@ pub struct DependencyConfig {
 }
 
 impl DependencyConfig {
+    pub(crate) fn feature(&self) -> FeatureName {
+        self.feature.clone().unwrap_or_default()
+    }
+
+    pub(crate) fn has_feature_selector(&self) -> bool {
+        self.feature.is_some()
+    }
+
     pub(crate) fn dependency_type(&self) -> DependencyType {
         if self.pypi {
             DependencyType::PypiDependency
@@ -368,7 +376,7 @@ impl DependencyConfig {
             )
         }
         // Print something if we've modified for features
-        if let Some(feature) = self.feature.non_default() {
+        if let Some(feature) = self.feature.as_ref().and_then(FeatureName::non_default) {
             {
                 eprintln!(
                     "{operation} these only for feature: {}",

--- a/crates/pixi_cli/src/remove/error.rs
+++ b/crates/pixi_cli/src/remove/error.rs
@@ -17,7 +17,7 @@ use rattler_conda_types::PackageName;
 #[derive(Debug)]
 pub(super) struct DependencyRemovalError {
     name: String,
-    dependency_type: DependencyType,
+    dependency_type: Option<DependencyType>,
     feature: FeatureName,
     suggestions: Vec<String>,
 }
@@ -33,8 +33,18 @@ impl DependencyRemovalError {
         let suggestions = collect_suggestions(manifest, &name, dependency_type, feature, platforms);
         Self {
             name,
-            dependency_type,
+            dependency_type: Some(dependency_type),
             feature: feature.clone(),
+            suggestions,
+        }
+    }
+
+    pub(super) fn new_unqualified(name: String, manifest: &WorkspaceManifest) -> Self {
+        let suggestions = collect_unqualified_suggestions(manifest, &name);
+        Self {
+            name,
+            dependency_type: None,
+            feature: FeatureName::DEFAULT,
             suggestions,
         }
     }
@@ -42,14 +52,12 @@ impl DependencyRemovalError {
 
 impl Display for DependencyRemovalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "dependency `{}` was not found in {}",
-            self.name,
-            Slot::from(self.dependency_type).table_name()
-        )?;
-        if !self.feature.is_default() {
-            write!(f, " of feature `{}`", self.feature)?;
+        write!(f, "dependency `{}` was not found", self.name)?;
+        if let Some(dependency_type) = self.dependency_type {
+            write!(f, " in {}", Slot::from(dependency_type).table_name())?;
+            if !self.feature.is_default() {
+                write!(f, " of feature `{}`", self.feature)?;
+            }
         }
         Ok(())
     }
@@ -160,6 +168,45 @@ fn collect_suggestions(
         suggestions.push(format!("did you mean {quoted}?"));
     }
     suggestions
+}
+
+fn collect_unqualified_suggestions(manifest: &WorkspaceManifest, name: &str) -> Vec<String> {
+    let mut similar = Vec::new();
+    for feature in manifest.features.values() {
+        for target in feature.targets.targets() {
+            for spec_type in SpecType::all() {
+                if let Some(dependencies) = target.dependencies(spec_type) {
+                    for package in dependencies.names() {
+                        let candidate = package.as_source();
+                        if is_similar(name, candidate)
+                            && !similar.iter().any(|existing| existing == candidate)
+                        {
+                            similar.push(candidate.to_string());
+                        }
+                    }
+                }
+            }
+            if let Some(dependencies) = &target.pypi_dependencies {
+                for package in dependencies.names() {
+                    let candidate = package.as_source();
+                    if is_similar(name, candidate)
+                        && !similar.iter().any(|existing| existing == candidate)
+                    {
+                        similar.push(candidate.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if similar.is_empty() {
+        Vec::new()
+    } else {
+        vec![format!(
+            "did you mean {}?",
+            similar.iter().map(|name| format!("`{name}`")).join(", ")
+        )]
+    }
 }
 
 /// Flatten the (feature × platform × spec-type) iteration into a single
@@ -442,6 +489,21 @@ pandas = "*"
                 &[],
             ),
             @"  × dependency `fizzbuzz` was not found in dependencies"
+        );
+    }
+
+    #[test]
+    fn unqualified_typo_suggests_names_across_locations() {
+        let manifest = parse(MIXED_MANIFEST);
+        insta::assert_snapshot!(
+            format_diagnostic(&DependencyRemovalError::new_unqualified(
+                "polrs".to_string(),
+                &manifest,
+            )),
+            @r"
+          × dependency `polrs` was not found
+          help: did you mean `polars`?
+        "
         );
     }
 

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -54,7 +54,7 @@ impl TryFrom<&Args> for DependencyOptions {
 
     fn try_from(args: &Args) -> miette::Result<Self> {
         Ok(DependencyOptions {
-            feature: args.dependency_config.feature.clone(),
+            feature: args.dependency_config.feature(),
             platforms: args.dependency_config.platforms.clone(),
             no_install: args.no_install_config.no_install,
             lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
@@ -72,8 +72,32 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
 
     let dependency_type = args.dependency_config.dependency_type();
-    let feature = args.dependency_config.feature.clone();
+    let feature = args.dependency_config.feature();
     let platforms = args.dependency_config.platforms.clone();
+
+    let unqualified = matches!(
+        dependency_type,
+        DependencyType::CondaDependency(pixi_manifest::SpecType::Run)
+    ) && feature.is_default()
+        && !args.dependency_config.has_feature_selector()
+        && platforms.is_empty();
+
+    if unqualified {
+        return match workspace_ctx
+            .remove_deps_unqualified(args.dependency_config.specs.clone(), (&args).try_into()?)
+            .await
+        {
+            Ok(()) => {
+                args.dependency_config
+                    .display_success("Removed", Default::default());
+                Ok(())
+            }
+            Err(RemoveError::NotFound { name }) => Err(miette::Report::new(
+                DependencyRemovalError::new_unqualified(name, (&workspace).workspace_manifest()),
+            )),
+            Err(other) => Err(miette::Report::new(other)),
+        };
+    }
 
     let result = match dependency_type {
         DependencyType::CondaDependency(spec_type) => {

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -9,9 +9,9 @@ use thiserror::Error;
 use toml_edit::{Array, DocumentMut, Item, Table, Value, value};
 
 use crate::{
-    FeatureName, ManifestKind, ManifestProvenance, PixiPlatform, PixiPlatformName,
-    PypiDependencyLocation, SpecType, TargetSelector, Task, TomlError,
-    manifests::table_name::TableName, toml::TomlDocument, utils::WithSourceCode,
+    FeatureName, ManifestKind, ManifestProvenance, PixiPlatform, PypiDependencyLocation, SpecType,
+    TargetSelector, Task, TomlError, manifests::table_name::TableName, toml::TomlDocument,
+    utils::WithSourceCode,
 };
 
 /// Discriminates between a 'pixi.toml' and a 'pyproject.toml' manifest.
@@ -220,7 +220,7 @@ impl ManifestDocument {
     pub fn remove_pypi_dependency(
         &mut self,
         dep: &PypiPackageName,
-        platform: Option<PixiPlatformName>,
+        target: Option<&TargetSelector>,
         feature_name: &FeatureName,
     ) -> Result<(), TomlError> {
         // For 'pyproject.toml' manifest, try and remove the dependency from native
@@ -242,7 +242,7 @@ impl ManifestDocument {
         let table_name = TableName::new()
             .with_prefix(self.table_prefix())
             .with_feature_name(Some(feature_name))
-            .with_target(platform.map(TargetSelector::Platform))
+            .with_target(target.cloned())
             .with_table(Some(consts::PYPI_DEPENDENCIES));
 
         self.manifest_mut()
@@ -289,13 +289,13 @@ impl ManifestDocument {
         &mut self,
         dep: &PackageName,
         spec_type: SpecType,
-        platform: Option<PixiPlatformName>,
+        target: Option<&TargetSelector>,
         feature_name: &FeatureName,
     ) -> Result<(), TomlError> {
         let table_name = TableName::new()
             .with_prefix(self.table_prefix())
             .with_feature_name(Some(feature_name))
-            .with_target(platform.map(TargetSelector::Platform))
+            .with_target(target.cloned())
             .with_table(Some(spec_type.name()));
 
         self.manifest_mut()

--- a/crates/pixi_manifest/src/manifests/workspace.rs
+++ b/crates/pixi_manifest/src/manifests/workspace.rs
@@ -1099,11 +1099,28 @@ impl WorkspaceManifestMut<'_> {
                 Err(e) => return Err(e.into()),
             };
             self.document
-                .remove_dependency(dep, spec_type, platform_name, feature_name)?;
+                .remove_dependency(dep, spec_type, selector.as_ref(), feature_name)?;
         }
         if !any_removed {
             return Err(DependencyError::NoDependency(dep.as_normalized().into()).into());
         }
+        Ok(())
+    }
+
+    /// Removes a dependency from one exact feature and target selector.
+    pub fn remove_dependency_from_target(
+        &mut self,
+        dep: &rattler_conda_types::PackageName,
+        spec_type: SpecType,
+        target: Option<&TargetSelector>,
+        feature_name: &FeatureName,
+    ) -> Result<(), RemoveDependencyError> {
+        self.workspace
+            .target_mut(target, feature_name)
+            .ok_or_else(|| DependencyError::NoDependency(dep.as_normalized().into()))?
+            .remove_dependency(dep, spec_type)?;
+        self.document
+            .remove_dependency(dep, spec_type, target, feature_name)?;
         Ok(())
     }
 
@@ -1184,11 +1201,27 @@ impl WorkspaceManifestMut<'_> {
                 Err(e) => return Err(e.into()),
             };
             self.document
-                .remove_pypi_dependency(dep, platform_name, feature_name)?;
+                .remove_pypi_dependency(dep, selector.as_ref(), feature_name)?;
         }
         if !any_removed {
             return Err(DependencyError::NoDependency(dep.as_source().into()).into());
         }
+        Ok(())
+    }
+
+    /// Removes a PyPI dependency from one exact feature and target selector.
+    pub fn remove_pypi_dependency_from_target(
+        &mut self,
+        dep: &PypiPackageName,
+        target: Option<&TargetSelector>,
+        feature_name: &FeatureName,
+    ) -> Result<(), RemoveDependencyError> {
+        self.workspace
+            .target_mut(target, feature_name)
+            .ok_or_else(|| DependencyError::NoDependency(dep.as_source().into()))?
+            .remove_pypi_dependency(dep)?;
+        self.document
+            .remove_pypi_dependency(dep, target, feature_name)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- make bare `pixi remove` resolve each package across Conda dependency types, PyPI dependencies, features, and targets
- keep explicit `--pypi`, `--host`, `--build`, `--feature`, and `--platform` selectors scoped
- report all matching locations when a package is ambiguous and resolve the full request before editing the manifest
- support normalized PyPI package names and native `pyproject.toml` dependencies

## Motivation

Bare removal previously assumed the default run-dependency table, so packages in PyPI tables, named features, or target-specific tables required users to identify their exact location manually.

Closes #6231.

## Validation

- `cargo check -p pixi_manifest -p pixi_api -p pixi_cli`
- `cargo test -p pixi_manifest` (458 passed)
- `cargo test -p pixi_api` (130 passed)
- `cargo test -p pixi_cli` (88 passed)
- focused integration tests for mixed locations and explicit selector scoping
- `cargo clippy -p pixi_manifest -p pixi_api -p pixi_cli --all-targets -- -D warnings`
- `cargo clippy -p pixi --test integration_rust -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
