### PR TITLE
docs: clarify pixi search channels

### DIFF
--- a/docs/reference/cli/pixi/search_extender
+++ b/docs/reference/cli/pixi/search_extender
@@ -1,3 +1,20 @@
+--8<-- [start:description]
+
+### Channel selection
+
+When no `--channel` option is provided, the channels depend on whether Pixi discovers a workspace:
+
+- Inside a workspace, Pixi uses the effective channels of the workspace's default environment.
+  These are normally the workspace channels, but can also reflect channels configured through features of a customized
+  default environment.
+- Outside a workspace, Pixi uses the [`default-channels`](../../pixi_configuration.md#default-channels) from the
+  configuration.
+  If they are not configured, `conda-forge` is used.
+
+Providing one or more `--channel` options replaces these defaults for the search.
+
+--8<-- [end:description]
+
 --8<-- [start:example]
 
 ## Examples

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -78,16 +78,17 @@ The following reference describes all available configuration options.
 
 ### `default-channels`
 
-The default channels to select when running `pixi init` or `pixi global install`.
-This defaults to only conda-forge.
+The default channels to select when running commands that do not use channels from an existing workspace, such as
+`pixi init` or `pixi global install`. They are also used by `pixi search` when no workspace is discovered and no
+`--channel` option is provided. This defaults to only `conda-forge`.
 
 ```toml title="config.toml"
 --8<-- "docs/source_files/pixi_config_tomls/main_config.toml:default-channels"
 ```
 
 !!! note
-The `default-channels` are only used when initializing a new workspace. Once initialized the `channels` are used from the
-workspace manifest.
+    Within a workspace, `pixi search` uses the effective channels of the workspace's default environment instead of
+    `default-channels`. Providing `--channel` overrides both sources.
 
 ### `shell`
 

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -78,17 +78,20 @@ The following reference describes all available configuration options.
 
 ### `default-channels`
 
-The default channels to select when running commands that do not use channels from an existing workspace, such as
-`pixi init` or `pixi global install`. They are also used by `pixi search` when no workspace is discovered and no
-`--channel` option is provided. This defaults to only `conda-forge`.
+The `default-channels` provide fallback channels for commands that do not obtain channels from an existing workspace or
+environment. Whether they are used depends on the command, rather than the directory from which it is invoked. Examples
+include `pixi init`, `pixi exec`, creating an environment with `pixi global install`, and running `pixi search` when no
+workspace is discovered. This defaults to only `conda-forge`.
 
 ```toml title="config.toml"
 --8<-- "docs/source_files/pixi_config_tomls/main_config.toml:default-channels"
 ```
 
 !!! note
-    Within a workspace, `pixi search` uses the effective channels of the workspace's default environment instead of
-    `default-channels`. Providing `--channel` overrides both sources.
+    Commands that operate on an existing workspace use the channels from its manifest rather than `default-channels`.
+    For example, `pixi search` uses the effective channels of the workspace's default environment when it discovers a
+    workspace. Workspace-independent commands such as `pixi exec` still use `default-channels` when invoked from a
+    workspace directory.
 
 ### `shell`
 


### PR DESCRIPTION
### Description

Clarify how `pixi search` selects channels when `--channel` is omitted: workspace default-environment channels inside a workspace, and configured `default-channels` outside one.

Also correct the `default-channels` configuration reference.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

```plaintext
Please clarify the docs of `pixi search`: The default-channels of the configuration are only used outside a workspace. Within a workspace, the workspace-specific channels are used.

1. Check that this is indeed pixi's behaviour by reading the source code. Understand if there are any other edge cases.
2. Verify this behaviour is indeed not completely documented.
3. Improve the docs on this.
4. Open a DRAFT PR. Respect the PR template and keep the PR body short and concise. Omit the "testing" section you otherwise seem to write quite often.```

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
