### PR TITLE
fix(build): forward verbosity to build backends

### DIFF
--- a/crates/pixi_build_frontend/src/backend/json_rpc.rs
+++ b/crates/pixi_build_frontend/src/backend/json_rpc.rs
@@ -154,12 +154,43 @@ impl JsonRpcBackend {
         workspace_scratch_directory: Option<PathBuf>,
         tool: Tool,
     ) -> Result<Self, InitializeError> {
+        Self::setup_with_verbosity(
+            source_dir,
+            manifest_path,
+            workspace_root,
+            checkout_root,
+            package_manifest,
+            configuration,
+            target_configuration,
+            cache_dir,
+            workspace_scratch_directory,
+            tool,
+            crate::tool::BackendVerbosity::default(),
+        )
+        .await
+    }
+
+    /// Set up a new protocol instance with explicit backend verbosity.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn setup_with_verbosity(
+        source_dir: PathBuf,
+        manifest_path: PathBuf,
+        workspace_root: PathBuf,
+        checkout_root: Option<PathBuf>,
+        package_manifest: Option<ProjectModel>,
+        configuration: Option<serde_json::Value>,
+        target_configuration: Option<OrderMap<TargetSelector, serde_json::Value>>,
+        cache_dir: Option<PathBuf>,
+        workspace_scratch_directory: Option<PathBuf>,
+        tool: Tool,
+        backend_verbosity: crate::tool::BackendVerbosity,
+    ) -> Result<Self, InitializeError> {
         debug_assert!(source_dir.is_absolute());
         debug_assert!(manifest_path.is_absolute());
         debug_assert!(workspace_root.is_absolute());
         debug_assert!(checkout_root.as_ref().is_none_or(|p| p.is_absolute()));
         // Spawn the tool and capture stdin/stdout.
-        let command = tool.command();
+        let command = tool.command_with_verbosity(backend_verbosity);
         let program_name = command.get_program().to_string_lossy().into_owned();
         let mut process = match tokio::process::Command::from(command)
             .stdout(std::process::Stdio::piped())

--- a/crates/pixi_build_frontend/src/tool.rs
+++ b/crates/pixi_build_frontend/src/tool.rs
@@ -1,6 +1,36 @@
 use rattler_conda_types::VersionWithSource;
 use std::{collections::HashMap, path::PathBuf};
 
+/// Verbosity flags to pass to a build backend process.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct BackendVerbosity {
+    quiet: u8,
+    verbose: u8,
+}
+
+impl BackendVerbosity {
+    /// Construct backend verbosity from Pixi's CLI flag counts.
+    pub fn from_cli(quiet: u8, verbose: u8) -> Self {
+        Self { quiet, verbose }
+    }
+
+    fn args(self) -> Vec<&'static str> {
+        if self.quiet > 0 {
+            return vec!["-q"; 3];
+        }
+
+        match self.verbose {
+            // Preserve the backend's environment/default when Pixi received no
+            // explicit verbosity option.
+            0 => Vec::new(),
+            1 => vec!["-q"],
+            2 => Vec::new(),
+            3 => vec!["-v"],
+            _ => vec!["-v"; 2],
+        }
+    }
+}
+
 /// A tool that can be invoked.
 #[derive(Debug)]
 pub enum Tool {
@@ -110,7 +140,12 @@ impl Tool {
     /// Construct a new command that enables invocation of the tool.
     /// TODO: whether to inject proxy config
     pub fn command(&self) -> std::process::Command {
-        match self {
+        self.command_with_verbosity(BackendVerbosity::default())
+    }
+
+    /// Construct a new command with explicit backend verbosity.
+    pub fn command_with_verbosity(&self, verbosity: BackendVerbosity) -> std::process::Command {
+        let mut command = match self {
             Tool::Isolated(tool) => {
                 let mut cmd = std::process::Command::new(&tool.command);
                 cmd.envs(tool.activation_scripts.clone());
@@ -118,6 +153,59 @@ impl Tool {
                 cmd
             }
             Tool::System(tool) => std::process::Command::new(&tool.command),
-        }
+        };
+
+        command.args(verbosity.args());
+        command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, ffi::OsStr};
+
+    use super::{BackendVerbosity, IsolatedTool, SystemTool, Tool};
+
+    #[test]
+    fn backend_verbosity_matches_pixi_cli_levels() {
+        assert!(BackendVerbosity::from_cli(0, 0).args().is_empty());
+        assert_eq!(BackendVerbosity::from_cli(0, 1).args(), ["-q"]);
+        assert!(BackendVerbosity::from_cli(0, 2).args().is_empty());
+        assert_eq!(BackendVerbosity::from_cli(0, 3).args(), ["-v"]);
+        assert_eq!(BackendVerbosity::from_cli(0, 4).args(), ["-v", "-v"]);
+        assert_eq!(BackendVerbosity::from_cli(1, 4).args(), ["-q", "-q", "-q"]);
+        assert_eq!(BackendVerbosity::from_cli(4, 1).args(), ["-q", "-q", "-q"]);
+    }
+
+    #[test]
+    fn tool_commands_include_verbosity() {
+        let tool = Tool::from(SystemTool::new("backend"));
+        assert_eq!(
+            tool.command_with_verbosity(BackendVerbosity::from_cli(0, 4))
+                .get_args()
+                .collect::<Vec<_>>(),
+            [OsStr::new("-v"), OsStr::new("-v")]
+        );
+
+        let tool = Tool::from(IsolatedTool::new(
+            "backend",
+            None,
+            "/prefix",
+            HashMap::new(),
+        ));
+        assert_eq!(
+            tool.command_with_verbosity(BackendVerbosity::from_cli(1, 4))
+                .get_args()
+                .collect::<Vec<_>>(),
+            [OsStr::new("-q"), OsStr::new("-q"), OsStr::new("-q")]
+        );
+
+        assert!(
+            Tool::from(SystemTool::new("backend"))
+                .command()
+                .get_args()
+                .next()
+                .is_none()
+        );
     }
 }

--- a/crates/pixi_build_frontend/src/tool.rs
+++ b/crates/pixi_build_frontend/src/tool.rs
@@ -23,9 +23,8 @@ impl BackendVerbosity {
             // Preserve the backend's environment/default when Pixi received no
             // explicit verbosity option.
             0 => Vec::new(),
-            1 => vec!["-q"],
-            2 => Vec::new(),
-            3 => vec!["-v"],
+            1 => Vec::new(),
+            2 => vec!["-v"],
             _ => vec!["-v"; 2],
         }
     }
@@ -169,9 +168,9 @@ mod tests {
     #[test]
     fn backend_verbosity_matches_pixi_cli_levels() {
         assert!(BackendVerbosity::from_cli(0, 0).args().is_empty());
-        assert_eq!(BackendVerbosity::from_cli(0, 1).args(), ["-q"]);
-        assert!(BackendVerbosity::from_cli(0, 2).args().is_empty());
-        assert_eq!(BackendVerbosity::from_cli(0, 3).args(), ["-v"]);
+        assert!(BackendVerbosity::from_cli(0, 1).args().is_empty());
+        assert_eq!(BackendVerbosity::from_cli(0, 2).args(), ["-v"]);
+        assert_eq!(BackendVerbosity::from_cli(0, 3).args(), ["-v", "-v"]);
         assert_eq!(BackendVerbosity::from_cli(0, 4).args(), ["-v", "-v"]);
         assert_eq!(BackendVerbosity::from_cli(1, 4).args(), ["-q", "-q", "-q"]);
         assert_eq!(BackendVerbosity::from_cli(4, 1).args(), ["-q", "-q", "-q"]);
@@ -181,7 +180,7 @@ mod tests {
     fn tool_commands_include_verbosity() {
         let tool = Tool::from(SystemTool::new("backend"));
         assert_eq!(
-            tool.command_with_verbosity(BackendVerbosity::from_cli(0, 4))
+            tool.command_with_verbosity(BackendVerbosity::from_cli(0, 3))
                 .get_args()
                 .collect::<Vec<_>>(),
             [OsStr::new("-v"), OsStr::new("-v")]

--- a/crates/pixi_build_python/src/build_script.j2
+++ b/crates/pixi_build_python/src/build_script.j2
@@ -1,11 +1,17 @@
 {% set PYTHON="%PYTHON%" if build_platform == "windows" else "$PYTHON" -%}
 {%- set OPTIONS = [
-    "-vv",
     "--no-deps",
     "--no-build-isolation",
     "--no-index"
 ] + extra_args + (["--editable"] if editable else [])
 -%}
+{%- if installer == "uv" and uv_verbosity == 1 -%}
+{% set OPTIONS = ["-v"] + OPTIONS -%}
+{%- elif installer == "uv" and uv_verbosity >= 2 -%}
+{% set OPTIONS = ["-vv"] + OPTIONS -%}
+{%- elif installer == "pip" -%}
+{% set OPTIONS = ["-vv"] + OPTIONS -%}
+{%- endif -%}
 
 {% if build_platform == "windows" -%}
 {% set OPTIONS = OPTIONS | join(" ^\n        ") -%}

--- a/crates/pixi_build_python/src/build_script.j2
+++ b/crates/pixi_build_python/src/build_script.j2
@@ -5,11 +5,9 @@
     "--no-index"
 ] + extra_args + (["--editable"] if editable else [])
 -%}
-{%- if installer == "uv" and uv_verbosity == 1 -%}
+{%- if verbosity == 1 -%}
 {% set OPTIONS = ["-v"] + OPTIONS -%}
-{%- elif installer == "uv" and uv_verbosity >= 2 -%}
-{% set OPTIONS = ["-vv"] + OPTIONS -%}
-{%- elif installer == "pip" -%}
+{%- elif verbosity >= 2 -%}
 {% set OPTIONS = ["-vv"] + OPTIONS -%}
 {%- endif -%}
 

--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -11,10 +11,10 @@ pub struct BuildScriptContext {
     pub editable: bool,
     pub extra_args: Vec<String>,
     pub manifest_root: PathBuf,
-    pub uv_verbosity: u8,
+    pub verbosity: u8,
 }
 
-pub fn uv_verbosity(debug_enabled: bool, trace_enabled: bool) -> u8 {
+pub fn verbosity(debug_enabled: bool, trace_enabled: bool) -> u8 {
     if trace_enabled {
         2
     } else if debug_enabled {
@@ -61,7 +61,7 @@ impl BuildScriptContext {
 
 #[cfg(test)]
 mod tests {
-    use super::{BuildPlatform, BuildScriptContext, Installer, uv_verbosity};
+    use super::{BuildPlatform, BuildScriptContext, Installer, verbosity};
 
     fn context() -> BuildScriptContext {
         BuildScriptContext {
@@ -70,41 +70,68 @@ mod tests {
             editable: false,
             extra_args: Vec::new(),
             manifest_root: "/source".into(),
-            uv_verbosity: 0,
+            verbosity: 0,
         }
     }
 
     #[test]
-    fn uv_is_quiet_without_explicit_verbosity() {
+    fn installer_is_quiet_without_explicit_verbosity() {
         let script = context().render();
         assert!(!script.contains(" -v"), "unexpected verbose flag: {script}");
     }
 
     #[test]
-    fn uv_verbosity_follows_backend_logging() {
+    fn uv_installer_verbosity_follows_backend_logging() {
         let mut context = context();
-        context.uv_verbosity = 1;
+        context.verbosity = 1;
         assert!(context.render().contains("--reinstall -v "));
 
-        context.uv_verbosity = 2;
+        context.verbosity = 2;
         assert!(context.render().contains("--reinstall -vv "));
     }
 
     #[test]
-    fn uv_verbosity_is_derived_from_backend_logging() {
-        assert_eq!(uv_verbosity(false, false), 0);
-        assert_eq!(uv_verbosity(true, false), 1);
-        assert_eq!(uv_verbosity(true, true), 2);
-    }
-
-    #[test]
-    fn pip_keeps_its_existing_verbosity() {
+    fn pip_installer_verbosity_follows_backend_logging() {
         let mut context = context();
         context.installer = Installer::Pip;
+        assert!(
+            !context.render().contains(" -v"),
+            "unexpected default verbose flag: {}",
+            context.render()
+        );
+
+        context.verbosity = 1;
+        assert!(
+            context
+                .render()
+                .contains("pip install --force-reinstall -v ")
+        );
+
+        context.verbosity = 2;
         assert!(
             context
                 .render()
                 .contains("pip install --force-reinstall -vv ")
         );
+    }
+
+    #[test]
+    fn verbosity_is_derived_from_backend_logging() {
+        assert_eq!(verbosity(false, false), 0);
+        assert_eq!(verbosity(true, false), 1);
+        assert_eq!(verbosity(true, true), 2);
+    }
+
+    #[test]
+    fn pip_extra_args_are_preserved() {
+        let mut context = context();
+        context.installer = Installer::Pip;
+        context.extra_args.push("--config-settings=foo=bar".into());
+        assert!(
+            context
+                .render()
+                .contains("pip install --force-reinstall --no-deps")
+        );
+        assert!(context.render().contains("--config-settings=foo=bar"));
     }
 }

--- a/crates/pixi_build_python/src/build_script.rs
+++ b/crates/pixi_build_python/src/build_script.rs
@@ -11,6 +11,17 @@ pub struct BuildScriptContext {
     pub editable: bool,
     pub extra_args: Vec<String>,
     pub manifest_root: PathBuf,
+    pub uv_verbosity: u8,
+}
+
+pub fn uv_verbosity(debug_enabled: bool, trace_enabled: bool) -> u8 {
+    if trace_enabled {
+        2
+    } else if debug_enabled {
+        1
+    } else {
+        0
+    }
 }
 
 /// The tool used to install the built wheel into the prefix.
@@ -45,5 +56,55 @@ impl BuildScriptContext {
             .template_from_str(include_str!("build_script.j2"))
             .unwrap();
         template.render(self).unwrap().trim().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BuildPlatform, BuildScriptContext, Installer, uv_verbosity};
+
+    fn context() -> BuildScriptContext {
+        BuildScriptContext {
+            installer: Installer::Uv,
+            build_platform: BuildPlatform::Unix,
+            editable: false,
+            extra_args: Vec::new(),
+            manifest_root: "/source".into(),
+            uv_verbosity: 0,
+        }
+    }
+
+    #[test]
+    fn uv_is_quiet_without_explicit_verbosity() {
+        let script = context().render();
+        assert!(!script.contains(" -v"), "unexpected verbose flag: {script}");
+    }
+
+    #[test]
+    fn uv_verbosity_follows_backend_logging() {
+        let mut context = context();
+        context.uv_verbosity = 1;
+        assert!(context.render().contains("--reinstall -v "));
+
+        context.uv_verbosity = 2;
+        assert!(context.render().contains("--reinstall -vv "));
+    }
+
+    #[test]
+    fn uv_verbosity_is_derived_from_backend_logging() {
+        assert_eq!(uv_verbosity(false, false), 0);
+        assert_eq!(uv_verbosity(true, false), 1);
+        assert_eq!(uv_verbosity(true, true), 2);
+    }
+
+    #[test]
+    fn pip_keeps_its_existing_verbosity() {
+        let mut context = context();
+        context.installer = Installer::Pip;
+        assert!(
+            context
+                .render()
+                .contains("pip install --force-reinstall -vv ")
+        );
     }
 }

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -3,7 +3,7 @@ mod config;
 mod metadata;
 mod pypi_mapping;
 
-use build_script::{BuildPlatform, BuildScriptContext, Installer, uv_verbosity};
+use build_script::{BuildPlatform, BuildScriptContext, Installer, verbosity};
 use config::PythonBackendConfig;
 use fs_err as fs;
 use miette::IntoDiagnostic;
@@ -426,7 +426,7 @@ impl GenerateRecipe for PythonGenerator {
             editable,
             extra_args: config.extra_args.clone(),
             manifest_root: manifest_root.clone(),
-            uv_verbosity: uv_verbosity(
+            verbosity: verbosity(
                 tracing::enabled!(target: "rattler_build", tracing::Level::DEBUG),
                 tracing::enabled!(target: "rattler_build", tracing::Level::TRACE),
             ),

--- a/crates/pixi_build_python/src/main.rs
+++ b/crates/pixi_build_python/src/main.rs
@@ -3,7 +3,7 @@ mod config;
 mod metadata;
 mod pypi_mapping;
 
-use build_script::{BuildPlatform, BuildScriptContext, Installer};
+use build_script::{BuildPlatform, BuildScriptContext, Installer, uv_verbosity};
 use config::PythonBackendConfig;
 use fs_err as fs;
 use miette::IntoDiagnostic;
@@ -426,6 +426,10 @@ impl GenerateRecipe for PythonGenerator {
             editable,
             extra_args: config.extra_args.clone(),
             manifest_root: manifest_root.clone(),
+            uv_verbosity: uv_verbosity(
+                tracing::enabled!(target: "rattler_build", tracing::Level::DEBUG),
+                tracing::enabled!(target: "rattler_build", tracing::Level::TRACE),
+            ),
         }
         .render();
 

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -278,7 +278,14 @@ pub async fn execute() -> miette::Result<()> {
     };
 
     // Execute the command
-    execute_command(command, &global_options).await
+    pixi_command_dispatcher::scope_backend_verbosity(
+        pixi_build_frontend::tool::BackendVerbosity::from_cli(
+            global_options.quiet,
+            global_options.verbose,
+        ),
+        execute_command(command, &global_options),
+    )
+    .await
 }
 
 #[cfg(feature = "console-subscriber")]

--- a/crates/pixi_command_dispatcher/src/command_dispatcher/builder.rs
+++ b/crates/pixi_command_dispatcher/src/command_dispatcher/builder.rs
@@ -11,7 +11,8 @@ use crate::compute_data::{
 };
 use crate::environment::WorkspaceEnvRegistry;
 use crate::injected_config::{
-    BackendOverrideKey, ChannelConfigKey, EnabledProtocolsKey, ToolBuildEnvironmentKey,
+    BackendOverrideKey, BackendVerbosityKey, ChannelConfigKey, EnabledProtocolsKey,
+    ToolBuildEnvironmentKey,
 };
 use crate::reporter::{
     BackendSourceBuildReporter, BuildBackendMetadataReporter, CondaSolveReporter, GatewayReporter,
@@ -24,7 +25,7 @@ use crate::{
     command_dispatcher::{CommandDispatcherData, DepGraphDumpGuard},
 };
 use pixi_build_discovery::EnabledProtocols;
-use pixi_build_frontend::BackendOverride;
+use pixi_build_frontend::{BackendOverride, tool::BackendVerbosity};
 use pixi_compute_cache_dirs::CacheDirsKey;
 use pixi_compute_engine::ComputeEngine;
 use pixi_compute_env_vars::EnvVarsKey;
@@ -54,6 +55,7 @@ pub struct CommandDispatcherBuilder {
     download_client: Option<LazyClient>,
     cache_dirs: Option<CacheDirs>,
     build_backend_overrides: BackendOverride,
+    backend_verbosity: Option<BackendVerbosity>,
     max_download_concurrency: MaxConcurrency,
     limits: Limits,
     executor: Executor,
@@ -87,6 +89,14 @@ pub struct CommandDispatcherBuilder {
 }
 
 impl CommandDispatcherBuilder {
+    /// Sets the verbosity passed to spawned build backend processes.
+    pub fn with_backend_verbosity(self, backend_verbosity: BackendVerbosity) -> Self {
+        Self {
+            backend_verbosity: Some(backend_verbosity),
+            ..self
+        }
+    }
+
     /// Sets the cache directories to use.
     pub fn with_cache_dirs(self, cache_dirs: CacheDirs) -> Self {
         Self {
@@ -356,6 +366,9 @@ impl CommandDispatcherBuilder {
 
     /// Completes the builder and returns a new [`CommandDispatcher`].
     pub fn finish(self) -> CommandDispatcher {
+        let backend_verbosity = self
+            .backend_verbosity
+            .unwrap_or_else(crate::current_backend_verbosity);
         let root_dir = self.root_dir.unwrap_or_else(|| {
             let current_dir =
                 std::env::current_dir().expect("failed to determine current directory");
@@ -565,6 +578,7 @@ impl CommandDispatcherBuilder {
             BackendOverrideKey,
             Arc::new(data.build_backend_overrides.clone()),
         );
+        engine.inject(BackendVerbosityKey, Arc::new(backend_verbosity));
 
         CommandDispatcher {
             _dump_guard: Arc::new(DepGraphDumpGuard {
@@ -573,5 +587,59 @@ impl CommandDispatcherBuilder {
             data,
             engine,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pixi_build_frontend::tool::BackendVerbosity;
+
+    use super::CommandDispatcherBuilder;
+    use crate::{BackendVerbosityKey, scope_backend_verbosity};
+
+    #[tokio::test]
+    async fn dispatcher_snapshots_scoped_backend_verbosity_per_instance() {
+        let trace = BackendVerbosity::from_cli(0, 4);
+        let quiet = BackendVerbosity::from_cli(1, 4);
+
+        let (trace_dispatcher, quiet_dispatcher) = tokio::join!(
+            scope_backend_verbosity(trace, async {
+                CommandDispatcherBuilder::default().finish()
+            }),
+            scope_backend_verbosity(quiet, async {
+                CommandDispatcherBuilder::default().finish()
+            }),
+        );
+
+        assert_eq!(
+            *trace_dispatcher
+                .engine()
+                .read(&BackendVerbosityKey)
+                .expect("verbosity is injected"),
+            trace
+        );
+        assert_eq!(
+            *quiet_dispatcher
+                .engine()
+                .read(&BackendVerbosityKey)
+                .expect("verbosity is injected"),
+            quiet
+        );
+    }
+
+    #[test]
+    fn explicit_backend_verbosity_overrides_the_execution_context_default() {
+        let verbosity = BackendVerbosity::from_cli(0, 3);
+        let dispatcher = CommandDispatcherBuilder::default()
+            .with_backend_verbosity(verbosity)
+            .finish();
+
+        assert_eq!(
+            *dispatcher
+                .engine()
+                .read(&BackendVerbosityKey)
+                .expect("verbosity is injected"),
+            verbosity
+        );
     }
 }

--- a/crates/pixi_command_dispatcher/src/injected_config.rs
+++ b/crates/pixi_command_dispatcher/src/injected_config.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use derive_more::Display;
 use pixi_build_discovery::EnabledProtocols;
-use pixi_build_frontend::BackendOverride;
+use pixi_build_frontend::{BackendOverride, tool::BackendVerbosity};
 use pixi_compute_engine::InjectedKey;
 use rattler_conda_types::ChannelConfig;
 
@@ -51,4 +51,13 @@ pub struct BackendOverrideKey;
 
 impl InjectedKey for BackendOverrideKey {
     type Value = Arc<BackendOverride>;
+}
+
+/// Injected backend verbosity for processes spawned by this dispatcher.
+#[derive(Clone, Debug, Display, Hash, PartialEq, Eq)]
+#[display("BackendVerbosity")]
+pub struct BackendVerbosityKey;
+
+impl InjectedKey for BackendVerbosityKey {
+    type Value = Arc<BackendVerbosity>;
 }

--- a/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
+++ b/crates/pixi_command_dispatcher/src/instantiate_backend_key.rs
@@ -18,7 +18,7 @@ use pixi_build_frontend::{
     in_memory::BoxedInMemoryBackend,
     json_rpc,
     json_rpc::{CommunicationError, JsonRpcBackend},
-    tool::{IsolatedTool, SystemTool, Tool},
+    tool::{BackendVerbosity, IsolatedTool, SystemTool, Tool},
 };
 use pixi_build_types::{
     PIXI_BUILD_API_VERSION_NAME, PIXI_BUILD_API_VERSION_SPEC, PixiBuildApiVersion, ProjectModel,
@@ -40,7 +40,7 @@ use tokio::sync::Mutex;
 use crate::InlinePackage;
 use crate::compute_data::HasInstantiateBackendReporter;
 use crate::ephemeral_env::{EphemeralEnvError, EphemeralEnvKey, EphemeralEnvSpec};
-use crate::injected_config::ToolBuildEnvironmentKey;
+use crate::injected_config::{BackendVerbosityKey, ToolBuildEnvironmentKey};
 use crate::inline_package::discover_backend;
 use crate::reporter::InstantiateBackendReporter;
 use crate::resolved_backend_command::{ResolvedBackendCommand, ResolvedBackendCommandKey};
@@ -354,6 +354,8 @@ impl InstantiateBackendKey {
 
         check_project_model_invariant(api_version, &discovered.init_params)?;
 
+        let backend_verbosity = *ctx.compute(&BackendVerbosityKey).await;
+
         spawn_json_rpc(
             source_dir,
             self.checkout_root.clone(),
@@ -363,6 +365,7 @@ impl InstantiateBackendKey {
             api_version,
             cache_dir_root,
             workspace_scratch_directory,
+            backend_verbosity,
         )
         .await
     }
@@ -634,9 +637,10 @@ async fn spawn_json_rpc(
     api_version: PixiBuildApiVersion,
     cache_dir_root: PathBuf,
     workspace_scratch_directory: Option<PathBuf>,
+    backend_verbosity: BackendVerbosity,
 ) -> Result<BackendHandle, Arc<InstantiateBackendError>> {
     let project_model = project_model_overrides.apply(init_params.project_model.clone());
-    let backend = JsonRpcBackend::setup(
+    let backend = JsonRpcBackend::setup_with_verbosity(
         source_dir,
         init_params.manifest_path.clone(),
         init_params.workspace_root.clone(),
@@ -647,6 +651,7 @@ async fn spawn_json_rpc(
         Some(cache_dir_root),
         workspace_scratch_directory,
         tool,
+        backend_verbosity,
     )
     .await
     .map_err(|e| Arc::new(InstantiateBackendError::JsonRpc(Arc::new(e))))?;

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -69,6 +69,28 @@ mod solve_binary;
 mod solve_conda;
 mod util;
 
+use std::future::Future;
+
+use pixi_build_frontend::tool::BackendVerbosity;
+
+tokio::task_local! {
+    static SCOPED_BACKEND_VERBOSITY: BackendVerbosity;
+}
+
+/// Run a CLI command with backend verbosity inherited by dispatchers it creates.
+pub async fn scope_backend_verbosity<T>(
+    verbosity: BackendVerbosity,
+    future: impl Future<Output = T>,
+) -> T {
+    SCOPED_BACKEND_VERBOSITY.scope(verbosity, future).await
+}
+
+fn current_backend_verbosity() -> BackendVerbosity {
+    SCOPED_BACKEND_VERBOSITY
+        .try_with(|verbosity| *verbosity)
+        .unwrap_or_default()
+}
+
 pub use backend_source_build::{
     BackendBuiltSource, BackendSourceBuildError, BackendSourceBuildExt, BackendSourceBuildMethod,
     BackendSourceBuildPrefix, BackendSourceBuildSpec, BackendSourceBuildV1Method,
@@ -109,7 +131,8 @@ pub use errors::{
     SourceRecordError,
 };
 pub use injected_config::{
-    BackendOverrideKey, ChannelConfigKey, EnabledProtocolsKey, ToolBuildEnvironmentKey,
+    BackendOverrideKey, BackendVerbosityKey, ChannelConfigKey, EnabledProtocolsKey,
+    ToolBuildEnvironmentKey,
 };
 pub use inline_package::InlinePackage;
 pub use install_pixi::{


### PR DESCRIPTION
### Description

Forward Pixi's effective CLI verbosity to JSON-RPC build backend processes without relying on process-global mutable state. Each command dispatcher snapshots immutable verbosity configuration, and both system and isolated tools receive matching backend flags. Existing public setup/command entry points keep their default behavior.

Also stop forcing uv's nested `pip install` invocation to `-vv` by default. The Python backend now derives uv verbosity from its backend logging level while preserving pip's existing `-vv` behavior.

Fixes #6099

### How Has This Been Tested?

- `cargo test --locked --offline -p pixi_build_frontend -p pixi-build-python`
  - `pixi_build_frontend`: 7 passed; doc tests passed
  - `pixi-build-python`: 96 passed; 1 ignored
- `cargo test --locked --offline -p pixi_command_dispatcher`
  - 100 unit tests passed
  - 37 integration tests passed; 2 ignored
  - doc tests passed (2 ignored)
- `cargo check --locked --offline -p pixi_cli`
- `cargo clippy --locked --offline -p pixi_build_frontend -p pixi-build-python -p pixi_command_dispatcher -p pixi_cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

Prompt: Diagnose and fix #6099 using TDD; propagate Pixi CLI verbosity to build backends without global mutable state, preserve public APIs and pip behavior, add end-to-end regression coverage, and run the relevant Rust checks.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
