### PR TITLE
feat: add `lfs` field to git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6990,6 +6990,7 @@ dependencies = [
  "uv-distribution-types",
  "uv-flags",
  "uv-git",
+ "uv-git-types",
  "uv-install-wheel",
  "uv-installer",
  "uv-normalize",

--- a/crates/pixi_build_backend/src/encoded_source_spec_url.rs
+++ b/crates/pixi_build_backend/src/encoded_source_spec_url.rs
@@ -63,10 +63,12 @@ impl From<EncodedSourceSpecUrl> for SourcePackageSpec {
             };
 
             let subdirectory = pairs.remove("subdirectory").map(|s| s.into_owned());
+            let lfs = pairs.remove("lfs").map(|s| s == "true");
             GitSpec {
                 git: git_url,
                 rev,
                 subdirectory,
+                lfs,
             }
             .into()
         } else {
@@ -108,6 +110,9 @@ impl From<SourcePackageSpec> for EncodedSourceSpecUrl {
                         query_pairs.append_pair("tag", tag);
                     }
                     _ => {}
+                }
+                if let Some(lfs) = git.lfs {
+                    query_pairs.append_pair("lfs", if lfs { "true" } else { "false" });
                 }
             }
             pixi_build_types::SourcePackageLocationSpec::Path(path) => {
@@ -152,6 +157,14 @@ mod test {
                 git: "https://github.com/some/repo.git".parse().unwrap(),
                 rev: Some(GitReference::Rev("1234567890abcdef".into())),
                 subdirectory: Some("subdir".into()),
+                lfs: None,
+            }
+            .into(),
+            pixi_build_types::GitSpec {
+                git: "https://github.com/some/repo.git".parse().unwrap(),
+                rev: None,
+                subdirectory: None,
+                lfs: Some(true),
             }
             .into(),
             pixi_build_types::UrlSpec {

--- a/crates/pixi_build_backend/src/specs_conversion.rs
+++ b/crates/pixi_build_backend/src/specs_conversion.rs
@@ -650,6 +650,7 @@ mod test {
                 git: "https://github.com/example/repo".parse().unwrap(),
                 rev: Some(pixi_build_types::GitReference::Rev("1234abcd".into())),
                 subdirectory: Some("subdir".into()),
+                lfs: None,
             }),
             version: Some("3.16.*".parse().unwrap()),
             build: Some("*_asan*".parse().unwrap()),

--- a/crates/pixi_build_type_conversions/src/project_model.rs
+++ b/crates/pixi_build_type_conversions/src/project_model.rs
@@ -60,6 +60,7 @@ fn to_pixi_spec_v1(
                         git,
                         rev,
                         subdirectory,
+                        lfs,
                     } = git_spec;
                     pbt::SourcePackageLocationSpec::Git(pbt::GitSpec {
                         git,
@@ -70,6 +71,7 @@ fn to_pixi_spec_v1(
                             GitReference::DefaultBranch => pbt::GitReference::DefaultBranch,
                         }),
                         subdirectory: subdirectory.to_option_string(),
+                        lfs,
                     })
                 }
                 SourceLocationSpec::Path(path_spec) => {

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -645,8 +645,9 @@ pub struct GitSpec {
     /// The git subdirectory of the package
     pub subdirectory: Option<String>,
 
-    /// Whether to fetch Git LFS objects for the checkout. `None` defers to
-    /// the environment / git configuration.
+    /// Whether to fetch Git LFS objects for the checkout. `None` falls
+    /// back to the deprecated `PIXI_GIT_LFS` environment variable and
+    /// otherwise leaves pointer files.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub lfs: Option<bool>,
 }

--- a/crates/pixi_build_types/src/project_model.rs
+++ b/crates/pixi_build_types/src/project_model.rs
@@ -644,6 +644,11 @@ pub struct GitSpec {
 
     /// The git subdirectory of the package
     pub subdirectory: Option<String>,
+
+    /// Whether to fetch Git LFS objects for the checkout. `None` defers to
+    /// the environment / git configuration.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub lfs: Option<bool>,
 }
 
 /// A specification of a package from a path
@@ -1047,6 +1052,7 @@ impl Hash for GitSpec {
             .field("git", &self.git)
             .field("rev", &self.rev)
             .field("subdirectory", &self.subdirectory)
+            .field("lfs", &self.lfs)
             .finish(state);
     }
 }

