### PR TITLE
fix(reporters): log CEP-42 user-order conflicts at debug level

### DIFF
--- a/crates/pixi_reporters/src/repodata_reporter.rs
+++ b/crates/pixi_reporters/src/repodata_reporter.rs
@@ -8,7 +8,9 @@ use std::{
 use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle, style::ProgressTracker};
 use parking_lot::RwLock;
 use pixi_progress::ProgressBarPlacement;
-use rattler_repodata_gateway::{DownloadReporter, GatewayWarning, UnsupportedRepodataRevision};
+use rattler_repodata_gateway::{
+    ChannelRelationsWarning, DownloadReporter, GatewayWarning, UnsupportedRepodataRevision,
+};
 use url::Url;
 
 #[derive(Clone)]
@@ -27,7 +29,14 @@ impl rattler_repodata_gateway::Reporter for RepodataReporter {
     }
 
     fn on_gateway_warning(&self, warning: &GatewayWarning) {
-        tracing::warn!("{warning}");
+        match warning {
+            // CEP-42 makes the user's channel order authoritative, so an
+            // overridden relation is the specified outcome, not a problem.
+            GatewayWarning::ChannelRelations(ChannelRelationsWarning::UserOrderConflict {
+                ..
+            }) => tracing::debug!("{warning}"),
+            _ => tracing::warn!("{warning}"),
+        }
     }
 }
 


### PR DESCRIPTION
`on_gateway_warning` logged every `GatewayWarning` at warn level, so a relation that the explicit channel order overrides produced a line per resolve:

    WARN CEP-42 relation `https://prefix.dev/conda-forge/` ->
    `https://prefix.dev/robostack-noetic/` contradicts the explicit
    channel order and was ignored

CEP-42 makes the user order authoritative, so this is the specified outcome rather than a problem. Take a workspace where conda-forge is the default channel and a feature adds a robostack channel on top: the robostack channel declares conda-forge as its base, which contradicts the order the manifest asks for. Neither dropping the channel nor reordering it is an option, so the warning had no remedy.

`UserOrderConflict` now goes to debug; every other gateway warning still warns.

### How Has This Been Tested?

By running it :-)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
