### PR TITLE
ci: require approval before publishing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,10 @@ jobs:
     name: Tag release
     needs: [prepare, build]
     if: needs.prepare.outputs.publishing == 'true' && github.ref == 'refs/heads/main'
+    # The protected environment requires approval from a second maintainer
+    # before any tag is created or release is published.
+    environment:
+      name: release
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- gate the `tag-release` job on the protected `release` environment
- pause real releases for maintainer approval before creating the tag or publishing
- keep dry-run releases unaffected

## Repository configuration

The `release` environment should allow deployments only from `main`, require designated reviewers, and have **Prevent self-review** enabled.

## Validation

- `git diff --check`
- `actionlint` unavailable locally