### PR TITLE
feat: read the shared config layer of rattler-based tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,8 +1701,7 @@ dependencies = [
 [[package]]
 name = "coalesced_map"
 version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae1159673deb7e62cf1be84e4cda5dfc584fac013123096a2e720d777694ecd"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "dashmap",
  "tokio",
@@ -2881,8 +2880,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "file_url"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e68d9ad067554ef18d79494f0e0bcddaf263f41b0126eb7a937f9e942fcbbd8"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "itertools 0.15.0",
  "percent-encoding",
@@ -3871,7 +3869,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5314,7 +5312,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.2",
@@ -5794,8 +5792,7 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 [[package]]
 name = "path_resolver"
 version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ahash",
  "fs-err",
@@ -6694,6 +6691,7 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror 2.0.19",
  "toml_edit",
  "tracing",
@@ -7729,7 +7727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8047,8 +8045,7 @@ dependencies = [
 [[package]]
 name = "rattler"
 version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b9d30445441401c04b874996cfcd1dfbb617a28b76a5a98367ad58e121c3a7"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -8369,8 +8366,7 @@ dependencies = [
 [[package]]
 name = "rattler_cache"
 version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc91045d53da3c63c81b7666119a1f73ed2a69473e7b451649b62397d9148b77"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8404,8 +8400,7 @@ dependencies = [
 [[package]]
 name = "rattler_conda_types"
 version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "776dcc9348ae7e1843e1320ad1c1afc375bd2b73faeaa1bb49b1e002575f7791"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -8447,8 +8442,7 @@ dependencies = [
 [[package]]
 name = "rattler_config"
 version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66465befa4068f2b5ab01f4949f41e9bbb033d9d7e2833d9bde926fe2d0dfaf9"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "dirs",
  "fs-err",
@@ -8466,8 +8460,7 @@ dependencies = [
 [[package]]
 name = "rattler_digest"
 version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56538779701395adba456293b22fda6598b079f30c24d9a22c2bb15271bd67f3"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "blake2 0.11.0-rc.6",
  "digest 0.11.3",
@@ -8508,8 +8501,7 @@ dependencies = [
 [[package]]
 name = "rattler_index"
 version = "0.30.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a60d3106a66a529c227aebbca194d92a42d863a89a4fb1225c92ab702621120"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8548,8 +8540,7 @@ dependencies = [
 [[package]]
 name = "rattler_lock"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8535d2ec6bafe0eab07f234ef7dc04e53cd547b44f1943eb9dd903e8a1088a"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ahash",
  "file_url",
@@ -8577,8 +8568,7 @@ dependencies = [
 [[package]]
 name = "rattler_macros"
 version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1bde42798a908a8a2609836a062f01117b83a3fba6f8f6be3eb8c1d07bfdf2"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -8587,8 +8577,7 @@ dependencies = [
 [[package]]
 name = "rattler_menuinst"
 version = "0.2.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a6bc4214923ccd4ae3d2eab36c3bf8d4a91552ad83cdc4a67f713346dace9a"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "configparser",
  "dirs",
@@ -8618,8 +8607,7 @@ dependencies = [
 [[package]]
 name = "rattler_networking"
 version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1789dae98aabeedffa2d28f0fd218da55ca21746d7f4b8e909f80525cf3bef5"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -8659,8 +8647,7 @@ dependencies = [
 [[package]]
 name = "rattler_package_streaming"
 version = "0.26.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bb89525bd5df28e9abcbba31e5c97b029175e66433a43ed9087792d5b0bdb7"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -8668,6 +8655,7 @@ dependencies = [
  "astral_async_zip 0.0.20",
  "async-compression",
  "async-spooled-tempfile",
+ "bytes",
  "bzip2 0.6.1",
  "filetime",
  "fs-err",
@@ -8714,8 +8702,7 @@ dependencies = [
 [[package]]
 name = "rattler_pty"
 version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4bb899b6b8d316efe26fe43e003073ef93d230d9009a41d630e22473368c0e4"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "libc",
  "nix 0.31.3",
@@ -8726,8 +8713,7 @@ dependencies = [
 [[package]]
 name = "rattler_redaction"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -8737,8 +8723,7 @@ dependencies = [
 [[package]]
 name = "rattler_repodata_gateway"
 version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a562674a44022e676a4608f29f2f7d35e71de0386148dc5bfa72765e72676684"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8800,8 +8785,7 @@ dependencies = [
 [[package]]
 name = "rattler_s3"
 version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0274107867e75f151fdaaf361a15c06f24600cbe2ff5bab886be009c2f8baa27"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -8817,8 +8801,7 @@ dependencies = [
 [[package]]
 name = "rattler_shell"
 version = "0.27.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e484e0ac0106175cf7f2ae19a7c6d3da2af4b0434b5fb629ebe7b9dcc54542"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8859,8 +8842,7 @@ dependencies = [
 [[package]]
 name = "rattler_solve"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47428b4adefb08d4b7b915f29a3ea716f6a329b75723355ea1eb63fc0a4eaac2"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "futures",
  "hex",
@@ -8879,8 +8861,7 @@ dependencies = [
 [[package]]
 name = "rattler_upload"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc094f9ea319310dcb2ed1e65707c0e40a3e9fb5b7e1b0841b7149b479211cc"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8918,8 +8899,7 @@ dependencies = [
 [[package]]
 name = "rattler_virtual_packages"
 version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5bb5ca36e7e3c22c77ebb49737401d1ab4dd47a40fcdab19adb4a0319767b5"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "archspec",
  "libloading",
@@ -10569,8 +10549,7 @@ dependencies = [
 [[package]]
 name = "simple_spawn_blocking"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a7b2679ee03cca581f57e5a4fecac405aa6b5d5174abe65b4b41fa181d8438"
+source = "git+https://github.com/conda/rattler.git?rev=17848a13d98568c3189a3c034f9ffd45be89df03#17848a13d98568c3189a3c034f9ffd45be89df03"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6707,6 +6707,7 @@ dependencies = [
  "serde_ignored",
  "serde_json",
  "temp-env",
+ "tempfile",
  "thiserror 2.0.20",
  "toml_edit",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,29 @@ rattler_build_types = { version = "0.1.8" }
 rattler_build_variant_config = { version = "0.1.9" }
 
 [patch.crates-io]
+# TODO: drop once rattler_config with the shared config layer is released
+# (conda/rattler#2645). All rattler crates are patched to the same revision
+# so that only one version of each type exists in the dependency graph.
+rattler = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+file_url = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+simple_spawn_blocking = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_cache = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_conda_types = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_config = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_digest = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_index = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_lock = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_menuinst = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_networking = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_package_streaming = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_redaction = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_repodata_gateway = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_s3 = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_shell = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_solve = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_upload = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+rattler_virtual_packages = { git = "https://github.com/conda/rattler.git", rev = "17848a13d98568c3189a3c034f9ffd45be89df03" }
+
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "d8efd77673c9a90792da9da31b6c0da7ea8a324b" }
 
 # Redirect crates.io's `reqwest-middleware` to a local shim that re-exports

--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -2,7 +2,7 @@ use crate::cli_config::WorkspaceConfig;
 use clap::Parser;
 use miette::{IntoDiagnostic, WrapErr};
 use pixi_config;
-use pixi_config::Config;
+use pixi_config::{Config, ConfigError};
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_core::workspace::WorkspaceLocatorError;
@@ -274,20 +274,31 @@ fn alter_config(
     value: Option<String>,
     mode: AlterMode,
 ) -> miette::Result<()> {
-    let mut config = load_config(common_args)?;
     let to = determine_config_write_path(common_args)?;
+
+    // Edit only the file that is about to be written. Starting from the
+    // merged config would bake every inherited setting into it, so the user
+    // would silently stop following the layers they inherit from.
+    let mut config = match Config::from_path(&to) {
+        Ok(config) => config,
+        Err(ConfigError::FileNotFound(_)) => Config::default(),
+        Err(e) => return Err(e).into_diagnostic(),
+    };
 
     match mode {
         AlterMode::Prepend | AlterMode::Append => {
             let is_prepend = matches!(mode, AlterMode::Prepend);
 
             match key {
+                // `default-channels` replaces the lower layers rather than
+                // extending them, so the list written here has to be the
+                // whole one the user sees.
                 "default-channels" => {
                     let input = value.expect("value must be provided");
                     let channel = NamedChannelOrUrl::from_str(&input)
                         .into_diagnostic()
                         .context("invalid channel name")?;
-                    let mut new_channels = config.default_channels.clone();
+                    let mut new_channels = load_config(common_args)?.default_channels;
                     if is_prepend {
                         new_channels.insert(0, channel);
                     } else {
@@ -295,10 +306,14 @@ fn alter_config(
                     }
                     config.default_channels = new_channels;
                 }
+                // `extra-index-urls` is concatenated across layers, so only
+                // this file's own share of the list is edited; copying the
+                // lower layers in would list them twice. A prepend therefore
+                // lands ahead of this file's URLs, but after the lower ones.
                 "pypi-config.extra-index-urls" => {
                     let input = url::Url::parse(&value.expect("value must be provided"))
                         .map_err(|e| miette::miette!("Invalid URL: {}", e))?;
-                    let mut new_urls = config.pypi_config().extra_index_urls.clone();
+                    let mut new_urls = config.pypi_config.extra_index_urls.clone();
                     if is_prepend {
                         new_urls.insert(0, input);
                     } else {

--- a/crates/pixi_config/Cargo.toml
+++ b/crates/pixi_config/Cargo.toml
@@ -36,6 +36,7 @@ url = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
 rstest = { workspace = true }
 temp-env = { workspace = true }
+tempfile = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 nix = { workspace = true, features = ["fs"] }

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -14,6 +14,8 @@ use rattler_conda_types::{
     ChannelConfig, NamedChannelOrUrl, Platform, Version, VersionBumpType, VersionSpec,
     version_spec::{EqualityOperator, LogicalOperator, RangeOperator},
 };
+use rattler_config::config::{CommonConfig, ConfigBase};
+use rattler_config::locations::{ConfigLayer, config_search_paths};
 use rattler_networking::s3_middleware;
 use rattler_repodata_gateway::{Gateway, GatewayBuilder, SourceConfig, fetch::CacheAction};
 use reqwest::{NoProxy, Proxy};
@@ -1318,6 +1320,53 @@ impl Default for Config {
     }
 }
 
+/// Pixi's configuration acts as the tool-specific extension of
+/// [`rattler_config::config::ConfigBase`]: shared configuration files are
+/// parsed through `ConfigBase<Config>`, and the common keys they may contain
+/// are folded into a [`Config`] via the [`From<CommonConfig>`] impl below.
+impl rattler_config::config::Config for Config {
+    fn merge_config(self, other: &Self) -> Result<Self, rattler_config::config::MergeError> {
+        Ok(Config::merge_config(self, other.clone()))
+    }
+
+    fn validate(&self) -> Result<(), rattler_config::config::ValidationError> {
+        Config::validate(self)
+            .map_err(|e| rattler_config::config::ValidationError::Invalid(e.to_string()))
+    }
+
+    fn keys(&self) -> Vec<String> {
+        self.get_keys().iter().map(|s| (*s).to_string()).collect()
+    }
+}
+
+/// The keys shared by all rattler-based tools, as a pixi configuration. Used
+/// to fold a parsed shared configuration file into pixi's own layering; keys
+/// pixi does not model (like `index-config`) are dropped.
+impl From<CommonConfig> for Config {
+    fn from(common: CommonConfig) -> Self {
+        Self {
+            default_channels: common.default_channels.unwrap_or_default(),
+            authentication_override_file: common.authentication_override_file,
+            tls_no_verify: common.tls_no_verify,
+            tls_root_certs: common.tls_root_certs.map(|certs| match certs {
+                rattler_config::config::tls::TlsRootCerts::Webpki => TlsRootCerts::Webpki,
+                rattler_config::config::tls::TlsRootCerts::System => TlsRootCerts::System,
+            }),
+            mirrors: common.mirrors.into_iter().collect(),
+            repodata_config: common.repodata_config,
+            s3_options: common.s3_options,
+            concurrency: common.concurrency,
+            proxy_config: common.proxy_config,
+            build: common.build,
+            run_post_link_scripts: common.run_post_link_scripts,
+            allow_symbolic_links: common.allow_symbolic_links,
+            allow_hard_links: common.allow_hard_links,
+            allow_ref_links: common.allow_ref_links,
+            ..Default::default()
+        }
+    }
+}
+
 /// Emit a deprecation warning when a config layer (file, CLI flag, or env var)
 /// sets `tls-root-certs` to one of the deprecated spellings.
 ///
@@ -1665,6 +1714,58 @@ impl Config {
         Ok(config)
     }
 
+    /// Load a shared configuration file (a file every rattler-based tool
+    /// reads, see [`rattler_config::locations::ConfigLayer::Shared`]). Only
+    /// the keys shared by all rattler-based tools are honored; everything
+    /// else - including keys pixi would understand in its own files - is
+    /// ignored with a warning, so a shared file means the same thing to
+    /// every tool reading it.
+    ///
+    /// # Returns
+    ///
+    /// The common keys of the shared file, folded into a [`Config`]
+    ///
+    /// # Errors
+    ///
+    /// I/O errors or parsing errors
+    pub fn from_shared_path(path: &Path) -> Result<Config, ConfigError> {
+        tracing::debug!("Loading shared config from {}", path.display());
+        let s = match fs_err::read_to_string(path) {
+            Ok(content) => content,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    || e.kind() == std::io::ErrorKind::NotADirectory =>
+            {
+                return Err(ConfigError::FileNotFound(path.to_path_buf()));
+            }
+            Err(e) => return Err(ConfigError::ReadError(e)),
+        };
+
+        let (base, unused_keys) = ConfigBase::<Config>::from_toml_str_shared(&s)
+            .into_diagnostic()
+            .map_err(|e| ConfigError::ParseError(e, path.to_path_buf()))?;
+
+        if !unused_keys.is_empty() {
+            tracing::warn!(
+                "Ignoring '{}' in {}: not keys shared by all rattler-based tools",
+                console::style(
+                    unused_keys
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .yellow(),
+                path.display()
+            );
+        }
+
+        let mut config = Config::from(base.common);
+        config.loaded_from.push(path.to_path_buf());
+        tracing::debug!("Loaded shared config from: {}", path.display());
+        Ok(config)
+    }
+
     /// Try to load the system config file from the system path.
     ///
     /// # Returns
@@ -1712,10 +1813,16 @@ impl Config {
     ///
     /// - [`GlobalConfigSource::None`]: return [`Config::default`].
     /// - [`GlobalConfigSource::File`]: load only that file.
-    /// - [`GlobalConfigSource::Search`]: load `/etc/pixi/config.toml` and
-    ///   every entry in [`config_path_global`], merging them in order. This
-    ///   case is cached process-wide because the underlying files are
-    ///   env-independent.
+    /// - [`GlobalConfigSource::Search`]: load the default locations reported
+    ///   by [`rattler_config::locations::config_search_paths`], merging them
+    ///   in order (lowest precedence first): the system-wide shared file
+    ///   (`/etc/rattler/config.toml`), the system-wide pixi file
+    ///   (`/etc/pixi/config.toml`), the per-user shared files
+    ///   (`$XDG_CONFIG_HOME/rattler/config.toml`, `$RATTLER_HOME` when set),
+    ///   and the per-user pixi files ([`config_path_global`]). Shared files
+    ///   may only contain the keys shared by all rattler-based tools (see
+    ///   [`Config::from_shared_path`]). This case is cached process-wide
+    ///   because the underlying files are env-independent.
     ///
     /// The project-local `<project>/.pixi/config.toml` layer that
     /// [`Config::load_with`] adds on top is unaffected.
@@ -1723,14 +1830,18 @@ impl Config {
         // Cache only the default search-the-disk layers; non-default sources
         // (--no-config / --config-file) are per-invocation and can vary.
         static SEARCH_LAYERS: LazyLock<Config> = LazyLock::new(|| {
-            let mut config = Config::load_system();
-            for p in config_path_global() {
-                match Config::from_path(&p) {
+            let mut config = Config::default();
+            for location in config_search_paths("pixi") {
+                let loaded = match location.layer {
+                    ConfigLayer::Shared => Config::from_shared_path(&location.path),
+                    ConfigLayer::Tool => Config::from_path(&location.path),
+                };
+                match loaded {
                     Ok(c) => config = config.merge_config(c),
                     Err(ConfigError::FileNotFound(_)) => (),
                     Err(e) => tracing::error!(
                         "Failed to load global config '{}' with error: {}",
-                        p.display(),
+                        location.path.display(),
                         e
                     ),
                 }
@@ -3012,6 +3123,38 @@ UNUSED = "unused"
         config = config.merge_config(other);
         assert_eq!(config, original_other);
     }
+    #[test]
+    fn test_from_shared_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs_err::write(
+            &path,
+            r#"
+            default-channels = ["conda-forge"]
+            tls-no-verify = true
+            pinning-strategy = "no-pin"
+
+            [shell]
+            force-activate = true
+            "#,
+        )
+        .unwrap();
+
+        let config = Config::from_shared_path(&path).unwrap();
+
+        // Common keys are honored.
+        assert_eq!(
+            config.default_channels,
+            vec![NamedChannelOrUrl::from_str("conda-forge").unwrap()]
+        );
+        assert_eq!(config.tls_no_verify, Some(true));
+        // Pixi-only keys are ignored in shared files, even though pixi
+        // understands them in its own files.
+        assert_eq!(config.pinning_strategy, None);
+        assert_eq!(config.shell, ShellConfig::default());
+        assert_eq!(config.loaded_from, vec![path]);
+    }
+
     #[test]
     fn test_config_merge_multiple() {
         let mut config = Config::default();

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -14,6 +14,10 @@ use rattler_conda_types::{
     ChannelConfig, NamedChannelOrUrl, Platform, Version, VersionBumpType, VersionSpec,
     version_spec::{EqualityOperator, LogicalOperator, RangeOperator},
 };
+use rattler_config::config::{CommonConfig, ConfigBase};
+use rattler_config::locations::{
+    ConfigLayer, ConfigLocation, shared_system_config_path, shared_user_config_paths,
+};
 use rattler_networking::s3_middleware;
 use rattler_repodata_gateway::{Gateway, GatewayBuilder, SourceConfig, fetch::CacheAction};
 use reqwest::{NoProxy, Proxy};
@@ -1318,6 +1322,75 @@ impl Default for Config {
     }
 }
 
+/// Pixi's tool-specific extension of [`rattler_config::config::ConfigBase`],
+/// which lets shared configuration files be parsed as `ConfigBase<Config>`.
+impl rattler_config::config::Config for Config {
+    fn merge_config(self, other: &Self) -> Result<Self, rattler_config::config::MergeError> {
+        Ok(Config::merge_config(self, other.clone()))
+    }
+
+    fn validate(&self) -> Result<(), rattler_config::config::ValidationError> {
+        Config::validate(self)
+            .map_err(|e| rattler_config::config::ValidationError::Invalid(e.to_string()))
+    }
+
+    fn keys(&self) -> Vec<String> {
+        self.get_keys().iter().map(|s| (*s).to_string()).collect()
+    }
+}
+
+/// Folds the keys shared by all rattler-based tools into pixi's own layering.
+///
+/// Keys pixi does not model (like `index-config`) are dropped silently: a
+/// shared file serves every rattler-based tool, so a key meant for another
+/// one of them is not a mistake.
+impl From<CommonConfig> for Config {
+    fn from(common: CommonConfig) -> Self {
+        Self {
+            default_channels: common.default_channels.unwrap_or_default(),
+            authentication_override_file: common.authentication_override_file,
+            tls_no_verify: common.tls_no_verify,
+            tls_root_certs: common.tls_root_certs.map(|certs| match certs {
+                rattler_config::config::tls::TlsRootCerts::Webpki => TlsRootCerts::Webpki,
+                rattler_config::config::tls::TlsRootCerts::System => TlsRootCerts::System,
+            }),
+            mirrors: common.mirrors.into_iter().collect(),
+            repodata_config: common.repodata_config,
+            s3_options: common.s3_options,
+            concurrency: common.concurrency,
+            proxy_config: common.proxy_config,
+            build: common.build,
+            run_post_link_scripts: common.run_post_link_scripts,
+            allow_symbolic_links: common.allow_symbolic_links,
+            allow_hard_links: common.allow_hard_links,
+            allow_ref_links: common.allow_ref_links,
+            ..Default::default()
+        }
+    }
+}
+
+/// Warn about a proxy configuration that will not take effect: non-proxy
+/// hosts without a proxy to apply them to, or a proxy that the environment
+/// overrides.
+fn warn_about_proxy_config(config: &Config) {
+    if config.proxy_config.https.is_none() && config.proxy_config.http.is_none() {
+        if !config.proxy_config.non_proxy_hosts.is_empty() {
+            tracing::warn!(
+                "proxy-config.non-proxy-hosts is not empty but will be ignored, as no https or http config is set."
+            )
+        }
+    } else if *USE_PROXY_FROM_ENV {
+        let config_no_proxy =
+            Some(config.proxy_config.non_proxy_hosts.iter().join(",")).filter(|v| !v.is_empty());
+        if (*ENV_HTTPS_PROXY).as_deref() != config.proxy_config.https.as_ref().map(Url::as_str)
+            || (*ENV_HTTP_PROXY).as_deref() != config.proxy_config.http.as_ref().map(Url::as_str)
+            || *ENV_NO_PROXY != config_no_proxy
+        {
+            tracing::info!("proxy configs are overridden by proxy environment vars.")
+        }
+    }
+}
+
 /// Emit a deprecation warning when a config layer (file, CLI flag, or env var)
 /// sets `tls-root-certs` to one of the deprecated spellings.
 ///
@@ -1643,24 +1716,78 @@ impl Config {
             .validate()
             .map_err(|e| ConfigError::ValidationError(e, path.to_path_buf()))?;
 
-        // check proxy config
-        if config.proxy_config.https.is_none() && config.proxy_config.http.is_none() {
-            if !config.proxy_config.non_proxy_hosts.is_empty() {
-                tracing::warn!(
-                    "proxy-config.non-proxy-hosts is not empty but will be ignored, as no https or http config is set."
-                )
-            }
-        } else if *USE_PROXY_FROM_ENV {
-            let config_no_proxy = Some(config.proxy_config.non_proxy_hosts.iter().join(","))
-                .filter(|v| !v.is_empty());
-            if (*ENV_HTTPS_PROXY).as_deref() != config.proxy_config.https.as_ref().map(Url::as_str)
-                || (*ENV_HTTP_PROXY).as_deref()
-                    != config.proxy_config.http.as_ref().map(Url::as_str)
-                || *ENV_NO_PROXY != config_no_proxy
+        warn_about_proxy_config(&config);
+
+        Ok(config)
+    }
+
+    /// Load a shared configuration file, one that every rattler-based tool
+    /// reads (see [`rattler_config::locations::ConfigLayer::Shared`]).
+    ///
+    /// Only the keys shared by all rattler-based tools are honored. Anything
+    /// else is ignored with a warning, even a key pixi would accept in its
+    /// own files, so that a shared file means the same thing to every tool.
+    ///
+    /// # Returns
+    ///
+    /// The common keys of the shared file, folded into a [`Config`]
+    ///
+    /// # Errors
+    ///
+    /// I/O errors or parsing errors
+    pub fn from_shared_path(path: &Path) -> Result<Config, ConfigError> {
+        tracing::debug!("Loading shared config from {}", path.display());
+        let s = match fs_err::read_to_string(path) {
+            Ok(content) => content,
+            Err(e)
+                if e.kind() == std::io::ErrorKind::NotFound
+                    || e.kind() == std::io::ErrorKind::NotADirectory =>
             {
-                tracing::info!("proxy configs are overridden by proxy environment vars.")
+                return Err(ConfigError::FileNotFound(path.to_path_buf()));
             }
+            Err(e) => return Err(ConfigError::ReadError(e)),
+        };
+
+        let (base, unused_keys) = ConfigBase::<Config>::from_toml_str_shared(&s)
+            .into_diagnostic()
+            .map_err(|e| ConfigError::ParseError(e, path.to_path_buf()))?;
+
+        // `rattler_config` folds the deprecated `tls-root-certs` spellings
+        // into `system`, so read back what was actually written to keep
+        // warning about them.
+        if let Ok(document) = s.parse::<toml_edit::DocumentMut>()
+            && let Some(spelling) = document
+                .get("tls-root-certs")
+                .and_then(|item| item.as_str())
+            && let Ok(certs) = TlsRootCerts::from_str(spelling)
+        {
+            warn_deprecated_tls_root_certs(Some(certs), Some(&path.display().to_string()));
         }
+
+        if !unused_keys.is_empty() {
+            tracing::warn!(
+                "Ignoring '{}' in {}: not a key of the shared configuration",
+                console::style(
+                    unused_keys
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+                .yellow(),
+                path.display()
+            );
+        }
+
+        let mut config = Config::from(base.common);
+        config.loaded_from.push(path.to_path_buf());
+        tracing::debug!("Loaded shared config from: {}", path.display());
+
+        config
+            .validate()
+            .map_err(|e| ConfigError::ValidationError(e, path.to_path_buf()))?;
+
+        warn_about_proxy_config(&config);
 
         Ok(config)
     }
@@ -1678,20 +1805,26 @@ impl Config {
         Self::from_path(&config_path_system())
     }
 
-    /// Load the system config file from the system path.
+    /// Load the system-wide config layer: the shared file with the pixi file
+    /// merged on top, see [`system_config_locations`].
     ///
     /// # Returns
     ///
     /// The loaded system config
     pub fn load_system() -> Config {
-        Self::try_load_system().unwrap_or_else(|e| {
-            match e {
-                ConfigError::FileNotFound(_) => (), // it's fine that no file is there
-                e => tracing::error!("{e}"),
+        let mut config = Config::default();
+        for location in system_config_locations() {
+            let loaded = match location.layer {
+                ConfigLayer::Shared => Config::from_shared_path(&location.path),
+                ConfigLayer::Tool => Config::from_path(&location.path),
+            };
+            match loaded {
+                Ok(c) => config = config.merge_config(c),
+                Err(ConfigError::FileNotFound(_)) => (), // it's fine that no file is there
+                Err(e) => tracing::error!("{e}"),
             }
-
-            Self::default()
-        })
+        }
+        config
     }
 
     /// Validate the config file.
@@ -1712,10 +1845,11 @@ impl Config {
     ///
     /// - [`GlobalConfigSource::None`]: return [`Config::default`].
     /// - [`GlobalConfigSource::File`]: load only that file.
-    /// - [`GlobalConfigSource::Search`]: load `/etc/pixi/config.toml` and
-    ///   every entry in [`config_path_global`], merging them in order. This
-    ///   case is cached process-wide because the underlying files are
-    ///   env-independent.
+    /// - [`GlobalConfigSource::Search`]: merge every location reported by
+    ///   [`config_search_locations`], lowest precedence first. Shared files
+    ///   may only contain the keys shared by all rattler-based tools, see
+    ///   [`Config::from_shared_path`]. This case is cached process-wide
+    ///   because the underlying files are env-independent.
     ///
     /// The project-local `<project>/.pixi/config.toml` layer that
     /// [`Config::load_with`] adds on top is unaffected.
@@ -1723,14 +1857,18 @@ impl Config {
         // Cache only the default search-the-disk layers; non-default sources
         // (--no-config / --config-file) are per-invocation and can vary.
         static SEARCH_LAYERS: LazyLock<Config> = LazyLock::new(|| {
-            let mut config = Config::load_system();
-            for p in config_path_global() {
-                match Config::from_path(&p) {
+            let mut config = Config::default();
+            for location in config_search_locations() {
+                let loaded = match location.layer {
+                    ConfigLayer::Shared => Config::from_shared_path(&location.path),
+                    ConfigLayer::Tool => Config::from_path(&location.path),
+                };
+                match loaded {
                     Ok(c) => config = config.merge_config(c),
                     Err(ConfigError::FileNotFound(_)) => (),
                     Err(e) => tracing::error!(
                         "Failed to load global config '{}' with error: {}",
-                        p.display(),
+                        location.path.display(),
                         e
                     ),
                 }
@@ -2549,6 +2687,54 @@ pub fn config_path_global() -> Vec<PathBuf> {
     .collect()
 }
 
+/// Every configuration file pixi reads by default, from lowest to highest
+/// precedence: the shared system file, the pixi system file, the shared
+/// user files, and the pixi user files.
+///
+/// The pixi paths come from [`config_path_system`] and [`config_path_global`]
+/// rather than from [`rattler_config::locations`], so that a rebranded build
+/// (`PIXI_CONFIG_DIR`, `PIXI_DIR`) keeps reading and writing the same files.
+pub fn config_search_locations() -> Vec<ConfigLocation> {
+    let mut locations = system_config_locations();
+    locations.extend(layer_locations(
+        shared_user_config_paths(),
+        config_path_global(),
+    ));
+    locations
+}
+
+/// The system-wide configuration files: the shared file
+/// (`/etc/rattler/config.toml`) with the pixi file
+/// ([`config_path_system`]) on top.
+pub fn system_config_locations() -> Vec<ConfigLocation> {
+    layer_locations(
+        vec![shared_system_config_path()],
+        vec![config_path_system()],
+    )
+}
+
+/// Pair up the shared and pixi files of one level, shared first so that the
+/// pixi file wins. A path in both is only visited as a pixi file, which
+/// accepts a superset of the shared keys.
+fn layer_locations(shared: Vec<PathBuf>, tool: Vec<PathBuf>) -> Vec<ConfigLocation> {
+    let shared: Vec<PathBuf> = shared
+        .into_iter()
+        .filter(|path| !tool.contains(path))
+        .collect();
+
+    shared
+        .into_iter()
+        .map(|path| ConfigLocation {
+            path,
+            layer: ConfigLayer::Shared,
+        })
+        .chain(tool.into_iter().map(|path| ConfigLocation {
+            path,
+            layer: ConfigLayer::Tool,
+        }))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use indexmap::IndexMap;
@@ -3012,6 +3198,129 @@ UNUSED = "unused"
         config = config.merge_config(other);
         assert_eq!(config, original_other);
     }
+    #[test]
+    fn test_from_shared_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs_err::write(
+            &path,
+            r#"
+            default-channels = ["conda-forge"]
+            tls-no-verify = true
+            pinning-strategy = "no-pin"
+
+            [shell]
+            force-activate = true
+            "#,
+        )
+        .unwrap();
+
+        let config = Config::from_shared_path(&path).unwrap();
+
+        // Common keys are honored.
+        assert_eq!(
+            config.default_channels,
+            vec![NamedChannelOrUrl::from_str("conda-forge").unwrap()]
+        );
+        assert_eq!(config.tls_no_verify, Some(true));
+        // Pixi-only keys are ignored in shared files, even though pixi
+        // understands them in its own files.
+        assert_eq!(config.pinning_strategy, None);
+        assert_eq!(config.shell, ShellConfig::default());
+        assert_eq!(config.loaded_from, vec![path]);
+    }
+
+    #[test]
+    fn test_from_shared_path_keeps_deprecated_tls_root_certs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs_err::write(&path, "tls-root-certs = \"native\"\n").unwrap();
+
+        // The deprecated spelling still resolves to the system store, which
+        // is what the warning tells the user to write instead.
+        let config = Config::from_shared_path(&path).unwrap();
+        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::System));
+    }
+
+    #[test]
+    fn test_from_shared_path_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.toml");
+
+        assert!(matches!(
+            Config::from_shared_path(&path),
+            Err(ConfigError::FileNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_shared_config_loses_against_pixi_config() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let shared_path = dir.path().join("shared.toml");
+        fs_err::write(
+            &shared_path,
+            r#"
+            default-channels = ["shared-channel"]
+            tls-no-verify = true
+            "#,
+        )
+        .unwrap();
+
+        let pixi_path = dir.path().join("pixi.toml");
+        fs_err::write(&pixi_path, "default-channels = [\"pixi-channel\"]\n").unwrap();
+
+        let shared = Config::from_shared_path(&shared_path).unwrap();
+        let pixi = Config::from_path(&pixi_path).unwrap();
+        let config = shared.merge_config(pixi);
+
+        // The pixi file wins where both set a key.
+        assert_eq!(
+            config.default_channels,
+            vec![NamedChannelOrUrl::from_str("pixi-channel").unwrap()]
+        );
+        // Keys only the shared file sets survive.
+        assert_eq!(config.tls_no_verify, Some(true));
+        assert_eq!(config.loaded_from, vec![pixi_path, shared_path]);
+    }
+
+    #[test]
+    fn test_config_search_locations_order() {
+        let locations = config_search_locations();
+
+        // Pixi keeps computing its own paths, so a rebranded build reads the
+        // files it writes.
+        let pixi_paths: Vec<_> = locations
+            .iter()
+            .filter(|location| location.layer == ConfigLayer::Tool)
+            .map(|location| location.path.clone())
+            .collect();
+        let expected: Vec<_> = std::iter::once(config_path_system())
+            .chain(config_path_global())
+            .collect();
+        assert_eq!(pixi_paths, expected);
+
+        // The system files come first, and within each level the shared file
+        // comes before the pixi one.
+        let layers: Vec<_> = locations.iter().map(|location| location.layer).collect();
+        assert_eq!(layers[0], ConfigLayer::Shared);
+        assert_eq!(layers[1], ConfigLayer::Tool);
+        assert_eq!(locations[0].path, shared_system_config_path());
+        assert_eq!(locations[1].path, config_path_system());
+
+        let user_layers = &layers[2..];
+        let first_pixi = user_layers
+            .iter()
+            .position(|layer| *layer == ConfigLayer::Tool)
+            .expect("there is at least one user-level pixi path");
+        assert!(
+            user_layers[first_pixi..]
+                .iter()
+                .all(|layer| *layer == ConfigLayer::Tool),
+            "no shared file may sit above a user-level pixi file"
+        );
+    }
+
     #[test]
     fn test_config_merge_multiple() {
         let mut config = Config::default();

--- a/docs/reference/environment_variables.md
+++ b/docs/reference/environment_variables.md
@@ -30,12 +30,17 @@ Pixi can also be configured via environment variables.
     </tr>
     <tr>
       <td><code>PIXI_NO_CONFIG</code></td>
-      <td>When set to a truthy value (e.g. <code>1</code>), pixi skips loading system and user-level configuration files (such as <code>/etc/pixi/config.toml</code> and <code>~/.pixi/config.toml</code>). Project-local <code>&lt;project&gt;/.pixi/config.toml</code> is still loaded. Equivalent to passing <code>--no-config</code>. Useful in CI, scripts, and tests that need to be insulated from a developer's global settings.</td>
+      <td>When set to a truthy value (e.g. <code>1</code>), pixi skips loading system and user-level configuration files, both pixi's own (such as <code>/etc/pixi/config.toml</code> and <code>~/.pixi/config.toml</code>) and the <a href="pixi_configuration.md#configuration-shared-with-other-rattler-based-tools">shared</a> ones (such as <code>/etc/rattler/config.toml</code>). Project-local <code>&lt;project&gt;/.pixi/config.toml</code> is still loaded. Equivalent to passing <code>--no-config</code>. Useful in CI, scripts, and tests that need to be insulated from a developer's global settings.</td>
       <td>Not set.</td>
     </tr>
     <tr>
       <td><code>PIXI_CONFIG_FILE</code></td>
       <td>Path to a configuration file to load <em>instead of</em> the system and user-level config files. Project-local <code>&lt;project&gt;/.pixi/config.toml</code> is still merged on top. Equivalent to passing <code>--config-file &lt;PATH&gt;</code>.</td>
+      <td>Not set.</td>
+    </tr>
+    <tr>
+      <td><code>RATTLER_HOME</code></td>
+      <td>Directory holding a <a href="pixi_configuration.md#configuration-shared-with-other-rattler-based-tools">shared</a> <code>config.toml</code> that every rattler-based tool reads. It ranks above the other shared locations and below every pixi-specific one.</td>
       <td>Not set.</td>
     </tr>
     <tr>

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -8,36 +8,54 @@ The configuration is loaded in the following order:
 
     | **Priority** | **Location**                                                           | **Comments**                                          |
     |--------------|------------------------------------------------------------------------|-------------------------------------------------------|
-    | 7            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
-    | 6            | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
-    | 5            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
-    | 4            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
-    | 3            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
-    | 2            | `$HOME/.config/pixi/config.toml`                                       | User-specific configuration                           |
-    | 1            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 11           | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
+    | 10           | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
+    | 9            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
+    | 8            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
+    | 7            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
+    | 6            | `$HOME/.config/pixi/config.toml`                                       | User-specific configuration                           |
+    | 5            | `$RATTLER_HOME/config.toml`                                            | Shared configuration, only when `RATTLER_HOME` is set |
+    | 4            | `$XDG_CONFIG_HOME/rattler/config.toml`                                 | Shared XDG compliant user-specific configuration      |
+    | 3            | `$HOME/.config/rattler/config.toml`                                    | Shared user-specific configuration                    |
+    | 2            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 1            | `/etc/rattler/config.toml`                                             | Shared system-wide configuration                      |
 
 === "macOS"
 
     | **Priority** | **Location**                                                           | **Comments**                                          |
     |--------------|------------------------------------------------------------------------|-------------------------------------------------------|
-    | 7            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
-    | 6            | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
-    | 5            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
-    | 4            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
-    | 3            | `$HOME/Library/Application Support/pixi/config.toml`                   | User-specific configuration                           |
-    | 2            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
-    | 1            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 11           | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
+    | 10           | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
+    | 9            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
+    | 8            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
+    | 7            | `$HOME/Library/Application Support/pixi/config.toml`                   | User-specific configuration                           |
+    | 6            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
+    | 5            | `$RATTLER_HOME/config.toml`                                            | Shared configuration, only when `RATTLER_HOME` is set |
+    | 4            | `$HOME/Library/Application Support/rattler/config.toml`                | Shared user-specific configuration                    |
+    | 3            | `$XDG_CONFIG_HOME/rattler/config.toml`                                 | Shared XDG compliant user-specific configuration      |
+    | 2            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 1            | `/etc/rattler/config.toml`                                             | Shared system-wide configuration                      |
 
 === "Windows"
 
     | **Priority** | **Location**                                                           | **Comments**                                          |
     |--------------|------------------------------------------------------------------------|-------------------------------------------------------|
-    | 6            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
-    | 5            | `your_project\.pixi\config.toml`                                       | Project-specific configuration                        |
-    | 4            | `%PIXI_HOME%\config.toml`                                              | Global configuration in `PIXI_HOME`.                  |
-    | 3            | `%USERPROFILE%\.pixi\config.toml`                                      | Global configuration in the user home directory.      |
-    | 2            | `%APPDATA%\pixi\config.toml`                                           | User-specific configuration                           |
-    | 1            | `C:\ProgramData\pixi\config.toml`                                      | System-wide configuration                             |
+    | 9            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
+    | 8            | `your_project\.pixi\config.toml`                                       | Project-specific configuration                        |
+    | 7            | `%PIXI_HOME%\config.toml`                                              | Global configuration in `PIXI_HOME`.                  |
+    | 6            | `%USERPROFILE%\.pixi\config.toml`                                      | Global configuration in the user home directory.      |
+    | 5            | `%APPDATA%\pixi\config.toml`                                           | User-specific configuration                           |
+    | 4            | `%RATTLER_HOME%\config.toml`                                           | Shared configuration, only when `RATTLER_HOME` is set |
+    | 3            | `%APPDATA%\rattler\config.toml`                                        | Shared user-specific configuration                    |
+    | 2            | `C:\ProgramData\pixi\config.toml`                                      | System-wide configuration                             |
+    | 1            | `C:\ProgramData\rattler\config.toml`                                   | Shared system-wide configuration                      |
+
+The `rattler` locations hold the configuration shared by all rattler-based
+tools (Pixi, `rattler-build`, ...). These files may only contain the keys
+every tool understands, like `default-channels`, `mirrors`, `s3-options`, or
+`concurrency`; Pixi-specific keys (like `shell` or `detached-environments`)
+belong in the `pixi` locations and produce a warning when found in a shared
+file.
 
 !!! note
 The highest priority wins. If a configuration file is found in a higher priority location, the values from the

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -8,36 +8,47 @@ The configuration is loaded in the following order:
 
     | **Priority** | **Location**                                                           | **Comments**                                          |
     |--------------|------------------------------------------------------------------------|-------------------------------------------------------|
-    | 7            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
-    | 6            | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
-    | 5            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
-    | 4            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
-    | 3            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
-    | 2            | `$HOME/.config/pixi/config.toml`                                       | User-specific configuration                           |
-    | 1            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 11           | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
+    | 10           | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
+    | 9            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
+    | 8            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
+    | 7            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
+    | 6            | `$HOME/.config/pixi/config.toml`                                       | User-specific configuration                           |
+    | 5            | `$RATTLER_HOME/config.toml`                                            | Shared configuration, only when `RATTLER_HOME` is set |
+    | 4            | `$XDG_CONFIG_HOME/rattler/config.toml`                                 | Shared XDG compliant user-specific configuration      |
+    | 3            | `$HOME/.config/rattler/config.toml`                                    | Shared user-specific configuration                    |
+    | 2            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 1            | `/etc/rattler/config.toml`                                             | Shared system-wide configuration                      |
 
 === "macOS"
 
     | **Priority** | **Location**                                                           | **Comments**                                          |
     |--------------|------------------------------------------------------------------------|-------------------------------------------------------|
-    | 7            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
-    | 6            | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
-    | 5            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
-    | 4            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
-    | 3            | `$HOME/Library/Application Support/pixi/config.toml`                   | User-specific configuration                           |
-    | 2            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
-    | 1            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 11           | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
+    | 10           | `your_project/.pixi/config.toml`                                       | Project-specific configuration                        |
+    | 9            | `$PIXI_HOME/config.toml`                                               | Global configuration in `PIXI_HOME`.                  |
+    | 8            | `$HOME/.pixi/config.toml`                                              | Global configuration in the user home directory.      |
+    | 7            | `$HOME/Library/Application Support/pixi/config.toml`                   | User-specific configuration                           |
+    | 6            | `$XDG_CONFIG_HOME/pixi/config.toml`                                    | XDG compliant user-specific configuration             |
+    | 5            | `$RATTLER_HOME/config.toml`                                            | Shared configuration, only when `RATTLER_HOME` is set |
+    | 4            | `$HOME/Library/Application Support/rattler/config.toml`                | Shared user-specific configuration                    |
+    | 3            | `$XDG_CONFIG_HOME/rattler/config.toml`                                 | Shared XDG compliant user-specific configuration      |
+    | 2            | `/etc/pixi/config.toml`                                                | System-wide configuration                             |
+    | 1            | `/etc/rattler/config.toml`                                             | Shared system-wide configuration                      |
 
 === "Windows"
 
     | **Priority** | **Location**                                                           | **Comments**                                          |
     |--------------|------------------------------------------------------------------------|-------------------------------------------------------|
-    | 6            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
-    | 5            | `your_project\.pixi\config.toml`                                       | Project-specific configuration                        |
-    | 4            | `%PIXI_HOME%\config.toml`                                              | Global configuration in `PIXI_HOME`.                  |
-    | 3            | `%USERPROFILE%\.pixi\config.toml`                                      | Global configuration in the user home directory.      |
-    | 2            | `%APPDATA%\pixi\config.toml`                                           | User-specific configuration                           |
-    | 1            | `C:\ProgramData\pixi\config.toml`                                      | System-wide configuration                             |
+    | 9            | Command line arguments (`--tls-no-verify`, `--change-ps1=false`, etc.) | Configuration via command line arguments              |
+    | 8            | `your_project\.pixi\config.toml`                                       | Project-specific configuration                        |
+    | 7            | `%PIXI_HOME%\config.toml`                                              | Global configuration in `PIXI_HOME`.                  |
+    | 6            | `%USERPROFILE%\.pixi\config.toml`                                      | Global configuration in the user home directory.      |
+    | 5            | `%APPDATA%\pixi\config.toml`                                           | User-specific configuration                           |
+    | 4            | `%RATTLER_HOME%\config.toml`                                           | Shared configuration, only when `RATTLER_HOME` is set |
+    | 3            | `%APPDATA%\rattler\config.toml`                                        | Shared user-specific configuration                    |
+    | 2            | `C:\ProgramData\pixi\config.toml`                                      | System-wide configuration                             |
+    | 1            | `C:\ProgramData\rattler\config.toml`                                   | Shared system-wide configuration                      |
 
 !!! note
 The highest priority wins. If a configuration file is found in a higher priority location, the values from the
@@ -46,6 +57,12 @@ configuration read from lower priority locations are overwritten.
 !!! note
 To find the locations where `pixi` looks for configuration files, run
 `pixi info -vvv`.
+
+### Configuration shared with other rattler-based tools
+
+The `rattler` locations are read by every rattler-based tool, so a setting placed there applies to Pixi and `rattler-build` alike.
+They accept only the options that all of these tools understand, such as `default-channels`, `mirrors`, `s3-options` and `concurrency`.
+Options that only Pixi knows, like `shell` or `detached-environments`, belong in a `pixi` location; in a `rattler` file Pixi ignores them and warns about it.
 
 ### Skipping or overriding config discovery
 

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -523,6 +523,108 @@ def test_cli_config_options(
     )
 
 
+def isolated_config_env(tmp_path: Path) -> dict[str, str]:
+    """Point every configuration search path at a private directory.
+
+    The shared and pixi files are addressed through `RATTLER_HOME` and
+    `PIXI_HOME`, the only locations that are env-driven on every platform;
+    `dirs::config_dir` does not follow `XDG_CONFIG_HOME` on Windows. The
+    remaining variables keep the developer's own files out of the run.
+    """
+    home = tmp_path / "home"
+    rattler_home = home / ".rattler"
+    pixi_home = home / ".pixi"
+    xdg = home / "xdg"
+    for directory in (rattler_home, pixi_home, xdg):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    return {
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "XDG_CONFIG_HOME": str(xdg),
+        "RATTLER_HOME": str(rattler_home),
+        "PIXI_HOME": str(pixi_home),
+    }
+
+
+def test_config_shared_layer(pixi: Path, tmp_path: Path) -> None:
+    """A shared config file is read, loses against a pixi file, and is never
+    forked into one by `pixi config set`."""
+    env = isolated_config_env(tmp_path)
+    shared_config = Path(env["RATTLER_HOME"]) / "config.toml"
+    pixi_config = Path(env["PIXI_HOME"]) / "config.toml"
+
+    shared_config.write_text(
+        'default-channels = ["shared-channel"]\ntls-no-verify = true\npinning-strategy = "no-pin"\n'
+    )
+    pixi_config.write_text('default-channels = ["pixi-channel"]\n')
+
+    # The pixi file wins, keys only the shared file sets are still used, and a
+    # pixi-only key in a shared file is ignored with a warning.
+    verify_cli_command(
+        [pixi, "config", "list"],
+        env=env,
+        stdout_contains=['default-channels = ["pixi-channel"]', "tls-no-verify = true"],
+        stdout_excludes="shared-channel",
+        stderr_contains="pinning-strategy",
+    )
+
+    # Setting an unrelated key must not copy the shared settings into the pixi
+    # file, otherwise the user silently stops following the shared layer.
+    verify_cli_command([pixi, "config", "set", "--global", "shell.change-ps1", "false"], env=env)
+    written = tomli.loads(pixi_config.read_text())
+    assert written == {"default-channels": ["pixi-channel"], "shell": {"change-ps1": False}}
+
+    # Both layers are reported, and opting out skips the shared one as well.
+    verify_cli_command(
+        [pixi, "info"],
+        env=env,
+        stdout_contains=[str(shared_config), str(pixi_config)],
+    )
+    verify_cli_command(
+        [pixi, "info", "--no-config"],
+        env=env,
+        stdout_excludes=[str(shared_config), str(pixi_config)],
+    )
+
+
+def test_config_append_extends_the_visible_list(pixi: Path, tmp_path: Path) -> None:
+    """`config append` extends the list the user sees, exactly once, for both
+    the keys that replace lower layers and the ones that concatenate."""
+    env = isolated_config_env(tmp_path)
+    workspace = tmp_path / "home" / "workspace"
+    workspace.mkdir(parents=True)
+
+    # `default-channels` replaces lower layers, `extra-index-urls` concatenates.
+    (Path(env["RATTLER_HOME"]) / "config.toml").write_text(
+        'default-channels = ["shared-channel"]\n'
+    )
+    (Path(env["PIXI_HOME"]) / "config.toml").write_text(
+        '[pypi-config]\nextra-index-urls = ["https://global.example/simple"]\n'
+    )
+    manifest = workspace / "pixi.toml"
+    manifest.write_text('[workspace]\nname = "p"\nchannels = []\nplatforms = ["linux-64"]\n')
+
+    for key, added in [
+        ("default-channels", "extra-channel"),
+        ("pypi-config.extra-index-urls", "https://mine.example/simple"),
+    ]:
+        verify_cli_command(
+            [pixi, "config", "append", "--local", "--manifest-path", manifest, key, added],
+            env=env,
+        )
+
+    listed = verify_cli_command(
+        [pixi, "config", "list", "--manifest-path", manifest], env=env
+    ).stdout
+    config = tomli.loads(listed)
+    assert config["default-channels"] == ["shared-channel", "extra-channel"]
+    assert config["pypi-config"]["extra-index-urls"] == [
+        "https://global.example/simple",
+        "https://mine.example/simple",
+    ]
+
+
 def test_config_allow_links(pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str) -> None:
     """Test that allow-*-links config keys can be set, read, and unset via the CLI."""
     manifest_path = tmp_pixi_workspace / "pixi.toml"


### PR DESCRIPTION
### Description

Pixi and `rattler-build` understand largely the same settings: mirrors, S3 options, default channels, TLS.
With conda/rattler#2645 there is now a **shared config layer** these tools additionally read: `/etc/rattler/config.toml` and `$XDG_CONFIG_HOME/rattler/config.toml`.

- Read the shared locations, each merged with a lower priority than pixi-specific counterpart
- Pixi keeps computing its own paths, so a rebranded build (`PIXI_CONFIG_DIR`, `PIXI_DIR`) still reads the files it writes
- `pixi config list --system` now covers the whole system layer, not just `/etc/pixi/config.toml`
- Document the new locations, what belongs in them, and `RATTLER_HOME`


### How Has This Been Tested?

- Added tests, including an integration test covering precedence, the ignored-key warning, and the `config set` fix
- Still need to user test this

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
