### PR TITLE
docs(conda&pypi): suggest constraints not dependencies

### DIFF
--- a/docs/concepts/conda_pypi.md
+++ b/docs/concepts/conda_pypi.md
@@ -230,14 +230,16 @@ Error:   × failed to solve the pypi requirements of environment 'default' for p
         typing-extensions==4.15.0
 ```
 
-A solution in this case would be to add to the conda dependencies `typing-extensions < 4.15`,
+A solution in this case would be to add to the conda constraints `typing-extensions < 4.15`,
 that is, the same constraint imposed by the PyPI package(s):
 
 ```toml title="pixi.toml"
 [dependencies]
 some-conda-package = "*"  #  depends on any typing-extensions
-typing_extensions = "<4.15"
+
+[constraints]
+typing_extensions = "<4.15"  # bring some-pypi-package pypi constraint to conda
 
 [pypi-dependencies]
-some-pypi-package = "==0.1.0"  # depends on typing-extensions<4.14
+some-pypi-package = "==0.1.0"  # depends on typing-extensions<4.15
 ```


### PR DESCRIPTION
### Description

Minor docs update.
I would suggest to use `[constraints]` over `[dependencies]` for transitive dependencies, as it stays transitive this way.

### How Has This Been Tested?

not tested, just changing the dummy example based on reading the docs on [`[constraints]`](https://pixi.prefix.dev/latest/reference/pixi_manifest/#constraints)

### AI Disclosure
This PR doesn't contain AI-generated content.

### Checklist:
- [x] I have made corresponding changes to the documentation
