### PR TITLE
fix: dedup paths yielded by the glob walk

### DIFF
--- a/crates/pixi_glob/src/glob_set/walk.rs
+++ b/crates/pixi_glob/src/glob_set/walk.rs
@@ -1,6 +1,7 @@
 //! Contains the directory walking implementation
 use itertools::Itertools;
 use parking_lot::Mutex;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -241,6 +242,8 @@ pub fn walk_globs(
         results.append(&mut leaves);
     }
 
+    dedup_matches(&mut results);
+
     // Log some statistics as long as we are unsure with regards to performance
     let matched = results.len();
     let elapsed = start.elapsed();
@@ -259,6 +262,13 @@ pub fn walk_globs(
     );
 
     Ok(results)
+}
+
+/// Drop repeated paths: readdir is not duplicate-free on every filesystem
+/// (e.g. FUSE-backed mounts like virtiofs or NFS under concurrent load).
+fn dedup_matches(results: &mut Vec<Match>) {
+    let mut seen = HashSet::with_capacity(results.len());
+    results.retain(|m| seen.insert(m.path().to_path_buf()));
 }
 
 /// Ensures plain file names behave as "current directory" matches for the ignore crate.
@@ -451,9 +461,12 @@ pub fn set_ignore_hidden_patterns(patterns: &[String]) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use crate::glob_set::Match;
     use crate::glob_set::walk::set_ignore_hidden_patterns;
 
-    use super::anchor_literal_pattern;
+    use super::{anchor_literal_pattern, dedup_matches};
 
     #[test]
     fn anchors_literal_file_patterns() {
@@ -483,6 +496,24 @@ mod tests {
         assert_eq!(
             anchor_literal_pattern("../pixi.toml".to_string()),
             "../pixi.toml"
+        );
+    }
+
+    #[test]
+    fn dedup_matches_collapses_identical_paths() {
+        let mut results = vec![
+            Match::Leaf(PathBuf::from("/ws/pkg_b/package.xml")),
+            Match::Leaf(PathBuf::from("/ws/pkg_a/package.xml")),
+            Match::Leaf(PathBuf::from("/ws/pkg_b/package.xml")),
+        ];
+        dedup_matches(&mut results);
+        let paths: Vec<_> = results.iter().map(Match::path).collect();
+        assert_eq!(
+            paths,
+            vec![
+                std::path::Path::new("/ws/pkg_b/package.xml"),
+                std::path::Path::new("/ws/pkg_a/package.xml"),
+            ]
         );
     }
 


### PR DESCRIPTION

### Description

Readdir is not duplicate-free on every filesystem: FUSE-backed mounts (virtiofs Docker Desktop bind mounts, NFS) can yield the same dirent twice when a directory is listed under concurrent load. The walk then returned the same path twice, making `pixi-build-ros` report a workspace package as a duplicate of itself.

Similar to this issue: https://github.com/macfuse/macfuse/issues/464

The impact of this is hard to measure but we got a report that some can reproduce this on their mac with docker images. 

### How Has This Been Tested?

It's tested in CI, it's not reproducible for me but the change is so minimal that I'm fine trying it out. 

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude fable 5

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
