### PR TITLE
fix(pixi-build-cmake): Small fixes to better handle paths containing spaces

### DIFF
--- a/crates/pixi_build_cmake/src/build_script.j2
+++ b/crates/pixi_build_cmake/src/build_script.j2
@@ -7,6 +7,10 @@
 {%- set build_dir = "build" -%}
 {%- set library_prefix =  "%LIBRARY_PREFIX%" if build_platform == "windows" else "$PREFIX" -%}
 
+{# `${PYTHON_ARG:+...}` and `%PYTHON_ARG%` both vanish when the probe below
+   found no interpreter -#}
+{%- set python_arg = "%PYTHON_ARG%" if is_cmd_exe else "${PYTHON_ARG:+\"$PYTHON_ARG\"}" -%}
+
 {# Set up default CMake arguments -#}
 {%- set cmake_args = [
     env("CMAKE_ARGS"),
@@ -16,6 +20,7 @@
     "-DCMAKE_INSTALL_PREFIX=\"" ~ library_prefix ~ "\"",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
     "-DBUILD_SHARED_LIBS=ON",
+    python_arg,
 ] + extra_args
 -%}
 
@@ -25,12 +30,19 @@ cmake --version
 
 {# Point CMake at the python interpreter when one is present in the host
    environment. $PYTHON is set by rattler-build whether or not python is
-   installed, so the probe has to test the filesystem. -#}
+   installed, so the probe has to test the filesystem.
+
+   The flag is kept in its own variable rather than appended to CMAKE_ARGS,
+   which is expanded unquoted below: a path holding a space would be split
+   into two arguments there, and quoting it inside the string would not help,
+   as the shell removes no quotes from the result of an expansion. -#}
 {% if is_cmd_exe -%}
-if exist "%PYTHON%" set "CMAKE_ARGS=%CMAKE_ARGS% -DPython_EXECUTABLE=%PYTHON%"
+set PYTHON_ARG=
+if exist "%PYTHON%" set PYTHON_ARG=-DPython_EXECUTABLE="%PYTHON%"
 {% else -%}
+PYTHON_ARG=
 if [ -x "$PYTHON" ]; then
-    CMAKE_ARGS="$CMAKE_ARGS -DPython_EXECUTABLE=$PYTHON"
+    PYTHON_ARG=-DPython_EXECUTABLE="$PYTHON"
 fi
 {% endif -%}
 

--- a/crates/pixi_build_cmake/src/build_script.j2
+++ b/crates/pixi_build_cmake/src/build_script.j2
@@ -13,7 +13,7 @@
     "-GNinja",
     "-S \"" ~ source_dir ~ "\"",
     "-DCMAKE_BUILD_TYPE=Release",
-    "-DCMAKE_INSTALL_PREFIX=" ~ library_prefix,
+    "-DCMAKE_INSTALL_PREFIX=\"" ~ library_prefix ~ "\"",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
     "-DBUILD_SHARED_LIBS=ON",
 ] + extra_args

--- a/crates/pixi_build_cmake/src/build_script.rs
+++ b/crates/pixi_build_cmake/src/build_script.rs
@@ -90,7 +90,7 @@ mod test {
     /// This is what proves the quoting works rather than merely being present:
     /// the shell, not a string comparison, decides where the arguments split.
     #[cfg(unix)]
-    fn configure_arguments(prefix: &str) -> Vec<String> {
+    fn configure_arguments(prefix: &str, python: Option<&str>) -> Vec<String> {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().expect("failed to create a temp dir");
@@ -119,7 +119,18 @@ mod test {
             .env("PATH", format!("{}:/usr/bin:/bin", dir.path().display()))
             .env("PREFIX", prefix)
             .env("CMAKE_ARGS", "")
-            .env("PYTHON", dir.path().join("no-such-python"))
+            .env(
+                "PYTHON",
+                python.map_or_else(
+                    || {
+                        dir.path()
+                            .join("no-such-python")
+                            .to_string_lossy()
+                            .into_owned()
+                    },
+                    str::to_string,
+                ),
+            )
             .output()
             .expect("failed to run the script");
         assert!(
@@ -145,11 +156,70 @@ mod test {
     #[cfg(unix)]
     #[test]
     fn test_configure_gets_a_spaced_prefix_as_one_argument() {
-        let arguments = configure_arguments("/tmp/a prefix with spaces");
+        let arguments = configure_arguments("/tmp/a prefix with spaces", None);
 
         assert!(
             arguments.contains(&"-DCMAKE_INSTALL_PREFIX=/tmp/a prefix with spaces".to_string()),
             "the prefix was split up: {arguments:?}"
+        );
+    }
+
+    /// The interpreter flag must not go through CMAKE_ARGS, which the
+    /// configure step expands unquoted and would split on the space.
+    #[test]
+    fn test_the_python_flag_bypasses_cmake_args() {
+        for platform in [BuildPlatform::Unix, BuildPlatform::Windows] {
+            let script = render(platform);
+            assert!(
+                !script.contains("CMAKE_ARGS% -DPython_EXECUTABLE")
+                    && !script.contains("CMAKE_ARGS -DPython_EXECUTABLE"),
+                "the interpreter is appended to CMAKE_ARGS on {platform}"
+            );
+            assert!(
+                script.contains("PYTHON_ARG"),
+                "the interpreter flag has no variable of its own on {platform}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_configure_gets_a_spaced_interpreter_as_one_argument() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // The probe only passes the flag on for an executable file.
+        let home = tempfile::tempdir().expect("failed to create a temp dir");
+        let python = home.path().join("a dir with spaces").join("python");
+        fs_err::create_dir_all(python.parent().unwrap()).unwrap();
+        fs_err::write(&python, "#!/bin/sh\nexit 0\n").unwrap();
+        let mut permissions = fs_err::metadata(&python).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs_err::set_permissions(&python, permissions).unwrap();
+
+        let arguments = configure_arguments("/tmp/prefix", Some(&python.to_string_lossy()));
+
+        assert!(
+            arguments.contains(&format!("-DPython_EXECUTABLE={}", python.display())),
+            "the interpreter path was split up: {arguments:?}"
+        );
+    }
+
+    /// Without an interpreter the flag must vanish rather than arrive empty,
+    /// which would make cmake complain about an unparsable definition.
+    #[cfg(unix)]
+    #[test]
+    fn test_configure_gets_no_python_flag_without_an_interpreter() {
+        let arguments = configure_arguments("/tmp/prefix", None);
+
+        assert!(
+            !arguments
+                .iter()
+                .any(|argument| argument.contains("Python_EXECUTABLE")),
+            "an interpreter flag was passed anyway: {arguments:?}"
+        );
+        assert!(
+            !arguments.iter().any(|argument| argument.is_empty()),
+            "an empty argument reached cmake: {arguments:?}"
         );
     }
 }

--- a/crates/pixi_build_cmake/src/build_script.rs
+++ b/crates/pixi_build_cmake/src/build_script.rs
@@ -59,4 +59,97 @@ mod test {
             insta::assert_snapshot!(script);
         });
     }
+
+    /// Renders the script for a platform.
+    fn render(build_platform: BuildPlatform) -> String {
+        BuildScriptContext {
+            build_platform,
+            source_dir: String::from("/src/demo"),
+            extra_args: vec![],
+        }
+        .render()
+    }
+
+    /// An install prefix holding a space must reach cmake as one argument, so
+    /// the value has to be quoted in the script.
+    #[test]
+    fn test_the_install_prefix_is_quoted() {
+        assert!(
+            render(BuildPlatform::Unix).contains(r#"-DCMAKE_INSTALL_PREFIX="$PREFIX""#),
+            "the unix install prefix is unquoted"
+        );
+        assert!(
+            render(BuildPlatform::Windows).contains(r#"-DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%""#),
+            "the windows install prefix is unquoted"
+        );
+    }
+
+    /// Runs a rendered script with stubs on PATH instead of a real toolchain,
+    /// and returns the arguments the configure step passed to cmake.
+    ///
+    /// This is what proves the quoting works rather than merely being present:
+    /// the shell, not a string comparison, decides where the arguments split.
+    #[cfg(unix)]
+    fn configure_arguments(prefix: &str) -> Vec<String> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("failed to create a temp dir");
+        let record = dir.path().join("argv");
+
+        let write_stub = |name: &str, body: &str| {
+            let path = dir.path().join(name);
+            fs_err::write(&path, body).expect("failed to write a stub");
+            let mut permissions = fs_err::metadata(&path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs_err::set_permissions(&path, permissions).expect("failed to chmod a stub");
+        };
+        write_stub(
+            "cmake",
+            "#!/bin/sh\n{ echo '--- invocation'; for arg in \"$@\"; do echo \"$arg\"; done; } >> \"$ARGV_RECORD\"\nexit 0\n",
+        );
+        write_stub("ninja", "#!/bin/sh\nexit 0\n");
+
+        let script = dir.path().join("build.sh");
+        fs_err::write(&script, render(BuildPlatform::Unix)).expect("failed to write the script");
+
+        let output = std::process::Command::new("bash")
+            .arg(&script)
+            .current_dir(dir.path())
+            .env("ARGV_RECORD", &record)
+            .env("PATH", format!("{}:/usr/bin:/bin", dir.path().display()))
+            .env("PREFIX", prefix)
+            .env("CMAKE_ARGS", "")
+            .env("PYTHON", dir.path().join("no-such-python"))
+            .output()
+            .expect("failed to run the script");
+        assert!(
+            output.status.success(),
+            "the script failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        // The configure call is the invocation that names the source directory.
+        let recorded = fs_err::read_to_string(&record).expect("the stub recorded nothing");
+        recorded
+            .split("--- invocation\n")
+            .map(|invocation| {
+                invocation
+                    .lines()
+                    .map(str::to_string)
+                    .collect::<Vec<String>>()
+            })
+            .find(|arguments| arguments.iter().any(|argument| argument == "-S"))
+            .expect("no configure invocation was recorded")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_configure_gets_a_spaced_prefix_as_one_argument() {
+        let arguments = configure_arguments("/tmp/a prefix with spaces");
+
+        assert!(
+            arguments.contains(&"-DCMAKE_INSTALL_PREFIX=/tmp/a prefix with spaces".to_string()),
+            "the prefix was split up: {arguments:?}"
+        );
+    }
 }

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-no-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-no-extra-args.snap
@@ -16,7 +16,7 @@ if [ ! -f "build.ninja" ]; then
         -GNinja \
         -S "my-prefix-dir" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=$PREFIX \
+        -DCMAKE_INSTALL_PREFIX="$PREFIX" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DBUILD_SHARED_LIBS=ON
 fi

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-no-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-no-extra-args.snap
@@ -5,8 +5,9 @@ expression: script
 ninja --version
 cmake --version
 
+PYTHON_ARG=
 if [ -x "$PYTHON" ]; then
-    CMAKE_ARGS="$CMAKE_ARGS -DPython_EXECUTABLE=$PYTHON"
+    PYTHON_ARG=-DPython_EXECUTABLE="$PYTHON"
 fi
 mkdir -p build
 pushd build
@@ -18,7 +19,8 @@ if [ ! -f "build.ninja" ]; then
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX="$PREFIX" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        -DBUILD_SHARED_LIBS=ON
+        -DBUILD_SHARED_LIBS=ON \
+        ${PYTHON_ARG:+"$PYTHON_ARG"}
 fi
 
 cmake --build . --target install

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-with-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-with-extra-args.snap
@@ -16,7 +16,7 @@ if [ ! -f "build.ninja" ]; then
         -GNinja \
         -S "my-prefix-dir" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=$PREFIX \
+        -DCMAKE_INSTALL_PREFIX="$PREFIX" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DBUILD_SHARED_LIBS=ON \
         test-arg

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-with-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@unix-with-extra-args.snap
@@ -5,8 +5,9 @@ expression: script
 ninja --version
 cmake --version
 
+PYTHON_ARG=
 if [ -x "$PYTHON" ]; then
-    CMAKE_ARGS="$CMAKE_ARGS -DPython_EXECUTABLE=$PYTHON"
+    PYTHON_ARG=-DPython_EXECUTABLE="$PYTHON"
 fi
 mkdir -p build
 pushd build
@@ -19,6 +20,7 @@ if [ ! -f "build.ninja" ]; then
         -DCMAKE_INSTALL_PREFIX="$PREFIX" \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DBUILD_SHARED_LIBS=ON \
+        ${PYTHON_ARG:+"$PYTHON_ARG"} \
         test-arg
 fi
 

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-no-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-no-extra-args.snap
@@ -5,7 +5,8 @@ expression: script
 ninja --version
 cmake --version
 
-if exist "%PYTHON%" set "CMAKE_ARGS=%CMAKE_ARGS% -DPython_EXECUTABLE=%PYTHON%"
+set PYTHON_ARG=
+if exist "%PYTHON%" set PYTHON_ARG=-DPython_EXECUTABLE="%PYTHON%"
 if not exist build mkdir build
 pushd build
 
@@ -16,7 +17,8 @@ if not exist build.ninja (
         -DCMAKE_BUILD_TYPE=Release ^
         -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
-        -DBUILD_SHARED_LIBS=ON
+        -DBUILD_SHARED_LIBS=ON ^
+        %PYTHON_ARG%
     @if errorlevel 1 exit 1
 )
 

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-no-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-no-extra-args.snap
@@ -14,7 +14,7 @@ if not exist build.ninja (
         -GNinja ^
         -S "my-prefix-dir" ^
         -DCMAKE_BUILD_TYPE=Release ^
-        -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+        -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
         -DBUILD_SHARED_LIBS=ON
     @if errorlevel 1 exit 1

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-with-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-with-extra-args.snap
@@ -14,7 +14,7 @@ if not exist build.ninja (
         -GNinja ^
         -S "my-prefix-dir" ^
         -DCMAKE_BUILD_TYPE=Release ^
-        -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+        -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
         -DBUILD_SHARED_LIBS=ON ^
         test-arg

--- a/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-with-extra-args.snap
+++ b/crates/pixi_build_cmake/src/snapshots/pixi_build_cmake__build_script__test__build_script@windows-with-extra-args.snap
@@ -5,7 +5,8 @@ expression: script
 ninja --version
 cmake --version
 
-if exist "%PYTHON%" set "CMAKE_ARGS=%CMAKE_ARGS% -DPython_EXECUTABLE=%PYTHON%"
+set PYTHON_ARG=
+if exist "%PYTHON%" set PYTHON_ARG=-DPython_EXECUTABLE="%PYTHON%"
 if not exist build mkdir build
 pushd build
 
@@ -17,6 +18,7 @@ if not exist build.ninja (
         -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ^
         -DBUILD_SHARED_LIBS=ON ^
+        %PYTHON_ARG% ^
         test-arg
     @if errorlevel 1 exit 1
 )


### PR DESCRIPTION
### Description

Path escaping fixes for PREFIX and Python interpreter.

### How Has This Been Tested?

New unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
