### PR TITLE
test: Use temp-var consistently

### DIFF
--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -1785,23 +1785,8 @@ mod tests {
         }
     }
 
-    struct EnvVarGuard;
-
-    // prevents race conditions on the env variable PIXI_OVERRIDE_PLATFORM
-    static ENV_VAR_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            unsafe {
-                std::env::remove_var(consts::PIXI_OVERRIDE_PLATFORM);
-            }
-        }
-    }
-
     #[test]
     fn test_best_declared_platform_override_env_var() {
-        let _lock = ENV_VAR_MUTEX.lock().unwrap();
-
         let temp_dir = tempfile::tempdir().unwrap();
         let contents = r#"
         [project]
@@ -1810,30 +1795,30 @@ mod tests {
         platforms = []
         "#;
         let workspace = Workspace::from_str(&temp_dir.path().join("pixi.toml"), contents).unwrap();
-        unsafe {
-            std::env::set_var(consts::PIXI_OVERRIDE_PLATFORM, "linux-aarch64");
-        }
-        let _guard = EnvVarGuard;
 
-        let env = workspace.default_environment();
-        // No declared platforms → None even with a valid override.
-        assert!(env.best_declared_platform().is_none());
-        // The host_platform helper honours the override.
-        assert_eq!(
-            workspace
-                .host_platform(
-                    PlatformSource::Defaults,
-                    PlatformOverrides::EnvironmentVariableOverrides
-                )
-                .subdir(),
-            Platform::LinuxAarch64,
+        temp_env::with_var(
+            consts::PIXI_OVERRIDE_PLATFORM,
+            Some("linux-aarch64"),
+            || {
+                let env = workspace.default_environment();
+                // No declared platforms → None even with a valid override.
+                assert!(env.best_declared_platform().is_none());
+                // The host_platform helper honours the override.
+                assert_eq!(
+                    workspace
+                        .host_platform(
+                            PlatformSource::Defaults,
+                            PlatformOverrides::EnvironmentVariableOverrides
+                        )
+                        .subdir(),
+                    Platform::LinuxAarch64,
+                );
+            },
         );
     }
 
     #[test]
     fn test_best_declared_platform_override_invalid_value() {
-        let _lock = ENV_VAR_MUTEX.lock().unwrap();
-
         let temp_dir = tempfile::tempdir().unwrap();
         let contents = r#"
         [project]
@@ -1842,23 +1827,26 @@ mod tests {
         platforms = []
         "#;
         let workspace = Workspace::from_str(&temp_dir.path().join("pixi.toml"), contents).unwrap();
-        unsafe {
-            std::env::set_var(consts::PIXI_OVERRIDE_PLATFORM, "not-a-platform");
-        }
-        let _guard = EnvVarGuard;
 
-        let env = workspace.default_environment();
-        // No declared platforms → None regardless of the (invalid) override.
-        assert!(env.best_declared_platform().is_none());
-        // The host_platform helper still falls back to Platform::current() on invalid values.
-        assert_eq!(
-            workspace
-                .host_platform(
-                    PlatformSource::Defaults,
-                    PlatformOverrides::EnvironmentVariableOverrides
-                )
-                .subdir(),
-            Platform::current(),
+        temp_env::with_var(
+            consts::PIXI_OVERRIDE_PLATFORM,
+            Some("not-a-platform"),
+            || {
+                let env = workspace.default_environment();
+                // No declared platforms → None regardless of the (invalid) override.
+                assert!(env.best_declared_platform().is_none());
+                // The host_platform helper still falls back to Platform::current()
+                // on invalid values.
+                assert_eq!(
+                    workspace
+                        .host_platform(
+                            PlatformSource::Defaults,
+                            PlatformOverrides::EnvironmentVariableOverrides
+                        )
+                        .subdir(),
+                    Platform::current(),
+                );
+            },
         );
     }
 }


### PR DESCRIPTION
Do not try to poorly re-implement safe access to
env vars. We have pre-existing helpers for that.

Makes the test less flaky.

### How Has This Been Tested?

By running the tests repeatedly.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
