### PR TITLE
feat(build): propagate output down-prioritization

### DIFF
--- a/crates/pixi_build_backend/src/intermediate_backend.rs
+++ b/crates/pixi_build_backend/src/intermediate_backend.rs
@@ -488,6 +488,21 @@ where
                     license: recipe.about.license.clone().map(|l| l.to_string()),
                     license_family: recipe.about.license_family.clone(),
                     flags: recipe.build().flags.clone(),
+                    track_features: recipe
+                        .build()
+                        .variant
+                        .down_prioritize_variant
+                        .map(|priority| {
+                            (0..priority.unsigned_abs())
+                                .map(|index| {
+                                    format!(
+                                        "{}-p-{index}",
+                                        recipe.package().name().as_normalized()
+                                    )
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default(),
                     noarch,
                     purls: None,
                     python_site_packages_path: None,

--- a/crates/pixi_build_backend/tests/integration/protocol.rs
+++ b/crates/pixi_build_backend/tests/integration/protocol.rs
@@ -24,6 +24,7 @@ mod imp {
     use pixi_build_backend::generated_recipe::{
         BackendConfig, DefaultMetadataProvider, GenerateRecipe, GeneratedRecipe, PythonParams,
     };
+    use rattler_build_recipe::stage0::Value;
     use rattler_conda_types::ChannelUrl;
     use serde::{Deserialize, Serialize};
     use std::{
@@ -73,8 +74,14 @@ mod imp {
             _workspace_directory: Option<PathBuf>,
             _checkout_root: Option<PathBuf>,
         ) -> miette::Result<GeneratedRecipe> {
-            GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
-                .into_diagnostic()
+            let mut generated =
+                GeneratedRecipe::from_model(model.clone(), &mut DefaultMetadataProvider)
+                    .into_diagnostic()?;
+            if model.name.as_deref() == Some("downprioritized") {
+                generated.recipe.build.variant.down_prioritize_variant =
+                    Some(Value::new_concrete(2, None));
+            }
+            Ok(generated)
         }
     }
 }
@@ -157,6 +164,27 @@ async fn test_conda_build_v1() {
     });
 
     assert!(build_dir.join("debug").join("recipe.yaml").exists());
+}
+
+#[tokio::test]
+async fn test_conda_outputs_exposes_downprioritize_track_features() {
+    let original_model = load_project_model_from_json("minimal_project_model_for_build.json");
+    let mut model = convert_test_model_to_project_model_v1(original_model);
+    model.name = Some("downprioritized".to_string());
+
+    let result = intermediate_conda_outputs::<TestGenerateRecipe>(
+        Some(model),
+        None,
+        Platform::current(),
+        None,
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        result.outputs[0].metadata.track_features,
+        ["downprioritized-p-0", "downprioritized-p-1"]
+    );
 }
 
 #[tokio::test]

--- a/crates/pixi_build_backend_passthrough/src/lib.rs
+++ b/crates/pixi_build_backend_passthrough/src/lib.rs
@@ -620,6 +620,7 @@ fn create_output(
             license: project_model.license.clone(),
             license_family: None,
             flags: index_json.flags.clone(),
+            track_features: index_json.track_features.clone(),
             noarch: index_json.noarch,
             purls: None,
             python_site_packages_path: None,

--- a/crates/pixi_build_rattler_build/src/protocol.rs
+++ b/crates/pixi_build_rattler_build/src/protocol.rs
@@ -198,6 +198,20 @@ impl Protocol for RattlerBuildBackend {
                     license: recipe.about.license.clone().map(|l| l.to_string()),
                     license_family: recipe.about.license_family.clone(),
                     flags: build.flags.clone(),
+                    track_features: build
+                        .variant
+                        .down_prioritize_variant
+                        .map(|priority| {
+                            (0..priority.unsigned_abs())
+                                .map(|index| {
+                                    format!(
+                                        "{}-p-{index}",
+                                        recipe.package().name().as_normalized()
+                                    )
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default(),
                     noarch,
                     purls: None,
                     python_site_packages_path,

--- a/crates/pixi_build_types/src/procedures/conda_outputs.rs
+++ b/crates/pixi_build_types/src/procedures/conda_outputs.rs
@@ -172,6 +172,10 @@ pub struct CondaOutputMetadata {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub flags: Vec<Flag>,
 
+    /// Track features used to down-prioritize this output during solving.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub track_features: Vec<String>,
+
     /// The noarch type of the package
     pub noarch: NoArchType,
 

--- a/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
+++ b/crates/pixi_command_dispatcher/src/build_backend_metadata/mod.rs
@@ -1210,6 +1210,7 @@ mod tests {
                 license: None,
                 license_family: None,
                 flags: Default::default(),
+                track_features: Default::default(),
                 noarch: NoArchType::none(),
                 purls: None,
                 python_site_packages_path: None,

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -434,7 +434,7 @@ async fn assemble_source_record_inner(
             .map(|purls| purls.iter().cloned().collect()),
         python_site_packages_path: output.metadata.python_site_packages_path.clone(),
         features: None,
-        track_features: vec![],
+        track_features: output.metadata.track_features.clone(),
         legacy_bz2_md5: None,
         legacy_bz2_size: None,
         extra_depends,

--- a/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/source_record.rs
@@ -931,7 +931,7 @@ fn build_full_source_record_from_output(
             .map(|purls| purls.iter().cloned().collect()),
         python_site_packages_path: output.metadata.python_site_packages_path.clone(),
         features: None,
-        track_features: vec![],
+        track_features: output.metadata.track_features.clone(),
         legacy_bz2_md5: None,
         legacy_bz2_size: None,
         // Reuse the locked record's already-resolved extras, mirroring how
@@ -1102,6 +1102,7 @@ mod tests {
                 license: None,
                 license_family: None,
                 flags: Default::default(),
+                track_features: Default::default(),
                 noarch: NoArchType::none(),
                 purls: None,
                 python_site_packages_path: None,


### PR DESCRIPTION
### Description

Propagate rattler-build's `build.variant.down_prioritize_variant` through the Pixi build protocol and into source package records.

- adds optional `trackFeatures` metadata to `conda/outputs`
- translates down-prioritization levels into conda track features
- preserves track features while assembling and validating source records
- supports both generated recipes and passthrough/rattler-build backends

This is an additive, serde-defaulted protocol field: new Pixi accepts old backend responses, and old Pixi ignores the unknown field from new backends. Therefore this does not require a `pixi-build-api-version` bump. Older Pixi versions simply do not honor the preference hint.

It might be nice to land this before we bump the pixi-build-api! 

### How Has This Been Tested?

- `cargo test -p pixi_build_backend --test integration test_conda_outputs_exposes_downprioritize_track_features`
- `cargo check -p pixi_build_backend_passthrough -p pixi-build-rattler-build -p pixi_command_dispatcher -p pixi_core --all-targets`
- Clippy with `-D warnings` for all affected crates

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI Codex

Prompt: Add support for propagating down-prioritization metadata through Pixi's build API, as the foundational PR in a stack for Mojo source/precompiled variants.

### Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code where needed
- [x] I have added sufficient tests to cover my changes
- [x] I verified this is an additive build protocol change and does not affect the workspace manifest JSON schema
