### PR TITLE
fix: scope the build source check to the package that declares it

### DIFF
--- a/crates/pixi/tests/integration_rust/source_package_tests.rs
+++ b/crates/pixi/tests/integration_rust/source_package_tests.rs
@@ -14,6 +14,7 @@ use crate::{
     setup_tracing,
 };
 use pixi_cli::publish;
+use pixi_core::{UpdateLockFileOptions, environment::LockFileUsage};
 use pixi_test_utils::{GitRepoFixture, MockRepoData, Package, format_diagnostic};
 
 fn write_source_package_manifest(path: &std::path::Path, name: &str, version: &str, extra: &str) {
@@ -2711,6 +2712,432 @@ subdirectory = "."
     assert_eq!(
         extract_git_build_sources(&pixi.lock_file().await.unwrap()),
         new_sources,
+    );
+}
+
+/// A lock file stores the commit a git reference resolved to, not the
+/// reference as written. A manifest pinning an abbreviated `rev` must still
+/// satisfy its own lock, otherwise `--locked` rejects a lock that re-locking
+/// reproduces unchanged.
+#[tokio::test]
+async fn test_abbreviated_git_rev_build_source_keeps_lock_satisfied() {
+    setup_tracing();
+
+    let fixture = GitRepoFixture::new("lock-behaviour-base");
+    let short_rev = fixture.git(&["rev-parse", "--short", "HEAD"]);
+    let full_rev = fixture.git(&["rev-parse", "HEAD"]);
+    assert_ne!(short_rev, full_rev, "expected an abbreviated revision");
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    fs::write(
+        pixi.manifest_path(),
+        format!(
+            r#"
+[workspace]
+channels = []
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "." }}
+
+[package]
+name = "my-package"
+version = "0.1.0"
+
+[package.build]
+backend = {{ name = "passthrough", version = "*" }}
+
+[package.build.source]
+git = "{git_url}"
+subdirectory = "."
+rev = "{short_rev}"
+"#,
+            platform = Platform::current(),
+            git_url = &fixture.base_url,
+        ),
+    )
+    .unwrap();
+
+    write_lock(&pixi).await;
+
+    // Twice: the first proves the lock is satisfied, the second that the first
+    // did not quietly rewrite it.
+    assert_locked_accepts_unchanged(&pixi, "short rev spelling, first check").await;
+    assert_locked_accepts_unchanged(&pixi, "short rev spelling, second check").await;
+}
+
+/// Regression test for gh-6727: a workspace `[package]` that no environment
+/// includes, next to a dependency of the same name. The included package's
+/// build source comes from its own manifest, so the lock stays satisfied. The
+/// uninvolved `[package]` must not be compared against it.
+#[tokio::test]
+async fn test_unincluded_workspace_package_shares_name_with_dependency() {
+    setup_tracing();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    // The dependency: `my-package` builds from a subdirectory, so the lock
+    // records a build source for it.
+    let dependency_dir = pixi.workspace_path().join("dependency");
+    let dependency_source_dir = dependency_dir.join("src");
+    fs::create_dir_all(&dependency_source_dir).unwrap();
+    fs::write(
+        dependency_dir.join("pixi.toml"),
+        r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+source.path = "src"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        dependency_source_dir.join("pixi.toml"),
+        r#"
+[package]
+name = "my-package"
+version = "1.0.0"
+
+[package.build]
+backend = { name = "in-memory", version = "0.1.0" }
+"#,
+    )
+    .unwrap();
+
+    // The workspace declares its own `my-package` without a build source and
+    // never depends on it.
+    fs::write(
+        pixi.manifest_path(),
+        format!(
+            r#"
+[workspace]
+channels = []
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[dependencies]
+my-package = {{ path = "./dependency" }}
+
+[package]
+name = "my-package"
+version = "0.1.0"
+
+[package.build]
+backend = {{ name = "in-memory", version = "0.1.0" }}
+"#,
+            platform = Platform::current(),
+        ),
+    )
+    .unwrap();
+
+    write_lock(&pixi).await;
+    assert_locked_accepts_unchanged(&pixi, "same-named package outside the environment").await;
+}
+
+/// The raw bytes of the workspace's lock file.
+fn lock_text(pixi: &PixiControl) -> String {
+    fs::read_to_string(pixi.workspace_path().join("pixi.lock")).unwrap()
+}
+
+/// Every path-typed `package_build_source` in the given environment, sorted.
+fn path_build_sources_for_env(lock: &LockFile, env_name: &str) -> Vec<String> {
+    let Some(env) = lock.environment(env_name) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for (_, packages) in env.packages_by_platform() {
+        for pkg in packages {
+            let Some(src) = pkg.as_source_conda() else {
+                continue;
+            };
+            if let Some(PackageBuildSource::Path { path }) = &src.package_build_source {
+                out.push(path.to_string());
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Resolve and write the lock file without building a prefix.
+async fn write_lock(pixi: &PixiControl) {
+    pixi.workspace()
+        .unwrap()
+        .update_lock_file(
+            None,
+            UpdateLockFileOptions {
+                lock_file_usage: LockFileUsage::Update,
+                no_install: true,
+                ..UpdateLockFileOptions::default()
+            },
+        )
+        .await
+        .expect("locking must succeed");
+}
+
+/// The `--locked` satisfiability check, without building a prefix. These tests
+/// are about what the lock file is allowed to contain, so installing would only
+/// cost time.
+async fn verify_locked(pixi: &PixiControl) -> miette::Result<()> {
+    pixi.workspace()?
+        .update_lock_file(
+            None,
+            UpdateLockFileOptions {
+                lock_file_usage: LockFileUsage::Locked,
+                no_install: true,
+                ..UpdateLockFileOptions::default()
+            },
+        )
+        .await
+        .map(|_| ())
+}
+
+/// `--locked` must succeed without touching the lock file.
+async fn assert_locked_accepts_unchanged(pixi: &PixiControl, what: &str) {
+    let before = lock_text(pixi);
+    if let Err(err) = verify_locked(pixi).await {
+        panic!("`--locked` must accept the lock ({what}), got: {err:?}");
+    }
+    assert_eq!(
+        lock_text(pixi),
+        before,
+        "a successful --locked check must leave the lock byte-identical ({what})"
+    );
+}
+
+/// `--locked` must fail without touching the lock file; re-locking must then
+/// rewrite the pin, after which `--locked` must succeed.
+async fn assert_rejected_then_relock_accepts(pixi: &PixiControl, what: &str) {
+    let before = lock_text(pixi);
+    assert!(
+        verify_locked(pixi).await.is_err(),
+        "`--locked` must reject the stale lock after {what}"
+    );
+    assert_eq!(
+        lock_text(pixi),
+        before,
+        "a failed --locked check must leave the lock byte-identical ({what})"
+    );
+    write_lock(pixi).await;
+    assert_ne!(
+        lock_text(pixi),
+        before,
+        "re-locking after {what} must rewrite the pinned build source"
+    );
+    if let Err(err) = verify_locked(pixi).await {
+        panic!("`--locked` must accept the refreshed lock after {what}, got: {err:?}");
+    }
+}
+
+/// A branch that gained commits upstream is not drift. The requested reference
+/// is unchanged, so the locked pin is reused and `--locked` keeps accepting.
+#[tokio::test]
+async fn locked_accepts_branch_build_source_after_upstream_moves() {
+    setup_tracing();
+
+    let fixture = GitRepoFixture::new("lock-behaviour-base");
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let dep_dir = pixi.workspace_path().join("dep-package");
+    fs::create_dir_all(&dep_dir).unwrap();
+    write_source_package_manifest(
+        &dep_dir,
+        "dep-package",
+        "1.0.0",
+        &format!(
+            r#"
+[package.build.source]
+git = "{}"
+subdirectory = "."
+branch = "main"
+"#,
+            fixture.base_url,
+        ),
+    );
+    write_source_workspace_manifest(&pixi.manifest_path(), &[], &["dep-package"]);
+
+    write_lock(&pixi).await;
+    assert_locked_accepts_unchanged(&pixi, "branch freshly pinned").await;
+
+    // Advance `main` past the pinned commit.
+    fs::write(fixture.repo_path.join("README.md"), "upstream moved\n").unwrap();
+    fixture.git(&["commit", "-am", "upstream moved"]);
+
+    assert_locked_accepts_unchanged(&pixi, "branch moved upstream, pin must be reused").await;
+}
+
+/// A different `source.path` builds different code, so it must invalidate the
+/// lock.
+#[tokio::test]
+async fn locked_rejects_changed_build_source_subdirectory() {
+    setup_tracing();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let dep_dir = pixi.workspace_path().join("dep-package");
+    for subdir in ["src", "src2"] {
+        let path = dep_dir.join(subdir);
+        fs::create_dir_all(&path).unwrap();
+        write_source_package_manifest(&path, "dep-package", "1.0.0", "");
+    }
+    write_source_package_manifest(&dep_dir, "dep-package", "1.0.0", r#"source.path = "src""#);
+    write_source_workspace_manifest(&pixi.manifest_path(), &[], &["dep-package"]);
+
+    write_lock(&pixi).await;
+    assert_locked_accepts_unchanged(&pixi, "source.path = src").await;
+
+    write_source_package_manifest(&dep_dir, "dep-package", "1.0.0", r#"source.path = "src2""#);
+    assert_rejected_then_relock_accepts(&pixi, "changing source.path from src to src2").await;
+
+    assert_eq!(
+        path_build_sources_for_env(
+            &pixi.lock_file().await.unwrap(),
+            consts::DEFAULT_ENVIRONMENT_NAME
+        ),
+        vec!["src2".to_string()],
+        "after the re-lock the new subdirectory must be recorded"
+    );
+}
+
+/// Build source drift two hops out, in a source dependency of a source
+/// dependency, must invalidate the lock: the check follows each record's own
+/// manifest, not the workspace's.
+#[tokio::test]
+async fn locked_rejects_drift_in_source_dependency_of_source_dependency() {
+    setup_tracing();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let outer_dir = pixi.workspace_path().join("outer-pkg");
+    let inner_dir = outer_dir.join("inner");
+    for subdir in ["src", "src2"] {
+        let path = inner_dir.join(subdir);
+        fs::create_dir_all(&path).unwrap();
+        write_source_package_manifest(&path, "inner-pkg", "1.0.0", "");
+    }
+    write_source_package_manifest(&inner_dir, "inner-pkg", "1.0.0", r#"source.path = "src""#);
+    fs::create_dir_all(&outer_dir).unwrap();
+    write_source_package_manifest(
+        &outer_dir,
+        "outer-pkg",
+        "1.0.0",
+        r#"
+[package.run-dependencies]
+inner-pkg = { path = "./inner" }
+"#,
+    );
+    write_source_workspace_manifest(&pixi.manifest_path(), &[], &["outer-pkg"]);
+
+    write_lock(&pixi).await;
+    let lock = pixi.lock_file().await.unwrap();
+    for pkg in ["outer-pkg", "inner-pkg"] {
+        assert!(
+            lock.contains_conda_package(consts::DEFAULT_ENVIRONMENT_NAME, Platform::current(), pkg),
+            "{pkg} must be locked"
+        );
+    }
+    assert_locked_accepts_unchanged(&pixi, "nested source dependency in place").await;
+
+    write_source_package_manifest(&inner_dir, "inner-pkg", "1.0.0", r#"source.path = "src2""#);
+    assert_rejected_then_relock_accepts(
+        &pixi,
+        "changing the build source of a source dependency of a source dependency",
+    )
+    .await;
+}
+
+/// Two packages sharing a name from different locations are tracked
+/// independently. Drifting one invalidates the lock, and the re-lock leaves
+/// the other's pin alone.
+#[tokio::test]
+async fn locked_tracks_same_name_packages_from_different_locations_independently() {
+    setup_tracing();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let pixi = PixiControl::new()
+        .unwrap()
+        .with_backend_override(backend_override);
+
+    let pkg_a_dir = pixi.workspace_path().join("pkg-a");
+    let pkg_b_dir = pixi.workspace_path().join("pkg-b");
+    for path in [
+        pkg_a_dir.join("src"),
+        pkg_b_dir.join("src"),
+        pkg_b_dir.join("src2"),
+    ] {
+        fs::create_dir_all(&path).unwrap();
+        write_source_package_manifest(&path, "shared-pkg", "1.0.0", "");
+    }
+    for dir in [&pkg_a_dir, &pkg_b_dir] {
+        write_source_package_manifest(dir, "shared-pkg", "1.0.0", r#"source.path = "src""#);
+    }
+
+    fs::write(
+        pixi.manifest_path(),
+        format!(
+            r#"
+[workspace]
+channels = []
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+
+[feature.a.dependencies]
+shared-pkg = {{ path = "./pkg-a" }}
+
+[feature.b.dependencies]
+shared-pkg = {{ path = "./pkg-b" }}
+
+[environments]
+env-a = ["a"]
+env-b = ["b"]
+"#,
+            platform = Platform::current(),
+        ),
+    )
+    .unwrap();
+
+    write_lock(&pixi).await;
+    assert_locked_accepts_unchanged(&pixi, "two same-name packages in sync").await;
+
+    // Drift only pkg-b's build source.
+    write_source_package_manifest(&pkg_b_dir, "shared-pkg", "1.0.0", r#"source.path = "src2""#);
+    assert_rejected_then_relock_accepts(
+        &pixi,
+        "changing the build source of one of two same-name packages",
+    )
+    .await;
+
+    let lock = pixi.lock_file().await.unwrap();
+    assert_eq!(
+        path_build_sources_for_env(&lock, "env-a"),
+        vec!["src".to_string()],
+        "the untouched package's pin must survive the re-lock"
+    );
+    assert_eq!(
+        path_build_sources_for_env(&lock, "env-b"),
+        vec!["src2".to_string()],
+        "the drifted package's pin must follow its manifest"
     );
 }
 

--- a/crates/pixi_core/src/lock_file/satisfiability/errors.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/errors.rs
@@ -674,9 +674,16 @@ pub enum PlatformUnsat {
     },
 
     #[error(
-        "the locked package build source for '{0}' does not match the requested build source, {1}"
+        "the build source of '{package}' is locked as {locked}, but its manifest now resolves to {resolved}"
     )]
-    PackageBuildSourceMismatch(String, SourceMismatchError),
+    PackageBuildSourceChanged {
+        /// The source package whose build source drifted.
+        package: String,
+        /// The build source recorded in the lock file.
+        locked: String,
+        /// The build source its manifest resolves to now.
+        resolved: String,
+    },
 
     #[error("the metadata of source package '{0}' changed: {1}")]
     SourcePackageMetadataChanged(String, String),

--- a/crates/pixi_core/src/lock_file/satisfiability/platform.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/platform.rs
@@ -41,8 +41,7 @@ use super::legacy;
 use super::pypi::{lock_pypi_packages, pypi_satisfies_editable, pypi_satisfies_requirement};
 use super::pypi_metadata;
 use super::source_record::{
-    verify_build_source_matches_manifest, verify_immutable_record_identity,
-    verify_partial_source_record_against_backend,
+    verify_immutable_record_identity, verify_partial_source_record_against_backend,
 };
 use crate::{
     lock_file::{
@@ -1314,10 +1313,6 @@ async fn verify_package_platform_satisfiability(
     // looked up from the manifest at install time. This allows different
     // environments in a solve-group to have different editability settings for
     // the same path-based package.
-
-    // Verify the pixi build package's package_build_source matches the manifest.
-    verify_build_source_matches_manifest(ctx.environment, locked_pixi_records)
-        .map_err(CommandDispatcherError::Failed)?;
 
     Ok((
         VerifiedIndividualEnvironment {

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -8,9 +8,7 @@ use pixi_command_dispatcher::{
         pin_compatible::PinCompatibilityMap,
     },
 };
-use pixi_record::{
-    PinnedBuildSourceSpec, PinnedSourceSpec, PixiRecord, SourceMismatchError, SourceRecordData,
-};
+use pixi_record::{PinnedBuildSourceSpec, PixiRecord, SourceRecordData};
 use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceLocationSpec, SpecConversionError};
 use pixi_spec_containers::DependencyMap;
 use rattler_conda_types::{
@@ -23,79 +21,13 @@ use super::platform::{
     VerifySatisfiabilityContext, failed_to_parse_match_spec_unsat,
     spec_conversion_to_match_spec_error,
 };
-use crate::{
-    lock_file::PixiRecordsByName,
-    workspace::{Environment, HasWorkspaceRef},
-};
 
-/// Verify that the current package's build.source in the manifest
-/// matches the lock file's `package_build_source` (if applicable).
-/// Path-based sources are not represented in the lock file's
-/// `package_build_source` and are skipped.
-pub(super) fn verify_build_source_matches_manifest(
-    environment: &Environment<'_>,
-    locked_pixi_records: &PixiRecordsByName,
-) -> Result<(), Box<PlatformUnsat>> {
-    let Some(pkg_manifest) = environment.workspace().package.as_ref() else {
-        return Ok(());
-    };
-    let Some(pkg_name) = &pkg_manifest.value.package.name else {
-        return Ok(());
-    };
-    let package_name = PackageName::new_unchecked(pkg_name);
-    let manifest_source_location = pkg_manifest.value.build.source.clone();
-
-    // Find the source record for the current package in locked conda packages.
-    let Some(record) = locked_pixi_records.by_name(&package_name) else {
-        return Ok(());
-    };
-
-    let PixiRecord::Source(src_record) = record else {
-        return Ok(());
-    };
-
-    let lock_file_source_location = src_record.build_source.clone();
-
-    let ok = Ok(());
-    let error = Err(Box::new(PlatformUnsat::PackageBuildSourceMismatch(
-        src_record.name().as_source().to_string(),
-        SourceMismatchError::SourceTypeMismatch,
-    )));
-    let sat_err = |e| {
-        Box::new(PlatformUnsat::PackageBuildSourceMismatch(
-            src_record.name().as_source().to_string(),
-            e,
-        ))
-    };
-
-    match (
-        manifest_source_location,
-        lock_file_source_location.map(PinnedBuildSourceSpec::into_pinned),
-    ) {
-        (None, None) => ok,
-        (Some(SourceLocationSpec::Url(murl_spec)), Some(PinnedSourceSpec::Url(lurl_spec))) => {
-            lurl_spec.satisfies(&murl_spec).map_err(sat_err)
-        }
-        (
-            Some(SourceLocationSpec::Git(mut mgit_spec)),
-            Some(PinnedSourceSpec::Git(mut lgit_spec)),
-        ) => {
-            // Ignore subdirectory for comparison, they should not
-            // trigger lock file invalidation.
-            mgit_spec.subdirectory = Default::default();
-            lgit_spec.source.subdirectory = Default::default();
-
-            // Ensure that we always compare references.
-            if mgit_spec.rev.is_none() {
-                mgit_spec.rev = Some(pixi_spec::GitReference::DefaultBranch);
-            }
-            lgit_spec.satisfies(&mgit_spec).map_err(sat_err)
-        }
-        (Some(SourceLocationSpec::Path(mpath_spec)), Some(PinnedSourceSpec::Path(lpath_spec))) => {
-            lpath_spec.satisfies(&mpath_spec).map_err(sat_err)
-        }
-        // If they not equal kind we error-out
-        (_, _) => error,
+/// Render a build source for a diagnostic. Without one, a package builds the
+/// checkout its manifest lives in.
+fn describe_build_source(build_source: Option<&PinnedBuildSourceSpec>) -> String {
+    match build_source {
+        Some(build_source) => format!("'{build_source}'"),
+        None => String::from("the source the manifest itself lives in"),
     }
 }
 
@@ -180,6 +112,30 @@ pub(super) async fn verify_partial_source_record_against_backend(
                 ),
             )),
         })?;
+
+    // The query above read `[package.build.source]` from the manifest at this
+    // record's own `manifest_source`, and resolved where it points. It only
+    // honors the pin we passed in while that pin still matches what the
+    // manifest asks for, so a different result means the manifest now points
+    // at other source code than the lock was built from. Note that the
+    // manifest itself did not have to move for that: editing its
+    // `[package.build.source]` is enough. A branch that only moved upstream
+    // keeps its reference, so the pin is reused and the lock stays valid.
+    let resolved_build_source = backend_metadata.source.build_source();
+    let unchanged = match (resolved_build_source, record.build_source.as_ref()) {
+        (None, None) => true,
+        (Some(resolved), Some(locked)) => resolved.matches_locked(locked),
+        _ => false,
+    };
+    if !unchanged {
+        return Err(CommandDispatcherError::Failed(Box::new(
+            PlatformUnsat::PackageBuildSourceChanged {
+                package: pkg_name.as_source().to_string(),
+                locked: describe_build_source(record.build_source.as_ref()),
+                resolved: describe_build_source(resolved_build_source),
+            },
+        )));
+    }
 
     // Pick the matching output by (name, variants). Variants are
     // compared after normalizing both sides through `pixi_variant`'s

--- a/crates/pixi_record/src/source_record.rs
+++ b/crates/pixi_record/src/source_record.rs
@@ -228,6 +228,17 @@ impl PinnedBuildSourceSpec {
             PinnedBuildSourceSpec::Relative(_, pinned) => pinned,
         }
     }
+
+    /// Whether both build sources are the same as far as a lock file can tell.
+    ///
+    /// Comparing the specs directly is too strict: writing one to the lock
+    /// drops the `lfs` flag and rewrites a git reference into the commit it
+    /// resolved to, so a pin read back never equals the pin it came from.
+    /// Compare in the lock's own representation instead.
+    pub fn matches_locked(&self, other: &Self) -> bool {
+        build_source_to_package_build_source(Some(self.clone()))
+            == build_source_to_package_build_source(Some(other.clone()))
+    }
 }
 
 impl From<PinnedBuildSourceSpec> for PinnedSourceSpec {
@@ -1273,6 +1284,49 @@ mod tests {
             .finish()
             .render_to_string()
             .expect("failed to render lock file")
+    }
+
+    /// A build source read back from a lock file must still match the pin it
+    /// was written from. A stricter comparison reports a change on every run
+    /// and never converges.
+    #[test]
+    fn build_source_matches_itself_across_a_lock_file() {
+        let commit = "1234567890123456789012345678901234567890";
+        let git_build_source = |reference: GitReference, lfs: Option<bool>| {
+            PinnedBuildSourceSpec::Absolute(PinnedSourceSpec::Git(PinnedGitSpec {
+                git: url::Url::parse("https://example.com/repo.git").expect("valid url"),
+                source: PinnedGitCheckout {
+                    commit: GitSha::from_str(commit).expect("valid sha"),
+                    subdirectory: Default::default(),
+                    reference,
+                    lfs,
+                },
+            }))
+        };
+
+        // What the manifest asked for, freshly resolved.
+        let resolved = git_build_source(GitReference::Rev("1234567".into()), Some(true));
+
+        // The same build source, written to a lock file and read back.
+        let locked = package_build_source_to_build_source(
+            build_source_to_package_build_source(Some(resolved.clone())),
+            &PinnedSourceSpec::Path(PinnedPathSpec {
+                path: "./pkg".into(),
+            }),
+        )
+        .expect("build source round trips")
+        .expect("build source is preserved");
+
+        assert_ne!(
+            resolved, locked,
+            "the round trip is lossy, which is why `matches_locked` exists"
+        );
+        assert!(resolved.matches_locked(&locked));
+        assert!(locked.matches_locked(&resolved));
+
+        // A different commit is a real change and stays visible.
+        let other_commit = git_build_source(GitReference::Branch("main".into()), None);
+        assert!(!other_commit.matches_locked(&locked));
     }
 
     #[test]


### PR DESCRIPTION
### Description

@lucascolley found that if a `pixi.toml` contains a `[package]` that is not actually included, and another source package with the same name is included, the lock file is always invalid.

The cause is `verify_build_source_matches_manifest`: it looked up a locked record **by name** and compared it against the workspace's own `[package].build.source`. With an uninvolved workspace `[package]`, that compares two unrelated packages and can never match.

My first version of this PR removed the check. That turned out to lose real drift detection, because nothing else compares `[package.build.source]` against the lock:

- `verify_immutable_record_identity` recomputes its hash from the locked record's own fields, so it reproduces the stored value by construction.
- `verify_partial_source_record_against_backend` passes the locked pin in as `preferred_build_source`, so the metadata query resolves against the locked commit instead of what the manifest asks for.

The result was silent: point `[package.build.source]` at a different branch, run `pixi install --locked`, and it installs the previously locked commit without a word. `test_git_path_lock_behaviour` covers exactly that and fails with the check removed.

So the check moved instead of disappearing. `build_backend_metadata` already discovers the manifest at each record's own `manifest_source` and resolves the build source that manifest declares (`resolve_checkouts`), and it already surfaces the result as `BuildBackendMetadata::source`. Comparing that against the locked pin catches drift wherever the package lives, per record, and never looks at an uninvolved workspace `[package]`.

The comparison goes through the new `PinnedBuildSourceSpec::matches_locked`, which compares in the lock file's own representation rather than comparing the pins directly. A lock cannot store the `lfs` flag and records a git reference as the commit it resolved to, so a stricter comparison rejects locks that re-locking reproduces byte for byte. Concretely: a manifest pinning an abbreviated `rev` would produce a lock that could never satisfy `--locked` again.

One deliberate behaviour change: a git `subdirectory` edit now invalidates the lock, where the removed check explicitly ignored it. A different subdirectory builds different code, and `matches_source_spec` already treats subdirectory as significant, so re-pinning happened anyway.

Fixes #6727

### How Has This Been Tested?

New regression test for the reported bug, `test_unincluded_workspace_package_shares_name_with_dependency`. It fails on `main` with "lock file not up-to-date with the workspace" straight after a successful `pixi lock`, and passes here.

New tests around the check itself:

- `test_abbreviated_git_rev_build_source_keeps_lock_satisfied`: a short `rev` must survive the lock round trip. Fails without `matches_locked`.
- `locked_accepts_branch_build_source_after_upstream_moves`: a branch moving upstream is not drift, the pin is reused.
- `locked_rejects_changed_build_source_subdirectory`
- `locked_rejects_drift_in_source_dependency_of_source_dependency`: drift two hops out from the workspace.
- `locked_tracks_same_name_packages_from_different_locations_independently`
- `build_source_matches_itself_across_a_lock_file` in `pixi_record`, a fast unit test for the round trip itself.

`test_git_path_lock_behaviour` passes again. Full `integration_rust` suite green (173 passed, 48 ignored), `pixi_core` 300, `pixi_record` 58. Run with `--test-threads=1`: on Windows the git fixtures in `source_package_tests` are flaky in parallel, on `main` as well.

### AI Disclosure

AI was used for this PR. The original removal was written by hand; the replacement check, the tests, and this description were written with Claude Code, reviewed by me.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