--- a/crates/pixi_command_dispatcher/src/build/conversion.rs
+++ b/crates/pixi_command_dispatcher/src/build/conversion.rs
@@ -48,6 +48,7 @@ pub fn from_source_package_location_spec(
 
         SourcePackageLocationSpec::Git(git) => SourceLocationSpec::Git(GitLocationSpec {
             git: git.git,
+            lfs: git.lfs,
             rev: git.rev.map(|r| match r {
                 pixi_build_frontend::types::GitReference::Branch(b) => {
                     pixi_spec::GitReference::Branch(b)

--- a/crates/pixi_command_dispatcher/src/installed_source_hints.rs
+++ b/crates/pixi_command_dispatcher/src/installed_source_hints.rs
@@ -358,6 +358,7 @@ mod tests {
                 commit: GitSha::from_str(commit).expect("valid sha"),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".into()),
+                lfs: None,
             },
         });
         let data = SourceRecordData::Partial(PartialSourceRecordData {

--- a/crates/pixi_compute_sources/src/checkout.rs
+++ b/crates/pixi_compute_sources/src/checkout.rs
@@ -77,6 +77,11 @@ pub enum SourceCheckoutError {
     #[error("the manifest path {0} should have a parent directory")]
     ParentDir(PathBuf),
 
+    #[error(
+        "`lfs = true` is set for the git source `{0}` but its LFS objects could not be fetched; make sure `git-lfs` is installed and on PATH"
+    )]
+    LfsNotReady(String),
+
     #[error("the subdirectory {0} does not exist in the source checkout")]
     SubdirDoesNotExist(PathBuf),
 

--- a/crates/pixi_compute_sources/src/git.rs
+++ b/crates/pixi_compute_sources/src/git.rs
@@ -101,13 +101,22 @@ impl LifecycleKind for GitReporterLifecycle {
 /// Stripping `precise` from the key let `checkout_pinned_source(A)`
 /// silently return the branch's HEAD instead of commit `A`
 /// (prefix-dev/pixi#6073).
+///
+/// The LFS preference is part of the key so callers asking for the same
+/// commit with different LFS preferences get distinct compute futures.
 #[derive(Clone, Debug, Display, Hash, PartialEq, Eq)]
-#[display("{}@{}", _0.repository(), _0.reference())]
-pub struct CheckoutGit(GitUrl);
+#[display("{}@{}", url.repository(), url.reference())]
+pub struct CheckoutGit {
+    url: GitUrl,
+    lfs: Option<bool>,
+}
 
 impl CheckoutGit {
-    pub fn new(git_url: &GitUrl) -> Self {
-        Self(git_url.clone())
+    pub fn new(git_url: &GitUrl, lfs: Option<bool>) -> Self {
+        Self {
+            url: git_url.clone(),
+            lfs,
+        }
     }
 }
 
@@ -123,7 +132,7 @@ impl Key for CheckoutGit {
         let semaphore = data.git_checkout_semaphore().cloned();
         let reporter = data.git_checkout_reporter().cloned();
 
-        let reporter_env = RepositoryReference::from(&self.0);
+        let reporter_env = RepositoryReference::from(&self.url);
         let lifecycle =
             ReporterLifecycle::<GitReporterLifecycle>::queued(reporter.as_deref(), &reporter_env);
 
@@ -143,10 +152,11 @@ impl Key for CheckoutGit {
         Arc::new(
             resolver
                 .fetch(
-                    self.0.clone(),
+                    self.url.clone(),
                     client,
                     cache_dir.into_std_path_buf(),
                     offline,
+                    self.lfs,
                     None,
                 )
                 .await,
@@ -181,6 +191,7 @@ impl GitSourceCheckoutExt for ComputeCtx {
             .unwrap_or(GitReference::DefaultBranch);
         let pinned_git_reference = git_spec.rev.clone().unwrap_or_default();
         let subdirectory = git_spec.subdirectory.clone();
+        let lfs = git_spec.lfs;
 
         let git_url = match GitUrl::try_from(git_spec.git).map_err(GitError::from) {
             Ok(url) => url.with_reference(git_reference),
@@ -189,15 +200,21 @@ impl GitSourceCheckoutExt for ComputeCtx {
             }
         };
 
-        let fut = self.compute(&CheckoutGit::new(&git_url));
+        let fut = self.compute(&CheckoutGit::new(&git_url, lfs));
         Either::Right(async move {
             let fetch = fut.await.as_ref().clone()?;
+            if lfs == Some(true) && !fetch.lfs_ready() {
+                return Err(SourceCheckoutError::LfsNotReady(
+                    fetch.repository().url.clone().into_url().to_string(),
+                ));
+            }
             let pinned = PinnedGitSpec {
                 git: fetch.repository().url.clone().into_url(),
                 source: PinnedGitCheckout {
                     commit: fetch.commit(),
                     subdirectory,
                     reference: pinned_git_reference,
+                    lfs,
                 },
             };
             Ok(SourceCheckout::from_git(fetch, pinned))
@@ -213,9 +230,15 @@ impl GitSourceCheckoutExt for ComputeCtx {
             git_spec.source.reference.clone().into(),
             git_spec.source.commit,
         );
-        let fut = self.compute(&CheckoutGit::new(&git_url));
+        let lfs = git_spec.source.lfs;
+        let fut = self.compute(&CheckoutGit::new(&git_url, lfs));
         async move {
             let fetch = fut.await.as_ref().clone()?;
+            if lfs == Some(true) && !fetch.lfs_ready() {
+                return Err(SourceCheckoutError::LfsNotReady(
+                    fetch.repository().url.clone().into_url().to_string(),
+                ));
+            }
             Ok(SourceCheckout::from_git(fetch, git_spec))
         }
     }

--- a/crates/pixi_compute_sources/tests/adversarial_lfs.rs
+++ b/crates/pixi_compute_sources/tests/adversarial_lfs.rs
@@ -225,7 +225,9 @@ async fn lock_roundtrip_with_subdirectory_materializes_lfs() {
     let locked = pinned.clone().into_locked_git_url();
     let locked_url = locked.to_url();
     assert!(
-        locked_url.query_pairs().any(|(k, v)| k == "lfs" && v == "true"),
+        locked_url
+            .query_pairs()
+            .any(|(k, v)| k == "lfs" && v == "true"),
         "locked URL should carry ?lfs=true: {locked_url}"
     );
     assert!(

--- a/crates/pixi_compute_sources/tests/adversarial_lfs.rs
+++ b/crates/pixi_compute_sources/tests/adversarial_lfs.rs
@@ -1,0 +1,385 @@
+//! Adversarial integration tests for the `lfs` flag on git source
+//! checkouts. They exercise cache interactions between LFS and plain
+//! checkouts of the same commit, the lock file round trip, explicit
+//! `lfs = false`, broken LFS remotes, and repos without LFS files.
+//!
+//! Tests use [`pixi_test_utils::GitRepoFixture`] (local `git` binary,
+//! no network) and require `git-lfs` on the host; they skip otherwise.
+
+mod common;
+
+use std::path::Path;
+
+use common::{EngineConfig, build_test_engine};
+use pixi_compute_sources::{GitSourceCheckoutExt, SourceCheckoutError};
+use pixi_record::{PinnedGitSpec, PinnedSourceSpec};
+use pixi_spec::{GitLocationSpec, Subdirectory};
+use pixi_test_utils::{GitRepoFixture, git_lfs_available};
+
+/// Returns whether `path` looks like a git-lfs pointer file.
+fn is_lfs_pointer(path: &Path) -> bool {
+    let contents = fs_err::read_to_string(path).unwrap_or_default();
+    contents.starts_with("version https://git-lfs.github.com/spec/")
+}
+
+/// Skip helper mirroring the one in `pixi_git/tests/lfs.rs`.
+fn require_git_lfs(test: &str) -> bool {
+    if !git_lfs_available() {
+        eprintln!("skipping {test}: git-lfs is not installed");
+        return false;
+    }
+    true
+}
+
+/// Extracts the pinned git spec from a checkout or panics.
+fn pinned_git(pinned: &PinnedSourceSpec) -> &PinnedGitSpec {
+    match pinned {
+        PinnedSourceSpec::Git(git) => git,
+        other => panic!("expected git pinned spec, got {other:?}"),
+    }
+}
+
+/// Checking out the same commit twice in one process, first plain
+/// (`lfs = None`) and then with `lfs = Some(true)`, yields two distinct
+/// checkout directories and the LFS checkout has the real blob. The
+/// plain checkout must not be reused for (or poisoned by) the LFS one.
+#[tokio::test]
+async fn same_commit_plain_then_lfs() {
+    if !require_git_lfs("same_commit_plain_then_lfs") {
+        return;
+    }
+    let repo = GitRepoFixture::new("lfs-sample");
+    let original = fs_err::read(repo.repo_path.join("data.bin")).expect("fixture has data.bin");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let base_spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default());
+    let plain_spec = base_spec.clone();
+    let lfs_spec = base_spec.with_lfs(Some(true));
+
+    let (plain, lfs) = engine
+        .with_ctx(async |ctx| {
+            let plain = ctx.pin_and_checkout_git(plain_spec).await?;
+            let lfs = ctx.pin_and_checkout_git(lfs_spec).await?;
+            Ok::<_, SourceCheckoutError>((plain, lfs))
+        })
+        .await
+        .expect("engine scope")
+        .expect("both checkouts should succeed");
+
+    assert_ne!(
+        plain.path, lfs.path,
+        "plain and LFS checkouts of the same commit must live in different directories"
+    );
+    assert_eq!(pinned_git(&plain.pinned).source.lfs, None);
+    assert_eq!(pinned_git(&lfs.pinned).source.lfs, Some(true));
+    assert_eq!(
+        pinned_git(&plain.pinned).source.commit,
+        pinned_git(&lfs.pinned).source.commit,
+        "both checkouts should pin the same commit"
+    );
+
+    let lfs_data = lfs.path.as_std_path().join("data.bin");
+    assert!(
+        !is_lfs_pointer(&lfs_data),
+        "LFS checkout must contain the real blob, not a pointer"
+    );
+    assert_eq!(
+        fs_err::read(&lfs_data).expect("data.bin in LFS checkout"),
+        original,
+        "LFS checkout content must match the fixture source"
+    );
+}
+
+/// The reverse order: `lfs = Some(true)` first, then `lfs = None`. The
+/// second (plain) checkout must not silently reuse the LFS checkout
+/// directory, and the LFS checkout stays intact afterwards.
+#[tokio::test]
+async fn same_commit_lfs_then_plain() {
+    if !require_git_lfs("same_commit_lfs_then_plain") {
+        return;
+    }
+    let repo = GitRepoFixture::new("lfs-sample");
+    let original = fs_err::read(repo.repo_path.join("data.bin")).expect("fixture has data.bin");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let base_spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default());
+    let lfs_spec = base_spec.clone().with_lfs(Some(true));
+    let plain_spec = base_spec;
+
+    let (lfs, plain) = engine
+        .with_ctx(async |ctx| {
+            let lfs = ctx.pin_and_checkout_git(lfs_spec).await?;
+            let plain = ctx.pin_and_checkout_git(plain_spec).await?;
+            Ok::<_, SourceCheckoutError>((lfs, plain))
+        })
+        .await
+        .expect("engine scope")
+        .expect("both checkouts should succeed");
+
+    assert_ne!(
+        lfs.path, plain.path,
+        "LFS and plain checkouts of the same commit must live in different directories"
+    );
+    assert_eq!(pinned_git(&lfs.pinned).source.lfs, Some(true));
+    assert_eq!(pinned_git(&plain.pinned).source.lfs, None);
+
+    let lfs_data = lfs.path.as_std_path().join("data.bin");
+    assert!(
+        !is_lfs_pointer(&lfs_data),
+        "LFS checkout must still contain the real blob after the plain checkout ran"
+    );
+    assert_eq!(
+        fs_err::read(&lfs_data).expect("data.bin in LFS checkout"),
+        original,
+    );
+}
+
+/// `lfs = Some(false)` succeeds, leaves the pointer file in place, and
+/// records the preference in the pinned spec.
+#[tokio::test]
+async fn explicit_lfs_false_keeps_pointer() {
+    if !require_git_lfs("explicit_lfs_false_keeps_pointer") {
+        return;
+    }
+    let repo = GitRepoFixture::new("lfs-sample");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default())
+        .with_lfs(Some(false));
+
+    let checkout = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope")
+        .expect("checkout with lfs = false should succeed");
+
+    assert_eq!(pinned_git(&checkout.pinned).source.lfs, Some(false));
+    let data = checkout.path.as_std_path().join("data.bin");
+    assert!(data.is_file(), "data.bin missing from checkout");
+    assert!(
+        is_lfs_pointer(&data),
+        "data.bin must remain an LFS pointer when lfs = false"
+    );
+}
+
+/// Full lock round trip with a subdirectory: pin a checkout with
+/// `lfs = Some(true)` and `subdirectory = "pkg"`, serialize the pin to a
+/// locked git URL, parse it back, and check out the parsed pin in a
+/// completely fresh engine with a fresh cache. The re-checkout must
+/// materialize the real LFS content inside the subdirectory.
+#[tokio::test]
+async fn lock_roundtrip_with_subdirectory_materializes_lfs() {
+    if !require_git_lfs("lock_roundtrip_with_subdirectory_materializes_lfs") {
+        return;
+    }
+
+    // Build a custom fixture with the LFS file inside a subdirectory.
+    let payload: Vec<u8> = (0u16..1024).map(|i| (i % 251) as u8).collect();
+    let fixture_dir = tempfile::tempdir().expect("create fixture tempdir");
+    let commit_dir = fixture_dir.path().join("001_v0.1.0");
+    fs_err::create_dir_all(commit_dir.join("pkg")).unwrap();
+    fs_err::write(
+        commit_dir.join("dot-gitattributes"),
+        "*.bin filter=lfs diff=lfs merge=lfs -text\n",
+    )
+    .unwrap();
+    fs_err::write(commit_dir.join("pkg").join("data.bin"), &payload).unwrap();
+    fs_err::write(commit_dir.join("README.md"), "lfs subdir fixture\n").unwrap();
+    let repo = GitRepoFixture::from_path(fixture_dir.path(), "lfs-subdir");
+    assert!(repo.uses_lfs, "fixture should auto-detect LFS");
+
+    // First engine: resolve and pin.
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+    let spec = GitLocationSpec::new(
+        repo.base_url.clone(),
+        None,
+        Subdirectory::try_from("pkg").unwrap(),
+    )
+    .with_lfs(Some(true));
+
+    let checkout = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope")
+        .expect("initial checkout should succeed");
+    let pinned = pinned_git(&checkout.pinned).clone();
+    assert_eq!(pinned.source.lfs, Some(true));
+
+    // Lock round trip: the URL carries both query pairs and parses back
+    // into an identical pin.
+    let locked = pinned.clone().into_locked_git_url();
+    let locked_url = locked.to_url();
+    assert!(
+        locked_url.query_pairs().any(|(k, v)| k == "lfs" && v == "true"),
+        "locked URL should carry ?lfs=true: {locked_url}"
+    );
+    assert!(
+        locked_url
+            .query_pairs()
+            .any(|(k, v)| k == "subdirectory" && v == "pkg"),
+        "locked URL should carry ?subdirectory=pkg: {locked_url}"
+    );
+    let reparsed = locked.to_pinned_git_spec().expect("parse locked URL");
+    assert_eq!(reparsed, pinned, "pin must survive the lock round trip");
+
+    // Second engine with a fresh cache: check out from the parsed pin
+    // only, as an install from the lock file would.
+    let fresh_engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+    let reinstalled = fresh_engine
+        .with_ctx(async |ctx| ctx.checkout_pinned_git(reparsed).await)
+        .await
+        .expect("engine scope")
+        .expect("pinned checkout should succeed");
+
+    assert!(
+        reinstalled.path.as_std_path().ends_with("pkg"),
+        "checkout path should point into the subdirectory: {:?}",
+        reinstalled.path
+    );
+    let data = reinstalled.path.as_std_path().join("data.bin");
+    assert!(
+        !is_lfs_pointer(&data),
+        "pinned re-checkout must materialize the real blob"
+    );
+    assert_eq!(
+        fs_err::read(&data).expect("data.bin in pinned checkout"),
+        payload,
+        "pinned re-checkout content must match the fixture source"
+    );
+}
+
+/// A remote whose LFS objects are gone must fail the checkout when
+/// `lfs = true` instead of silently leaving pointer files.
+#[tokio::test]
+async fn missing_remote_lfs_objects_error() {
+    if !require_git_lfs("missing_remote_lfs_objects_error") {
+        return;
+    }
+    let repo = GitRepoFixture::new("lfs-sample");
+
+    // Wipe the LFS object store of the remote so `git lfs fetch` cannot
+    // retrieve the blob.
+    let objects = repo.repo_path.join(".git/lfs/objects");
+    assert!(objects.is_dir(), "fixture should have LFS objects");
+    fs_err::remove_dir_all(&objects).unwrap();
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default())
+        .with_lfs(Some(true));
+
+    let result = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope");
+
+    // With git-lfs installed the checkout fails during `git reset --hard`
+    // because `filter.lfs.required=true` makes the smudge failure fatal
+    // (a `GitError`); without a usable smudge filter the fetch succeeds
+    // with pointers and the checkout layer reports `LfsNotReady`. Both
+    // are LFS-related errors; a silent pointer checkout is the bug.
+    let err = result.expect_err("checkout must fail when LFS objects are missing from the remote");
+    assert!(
+        matches!(
+            err,
+            SourceCheckoutError::GitError(_) | SourceCheckoutError::LfsNotReady(_)
+        ),
+        "unexpected error variant: {err:?}"
+    );
+    assert!(
+        err.to_string().to_lowercase().contains("lfs"),
+        "error should mention LFS: {err}"
+    );
+}
+
+/// In offline mode with a cold cache the LFS fetch is skipped, the git
+/// checkout itself succeeds (local file transport) with pointer files,
+/// and the checkout layer must then report [`SourceCheckoutError::LfsNotReady`]
+/// instead of silently returning the pointers.
+#[tokio::test]
+async fn offline_cold_cache_lfs_true_reports_lfs_not_ready() {
+    if !require_git_lfs("offline_cold_cache_lfs_true_reports_lfs_not_ready") {
+        return;
+    }
+    let repo = GitRepoFixture::new("lfs-sample");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        offline: true,
+        ..Default::default()
+    });
+
+    let spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default())
+        .with_lfs(Some(true));
+
+    let result = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope");
+
+    match result {
+        Err(SourceCheckoutError::LfsNotReady(url)) => {
+            assert!(
+                url.contains("lfs-sample"),
+                "error should name the repository, got: {url}"
+            );
+        }
+        Err(other) => panic!("expected LfsNotReady, got: {other:?}"),
+        Ok(checkout) => panic!(
+            "expected LfsNotReady, got a successful checkout at {:?}",
+            checkout.path
+        ),
+    }
+}
+
+/// `lfs = Some(true)` on a repository that has no LFS-tracked files at
+/// all must succeed rather than error.
+#[tokio::test]
+async fn lfs_true_without_lfs_files_succeeds() {
+    if !require_git_lfs("lfs_true_without_lfs_files_succeeds") {
+        return;
+    }
+    let repo = GitRepoFixture::new("minimal-pypi-package");
+    assert!(!repo.uses_lfs, "fixture must not use LFS");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default())
+        .with_lfs(Some(true));
+
+    let checkout = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope")
+        .expect("lfs = true on a repo without LFS files should succeed");
+
+    assert_eq!(pinned_git(&checkout.pinned).source.lfs, Some(true));
+    assert!(
+        checkout.path.as_std_path().join("pyproject.toml").is_file(),
+        "checkout should contain the repo contents"
+    );
+}

--- a/crates/pixi_compute_sources/tests/common/mod.rs
+++ b/crates/pixi_compute_sources/tests/common/mod.rs
@@ -200,6 +200,7 @@ pub struct EngineConfig {
     pub sequential: bool,
     pub max_concurrent_url: Option<usize>,
     pub max_concurrent_git: Option<usize>,
+    pub offline: bool,
 }
 
 /// Build a [`ComputeEngine`] populated with the entries the
@@ -228,6 +229,9 @@ pub fn build_test_engine(config: EngineConfig) -> ComputeEngine {
     }
     if let Some(n) = config.max_concurrent_git {
         builder = builder.with_data(GitCheckoutSemaphore(Arc::new(Semaphore::new(n))));
+    }
+    if config.offline {
+        builder = builder.with_data(pixi_compute_network::Offline(true));
     }
     let engine = builder.build();
     engine.inject(CacheDirsKey, Arc::new(cache_dirs));

--- a/crates/pixi_compute_sources/tests/git_checkout.rs
+++ b/crates/pixi_compute_sources/tests/git_checkout.rs
@@ -10,7 +10,7 @@ use common::{EngineConfig, LifecycleReporter, build_test_engine};
 use pixi_compute_sources::GitSourceCheckoutExt;
 use pixi_record::PinnedSourceSpec;
 use pixi_spec::{GitLocationSpec, Subdirectory};
-use pixi_test_utils::GitRepoFixture;
+use pixi_test_utils::{GitRepoFixture, git_lfs_available};
 
 /// `pin_and_checkout_git` against a fresh fixture clones the repo,
 /// returns a checkout pointing at the head commit, and produces a
@@ -50,6 +50,39 @@ async fn pin_and_checkout_git_default_branch() {
         }
         other => panic!("expected git pinned spec, got {other:?}"),
     }
+}
+
+/// A spec with `lfs = Some(true)` materialises LFS-tracked files as real
+/// content instead of leaving git-lfs pointer files in the checkout.
+#[tokio::test]
+async fn pin_and_checkout_git_with_lfs() {
+    if !git_lfs_available() {
+        eprintln!("skipping pin_and_checkout_git_with_lfs: git-lfs is not installed");
+        return;
+    }
+    let repo = GitRepoFixture::new("lfs-sample");
+    let original = fs_err::read(repo.repo_path.join("data.bin")).expect("fixture has data.bin");
+
+    let engine = build_test_engine(EngineConfig {
+        sequential: true,
+        ..Default::default()
+    });
+
+    let spec = GitLocationSpec::new(repo.base_url.clone(), None, Subdirectory::default())
+        .with_lfs(Some(true));
+
+    let checkout = engine
+        .with_ctx(async |ctx| ctx.pin_and_checkout_git(spec).await)
+        .await
+        .expect("engine scope")
+        .expect("git checkout should succeed");
+
+    let data = checkout.path.as_std_path().join("data.bin");
+    let got = fs_err::read(&data).expect("data.bin missing from checkout");
+    assert_eq!(
+        got, original,
+        "data.bin should be the real blob, not an LFS pointer"
+    );
 }
 
 /// One git checkout fires the full reporter sequence. The

--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -523,6 +523,13 @@ pub enum PlatformUnsat {
         found_ref: String,
     },
 
+    #[error("'{name}' has mismatching git lfs preference: '{expected_lfs} != {found_lfs}'")]
+    LockedPyPIGitLfsMismatch {
+        name: String,
+        expected_lfs: bool,
+        found_lfs: bool,
+    },
+
     #[error("'{0}' expected a git url but the lock file has: '{1}'")]
     LockedPyPIRequiresGitUrl(String, String),
 

--- a/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/pypi.rs
@@ -287,6 +287,27 @@ pub(crate) fn pypi_satisfies_requirement(
                             }
                             .into());
                         }
+
+                        // The LFS preference must match; uv's `GitLfs` is
+                        // binary, so an absent preference compares as
+                        // disabled on both sides. Only manifest-origin
+                        // requirements carry a trustworthy preference:
+                        // `requires_dist` entries are PEP 508 strings that
+                        // cannot express LFS and would compare as the
+                        // `UV_GIT_LFS` fallback, spuriously invalidating
+                        // the lock on every run.
+                        if origin == RequirementOrigin::Manifest {
+                            let spec_lfs = git.lfs().enabled();
+                            let lock_lfs = pinned_git_spec.source.lfs == Some(true);
+                            if spec_lfs != lock_lfs {
+                                return Err(PlatformUnsat::LockedPyPIGitLfsMismatch {
+                                    name: spec.name.clone().to_string(),
+                                    expected_lfs: spec_lfs,
+                                    found_lfs: lock_lfs,
+                                }
+                                .into());
+                            }
+                        }
                         // If the spec uses DefaultBranch, we need to check what the lock has
                         // DefaultBranch in it
                         // otherwise any explicit ref in lock is not satisfiable

--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -107,10 +107,15 @@ fn git_output(cmd: &mut Command) -> Result<std::process::Output, GitError> {
     Ok(output)
 }
 
-/// Value for `GIT_LFS_SKIP_SMUDGE`, or `None` to leave the var unset.
-/// `Some(true)` → "0" (run smudge), `Some(false)` → "1" (skip smudge).
-fn lfs_skip_smudge_env(lfs: Option<bool>) -> Option<&'static str> {
-    lfs.map(|on| if on { "0" } else { "1" })
+/// Value for `GIT_LFS_SKIP_SMUDGE`: `Some(true)` → "0" (run smudge),
+/// anything else → "1" (skip smudge). The smudge filter only ever runs
+/// when LFS was requested: pixi checks out via a local clone of its bare
+/// database, and that database only holds LFS objects when they were
+/// explicitly fetched. Leaving the filter enabled on a machine with a
+/// global `git lfs install` would make it download from the object-less
+/// database and fail the checkout through `filter.lfs.required`.
+fn lfs_skip_smudge_env(lfs: Option<bool>) -> &'static str {
+    if lfs == Some(true) { "0" } else { "1" }
 }
 
 /// Strategy when fetching refspecs for a [`GitReference`]
@@ -713,10 +718,8 @@ impl GitCheckout {
             .arg("reset")
             .arg("--hard")
             .arg(self.revision.as_str())
-            .current_dir(&self.repo.path);
-        if let Some(value) = skip_smudge {
-            reset_cmd.env(GIT_LFS_SKIP_SMUDGE, value);
-        }
+            .current_dir(&self.repo.path)
+            .env(GIT_LFS_SKIP_SMUDGE, skip_smudge);
         git_output(&mut reset_cmd)?;
 
         // Update submodules (`git submodule update --recursive`). Submodules
@@ -739,8 +742,8 @@ impl GitCheckout {
                 .env(GIT_LFS_SKIP_SMUDGE, "1")
                 .env(GIT_ALLOW_PROTOCOL, "file")
                 .env("LC_ALL", "C");
-        } else if let Some(value) = skip_smudge {
-            submodule_cmd.env(GIT_LFS_SKIP_SMUDGE, value);
+        } else {
+            submodule_cmd.env(GIT_LFS_SKIP_SMUDGE, skip_smudge);
         }
         git_output(&mut submodule_cmd).map_err(|err| match err {
             GitError::Command(_, ref stderr)

--- a/crates/pixi_git/src/git.rs
+++ b/crates/pixi_git/src/git.rs
@@ -694,6 +694,21 @@ impl GitCheckout {
             // git-lfs to a remote server.
             reset_cmd.arg("-c").arg(format!("lfs.url={url}"));
         }
+        if lfs == Some(true) && GIT_LFS.is_ok() {
+            // The smudge filter only runs when the `filter.lfs.*` config is
+            // present, which normally comes from a machine-wide
+            // `git lfs install`. Pass the config explicitly so LFS files
+            // materialize even when git-lfs was never installed globally.
+            // Without a usable git-lfs the reset proceeds without the
+            // filter; the caller reports the missing LFS objects instead.
+            reset_cmd
+                .arg("-c")
+                .arg("filter.lfs.smudge=git-lfs smudge -- %f")
+                .arg("-c")
+                .arg("filter.lfs.process=git-lfs filter-process")
+                .arg("-c")
+                .arg("filter.lfs.required=true");
+        }
         reset_cmd
             .arg("reset")
             .arg("--hard")
@@ -743,13 +758,16 @@ impl GitCheckout {
         // Record whether this checkout is LFS-degraded: created while offline
         // with the smudge filter forcibly skipped while the revision actually
         // tracks LFS files, or with submodules whose smudge filter is always
-        // skipped offline. Such a checkout is re-created once a fully
-        // materialized one is possible. Without git-lfs installed the smudge
-        // filter never runs anyway, so nothing is degraded.
-        let lfs_degraded = offline
+        // skipped offline, or created with LFS requested but no usable
+        // git-lfs so the smudge filter never ran. Such a checkout is
+        // re-created once a fully materialized one is possible; a clean
+        // marker here would let a pointer-file checkout be silently re-used
+        // after git-lfs becomes available.
+        let lfs_degraded = (offline
             && GIT_LFS.is_ok()
             && ((lfs_forced_skip && self.repo.has_lfs_files())
-                || self.repo.path.join(".gitmodules").exists());
+                || self.repo.path.join(".gitmodules").exists()))
+            || (lfs == Some(true) && GIT_LFS.is_err());
         if lfs_degraded {
             fs_err::write(ok_file, CHECKOUT_LFS_DEGRADED)?;
         } else {

--- a/crates/pixi_git/src/resolver.rs
+++ b/crates/pixi_git/src/resolver.rs
@@ -52,12 +52,16 @@ impl GitResolver {
     /// local cache (or reachable over the local `file` transport) can be
     /// fetched; anything that requires network access fails with
     /// [`GitError::Offline`].
+    ///
+    /// `lfs` overrides the LFS preference when `Some`; `None` keeps the
+    /// environment-derived default of [`GitSource`].
     pub async fn fetch(
         &self,
         url: GitUrl,
         client: LazyClient,
         cache: PathBuf,
         offline: bool,
+        lfs: Option<bool>,
         reporter: Option<Arc<dyn Reporter>>,
     ) -> Result<Fetch, GitError> {
         debug!("Fetching source distribution from Git: {url}");
@@ -87,6 +91,11 @@ impl GitResolver {
 
         // Fetch the Git repository.
         let source = GitSource::new(url.clone(), client, cache).with_offline(offline);
+        let source = if lfs.is_some() {
+            source.with_lfs(lfs)
+        } else {
+            source
+        };
         let source = if let Some(reporter) = reporter {
             source.with_reporter(reporter)
         } else {

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -30,6 +30,12 @@ pub fn lfs_enabled_from_env() -> Option<bool> {
     if value.is_empty() {
         return None;
     }
+    static DEPRECATION_WARNING: std::sync::Once = std::sync::Once::new();
+    DEPRECATION_WARNING.call_once(|| {
+        tracing::warn!(
+            "the {PIXI_GIT_LFS_ENV} environment variable is deprecated; set `lfs = true` on the git dependency in the manifest instead"
+        );
+    });
     if value == "0"
         || value.eq_ignore_ascii_case("false")
         || value.eq_ignore_ascii_case("no")
@@ -170,20 +176,6 @@ impl GitSource {
         // path length limit on Windows.
         let short_id = db.to_short_id(actual_rev.into())?;
 
-        // Check out `actual_rev` from the database to a scoped location on the
-        // filesystem. This will use hard links and such to ideally make the
-        // checkout operation here pretty fast.
-        let checkout_path = self
-            .cache
-            .join("checkouts")
-            .join(&ident)
-            .join(short_id.as_str());
-
-        tracing::debug!(
-            "Copying git revision `{}` to path `{}`",
-            actual_rev,
-            checkout_path.display()
-        );
         // In offline mode git-lfs must not get a chance to download objects
         // through its smudge filter during checkout: unless the local
         // database already holds validated LFS artifacts, force-skip smudge.
@@ -193,6 +185,30 @@ impl GitSource {
             self.lfs
         };
         let lfs_forced_skip = checkout_lfs != self.lfs;
+
+        // Check out `actual_rev` from the database to a scoped location on the
+        // filesystem. This will use hard links and such to ideally make the
+        // checkout operation here pretty fast.
+        //
+        // An LFS checkout materializes different content than a plain one, so
+        // it lives in its own directory instead of re-using (or poisoning) a
+        // plain checkout of the same commit.
+        let checkout_name = if checkout_lfs == Some(true) {
+            format!("{short_id}-lfs")
+        } else {
+            short_id.clone()
+        };
+        let checkout_path = self
+            .cache
+            .join("checkouts")
+            .join(&ident)
+            .join(checkout_name);
+
+        tracing::debug!(
+            "Copying git revision `{}` to path `{}`",
+            actual_rev,
+            checkout_path.display()
+        );
         if lfs_forced_skip {
             tracing::warn!(
                 "skipping the git-lfs smudge filter for `{}` because pixi is in offline mode \

--- a/crates/pixi_git/src/source.rs
+++ b/crates/pixi_git/src/source.rs
@@ -64,8 +64,10 @@ pub struct GitSource {
     cache: PathBuf,
     /// The reporter to use for this source.
     reporter: Option<Arc<dyn Reporter>>,
-    /// `Some(true)` = fetch LFS, `Some(false)` = skip + force-skip smudge,
-    /// `None` = no opinion (don't touch `GIT_LFS_SKIP_SMUDGE`).
+    /// `Some(true)` = fetch LFS and run the smudge filter, anything else =
+    /// leave pointer files. The smudge filter is force-skipped whenever LFS
+    /// was not requested because the local database never holds LFS objects
+    /// in that case.
     lfs: Option<bool>,
     /// Whether fetching from the network is forbidden. When set, only
     /// revisions already present in the local git database can be checked

--- a/crates/pixi_git/tests/lfs.rs
+++ b/crates/pixi_git/tests/lfs.rs
@@ -74,10 +74,8 @@ fn fetch_without_lfs_leaves_pointer() {
     let cache = tempfile::tempdir().unwrap();
 
     let git_url = GitUrl::try_from(repo.base_url.clone()).unwrap();
-    // Tri-state `None` = "no opinion": don't set GIT_LFS_SKIP_SMUDGE, don't
-    // run `git lfs fetch`. The smudge filter still runs during reset, but
-    // git-lfs has nothing to fetch from a brand-new clone, so files end up
-    // as the pointer.
+    // Without an LFS request no `git lfs fetch` runs and the smudge filter
+    // is force-skipped, so files end up as the pointer.
     let fetch = GitSource::new(git_url, panic_client(), cache.path())
         .with_lfs(Some(false))
         .fetch()

--- a/crates/pixi_install_pypi/Cargo.toml
+++ b/crates/pixi_install_pypi/Cargo.toml
@@ -53,6 +53,7 @@ uv-distribution-filename = { workspace = true }
 uv-distribution-types = { workspace = true }
 uv-flags = { workspace = true }
 uv-git = { workspace = true }
+uv-git-types = { workspace = true }
 uv-install-wheel = { workspace = true }
 uv-installer = { workspace = true }
 uv-normalize = { workspace = true }

--- a/crates/pixi_install_pypi/src/plan/models.rs
+++ b/crates/pixi_install_pypi/src/plan/models.rs
@@ -70,6 +70,11 @@ pub(crate) enum NeedReinstall {
         installed_rev: String,
         locked_rev: String,
     },
+    /// The Git LFS state is different from the locked version
+    GitLfsMismatch {
+        installed_lfs: bool,
+        locked_lfs: bool,
+    },
     /// Unable to parse the installed git url
     UnableToParseGitUrl { url: String },
     /// Unable to get the installed dist metadata, something is definitely broken
@@ -134,6 +139,13 @@ impl std::fmt::Display for NeedReinstall {
             } => write!(
                 f,
                 "Git commits mismatch, installed commit: {installed_commit}, locked commit: {locked_commit}"
+            ),
+            NeedReinstall::GitLfsMismatch {
+                installed_lfs,
+                locked_lfs,
+            } => write!(
+                f,
+                "Git LFS state mismatch, installed with LFS: {installed_lfs}, locked with LFS: {locked_lfs}"
             ),
             NeedReinstall::UnableToParseGitUrl { url } => {
                 write!(f, "Unable to parse git url: {url}")

--- a/crates/pixi_install_pypi/src/plan/test/harness.rs
+++ b/crates/pixi_install_pypi/src/plan/test/harness.rs
@@ -121,6 +121,7 @@ impl InstalledDistBuilder {
         version: S,
         install_path: PathBuf,
         url: Url,
+        git_lfs: Option<bool>,
     ) -> (InstalledDist, DirectUrl) {
         let name = uv_normalize::PackageName::from_owned(name.as_ref().to_owned())
             .expect("unable to normalize");
@@ -146,7 +147,7 @@ impl InstalledDistBuilder {
                     .reference()
                     .as_str()
                     .map(ToString::to_string),
-                git_lfs: None,
+                git_lfs,
             },
         };
 
@@ -174,6 +175,7 @@ pub struct InstalledDistOptions {
     requires_python: Option<uv_pep440::VersionSpecifiers>,
     metadata_mtime: Option<std::time::SystemTime>,
     cache_info: Option<uv_cache_info::CacheInfo>,
+    git_lfs: Option<bool>,
 }
 
 impl InstalledDistOptions {
@@ -190,6 +192,13 @@ impl InstalledDistOptions {
 
     pub fn with_cache_info(mut self, cache_info: uv_cache_info::CacheInfo) -> Self {
         self.cache_info = Some(cache_info);
+        self
+    }
+
+    /// Record the Git LFS state in the installed dist's `direct_url.json`.
+    /// Only used for git dists.
+    pub fn with_git_lfs(mut self, git_lfs: bool) -> Self {
+        self.git_lfs = Some(git_lfs);
         self
     }
 
@@ -346,9 +355,10 @@ impl MockedSitePackages {
         url: Url,
         opts: InstalledDistOptions,
     ) -> Self {
+        let git_lfs = opts.git_lfs;
         let dist_info = self.create_file_backing(name.as_ref(), version.as_ref(), opts);
         let (installed_dist, direct_url) =
-            InstalledDistBuilder::git(name, version, dist_info.clone(), url);
+            InstalledDistBuilder::git(name, version, dist_info.clone(), url, git_lfs);
         self.create_direct_url(&dist_info, direct_url);
         self.installed_dist.push(installed_dist);
         self

--- a/crates/pixi_install_pypi/src/plan/test/mod.rs
+++ b/crates/pixi_install_pypi/src/plan/test/mod.rs
@@ -792,6 +792,118 @@ fn test_installed_git_require_git_commit_mismatch() {
     );
 }
 
+/// When only the `lfs` flag differs between the installed dist and the lock
+/// we should reinstall, in both directions
+#[test]
+fn test_installed_git_lfs_mismatch() {
+    let commit = "9d4f36d87dae9a968fb527e2cb87e8a507b0beb3";
+    let installed_url = Url::parse("git+https://github.com/pypa/pip.git@some-branch")
+        .expect("could not parse git url");
+
+    // Installed without LFS, locked with `lfs=true`
+    let site_packages = MockedSitePackages::new().add_git(
+        "pip",
+        "1.0.0",
+        installed_url.clone(),
+        InstalledDistOptions::default(),
+    );
+    let locked_lfs_url = Url::parse(
+        format!("git+https://github.com/pypa/pip.git?branch=some-branch&lfs=true#{commit}")
+            .as_str(),
+    )
+    .expect("could not parse git url");
+    let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_lfs_url.clone());
+
+    let plan = harness::install_planner();
+    let required_dists = required.to_required_dists();
+    let installs = plan
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            &uv_configuration::BuildOptions::default(),
+        )
+        .expect("should install");
+
+    assert_matches!(
+        installs.reinstalls[0].1,
+        NeedReinstall::GitLfsMismatch {
+            installed_lfs: false,
+            locked_lfs: true
+        }
+    );
+
+    // Installed with LFS, locked without the flag
+    let site_packages = MockedSitePackages::new().add_git(
+        "pip",
+        "1.0.0",
+        installed_url,
+        InstalledDistOptions::default().with_git_lfs(true),
+    );
+    let locked_url = Url::parse(
+        format!("git+https://github.com/pypa/pip.git?branch=some-branch#{commit}").as_str(),
+    )
+    .expect("could not parse git url");
+    let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_url);
+
+    let required_dists = required.to_required_dists();
+    let installs = plan
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            &uv_configuration::BuildOptions::default(),
+        )
+        .expect("should install");
+
+    assert_matches!(
+        installs.reinstalls[0].1,
+        NeedReinstall::GitLfsMismatch {
+            installed_lfs: true,
+            locked_lfs: false
+        }
+    );
+}
+
+/// When both the installed dist and the lock agree on `lfs=true`
+/// no reinstall is needed
+#[test]
+fn test_installed_git_lfs_the_same() {
+    let commit = "9d4f36d87dae9a968fb527e2cb87e8a507b0beb3";
+    let installed_url = Url::parse("git+https://github.com/pypa/pip.git@some-branch")
+        .expect("could not parse git url");
+
+    let site_packages = MockedSitePackages::new().add_git(
+        "pip",
+        "1.0.0",
+        installed_url,
+        InstalledDistOptions::default().with_git_lfs(true),
+    );
+    let locked_lfs_url = Url::parse(
+        format!("git+https://github.com/pypa/pip.git?branch=some-branch&lfs=true#{commit}")
+            .as_str(),
+    )
+    .expect("could not parse git url");
+    let required = RequiredPackages::new().add_git("pip", "1.0.0", locked_lfs_url);
+
+    let plan = harness::install_planner();
+    let required_dists = required.to_required_dists();
+    let installs = plan
+        .plan(
+            &site_packages,
+            NoCache,
+            &required_dists,
+            &uv_configuration::BuildOptions::default(),
+        )
+        .expect("should install");
+
+    assert!(
+        installs.reinstalls.is_empty(),
+        "expected no reinstalls but got {:?}",
+        installs.reinstalls
+    );
+}
+
 /// When having a git installed, and we require the same version from the registry
 /// we should reinstall, otherwise we should not
 /// note that we are using full git commits here, because it seems from my (Tim)

--- a/crates/pixi_install_pypi/src/plan/validation.rs
+++ b/crates/pixi_install_pypi/src/plan/validation.rs
@@ -7,6 +7,7 @@ use rattler_lock::UrlOrPath;
 use url::Url;
 use uv_cache_info::CacheInfoError;
 use uv_distribution_types::{Dist, InstalledDist, InstalledDistKind};
+use uv_git_types::GitLfs;
 use uv_pypi_types::{ParsedGitUrl, ParsedUrlError};
 
 use crate::utils::{check_url_freshness, is_direct_url, strip_direct_scheme};
@@ -311,6 +312,22 @@ pub(crate) fn need_reinstall(
                                     NeedReinstall::GitRevMismatch {
                                         installed_rev: installed_commit,
                                         locked_rev: locked_commit.to_string(),
+                                    },
+                                ));
+                            }
+
+                            // The same commit checked out with and without LFS
+                            // yields different content. The installed state
+                            // comes from `direct_url.json`, where an absent
+                            // flag means LFS was disabled.
+                            let installed_lfs =
+                                vcs_info.git_lfs.map(GitLfs::from).unwrap_or_default();
+                            let locked_lfs = locked_git_url.url.lfs();
+                            if installed_lfs != locked_lfs {
+                                return Ok(ValidateCurrentInstall::Reinstall(
+                                    NeedReinstall::GitLfsMismatch {
+                                        installed_lfs: installed_lfs.enabled(),
+                                        locked_lfs: locked_lfs.enabled(),
                                     },
                                 ));
                             }

--- a/crates/pixi_manifest/src/toml/build_backend.rs
+++ b/crates/pixi_manifest/src/toml/build_backend.rs
@@ -262,16 +262,31 @@ static BOTH_ADDITIONAL_DEPS_WARNING: Once = Once::new();
 fn spec_from_spanned_toml_location(
     spanned_toml: Spanned<TomlLocationSpec>,
 ) -> Result<SourceLocationSpec, DeserError> {
+    let span = spanned_toml.span;
     let source_location_spec = spanned_toml
         .value
         .into_source_location_spec()
         .map_err(|err| {
             DeserError::from(Error {
                 kind: toml_span::ErrorKind::Custom(Cow::Owned(err.to_string())),
-                span: spanned_toml.span,
+                span,
                 line_info: None,
             })
         })?;
+
+    // The lock file cannot record an LFS preference for build sources, so a
+    // fresh solve and an install from the lock file would behave differently.
+    if let SourceLocationSpec::Git(git) = &source_location_spec
+        && git.lfs.is_some()
+    {
+        return Err(DeserError::from(Error {
+            kind: toml_span::ErrorKind::Custom(Cow::Borrowed(
+                "`lfs` is not supported for build sources",
+            )),
+            span,
+            line_info: None,
+        }));
+    }
 
     Ok(source_location_spec)
 }

--- a/crates/pixi_manifest/src/toml/package.rs
+++ b/crates/pixi_manifest/src/toml/package.rs
@@ -2362,6 +2362,7 @@ mod test {
             branch: None,
             rev: None,
             tag: None,
+            lfs: None,
             subdirectory: None,
             md5: None,
             sha256: None,

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__additional_build_backend_keys.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__additional_build_backend_keys.snap
@@ -1,10 +1,9 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 388
 expression: "expect_parse_failure(r#\"\n            backend = { name = \"foobar\", version = \"*\", sub = \"bar\" }\n        \"#)"
 ---
-  × Unexpected keys, expected only 'version', 'url', 'git', 'path', 'branch', 'rev', 'tag', 'subdirectory', 'build', 'build-number', 'file-name', 'extras', 'flags', 'channel', 'subdir', 'license',
-  │ 'license-family', 'when', 'track-features', 'md5', 'sha256'
+  × Unexpected keys, expected only 'version', 'url', 'git', 'path', 'branch', 'rev', 'tag', 'lfs', 'subdirectory', 'build', 'build-number', 'file-name', 'extras', 'flags', 'channel', 'subdir',
+  │ 'license', 'license-family', 'when', 'track-features', 'md5', 'sha256'
    ╭─[pixi.toml:2:57]
  1 │
  2 │             backend = { name = "foobar", version = "*", sub = "bar" }

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__build_backend__test__configuration_parsing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_manifest/src/toml/build_backend.rs
-assertion_line: 379
 expression: parsed
 ---
 TomlPackageBuild {
@@ -31,6 +30,7 @@ TomlPackageBuild {
                             branch: None,
                             rev: None,
                             tag: None,
+                            lfs: None,
                             subdirectory: None,
                             md5: None,
                             sha256: None,

--- a/crates/pixi_pypi_spec/src/snapshots/pixi_pypi_spec__tests__deserialize_failing.snap
+++ b/crates/pixi_pypi_spec/src/snapshots/pixi_pypi_spec__tests__deserialize_failing.snap
@@ -3,7 +3,7 @@ source: crates/pixi_pypi_spec/src/lib.rs
 expression: "snapshot.into_iter().map(|Snapshot { input, result }|\nformat!(\"input: {input}\\nresult: {} \",\nresult.as_object().unwrap().get(\"error\").unwrap().as_str().unwrap())).join(\"\\n\")"
 ---
 input: pkg = { ver = "1.2.3" }
-result:   × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'url', 'subdirectory', 'index', 'env-markers'
+result:   × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'lfs', 'url', 'subdirectory', 'index', 'env-markers'
    ╭─[pixi.toml:1:9]
  1 │ pkg = { ver = "1.2.3" }
    ·         ─┬─
@@ -56,7 +56,7 @@ result:   × invalid port number
    ·                ───────────────────────────────────────────────
    ╰──── 
 input: pkg = { branch = "main", tag = "v1", rev = "123456"  }
-result:   × `branch`, `rev`, and `tag` are only valid when `git` is specified
+result:   × `branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified
    ╭─[pixi.toml:1:7]
  1 │ pkg = { branch = "main", tag = "v1", rev = "123456"  }
    ·       ────────────────────────────────────────────────

--- a/crates/pixi_pypi_spec/src/toml.rs
+++ b/crates/pixi_pypi_spec/src/toml.rs
@@ -13,7 +13,7 @@ use url::Url;
 
 #[derive(Error, Debug)]
 pub enum SpecConversion {
-    #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
+    #[error("`branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified")]
     MissingGit,
     #[error("Only one of `branch` or `tag` or `rev` can be specified")]
     MultipleGitSpecifiers,
@@ -71,6 +71,7 @@ struct RawPyPiRequirement {
     pub branch: Option<String>,
     pub tag: Option<String>,
     pub rev: Option<String>,
+    pub lfs: Option<bool>,
 
     // Url only
     pub url: Option<Url>,
@@ -84,7 +85,11 @@ struct RawPyPiRequirement {
 
 impl RawPyPiRequirement {
     fn into_pypi_requirement(self) -> Result<PixiPypiSpec, SpecConversion> {
-        if self.git.is_none() && (self.branch.is_some() || self.rev.is_some() || self.tag.is_some())
+        if self.git.is_none()
+            && (self.branch.is_some()
+                || self.rev.is_some()
+                || self.tag.is_some()
+                || self.lfs.is_some())
         {
             return Err(SpecConversion::MissingGit);
         }
@@ -148,17 +153,17 @@ impl RawPyPiRequirement {
                         return Err(SpecConversion::MultipleGitSpecifiers);
                     }
                 };
+                let mut git_spec = GitSpec::new(
+                    git,
+                    rev,
+                    self.subdirectory
+                        .map(pixi_spec::Subdirectory::try_from)
+                        .transpose()?
+                        .unwrap_or_default(),
+                );
+                git_spec.lfs = self.lfs;
                 PixiPypiSpec::with_extras_and_markers(
-                    PixiPypiSource::Git {
-                        git: GitSpec::new(
-                            git,
-                            rev,
-                            self.subdirectory
-                                .map(pixi_spec::Subdirectory::try_from)
-                                .transpose()?
-                                .unwrap_or_default(),
-                        ),
-                    },
+                    PixiPypiSource::Git { git: git_spec },
                     self.extras,
                     self.marker,
                 )
@@ -203,6 +208,7 @@ impl<'de> toml_span::Deserialize<'de> for RawPyPiRequirement {
         let rev = th
             .optional::<TomlFromStr<_>>("rev")
             .map(TomlFromStr::into_inner);
+        let lfs = th.optional("lfs");
 
         let url = th
             .optional::<TomlFromStr<_>>("url")
@@ -230,6 +236,7 @@ impl<'de> toml_span::Deserialize<'de> for RawPyPiRequirement {
             branch,
             tag,
             rev,
+            lfs,
             url,
             subdirectory,
             index,
@@ -335,6 +342,7 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         git,
                         rev,
                         subdirectory,
+                        lfs,
                         matchspec: _,
                     },
             } => {
@@ -374,6 +382,12 @@ impl From<PixiPypiSpec> for toml_edit::Value {
                         toml_edit::Value::String(toml_edit::Formatted::new(
                             subdirectory.to_string(),
                         )),
+                    );
+                }
+                if let Some(lfs) = lfs {
+                    table.insert(
+                        "lfs",
+                        toml_edit::Value::Boolean(toml_edit::Formatted::new(*lfs)),
                     );
                 }
                 insert_extras(&mut table, extras);
@@ -642,7 +656,7 @@ mod test {
     fn test_deserialize_fail_on_unknown() {
         let input = r#"foo = { borked = "bork"}"#;
         assert_snapshot!(format_parse_error(input, from_toml_str::<TomlIndexMap::<pep508_rs::PackageName, PixiPypiSpec>>(input).unwrap_err()), @r#"
-         × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'url', 'subdirectory', 'index', 'env-markers'
+         × Unexpected keys, expected only 'version', 'extras', 'path', 'editable', 'git', 'branch', 'tag', 'rev', 'lfs', 'url', 'subdirectory', 'index', 'env-markers'
           ╭─[pixi.toml:1:9]
         1 │ foo = { borked = "bork"}
           ·         ───┬──
@@ -685,6 +699,52 @@ mod test {
                 ),
             })
         );
+    }
+
+    #[test]
+    fn test_deserialize_pypi_from_git_lfs() {
+        let requirement = from_toml_str::<TomlIndexMap<pep508_rs::PackageName, PixiPypiSpec>>(
+            r#"foo = { git = "https://test.url.git", lfs = true }"#,
+        )
+        .unwrap()
+        .into_inner();
+        let git_spec = requirement
+            .first()
+            .unwrap()
+            .1
+            .as_git()
+            .expect("expected a git source");
+        assert_eq!(git_spec.lfs, Some(true));
+    }
+
+    #[test]
+    fn test_deserialize_pypi_from_git_lfs_false() {
+        let requirement = from_toml_str::<TomlIndexMap<pep508_rs::PackageName, PixiPypiSpec>>(
+            r#"foo = { git = "https://test.url.git", lfs = false }"#,
+        )
+        .unwrap()
+        .into_inner();
+        let git_spec = requirement
+            .first()
+            .unwrap()
+            .1
+            .as_git()
+            .expect("expected a git source");
+        assert_eq!(git_spec.lfs, Some(false));
+    }
+
+    #[test]
+    fn test_deserialize_pypi_lfs_without_git_fails() {
+        let input = r#"foo = { version = "*", lfs = true }"#;
+        let error =
+            from_toml_str::<TomlIndexMap<pep508_rs::PackageName, PixiPypiSpec>>(input).unwrap_err();
+        assert_snapshot!(format_parse_error(input, error), @r#"
+         × `branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified
+          ╭─[pixi.toml:1:7]
+        1 │ foo = { version = "*", lfs = true }
+          ·       ─────────────────────────────
+          ╰────
+        "#);
     }
 
     #[test]

--- a/crates/pixi_record/src/canonical_spec.rs
+++ b/crates/pixi_record/src/canonical_spec.rs
@@ -62,6 +62,11 @@ pub struct CanonicalGit {
     /// The subdirectory within the repository.
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+    /// Whether the checkout materializes Git LFS objects. Part of the
+    /// identity because the same commit yields different content with and
+    /// without LFS.
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub lfs: bool,
 }
 
 /// A canonical representation of a path source.
@@ -108,6 +113,7 @@ impl From<&PinnedGitSpec> for CanonicalGit {
             repository: RepositoryUrl::new(&spec.git),
             commit: spec.source.commit,
             subdirectory: spec.source.subdirectory.clone(),
+            lfs: spec.source.lfs == Some(true),
         }
     }
 }
@@ -182,6 +188,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".to_string()),
+                lfs: None,
             },
         });
 
@@ -191,6 +198,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Tag("v1.0.0".to_string()),
+                lfs: None,
             },
         });
 
@@ -208,6 +216,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -217,6 +226,7 @@ mod tests {
                 commit: GitSha::from_str("def456789012345678901234567890abcdabc123").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -235,6 +245,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -244,6 +255,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -261,6 +273,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir1").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -270,6 +283,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir2").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -205,12 +205,11 @@ impl PinnedSourceSpec {
                     return false;
                 }
 
-                // An explicit LFS preference must match the pin, so a
-                // manifest change re-pins instead of re-using a checkout
-                // with the wrong LFS materialization.
-                if let Some(requested_lfs) = source_git.lfs
-                    && pinned_git.source.lfs != Some(requested_lfs)
-                {
+                // The LFS preference is binary: an absent flag means LFS
+                // is disabled. Any flip, including removing `lfs = true`,
+                // re-pins instead of re-using a checkout with the wrong
+                // LFS materialization.
+                if pinned_git.source.lfs.unwrap_or(false) != source_git.lfs.unwrap_or(false) {
                     return false;
                 }
 
@@ -776,7 +775,7 @@ pub enum SourceMismatchError {
         /// The git url.
         git: Url,
         /// The locked LFS preference.
-        locked: String,
+        locked: bool,
         /// The requested LFS preference.
         requested: bool,
     },
@@ -912,20 +911,17 @@ impl PinnedGitSpec {
             });
         }
 
-        // Check if the requested LFS preference matches. A spec without an
-        // LFS preference places no constraint on the pin: `lfs = None` means
-        // the spec is indifferent, both for manifest specs that never set it
-        // and for requested specs read back from lock files written before
-        // `rattler_lock` carried the flag.
-        if let Some(requested_lfs) = spec.lfs
-            && self.source.lfs != Some(requested_lfs)
-        {
+        // The LFS preference is binary: an absent flag means LFS is
+        // disabled, both on the spec side and on pins from lock files
+        // written before `rattler_lock` carried the flag. Removing
+        // `lfs = true` from a spec therefore invalidates the pin, matching
+        // the pypi behavior.
+        let locked_lfs = self.source.lfs.unwrap_or(false);
+        let requested_lfs = spec.lfs.unwrap_or(false);
+        if locked_lfs != requested_lfs {
             return Err(SourceMismatchError::GitLfsMismatch {
                 git: self.git.clone(),
-                locked: self
-                    .source
-                    .lfs
-                    .map_or("None".to_string(), |lfs| lfs.to_string()),
+                locked: locked_lfs,
                 requested: requested_lfs,
             });
         }
@@ -1104,14 +1100,21 @@ mod tests {
         };
 
         assert!(pinned(Some(true)).satisfies(&requested(Some(true))).is_ok());
-        assert!(pinned(Some(true)).satisfies(&requested(None)).is_ok());
         assert!(pinned(None).satisfies(&requested(None)).is_ok());
+        // An absent flag means LFS is disabled, on both sides.
+        assert!(pinned(None).satisfies(&requested(Some(false))).is_ok());
+        assert!(pinned(Some(false)).satisfies(&requested(None)).is_ok());
         assert!(matches!(
             pinned(None).satisfies(&requested(Some(true))),
             Err(SourceMismatchError::GitLfsMismatch { .. })
         ));
         assert!(matches!(
             pinned(Some(true)).satisfies(&requested(Some(false))),
+            Err(SourceMismatchError::GitLfsMismatch { .. })
+        ));
+        // Removing `lfs = true` from the spec invalidates the pin.
+        assert!(matches!(
+            pinned(Some(true)).satisfies(&requested(None)),
             Err(SourceMismatchError::GitLfsMismatch { .. })
         ));
     }

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -913,9 +913,10 @@ impl PinnedGitSpec {
         }
 
         // Check if the requested LFS preference matches. A spec without an
-        // LFS preference places no constraint on the pin; requested specs
-        // read back from the lock file always have `lfs = None` because
-        // `rattler_lock` cannot carry the flag.
+        // LFS preference places no constraint on the pin: `lfs = None` means
+        // the spec is indifferent, both for manifest specs that never set it
+        // and for requested specs read back from lock files written before
+        // `rattler_lock` carried the flag.
         if let Some(requested_lfs) = spec.lfs
             && self.source.lfs != Some(requested_lfs)
         {

--- a/crates/pixi_record/src/pinned_source.rs
+++ b/crates/pixi_record/src/pinned_source.rs
@@ -205,6 +205,15 @@ impl PinnedSourceSpec {
                     return false;
                 }
 
+                // An explicit LFS preference must match the pin, so a
+                // manifest change re-pins instead of re-using a checkout
+                // with the wrong LFS materialization.
+                if let Some(requested_lfs) = source_git.lfs
+                    && pinned_git.source.lfs != Some(requested_lfs)
+                {
+                    return false;
+                }
+
                 // If source spec specifies a subdirectory, it must match
                 if source_git.subdirectory.is_empty() {
                     true // Source doesn't care about subdirectory
@@ -312,6 +321,9 @@ pub struct PinnedGitCheckout {
     /// The reference of the git checkout.
     #[serde(default, skip_serializing_if = "GitReference::is_default")]
     pub reference: GitReference,
+    /// Whether Git LFS objects were requested for the checkout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lfs: Option<bool>,
 }
 
 impl PinnedGitCheckout {
@@ -321,7 +333,14 @@ impl PinnedGitCheckout {
             commit,
             subdirectory,
             reference,
+            lfs: None,
         }
+    }
+
+    /// Sets the LFS preference of this checkout.
+    #[must_use]
+    pub fn with_lfs(self, lfs: Option<bool>) -> Self {
+        Self { lfs, ..self }
     }
 
     /// Extracts a pinned git checkout from the query pairs and the hash
@@ -330,6 +349,7 @@ impl PinnedGitCheckout {
         let url = &locked_url.0;
         let mut reference = None;
         let mut subdirectory = None;
+        let mut lfs = None;
 
         for (key, val) in url.query_pairs() {
             match &*key {
@@ -365,6 +385,11 @@ impl PinnedGitCheckout {
                         return Err(miette::miette!("multiple subdirectories in URL"));
                     }
                 }
+                "lfs" => {
+                    if lfs.replace(&*val == "true").is_some() {
+                        return Err(miette::miette!("multiple lfs flags in URL"));
+                    }
+                }
                 _ => continue,
             };
         }
@@ -383,6 +408,7 @@ impl PinnedGitCheckout {
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
             reference: reference.expect("reference should be set"),
+            lfs,
         })
     }
 }
@@ -446,6 +472,12 @@ impl PinnedGitSpec {
             GitReference::DefaultBranch => {}
         }
 
+        // Put the LFS preference in the query.
+        if let Some(lfs) = self.source.lfs {
+            url.query_pairs_mut()
+                .append_pair("lfs", if lfs { "true" } else { "false" });
+        }
+
         // Put the precise commit in the fragment.
         url.set_fragment(self.source.commit.to_string().as_str().into());
 
@@ -474,6 +506,7 @@ impl PinnedGitSpec {
                 commit: self.source.commit,
                 subdirectory: self.source.subdirectory.join(path.as_str()),
                 reference: self.source.reference.clone(),
+                lfs: self.source.lfs,
             },
         }
     }
@@ -736,6 +769,19 @@ pub enum SourceMismatchError {
     },
 
     #[error(
+        "the locked git lfs preference '{locked}' for '{git}' does not match the requested git lfs preference '{requested}'"
+    )]
+    /// The locked git LFS preference does not match the requested one.
+    GitLfsMismatch {
+        /// The git url.
+        git: Url,
+        /// The locked LFS preference.
+        locked: String,
+        /// The requested LFS preference.
+        requested: bool,
+    },
+
+    #[error(
         "the locked git subdirectory '{locked}' for '{git}' does not match the requested git subdirectory '{requested}'"
     )]
     /// The locked git rev does not match the requested git rev.
@@ -865,6 +911,23 @@ impl PinnedGitSpec {
                 requested: requested_ref.to_string(),
             });
         }
+
+        // Check if the requested LFS preference matches. A spec without an
+        // LFS preference places no constraint on the pin; requested specs
+        // read back from the lock file always have `lfs = None` because
+        // `rattler_lock` cannot carry the flag.
+        if let Some(requested_lfs) = spec.lfs
+            && self.source.lfs != Some(requested_lfs)
+        {
+            return Err(SourceMismatchError::GitLfsMismatch {
+                git: self.git.clone(),
+                locked: self
+                    .source
+                    .lfs
+                    .map_or("None".to_string(), |lfs| lfs.to_string()),
+                requested: requested_lfs,
+            });
+        }
         Ok(())
     }
 }
@@ -946,11 +1009,13 @@ impl From<PinnedUrlSpec> for UrlSourceSpec {
 
 impl From<PinnedGitSpec> for GitSpec {
     fn from(value: PinnedGitSpec) -> Self {
-        Self::new(
+        let mut spec = Self::new(
             value.git,
             Some(value.source.reference),
             value.source.subdirectory,
-        )
+        );
+        spec.lfs = value.source.lfs;
+        spec
     }
 }
 
@@ -966,6 +1031,90 @@ mod tests {
 
     use crate::{PinnedPathSpec, PinnedSourceSpec};
 
+    /// The `lfs` flag round-trips through the locked git URL as a
+    /// `?lfs=true` query pair.
+    #[test]
+    fn test_pinned_git_lfs_roundtrip() {
+        let spec = PinnedGitSpec {
+            git: Url::parse("https://github.com/example/repo.git").unwrap(),
+            source: PinnedGitCheckout {
+                commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
+                subdirectory: Default::default(),
+                reference: GitReference::DefaultBranch,
+                lfs: Some(true),
+            },
+        };
+
+        let locked = spec.into_locked_git_url();
+        assert!(
+            locked
+                .to_url()
+                .query_pairs()
+                .any(|(k, v)| k == "lfs" && v == "true"),
+            "locked URL should carry the lfs query pair: {locked}"
+        );
+
+        let parsed = PinnedGitCheckout::from_locked_url(&locked).unwrap();
+        assert_eq!(parsed, spec.source);
+    }
+
+    /// Without an LFS preference the locked git URL stays unchanged, so
+    /// existing lock files do not churn.
+    #[test]
+    fn test_pinned_git_no_lfs_does_not_serialize() {
+        let spec = PinnedGitSpec {
+            git: Url::parse("https://github.com/example/repo.git").unwrap(),
+            source: PinnedGitCheckout {
+                commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
+                subdirectory: Default::default(),
+                reference: GitReference::DefaultBranch,
+                lfs: None,
+            },
+        };
+
+        let locked = spec.into_locked_git_url();
+        assert!(locked.to_url().query_pairs().all(|(k, _)| k != "lfs"));
+
+        let parsed = PinnedGitCheckout::from_locked_url(&locked).unwrap();
+        assert_eq!(parsed.lfs, None);
+    }
+
+    /// A spec without an LFS preference accepts any pin, while an explicit
+    /// preference requires a matching pin.
+    #[test]
+    fn test_spec_satisfies_lfs() {
+        let pinned = |lfs: Option<bool>| PinnedGitSpec {
+            git: Url::parse("https://github.com/example/repo.git").unwrap(),
+            source: PinnedGitCheckout {
+                commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
+                subdirectory: Default::default(),
+                reference: GitReference::DefaultBranch,
+                lfs,
+            },
+        };
+        let requested = |lfs: Option<bool>| {
+            let mut spec = GitSpec::new(
+                Url::parse("https://github.com/example/repo.git").unwrap(),
+                None,
+                Subdirectory::default(),
+            );
+            spec.lfs = lfs;
+            spec.location()
+        };
+
+        assert!(pinned(Some(true)).satisfies(&requested(Some(true))).is_ok());
+        assert!(pinned(Some(true)).satisfies(&requested(None)).is_ok());
+        assert!(pinned(None).satisfies(&requested(None)).is_ok());
+        assert!(matches!(
+            pinned(None).satisfies(&requested(Some(true))),
+            Err(SourceMismatchError::GitLfsMismatch { .. })
+        ));
+        assert!(matches!(
+            pinned(Some(true)).satisfies(&requested(Some(false))),
+            Err(SourceMismatchError::GitLfsMismatch { .. })
+        ));
+    }
+
     #[test]
     fn test_spec_satisfies() {
         let locked_git_spec = PinnedGitSpec {
@@ -974,6 +1123,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -982,6 +1132,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec.location());
@@ -994,6 +1145,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1002,6 +1154,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec_without_git_suffix.satisfies(&requested_git_spec.location());
@@ -1014,6 +1167,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1022,6 +1176,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_without_suffix.location());
@@ -1034,6 +1189,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1042,6 +1198,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec.location());
@@ -1054,6 +1211,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1062,6 +1220,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec_with_prefix.location());
@@ -1079,6 +1238,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1087,6 +1247,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("d2e32".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec
@@ -1103,6 +1264,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::Rev("9de9e1b".to_string()),
+                lfs: None,
             },
         };
 
@@ -1111,6 +1273,7 @@ mod tests {
             subdirectory: Default::default(),
             rev: Some(pixi_spec::GitReference::Rev("9de9e1b".to_string())),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec
@@ -1127,6 +1290,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1137,6 +1301,7 @@ mod tests {
             // and request the default branch
             rev: None,
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec.satisfies(&requested_git_spec.location());
@@ -1151,6 +1316,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Subdirectory::try_from("some-subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1161,6 +1327,7 @@ mod tests {
             // and request the default branch
             rev: None,
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec
@@ -1178,6 +1345,7 @@ mod tests {
                 commit: GitSha::from_str("9de9e1b48cc421f05fc6aa6918cade3033a38c32").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1188,6 +1356,7 @@ mod tests {
             // and request the default branch
             rev: None,
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         };
 
         let result = locked_git_spec
@@ -1238,6 +1407,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1246,6 +1416,7 @@ mod tests {
             rev: None,
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         // Should match despite .git suffix difference
@@ -1260,6 +1431,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1268,6 +1440,7 @@ mod tests {
             rev: None,
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         // Should match despite .git suffix difference
@@ -1282,6 +1455,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1290,6 +1464,7 @@ mod tests {
             rev: None,
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec.location));
@@ -1303,6 +1478,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1311,6 +1487,7 @@ mod tests {
             rev: None,
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         // Should match - spec doesn't care about subdirectory
@@ -1325,6 +1502,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1333,6 +1511,7 @@ mod tests {
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         assert!(pinned.matches_source_spec(&spec.location));
@@ -1346,6 +1525,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Subdirectory::try_from("subdir1").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1354,6 +1534,7 @@ mod tests {
             rev: None,
             subdirectory: Subdirectory::try_from("subdir2").unwrap(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec.location));
@@ -1367,6 +1548,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1375,6 +1557,7 @@ mod tests {
             rev: None,
             subdirectory: Subdirectory::try_from("subdir").unwrap(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         // Should not match - spec requires a subdirectory that pinned doesn't have
@@ -1438,6 +1621,7 @@ mod tests {
             rev: None,
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec.location));
@@ -1451,6 +1635,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1497,6 +1682,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Rev("v1.0.0".to_string()),
+                lfs: None,
             },
         });
 
@@ -1505,6 +1691,7 @@ mod tests {
             rev: Some(GitReference::Rev("v2.0.0".to_string())),
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         assert!(!pinned.matches_source_spec(&spec.location));
@@ -1520,6 +1707,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::Branch("main".to_string()),
+                lfs: None,
             },
         });
 
@@ -1528,6 +1716,7 @@ mod tests {
             rev: Some(GitReference::Branch("main".to_string())),
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         assert!(pinned.matches_source_spec(&spec.location));
@@ -1541,6 +1730,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456789012345678901234567890abcd").unwrap(),
                 subdirectory: Default::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         });
 
@@ -1549,6 +1739,7 @@ mod tests {
             rev: None,
             subdirectory: Default::default(),
             matchspec: pixi_spec::MatchspecFields::default(),
+            lfs: None,
         });
 
         // Should match - GitHub URLs are case-insensitive
@@ -1577,6 +1768,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::new("recipes").unwrap(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 
@@ -1597,6 +1789,7 @@ mod tests {
                 commit: GitSha::from_str("abc123def456abc123def456abc123def456abc1").unwrap(),
                 subdirectory: Subdirectory::default(),
                 reference: GitReference::DefaultBranch,
+                lfs: None,
             },
         };
 

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -964,6 +964,9 @@ fn package_build_source_to_build_source(
                             .and_then(|s| pixi_spec::Subdirectory::try_from(s.to_string()).ok())
                             .unwrap_or_default(),
                         reference,
+                        // Rattler's `PackageBuildSource` cannot carry an LFS
+                        // flag, so build sources never request LFS.
+                        lfs: None,
                     },
                 }),
             )))
@@ -1481,6 +1484,7 @@ mod tests {
                     .unwrap(),
                 subdirectory: Default::default(),
                 reference: pixi_spec::GitReference::DefaultBranch,
+                lfs: None,
             },
         })
     }

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -23,8 +23,9 @@ pub struct GitSpec {
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
 
-    /// Whether to fetch Git LFS objects for the checkout. `None` defers to
-    /// the environment / git configuration.
+    /// Whether to fetch Git LFS objects for the checkout. `None` falls
+    /// back to the deprecated `PIXI_GIT_LFS` environment variable and
+    /// otherwise leaves pointer files.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub lfs: Option<bool>,
 
@@ -91,8 +92,9 @@ pub struct GitLocationSpec {
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
 
-    /// Whether to fetch Git LFS objects for the checkout. `None` defers to
-    /// the environment / git configuration.
+    /// Whether to fetch Git LFS objects for the checkout. `None` falls
+    /// back to the deprecated `PIXI_GIT_LFS` environment variable and
+    /// otherwise leaves pointer files.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub lfs: Option<bool>,
 }

--- a/crates/pixi_spec/src/git.rs
+++ b/crates/pixi_spec/src/git.rs
@@ -23,6 +23,11 @@ pub struct GitSpec {
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
 
+    /// Whether to fetch Git LFS objects for the checkout. `None` defers to
+    /// the environment / git configuration.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub lfs: Option<bool>,
+
     /// Match-spec selectors applied to the built output (flattened).
     #[serde(flatten)]
     pub matchspec: MatchspecFields,
@@ -35,6 +40,7 @@ impl GitSpec {
             git,
             rev,
             subdirectory,
+            lfs: None,
             matchspec: MatchspecFields::default(),
         }
     }
@@ -45,6 +51,7 @@ impl GitSpec {
             git: self.git.clone(),
             rev: self.rev.clone(),
             subdirectory: self.subdirectory.clone(),
+            lfs: self.lfs,
         }
     }
 
@@ -54,6 +61,7 @@ impl GitSpec {
             git: self.git,
             rev: self.rev,
             subdirectory: self.subdirectory,
+            lfs: self.lfs,
         }
     }
 }
@@ -82,6 +90,11 @@ pub struct GitLocationSpec {
     /// The git subdirectory of the package
     #[serde(skip_serializing_if = "Subdirectory::is_empty", default)]
     pub subdirectory: Subdirectory,
+
+    /// Whether to fetch Git LFS objects for the checkout. `None` defers to
+    /// the environment / git configuration.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub lfs: Option<bool>,
 }
 
 impl GitLocationSpec {
@@ -91,7 +104,14 @@ impl GitLocationSpec {
             git,
             rev,
             subdirectory,
+            lfs: None,
         }
+    }
+
+    /// Sets the LFS preference of this location.
+    #[must_use]
+    pub fn with_lfs(self, lfs: Option<bool>) -> Self {
+        Self { lfs, ..self }
     }
 
     /// Attaches match-spec selectors to this location, producing a [`GitSpec`].
@@ -100,6 +120,7 @@ impl GitLocationSpec {
             git: self.git,
             rev: self.rev,
             subdirectory: self.subdirectory,
+            lfs: self.lfs,
             matchspec,
         }
     }

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -974,29 +974,15 @@ impl From<UrlSpec> for rattler_lock::source::UrlSourceLocation {
 #[cfg(feature = "rattler_lock")]
 impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
     fn from(value: rattler_lock::source::GitSourceLocation) -> Self {
-        // `rattler_lock` has no LFS field, so the flag lives in an `lfs`
-        // query pair on the stored git URL. It must survive the round-trip:
-        // the requested specs feed the source records' identity hashes, and
-        // a lossy field would invalidate the lock file on every run.
-        let mut git = value.git;
-        let lfs = git
-            .query_pairs()
-            .find(|(k, _)| k == "lfs")
-            .map(|(_, v)| v == "true");
-        if lfs.is_some() {
-            let remaining: Vec<(String, String)> = git
-                .query_pairs()
-                .filter(|(k, _)| k != "lfs")
-                .map(|(k, v)| (k.into_owned(), v.into_owned()))
-                .collect();
-            git.set_query(None);
-            if !remaining.is_empty() {
-                git.query_pairs_mut().extend_pairs(remaining);
-            }
-        }
+        let rattler_lock::source::GitSourceLocation {
+            git,
+            rev,
+            subdirectory,
+            lfs,
+        } = value;
         Self {
             git,
-            rev: match value.rev {
+            rev: match rev {
                 Some(rattler_lock::source::GitReference::Branch(branch)) => {
                     Some(GitReference::Branch(branch))
                 }
@@ -1004,8 +990,7 @@ impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
                 Some(rattler_lock::source::GitReference::Rev(rev)) => Some(GitReference::Rev(rev)),
                 None => None,
             },
-            subdirectory: value
-                .subdirectory
+            subdirectory: subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
             lfs,
@@ -1016,15 +1001,8 @@ impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
 #[cfg(feature = "rattler_lock")]
 impl From<GitLocationSpec> for rattler_lock::source::GitSourceLocation {
     fn from(value: GitLocationSpec) -> Self {
-        // See `From<GitSourceLocation> for GitLocationSpec` for why the LFS
-        // flag is stored as a query pair on the git URL.
-        let mut git = value.git;
-        if let Some(lfs) = value.lfs {
-            git.query_pairs_mut()
-                .append_pair("lfs", if lfs { "true" } else { "false" });
-        }
         Self {
-            git,
+            git: value.git,
             rev: match value.rev {
                 Some(GitReference::Branch(branch)) => {
                     Some(rattler_lock::source::GitReference::Branch(branch))
@@ -1034,7 +1012,7 @@ impl From<GitLocationSpec> for rattler_lock::source::GitSourceLocation {
                 Some(GitReference::DefaultBranch) | None => None,
             },
             subdirectory: value.subdirectory.to_option_string(),
-            lfs: None,
+            lfs: value.lfs,
         }
     }
 }

--- a/crates/pixi_spec/src/lib.rs
+++ b/crates/pixi_spec/src/lib.rs
@@ -701,6 +701,7 @@ impl From<GitSpec> for SourceSpec {
                 git: value.git,
                 rev: value.rev,
                 subdirectory: value.subdirectory,
+                lfs: value.lfs,
             }),
             matchspec,
         }
@@ -973,8 +974,28 @@ impl From<UrlSpec> for rattler_lock::source::UrlSourceLocation {
 #[cfg(feature = "rattler_lock")]
 impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
     fn from(value: rattler_lock::source::GitSourceLocation) -> Self {
+        // `rattler_lock` has no LFS field, so the flag lives in an `lfs`
+        // query pair on the stored git URL. It must survive the round-trip:
+        // the requested specs feed the source records' identity hashes, and
+        // a lossy field would invalidate the lock file on every run.
+        let mut git = value.git;
+        let lfs = git
+            .query_pairs()
+            .find(|(k, _)| k == "lfs")
+            .map(|(_, v)| v == "true");
+        if lfs.is_some() {
+            let remaining: Vec<(String, String)> = git
+                .query_pairs()
+                .filter(|(k, _)| k != "lfs")
+                .map(|(k, v)| (k.into_owned(), v.into_owned()))
+                .collect();
+            git.set_query(None);
+            if !remaining.is_empty() {
+                git.query_pairs_mut().extend_pairs(remaining);
+            }
+        }
         Self {
-            git: value.git,
+            git,
             rev: match value.rev {
                 Some(rattler_lock::source::GitReference::Branch(branch)) => {
                     Some(GitReference::Branch(branch))
@@ -987,6 +1008,7 @@ impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
                 .subdirectory
                 .and_then(|s| Subdirectory::try_from(s).ok())
                 .unwrap_or_default(),
+            lfs,
         }
     }
 }
@@ -994,8 +1016,15 @@ impl From<rattler_lock::source::GitSourceLocation> for GitLocationSpec {
 #[cfg(feature = "rattler_lock")]
 impl From<GitLocationSpec> for rattler_lock::source::GitSourceLocation {
     fn from(value: GitLocationSpec) -> Self {
+        // See `From<GitSourceLocation> for GitLocationSpec` for why the LFS
+        // flag is stored as a query pair on the git URL.
+        let mut git = value.git;
+        if let Some(lfs) = value.lfs {
+            git.query_pairs_mut()
+                .append_pair("lfs", if lfs { "true" } else { "false" });
+        }
         Self {
-            git: value.git,
+            git,
             rev: match value.rev {
                 Some(GitReference::Branch(branch)) => {
                     Some(rattler_lock::source::GitReference::Branch(branch))
@@ -1038,6 +1067,26 @@ mod test {
     use url::Url;
 
     use crate::{BinarySpec, MatchspecFields, PixiSpec};
+
+    /// The LFS flag must survive the `rattler_lock` round-trip because the
+    /// requested specs feed the source records' identity hashes.
+    #[cfg(feature = "rattler_lock")]
+    #[test]
+    fn test_git_location_lfs_roundtrips_through_rattler_lock() {
+        use crate::{GitLocationSpec, GitReference, Subdirectory};
+
+        for lfs in [None, Some(true), Some(false)] {
+            let spec = GitLocationSpec::new(
+                Url::parse("https://github.com/example/repo.git").unwrap(),
+                Some(GitReference::Branch("main".into())),
+                Subdirectory::default(),
+            )
+            .with_lfs(lfs);
+            let locked: rattler_lock::source::GitSourceLocation = spec.clone().into();
+            let back: GitLocationSpec = locked.into();
+            assert_eq!(back, spec, "lfs = {lfs:?} should round-trip");
+        }
+    }
 
     #[test]
     fn test_is_binary() {

--- a/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
+++ b/crates/pixi_spec/src/snapshots/pixi_spec__toml__test__round_trip.snap
@@ -71,6 +71,18 @@ expression: snapshot
     git: "https://github.com/conda-forge/21cmfast-feedstock"
     branch: main
 - input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    lfs: true
+  result:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    lfs: true
+- input:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    lfs: false
+  result:
+    git: "https://github.com/conda-forge/21cmfast-feedstock"
+    lfs: false
+- input:
     path: "../mypkg"
     version: 1.2.3
   result:
@@ -156,6 +168,11 @@ expression: snapshot
     tag: v1
   result:
     error: "ERROR: only one of `branch`, `rev`, or `tag` can be specified"
+- input:
+    version: 1.2.3
+    lfs: true
+  result:
+    error: "ERROR: `branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified"
 - input:
     git: "https://github.com/conda-forge/21cmfast-feedstock"
     sha256: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3

--- a/crates/pixi_spec/src/source_anchor.rs
+++ b/crates/pixi_spec/src/source_anchor.rs
@@ -106,10 +106,12 @@ impl SourceAnchor {
                 git,
                 rev,
                 subdirectory,
+                lfs,
             }) => SourceLocationSpec::Git(GitLocationSpec {
                 git: git.clone(),
                 rev: rev.clone(),
                 subdirectory: join_subdirectory(subdirectory, path),
+                lfs: *lfs,
             }),
         }
     }
@@ -310,6 +312,7 @@ mod tests {
             git: "https://github.com/example/repo".parse().unwrap(),
             rev: None,
             subdirectory: Subdirectory::default(),
+            lfs: None,
         });
         assert_eq!(anchor.relativize_location(git.clone()), Some(git));
 
@@ -318,6 +321,7 @@ mod tests {
             git: "https://github.com/example/repo".parse().unwrap(),
             rev: None,
             subdirectory: Subdirectory::default(),
+            lfs: None,
         }));
         assert_eq!(
             git_anchor.relativize_location(path_location("package_b")),

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -138,6 +138,7 @@ fn toml_location_spec_has_any_field(loc: &TomlLocationSpec) -> bool {
         || loc.branch.is_some()
         || loc.rev.is_some()
         || loc.tag.is_some()
+        || loc.lfs.is_some()
         || loc.subdirectory.is_some()
         || loc.md5.is_some()
         || loc.sha256.is_some()
@@ -269,6 +270,9 @@ pub struct TomlLocationSpec {
     /// The git revision of the package
     pub tag: Option<String>,
 
+    /// Whether to fetch Git LFS objects for the package
+    pub lfs: Option<bool>,
+
     /// The git subdirectory of the package
     pub subdirectory: Option<String>,
 
@@ -341,7 +345,7 @@ fn version_spec_error<T: Into<String>>(input: T) -> Option<impl Display> {
 
 #[derive(Error, Debug)]
 pub enum SpecError {
-    #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
+    #[error("`branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified")]
     NotAGitSpec,
 
     #[error("only one of `branch`, `rev`, or `tag` can be specified")]
@@ -400,7 +404,7 @@ impl SpecError {
 
 #[derive(Error, Debug)]
 pub enum SourceSpecError {
-    #[error("`branch`, `rev`, and `tag` are only valid when `git` is specified")]
+    #[error("`branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified")]
     NotAGitSpec,
 
     #[error("only one of `branch`, `rev`, or `tag` can be specified")]
@@ -492,6 +496,7 @@ impl TomlSpec {
                 branch: m.branch.or(b.branch),
                 rev: m.rev.or(b.rev),
                 tag: m.tag.or(b.tag),
+                lfs: m.lfs.or(b.lfs),
                 subdirectory: m.subdirectory.or(b.subdirectory),
                 md5: m.md5.or(b.md5),
                 sha256: m.sha256.or(b.sha256),
@@ -592,7 +597,11 @@ impl TomlSpec {
     ///   locations.
     fn validate_field_combinations(&self) -> Result<LocationKind, SpecError> {
         let location_kind = if let Some(loc) = &self.location {
-            if loc.git.is_none() && (loc.branch.is_some() || loc.rev.is_some() || loc.tag.is_some())
+            if loc.git.is_none()
+                && (loc.branch.is_some()
+                    || loc.rev.is_some()
+                    || loc.tag.is_some()
+                    || loc.lfs.is_some())
             {
                 return Err(SpecError::NotAGitSpec);
             }
@@ -804,6 +813,7 @@ impl TomlSpec {
                     git,
                     rev,
                     subdirectory,
+                    lfs: loc.lfs,
                     matchspec,
                 })))
             }
@@ -1111,7 +1121,10 @@ impl TomlLocationSpec {
     fn validate_field_combinations(&self) -> Result<(), SourceSpecError> {
         let (is_git, is_path, is_url) = {
             if self.git.is_none()
-                && (self.branch.is_some() || self.rev.is_some() || self.tag.is_some())
+                && (self.branch.is_some()
+                    || self.rev.is_some()
+                    || self.tag.is_some()
+                    || self.lfs.is_some())
             {
                 return Err(SourceSpecError::NotAGitSpec);
             }
@@ -1183,6 +1196,7 @@ impl TomlLocationSpec {
                     git,
                     rev,
                     subdirectory,
+                    lfs: self.lfs,
                 })
             }
             (_, _, _) => return Err(SourceSpecError::MultipleIdentifiers),
@@ -1247,6 +1261,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlSpec {
         let branch = th.optional("branch");
         let rev = th.optional("rev");
         let tag = th.optional("tag");
+        let lfs = th.optional("lfs");
         let subdirectory = th.optional("subdirectory");
         let build = th
             .optional::<TomlFromStr<_>>("build")
@@ -1283,6 +1298,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlSpec {
                 branch,
                 rev,
                 tag,
+                lfs,
                 subdirectory,
                 md5,
                 sha256,
@@ -1413,6 +1429,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlLocationSpec {
         let branch = th.optional("branch");
         let rev = th.optional("rev");
         let tag = th.optional("tag");
+        let lfs = th.optional("lfs");
         let subdirectory = th.optional("subdirectory");
         let md5 = th
             .optional::<TomlDigest<rattler_digest::Md5>>("md5")
@@ -1430,6 +1447,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlLocationSpec {
             branch,
             rev,
             tag,
+            lfs,
             subdirectory,
             md5,
             sha256,
@@ -1638,6 +1656,8 @@ mod test {
             json!({ "url": "https://conda.anaconda.org/conda-forge/linux-64/21cmfast-3.3.1-py38h0db86a8_1.conda", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main" }),
+            json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "lfs": true }),
+            json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "lfs": false }),
             // Source specs with matchspec selectors:
             json!({ "path": "../mypkg", "version": "1.2.3" }),
             json!({ "path": "../mypkg", "version": ">=1.2", "build": "py37_*" }),
@@ -1652,6 +1672,7 @@ mod test {
             json!({ "path": "foobar", "version": "//" }),
             json!({ "path": "foobar", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "branch": "main", "tag": "v1" }),
+            json!({ "version": "1.2.3", "lfs": true }),
             json!({ "git": "https://github.com/conda-forge/21cmfast-feedstock", "sha256": "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3" }),
             // A `.conda` URL is binary; matchspec selectors must be rejected.
             json!({ "url": "https://example.com/foo.conda", "version": "1.2.3" }),
@@ -2485,6 +2506,37 @@ flags = ["cuda"]"#;
         let spec = parse_toml_ok(input);
         let url = spec.as_url_source().expect("expected a url source spec");
         assert!(url.matchspec.flags.is_some());
+    }
+
+    #[test]
+    fn test_git_lfs_toml() {
+        let input = r#"git = "https://example.com/foo.git"
+lfs = true"#;
+        let spec = parse_toml_ok(input);
+        let git = spec.as_git().expect("expected a git spec");
+        assert_eq!(git.lfs, Some(true));
+    }
+
+    #[test]
+    fn test_git_lfs_false_toml() {
+        let input = r#"git = "https://example.com/foo.git"
+lfs = false"#;
+        let spec = parse_toml_ok(input);
+        let git = spec.as_git().expect("expected a git spec");
+        assert_eq!(git.lfs, Some(false));
+    }
+
+    #[test]
+    fn test_lfs_without_git_toml() {
+        let input = r#"version = "1.2.3"
+lfs = true"#;
+        assert_snapshot!(parse_toml_error(input), @r#"
+         × `branch`, `rev`, `tag`, and `lfs` are only valid when `git` is specified
+          ╭─[pixi.toml:1:1]
+        1 │ ╭─▶ version = "1.2.3"
+        2 │ ╰─▶ lfs = true
+          ╰────
+        "#);
     }
 
     #[test]

--- a/crates/pixi_test_utils/src/git_fixture.rs
+++ b/crates/pixi_test_utils/src/git_fixture.rs
@@ -58,7 +58,7 @@ fn dir_uses_lfs(dir: &Path) -> bool {
 }
 
 /// True if `git lfs version` succeeds.
-fn git_lfs_available() -> bool {
+pub fn git_lfs_available() -> bool {
     std::process::Command::new("git")
         .args(["lfs", "version"])
         .output()

--- a/crates/pixi_test_utils/src/lib.rs
+++ b/crates/pixi_test_utils/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 pub mod git_fixture;
 pub mod mock_repo_data;
 
-pub use git_fixture::GitRepoFixture;
+pub use git_fixture::{GitRepoFixture, git_lfs_available};
 pub use mock_repo_data::{
     LocalChannel, MockRepoData, Package, PackageBuilder, create_conda_package,
 };

--- a/crates/pixi_uv_conversions/src/conversions.rs
+++ b/crates/pixi_uv_conversions/src/conversions.rs
@@ -389,7 +389,10 @@ pub fn into_pinned_git_spec(
             .and_then(|sd| pixi_spec::Subdirectory::try_from(sd.to_path_buf()).ok())
             .unwrap_or_default(),
         reference,
-    );
+    )
+    // Record only an enabled LFS preference: disabled is uv's default and
+    // recording it would churn lock files of projects that never use LFS.
+    .with_lfs(dist.git.lfs().enabled().then_some(true));
 
     // `url()` is the original URL; `repository()` is the canonical
     // (lowercased + `.git`-stripped) form that would corrupt the lockfile
@@ -427,7 +430,7 @@ pub fn to_parsed_git_url(
             },
             into_uv_git_reference(git_source.reference.into()),
             Some(into_uv_git_sha(git_source.commit)),
-            uv_git_types::GitLfs::Disabled,
+            to_uv_git_lfs(git_source.lfs),
         )
         .into_diagnostic()?,
         if git_source.subdirectory.is_empty() {
@@ -444,6 +447,16 @@ pub fn to_parsed_git_url(
     );
 
     Ok(parsed_git_url)
+}
+
+/// Converts a manifest LFS preference into the uv equivalent. uv only knows
+/// on/off, so `None` (no opinion) maps to `Disabled`, uv's default.
+pub fn to_uv_git_lfs(lfs: Option<bool>) -> uv_git_types::GitLfs {
+    if lfs == Some(true) {
+        uv_git_types::GitLfs::Enabled
+    } else {
+        uv_git_types::GitLfs::Disabled
+    }
 }
 
 /// Converts from the open-source variant to the uv-specific variant,

--- a/crates/pixi_uv_conversions/src/requirements.rs
+++ b/crates/pixi_uv_conversions/src/requirements.rs
@@ -112,6 +112,7 @@ pub fn as_uv_req(
                     git,
                     rev,
                     subdirectory,
+                    lfs,
                     matchspec: _,
                 },
         } => {
@@ -133,7 +134,7 @@ pub fn as_uv_req(
                         .and_then(|s| s.map(uv_git_types::GitOid::from_str))
                         .transpose()
                         .expect("could not parse sha"),
-                    uv_git_types::GitLfs::Disabled,
+                    crate::to_uv_git_lfs(*lfs),
                 )?,
                 subdirectory: if subdirectory.is_empty() {
                     None

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -47,6 +47,11 @@ Pixi can also be configured via environment variables.
       <td>Not set, pixi detects the current platform automatically.</td>
     </tr>
     <tr>
+      <td><code>PIXI_GIT_LFS</code></td>
+      <td>Deprecated: set <code>lfs = true</code> on the git dependency in the manifest instead. When set to a truthy value (e.g. <code>1</code>), pixi fetches Git LFS objects for git dependencies.</td>
+      <td>Not set.</td>
+    </tr>
+    <tr>
       <td><code>RATTLER_AUTH_FILE</code></td>
       <td>Overrides the default location of the credentials file. When set, this is the only source of authentication data used by pixi. See <a href="../../deployment/authentication/#override-the-authentication-storage">authentication docs</a> for the file format.</td>
       <td>

--- a/docs/reference/pixi_manifest.md
+++ b/docs/reference/pixi_manifest.md
@@ -990,6 +990,9 @@ boltons = { git = "https://github.com/mahmoud/boltons.git", tag = "25.0.0" }
 # With https, specific tag and some subdirectory
 boltons = { git = "https://github.com/mahmoud/boltons.git", tag = "25.0.0", subdirectory = "some-subdir" }
 
+# With https and Git LFS files fetched during checkout
+my-model = { git = "https://github.com/example/my-model.git", lfs = true }
+
 # You can also directly add a source dependency from a path, tip keep this relative to the root of the workspace.
 minimal-project = { path = "./minimal-project", editable = true}
 
@@ -1050,16 +1053,21 @@ Learn more about installing PyTorch [here](../python/pytorch.md).
 A git repository to install from.
 This support both https:// and ssh:// urls.
 
-Use `git` in combination with `rev` or `subdirectory`:
+Use `git` in combination with `rev`, `subdirectory` or `lfs`:
 
 - `rev`: A specific revision to install. e.g. `rev = "0106aced5faa299e6ede89d1230bd6784f2c3660`
 - `subdirectory`: A subdirectory to install from. `subdirectory = "src"` or `subdirectory = "src/packagex"`
+- `lfs`: Fetch Git LFS objects during the checkout. `lfs = true`
+  Requires `git-lfs` to be installed on the machine.
+  For PyPI dependencies Git LFS additionally has to be initialized with `git lfs install`.
+  This also works for conda source dependencies in `[dependencies]`.
 
 ```toml
 # Note don't forget the `ssh://` or `https://` prefix!
 pytest = { git = "https://github.com/pytest-dev/pytest.git"}
 httpx = { git = "https://github.com/encode/httpx.git", rev = "c7c13f18a5af4c64c649881b2fe8dbd72a519c32"}
 py-rattler = { git = "ssh://git@github.com/conda/rattler.git", subdirectory = "py-rattler" }
+my-model = { git = "https://github.com/example/my-model.git", lfs = true }
 ```
 
 ##### `path`

--- a/pixi.lock
+++ b/pixi.lock
@@ -257,6 +257,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
       - conda: https://prefix.dev/conda-forge/linux-64/git-2.55.0-pl5321h5685339_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/jsonschema-rs-0.48.5-py310hc0c0e77_0.conda
@@ -403,6 +404,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h74e174c_19.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/git-2.55.0-pl5321h06f7e71_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/git-lfs-3.7.1-h559afe9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/go-shfmt-3.13.1-h22914b5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/jsonschema-rs-0.48.5-py310hac035ee_0.conda
@@ -603,6 +605,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-19.1.7-he914875_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/dprint-0.50.0-hd2571bf_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/git-2.55.0-pl5321h083a29a_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/git-lfs-3.7.1-h2af6fe8_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/icu-78.3-h25d91c4_1.conda
@@ -735,6 +738,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-19.1.7-h855ad52_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/dprint-0.50.0-h8dba533_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/git-2.55.0-pl5321h545aa0d_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/git-lfs-3.7.1-hbb040a8_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_1.conda
@@ -859,6 +863,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cmake-4.4.0-hdcbee5b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/dprint-0.50.0-h63977a8_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/git-2.55.0-h57928b3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/git-lfs-3.7.1-h6121922_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/go-shfmt-3.13.1-h11686cb_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/jsonschema-rs-0.48.5-py310h622ab3e_0.conda
@@ -2797,6 +2802,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/compiler-rt22-22.1.8-hb700be7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_27.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -2871,6 +2877,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/compiler-rt22-22.1.8-hfefdfc9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-15.2.0-h74e174c_19.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gcc_linux-aarch64-15.2.0-h0bf4bd8_27.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/git-lfs-3.7.1-h559afe9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -2951,6 +2958,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/clang_osx-64-19.1.7-h8a78ed7_33.conda
       - conda: https://prefix.dev/conda-forge/osx-64/cmake-4.4.0-h2426fb6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-19.1.7-he914875_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/git-lfs-3.7.1-h2af6fe8_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/icu-78.3-h25d91c4_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/krb5-1.22.2-h3ddfcb2_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/ld64_osx-64-956.6-llvm19_1_hf4e8e46_4.conda
@@ -3011,6 +3019,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/clang_osx-arm64-19.1.7-h75f8d18_33.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cmake-4.4.0-h8cb302d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-19.1.7-h855ad52_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/git-lfs-3.7.1-hbb040a8_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ld64-956.6-llvm19_1_he86490a_4.conda
@@ -3065,6 +3074,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cargo-insta-1.48.0-h18a1a76_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cargo-nextest-0.9.140-h18a1a76_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cmake-4.4.0-hdcbee5b_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/git-lfs-3.7.1-h6121922_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcurl-8.21.0-h51a1c48_2.conda
@@ -3874,6 +3884,14 @@ packages:
   run_exports: {}
   size: 5840935
   timestamp: 1777214856418
+- conda: https://prefix.dev/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
+  sha256: 244db394018bd2ae18e4d833af566ac98ec7e98d967e3c70839765dc1c27a189
+  md5: 2319a87ec34c4d02c2a02711228fba26
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4957399
+  timestamp: 1781207228441
 - conda: https://prefix.dev/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
   sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
   md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
@@ -5710,6 +5728,14 @@ packages:
   run_exports: {}
   size: 5186021
   timestamp: 1777214864054
+- conda: https://prefix.dev/conda-forge/linux-aarch64/git-lfs-3.7.1-h559afe9_2.conda
+  sha256: 7b1cf3786c00d19efa819b3109affc7122683e85b8b168911a33b9c7b7edc813
+  md5: 8062d312c917080cfca6a863b2285180
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4485243
+  timestamp: 1781207235155
 - conda: https://prefix.dev/conda-forge/linux-aarch64/go-shfmt-3.13.1-h22914b5_0.conda
   sha256: 6167f8e73add65218da61dd05467fa24addcf300be85cc23a7287d6f27ce7426
   md5: 5a8073ee07ff67cd8a7acad84525564d
@@ -9161,6 +9187,16 @@ packages:
   run_exports: {}
   size: 5247937
   timestamp: 1777214924487
+- conda: https://prefix.dev/conda-forge/osx-64/git-lfs-3.7.1-h2af6fe8_2.conda
+  sha256: 91037ff3cbb1e61bb65ef03eb12701a4ac6e778348aa5197c7ac699251383aca
+  md5: aec623c4be4ac7c05c9e702fcd91ee7f
+  constrains:
+  - __osx >=10.12
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 5011426
+  timestamp: 1781207789274
 - conda: https://prefix.dev/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda
   sha256: 75aa5e7a875afdcf4903b7dc98577672a3dc17b528ac217b915f9528f93c85fc
   md5: 427101d13f19c4974552a4e5b072eef1
@@ -10709,6 +10745,14 @@ packages:
   run_exports: {}
   size: 4889040
   timestamp: 1777214915812
+- conda: https://prefix.dev/conda-forge/osx-arm64/git-lfs-3.7.1-hbb040a8_2.conda
+  sha256: 2bd2fe0f79d2d7513a80db91f1e816c1812d132df10f55447ff5bc4633fee69b
+  md5: 4dbffc47c7fb4feae217604e1a1e2d7c
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4528558
+  timestamp: 1781207741707
 - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
   sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
   md5: eed7278dfbab727b56f2c0b64330814b
@@ -12221,6 +12265,14 @@ packages:
   run_exports: {}
   size: 5285211
   timestamp: 1777214874231
+- conda: https://prefix.dev/conda-forge/win-64/git-lfs-3.7.1-h6121922_2.conda
+  sha256: 338394b1d0b197f3a3e893988c93254b10a49b70b3da8e20fbc78901a538e732
+  md5: 6e390758667cc219e06f2d9455ee0b93
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 4648526
+  timestamp: 1781207761047
 - conda: https://prefix.dev/conda-forge/win-64/go-shfmt-3.13.1-h11686cb_0.conda
   sha256: f698800c168ba3185bbda4fbfb4a10bb625129f3ca2a6194616e7a6867234be4
   md5: 354dc95ae9872158dc0f56a9b696d841

--- a/pixi.toml
+++ b/pixi.toml
@@ -119,6 +119,7 @@ description = "Build a backend packages"
 [feature.dev.dependencies]
 cargo-edit = ">=0.13.13,<0.14"
 cargo-nextest = ">=0.9.140,<0.10"
+git-lfs = ">=3.7.1,<4"
 
 [feature.dev.tasks]
 insta-review = { cmd = "cargo insta review --workspace", description = "Review cargo-insta snapshots" }

--- a/schema/model.py
+++ b/schema/model.py
@@ -441,6 +441,9 @@ class MatchspecTable(BinaryMatchspecTable):
     tag: NonEmptyStr | None = Field(None, description="A git tag to use")
     branch: NonEmptyStr | None = Field(None, description="A git branch to use")
     subdirectory: NonEmptyStr | None = Field(None, description="A subdirectory to use in the repo")
+    lfs: bool | None = Field(
+        None, description="If `true` Git LFS objects are fetched during the checkout"
+    )
 
     package: Package | None = Field(
         None,
@@ -563,6 +566,9 @@ class _PyPiGitRequirement(_PyPIRequirement):
     )
     subdirectory: NonEmptyStr | None = Field(
         None, description="The subdirectory in the repo, a path from the root of the repo."
+    )
+    lfs: bool | None = Field(
+        None, description="If `true` Git LFS objects are fetched during the checkout"
     )
 
 

--- a/schema/pixi_build_api.json
+++ b/schema/pixi_build_api.json
@@ -537,7 +537,7 @@
           ]
         },
         "lfs": {
-          "description": "Whether to fetch Git LFS objects for the checkout. `None` defers to\nthe environment / git configuration.",
+          "description": "Whether to fetch Git LFS objects for the checkout. `None` falls\nback to the deprecated `PIXI_GIT_LFS` environment variable and\notherwise leaves pointer files.",
           "type": [
             "boolean",
             "null"

--- a/schema/pixi_build_api.json
+++ b/schema/pixi_build_api.json
@@ -535,6 +535,13 @@
             "string",
             "null"
           ]
+        },
+        "lfs": {
+          "description": "Whether to fetch Git LFS objects for the checkout. `None` defers to\nthe environment / git configuration.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "required": [

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -1373,6 +1373,11 @@
           "type": "string",
           "minLength": 1
         },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
+        },
         "license": {
           "title": "License",
           "description": "The license of the package",
@@ -1582,6 +1587,11 @@
           "description": "The git URL to the repo",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "license": {
           "title": "License",
@@ -2124,6 +2134,11 @@
           "type": "string",
           "minLength": 1
         },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
+        },
         "subdirectory": {
           "title": "Subdirectory",
           "description": "The subdirectory in the repo, a path from the root of the repo.",
@@ -2151,6 +2166,11 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "rev": {
           "title": "Rev",
@@ -2185,6 +2205,11 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "subdirectory": {
           "title": "Subdirectory",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1116,6 +1116,11 @@
           "type": "string",
           "minLength": 1
         },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
+        },
         "license": {
           "title": "License",
           "description": "The license of the package",
@@ -1325,6 +1330,11 @@
           "description": "The git URL to the repo",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "license": {
           "title": "License",
@@ -1867,6 +1877,11 @@
           "type": "string",
           "minLength": 1
         },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
+        },
         "subdirectory": {
           "title": "Subdirectory",
           "description": "The subdirectory in the repo, a path from the root of the repo.",
@@ -1894,6 +1909,11 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "rev": {
           "title": "Rev",
@@ -1928,6 +1948,11 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "subdirectory": {
           "title": "Subdirectory",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1397,6 +1397,11 @@
           "type": "string",
           "minLength": 1
         },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
+        },
         "license": {
           "title": "License",
           "description": "The license of the package",
@@ -1606,6 +1611,11 @@
           "description": "The git URL to the repo",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "license": {
           "title": "License",
@@ -2148,6 +2158,11 @@
           "type": "string",
           "minLength": 1
         },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
+        },
         "subdirectory": {
           "title": "Subdirectory",
           "description": "The subdirectory in the repo, a path from the root of the repo.",
@@ -2175,6 +2190,11 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "rev": {
           "title": "Rev",
@@ -2209,6 +2229,11 @@
           "description": "The `git` URL to the repo e.g https://github.com/prefix-dev/pixi",
           "type": "string",
           "minLength": 1
+        },
+        "lfs": {
+          "title": "Lfs",
+          "description": "If `true` Git LFS objects are fetched during the checkout",
+          "type": "boolean"
         },
         "subdirectory": {
           "title": "Subdirectory",


### PR DESCRIPTION
### Description

Adds an `lfs` field to git dependencies so LFS-tracked files are checked out:

```toml
[dependencies]
my-model = { git = "https://github.com/example/my-model.git", lfs = true }

[pypi-dependencies]
my-model = { git = "https://github.com/example/my-model.git", lfs = true }
```

* `lfs = true/false` parses on conda and PyPI git specs, `lfs` without `git` is rejected like `branch`/`rev`/`tag`
* The lock file records it as a `?lfs=true` query pair on the locked git URL, following the existing `branch`/`tag`/`rev` convention; older pixi versions ignore unknown pairs and `None` is omitted, so locks without LFS don't churn
* `lfs = true` without a usable `git-lfs` fails loudly instead of silently installing pointer files
* The `PIXI_GIT_LFS` environment variable is deprecated with a warning

**Not** in this PR:

* no `lfs` on the `[package.build]` source (the lock file cannot record it there, so it is rejected with a clear error)
* no `pixi add --lfs` flag

Takes inspiration from the earlier attempt in [baszalmstra/pixi#20](<https://github.com/baszalmstra/pixi/issues/20>).

Fixes prefix-dev/pixi#6024  <br>Fixes [#2000](<https://github.com/prefix-dev/pixi/issues/2000>)

### How Has This Been Tested?

* Reproduced [https://github.com/traversaro/pixi-git-lfs-example-workspace](<https://github.com/traversaro/pixi-git-lfs-example-workspace>) with a dev build: pointer file without the flag, real content with `lfs = true` in both the `pixi-build` and `pypi` environments, `--locked` passes on the resulting lock
* Added tests

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.