### PR TITLE
fix(global): report completion shells when verbose

### DIFF
--- a/crates/pixi_global/src/common.rs
+++ b/crates/pixi_global/src/common.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     ffi::OsStr,
     io::Read,
     iter::Peekable,
@@ -381,8 +381,8 @@ pub enum StateChange {
     UpdatedEnvironment(EnvironmentUpdate),
     InstalledShortcut(String),
     UninstalledShortcut(String),
-    AddedCompletion(String),
-    RemovedCompletion(String),
+    AddedCompletion { name: String, shell: String },
+    RemovedCompletion { name: String, shell: String },
 }
 
 #[must_use]
@@ -702,64 +702,36 @@ impl StateChanges {
                             }
                         }
                     }
-                    StateChange::AddedCompletion(name) => {
-                        let mut installed_items = StateChanges::accumulate_changes(
+                    StateChange::AddedCompletion { name, shell } => {
+                        let installed_items = StateChanges::accumulate_changes(
                             &mut iter,
                             |next| match next {
-                                Some(StateChange::AddedCompletion(name)) => Some(name.clone()),
+                                Some(StateChange::AddedCompletion { name, shell }) => {
+                                    Some((name.clone(), shell.clone()))
+                                }
                                 _ => None,
                             },
-                            Some(name.clone()),
+                            Some((name.clone(), shell.clone())),
                         );
 
-                        installed_items.sort();
-
-                        if installed_items.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Exposed completion {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                installed_items[0],
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Exposed completions of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for installed_item in installed_items {
-                                pixi_progress::println!("   - {}", installed_item);
-                            }
+                        if tracing::enabled!(tracing::Level::INFO) {
+                            report_completion_changes(&env_name, "Exposed", installed_items);
                         }
                     }
-                    StateChange::RemovedCompletion(name) => {
-                        let mut uninstalled_items = StateChanges::accumulate_changes(
+                    StateChange::RemovedCompletion { name, shell } => {
+                        let uninstalled_items = StateChanges::accumulate_changes(
                             &mut iter,
                             |next| match next {
-                                Some(StateChange::RemovedCompletion(name)) => Some(name.clone()),
+                                Some(StateChange::RemovedCompletion { name, shell }) => {
+                                    Some((name.clone(), shell.clone()))
+                                }
                                 _ => None,
                             },
-                            Some(name.clone()),
+                            Some((name.clone(), shell.clone())),
                         );
 
-                        uninstalled_items.sort();
-
-                        if uninstalled_items.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Removed completion {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                uninstalled_items[0],
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Removed completions of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for uninstalled_item in uninstalled_items {
-                                pixi_progress::println!("   - {}", uninstalled_item);
-                            }
+                        if tracing::enabled!(tracing::Level::INFO) {
+                            report_completion_changes(&env_name, "Removed", uninstalled_items);
                         }
                     }
                 }
@@ -842,6 +814,33 @@ impl StateChanges {
             }
         }
     }
+}
+
+fn report_completion_changes(
+    env_name: &EnvironmentName,
+    action: &str,
+    completions: Vec<(String, String)>,
+) {
+    pixi_progress::println!(
+        "{}{} completions of environment {}:",
+        console::style(console::Emoji("✔ ", "")).green(),
+        action,
+        env_name.fancy_display()
+    );
+    for (name, shells) in group_completion_changes(completions) {
+        pixi_progress::println!("   - {} ({})", name, shells);
+    }
+}
+
+fn group_completion_changes(completions: Vec<(String, String)>) -> Vec<(String, String)> {
+    let mut grouped = BTreeMap::<String, Vec<String>>::new();
+    for (name, shell) in completions {
+        grouped.entry(name).or_default().push(shell);
+    }
+    grouped
+        .into_iter()
+        .map(|(name, shells)| (name, shells.into_iter().join(", ")))
+        .collect()
 }
 
 impl std::ops::BitOrAssign for StateChanges {
@@ -1114,6 +1113,24 @@ mod tests {
 
     use super::*;
     use crate::trampoline::Configuration;
+
+    #[test]
+    fn group_completion_shells_by_executable() {
+        let completions = vec![
+            ("rattler".to_string(), "bash".to_string()),
+            ("pixi".to_string(), "bash".to_string()),
+            ("rattler".to_string(), "zsh".to_string()),
+            ("rattler".to_string(), "fish".to_string()),
+        ];
+
+        assert_eq!(
+            group_completion_changes(completions),
+            vec![
+                ("pixi".to_string(), "bash".to_string()),
+                ("rattler".to_string(), "bash, zsh, fish".to_string()),
+            ]
+        );
+    }
 
     #[tokio::test]
     async fn test_create() {

--- a/crates/pixi_global/src/completions.rs
+++ b/crates/pixi_global/src/completions.rs
@@ -71,14 +71,16 @@ impl CompletionsDir {
 #[derive(Debug, Clone)]
 pub struct Completion {
     name: String,
+    shell: &'static str,
     source: PathBuf,
     destination: PathBuf,
 }
 
 impl Completion {
-    pub fn new(name: String, source: PathBuf, destination: PathBuf) -> Self {
+    pub fn new(name: String, shell: &'static str, source: PathBuf, destination: PathBuf) -> Self {
         Self {
             name,
+            shell,
             source,
             destination,
         }
@@ -98,7 +100,10 @@ impl Completion {
             .await
             .into_diagnostic()?;
 
-        Ok(Some(StateChange::AddedCompletion(self.name.clone())))
+        Ok(Some(StateChange::AddedCompletion {
+            name: self.name.clone(),
+            shell: self.shell.to_string(),
+        }))
     }
 
     /// Remove the shell completion
@@ -107,7 +112,10 @@ impl Completion {
             .await
             .into_diagnostic()?;
 
-        Ok(StateChange::RemovedCompletion(self.name.clone()))
+        Ok(StateChange::RemovedCompletion {
+            name: self.name.clone(),
+            shell: self.shell.to_string(),
+        })
     }
 }
 
@@ -155,7 +163,12 @@ pub fn contained_completions(
                 .join(bash_path.file_name().wrap_err_with(|| {
                     miette::miette!("Bash completion path needs to have a file name")
                 })?);
-        completion_scripts.push(Completion::new(name.to_string(), bash_path, destination));
+        completion_scripts.push(Completion::new(
+            name.to_string(),
+            "bash",
+            bash_path,
+            destination,
+        ));
     }
 
     if zsh_path.exists() {
@@ -165,7 +178,12 @@ pub fn contained_completions(
                 .join(zsh_path.file_name().wrap_err_with(|| {
                     miette::miette!("Zsh completion path needs to have a file name")
                 })?);
-        completion_scripts.push(Completion::new(name.to_string(), zsh_path, destination));
+        completion_scripts.push(Completion::new(
+            name.to_string(),
+            "zsh",
+            zsh_path,
+            destination,
+        ));
     }
 
     if fish_path.exists() {
@@ -175,7 +193,12 @@ pub fn contained_completions(
                 .join(fish_path.file_name().wrap_err_with(|| {
                     miette::miette!("Fish completion path needs to have a file name")
                 })?);
-        completion_scripts.push(Completion::new(name.to_string(), fish_path, destination));
+        completion_scripts.push(Completion::new(
+            name.to_string(),
+            "fish",
+            fish_path,
+            destination,
+        ));
     }
     Ok(completion_scripts)
 }


### PR DESCRIPTION
### Description

  Fixes #5898

  Suppresses the low-value shell completion summary during normal `pixi global update` output. With verbose logging enabled, the update now reports each exposed or removed completion executable together with
  the shells it applies to.

  ### How Has This Been Tested?

  - `cargo +1.95.0-x86_64-pc-windows-gnu test -p pixi_global group_completion_shells_by_executable`
  - `cargo +1.95.0-x86_64-pc-windows-gnu test -p pixi_global` (63 passed)
  - `cargo +1.95.0-x86_64-pc-windows-gnu fmt --all -- --check`
  - `git diff --check`

  Workspace Clippy could not finish because the Windows build volume ran out of space while compiling dependencies. It had not reached project diagnostics.

  ### AI Disclosure

  - [ ] This PR contains AI-generated content.
    - [ ] I have tested any AI-generated content in my PR.
    - [ ] I take responsibility for any AI-generated content in my PR.