### PR TITLE
docs: split `prepare-docs` into tasks with dependencies

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -169,8 +169,17 @@ docs = { cmd = "zensical serve", depends-on = [
   "prepare-docs",
 ], description = "Serve the docs locally" }
 generate-cli-docs = { cmd = "cargo run --locked --manifest-path crates/pixi_docs/Cargo.toml", description = "Generate CLI documentation" }
+generate-llmstxt = { cmd = "python scripts/generate_llmstxt.py", depends-on = [
+  "stage-docs-files",
+], description = "Generate llms.txt and llms-full.txt" }
+generate-redirects = { cmd = "python scripts/generate_redirects.py", description = "Generate redirect stub pages" }
 mike-serve = { cmd = "mike serve", description = "Serve versioned docs with mike" }
-prepare-docs = { cmd = "python scripts/stage_docs_files.py && python scripts/generate_redirects.py && python scripts/generate_llmstxt.py", description = "Stage docs files, generate redirect stubs and llms.txt" }
+prepare-docs = { depends-on = [
+  "stage-docs-files",
+  "generate-redirects",
+  "generate-llmstxt",
+], description = "Stage docs files, generate redirect stubs and llms.txt" }
+stage-docs-files = { cmd = "python scripts/stage_docs_files.py", description = "Stage files from outside the docs directory" }
 
 #
 # Feature for linting and formatting tools


### PR DESCRIPTION
### Description

- Split `prepare-docs` into `stage-docs-files`, `generate-redirects` and `generate-llmstxt` instead of chaining the scripts with `&&`
- `generate-llmstxt` depends on `stage-docs-files` explicitly, because it reads the staged `docs/CHANGELOG.md`

### How Has This Been Tested?

`pixi run prepare-docs` runs the three tasks in order, `pixi run build-docs` still builds with `--strict`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
