### PR TITLE
fix: tolerate unusable TLS certificates and quiet the empty SSL_CERT_DIR warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -1205,6 +1205,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -7404,12 +7413,15 @@ dependencies = [
  "rattler_conda_types",
  "rattler_networking",
  "rattler_shell",
+ "rcgen",
  "reqwest",
  "retry-policies",
  "rlimit",
  "rstest",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7417,11 +7429,13 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "tracing-subscriber",
  "url",
  "uv-configuration",
  "webpki-root-certs 1.0.9",
+ "x509-parser",
  "xxhash-rust",
 ]
 
@@ -7725,7 +7739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
@@ -8967,6 +8981,20 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -10987,7 +11015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -13991,6 +14019,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "oid-registry",
+ "ring",
  "rusticata-macros",
  "thiserror 2.0.20",
  "time",
@@ -14074,6 +14103,16 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ lzma-rust2 = { version = "0.19", default-features = false, features = [
   "xz",
 ] }
 rayon = "1.10.0"
+rcgen = "0.14"
 regex = "1.11.1"
 reqwest = { version = "0.13", default-features = false }
 reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5", features = [
@@ -158,6 +159,7 @@ rlimit = "0.11.0"
 roxmltree = "0.21.0"
 rstest = "0.26.0"
 rustc-hash = "2.1.2"
+rustls = "0.23"
 rustls-native-certs = "0.8"
 rustls-pki-types = "1"
 same-file = "1.0.6"
@@ -185,6 +187,7 @@ tempfile = "3.17.1"
 text_trees = "0.1.2"
 thiserror = "2.0.12"
 tokio = "1.43.0"
+tokio-rustls = "0.26"
 tokio-test = "0.4.5"
 tokio-util = "0.7.13"
 toml = "1.0.0"
@@ -225,8 +228,10 @@ uv-requirements-txt = { git = "https://github.com/astral-sh/uv", tag = "0.11.15"
 uv-resolver = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
 uv-types = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
 uv-workspace = { git = "https://github.com/astral-sh/uv", tag = "0.11.15" }
+webpki = { package = "rustls-webpki", version = "0.103", default-features = false, features = ["std"] }
 webpki-root-certs = "1"
 which = "8.0.0"
+x509-parser = "0.18"
 xxhash-rust = "0.8.15"
 zip = { version = "8.0.0", default-features = false }
 zstd = { version = "0.13.3", default-features = false }

--- a/crates/pixi_utils/Cargo.toml
+++ b/crates/pixi_utils/Cargo.toml
@@ -47,16 +47,21 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
 uv-configuration = { workspace = true }
+webpki = { workspace = true, optional = true }
 webpki-root-certs = { workspace = true }
+x509-parser = { workspace = true, optional = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["http1", "tokio"] }
 insta = { workspace = true }
+rcgen = { workspace = true }
 rstest = { workspace = true }
+rustls = { workspace = true }
 temp-env = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
+tokio-rustls = { workspace = true }
 
 [features]
 default = ["rustls"]
@@ -65,4 +70,10 @@ native-tls = [
   "rattler_networking/native-tls",
   "reqwest/native-tls",
 ]
-rustls = ["pixi_auth/rustls", "rattler_networking/rustls", "reqwest/rustls"]
+rustls = [
+  "pixi_auth/rustls",
+  "rattler_networking/rustls",
+  "reqwest/rustls",
+  "dep:webpki",
+  "dep:x509-parser",
+]

--- a/crates/pixi_utils/src/tls.rs
+++ b/crates/pixi_utils/src/tls.rs
@@ -1,9 +1,8 @@
 //! TLS certificate loading for pixi's reqwest client.
 //!
-//! Mirrors the [`Certificates`] design used by `uv-client` (uv PR #18550): a thin
-//! newtype over [`CertificateDer<'static>`] with factories for the bundled
-//! webpki roots, the platform's native store, and the `SSL_CERT_FILE` /
-//! `SSL_CERT_DIR` environment variables.
+//! [`Certificates`] is a thin newtype over [`CertificateDer<'static>`], with
+//! factories for the bundled webpki roots, the platform's native store, and the
+//! `SSL_CERT_FILE` / `SSL_CERT_DIR` environment variables.
 
 use std::{env, io, path::PathBuf};
 
@@ -11,7 +10,70 @@ use itertools::Itertools;
 use pixi_config::TlsRootCerts;
 use rustls_native_certs::{CertificateResult, load_certs_from_paths};
 use rustls_pki_types::CertificateDer;
+#[cfg(feature = "rustls")]
+use webpki::{Error as WebpkiError, anchor_from_trusted_cert};
+#[cfg(feature = "rustls")]
+use x509_parser::prelude::{FromDer, X509Certificate};
 
+/// Where a certificate came from.
+///
+/// Only used for diagnostics: when pixi drops a certificate this says which
+/// file or store to go look in.
+#[derive(Debug, Clone)]
+enum CertificateSource {
+    NativeStore,
+    SslCertFile(PathBuf),
+    SslCertDir(PathBuf),
+}
+
+impl std::fmt::Display for CertificateSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NativeStore => write!(f, "the system trust store"),
+            Self::SslCertFile(path) => write!(f, "`SSL_CERT_FILE` ({})", path.display()),
+            Self::SslCertDir(path) => write!(f, "`SSL_CERT_DIR` ({})", path.display()),
+        }
+    }
+}
+
+/// Explain why rustls refused a certificate as a trust anchor.
+///
+/// The raw errors are terse and say nothing about which certificate failed, so
+/// pull the subject out of the DER.
+///
+/// Only the variants that `anchor_from_trusted_cert` can actually return are
+/// named. It parses anchors with an ignore-unknown-critical-extension policy,
+/// and it rewrites a v1 version field to `BadDer` itself, so the extension and
+/// version errors never reach us.
+#[cfg(feature = "rustls")]
+fn describe_rejection(cert: &CertificateDer<'_>, err: WebpkiError) -> String {
+    let reason = match err {
+        WebpkiError::BadDer => "is malformed DER",
+        WebpkiError::TrailingData(_) => "has trailing data",
+        WebpkiError::ExtensionValueInvalid => "has a duplicate or invalid extension",
+        // The algorithm named inside the certificate has to match the one on the
+        // outside byte for byte. Certificates that differ only in the optional
+        // RSA NULL parameter land here, which is a common way for a hand-rolled
+        // corporate CA to be unusable.
+        WebpkiError::SignatureAlgorithmMismatch => {
+            "names a different signature algorithm inside than it is signed with"
+        }
+        _ => "cannot be used as a trust anchor",
+    };
+
+    // Parsing can fail where webpki already refused the DER. The reason on its
+    // own is still worth logging.
+    let Ok((_, parsed)) = X509Certificate::from_der(cert.as_ref()) else {
+        return reason.to_owned();
+    };
+
+    let subject = parsed.subject();
+    if subject.iter_attributes().next().is_some() {
+        format!("`{subject}` {reason}")
+    } else {
+        reason.to_owned()
+    }
+}
 /// A collection of TLS certificates in DER form.
 #[derive(Debug, Clone, Default)]
 pub struct Certificates(Vec<CertificateDer<'static>>);
@@ -19,7 +81,7 @@ pub struct Certificates(Vec<CertificateDer<'static>>);
 impl Certificates {
     /// Resolve the certificates to install on pixi's reqwest client.
     ///
-    /// Priority follows uv's model:
+    /// Priority:
     /// 1. `SSL_CERT_FILE` / `SSL_CERT_DIR` env vars (if set and valid)
     /// 2. The configured [`TlsRootCerts`] mode
     ///
@@ -54,30 +116,47 @@ impl Certificates {
         for err in &result.errors {
             tracing::warn!("failed to load a native root certificate: {err}");
         }
-        Self::from(result)
+        let loaded = result.certs.len();
+        let certs = Self::from(result).filter_invalid(&CertificateSource::NativeStore);
+        if certs.0.is_empty() {
+            // An empty anchor set is accepted by rustls without complaint, so
+            // every request would fail later with an unrelated-looking issuer
+            // error. Say it here, where the cause is still visible.
+            tracing::warn!(
+                "no usable certificates in the system trust store ({loaded} loaded); TLS connections will fail. Set `tls-root-certs = \"webpki\"` or point `SSL_CERT_FILE` at a bundle."
+            );
+        }
+        certs
     }
 
     /// Load custom CA certificates from `SSL_CERT_FILE` and `SSL_CERT_DIR`.
     ///
-    /// Returns `None` if neither variable is set, the referenced paths are
-    /// missing or inaccessible, or no valid certificates are found (with a
-    /// warning emitted in each case).
+    /// Returns `None` only when neither variable is set to a non-empty value.
+    /// Setting either one is taken as a deliberate choice about what to trust,
+    /// so it replaces the default roots even when it turns out to be missing,
+    /// unreadable, or empty of usable certificates. Falling back would quietly
+    /// widen trust to the public web PKI, which is the opposite of what someone
+    /// narrowing trust to their own CA asked for.
     pub fn from_env() -> Option<Self> {
         let mut certs = Self::default();
         let mut has_source = false;
 
         if let Some(ssl_cert_file) = env::var_os("SSL_CERT_FILE")
-            && let Some(file_certs) = Self::from_ssl_cert_file(&ssl_cert_file)
+            && !ssl_cert_file.is_empty()
         {
             has_source = true;
-            certs.merge(file_certs);
+            if let Some(file_certs) = Self::from_ssl_cert_file(&ssl_cert_file) {
+                certs.merge(file_certs);
+            }
         }
 
         if let Some(ssl_cert_dir) = env::var_os("SSL_CERT_DIR")
-            && let Some(dir_certs) = Self::from_ssl_cert_dir(&ssl_cert_dir)
+            && !ssl_cert_dir.is_empty()
         {
             has_source = true;
-            certs.merge(dir_certs);
+            if let Some(dir_certs) = Self::from_ssl_cert_dir(&ssl_cert_dir) {
+                certs.merge(dir_certs);
+            }
         }
 
         if has_source { Some(certs) } else { None }
@@ -94,10 +173,11 @@ impl Certificates {
                 for err in &result.errors {
                     tracing::warn!("failed to load `SSL_CERT_FILE` ({}): {err}", file.display());
                 }
-                let certs = Self::from(result);
+                let certs = Self::from(result)
+                    .filter_invalid(&CertificateSource::SslCertFile(file.clone()));
                 if certs.0.is_empty() {
                     tracing::warn!(
-                        "ignoring `SSL_CERT_FILE`: no certificates found in {}",
+                        "no usable certificates in `SSL_CERT_FILE`: {}",
                         file.display()
                     );
                     return None;
@@ -106,23 +186,20 @@ impl Certificates {
             }
             Ok(_) => {
                 tracing::warn!(
-                    "ignoring invalid `SSL_CERT_FILE`: path is not a file: {}",
+                    "invalid `SSL_CERT_FILE`: path is not a file: {}",
                     file.display()
                 );
                 None
             }
             Err(err) if err.kind() == io::ErrorKind::NotFound => {
                 tracing::warn!(
-                    "ignoring invalid `SSL_CERT_FILE`: path does not exist: {}",
+                    "invalid `SSL_CERT_FILE`: path does not exist: {}",
                     file.display()
                 );
                 None
             }
             Err(err) => {
-                tracing::warn!(
-                    "ignoring invalid `SSL_CERT_FILE` ({}): {err}",
-                    file.display()
-                );
+                tracing::warn!("invalid `SSL_CERT_FILE` ({}): {err}", file.display());
                 None
             }
         }
@@ -138,7 +215,7 @@ impl Certificates {
 
         if existing.is_empty() {
             tracing::warn!(
-                "ignoring invalid `SSL_CERT_DIR`: none of {} exist",
+                "invalid `SSL_CERT_DIR`: none of {} exist",
                 missing.iter().map(|p| p.display().to_string()).join(", ")
             );
             return None;
@@ -151,22 +228,72 @@ impl Certificates {
         }
 
         let mut certs = Self::default();
+        let mut loaded = 0;
         for dir in &existing {
             let result = load_certs_from_paths(None, Some(dir.as_path()));
             for err in &result.errors {
                 tracing::warn!("failed to load `SSL_CERT_DIR` ({}): {err}", dir.display());
             }
-            certs.merge(Self::from(result));
+            let dir_certs = Self::from(result);
+            loaded += dir_certs.0.len();
+            certs.merge(dir_certs.filter_invalid(&CertificateSource::SslCertDir(dir.clone())));
         }
 
         if certs.0.is_empty() {
-            tracing::warn!(
-                "ignoring `SSL_CERT_DIR`: no certificates found in {}",
-                existing.iter().map(|p| p.display().to_string()).join(", ")
-            );
+            let dirs = existing.iter().map(|p| p.display().to_string()).join(", ");
+            if loaded == 0 {
+                // An existing but empty directory is normal, not a misconfiguration.
+                // conda-forge's `openssl` ships `$PREFIX/ssl/certs` with nothing but a
+                // `.keep` placeholder and its activation script points `SSL_CERT_DIR`
+                // at it, while the real bundle sits next to it in `SSL_CERT_FILE`.
+                // Warning would fire on every command and there is nothing to fix.
+                tracing::debug!("no certificates in `SSL_CERT_DIR`: {dirs}");
+            } else {
+                // The directory did hold certificates and not one survived. That
+                // is a real misconfiguration, so keep it at a level the user sees.
+                tracing::warn!(
+                    "none of the {loaded} certificates in `SSL_CERT_DIR` ({dirs}) can be used; run with `-vvv` to see why each was rejected"
+                );
+            }
             return None;
         }
         Some(certs)
+    }
+
+    /// Drop certificates that rustls refuses as trust anchors.
+    ///
+    /// reqwest does not check the DER until the client is built, and then it
+    /// fails the whole build with one opaque error. A single bad certificate in
+    /// a corporate bundle therefore takes down every request pixi makes.
+    /// Dropping it keeps the rest of the bundle working. If a server genuinely
+    /// needs the dropped certificate, that request fails on its own and names
+    /// the server.
+    ///
+    /// Logged at debug: the certificate is almost never the user's to fix, and
+    /// the trust store on a managed machine routinely holds a few entries
+    /// rustls will not parse.
+    #[cfg(feature = "rustls")]
+    fn filter_invalid(mut self, source: &CertificateSource) -> Self {
+        self.0.retain(|cert| {
+            if let Err(err) = anchor_from_trusted_cert(cert) {
+                tracing::debug!(
+                    "ignoring certificate from {source}: {}",
+                    describe_rejection(cert, err)
+                );
+                return false;
+            }
+            true
+        });
+        self
+    }
+
+    /// Keep every certificate on native-tls builds.
+    ///
+    /// The platform verifier decides what it trusts, and it accepts anchors
+    /// rustls rejects. Filtering here would drop certificates that work.
+    #[cfg(not(feature = "rustls"))]
+    fn filter_invalid(self, _source: &CertificateSource) -> Self {
+        self
     }
 
     /// Whether this collection is empty.
@@ -194,5 +321,185 @@ impl Certificates {
 impl From<CertificateResult> for Certificates {
     fn from(result: CertificateResult) -> Self {
         Self(result.certs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Rewrite a real root certificate's explicit version field from v3 to v1.
+    ///
+    /// The DER keeps its length and still parses as a certificate, but
+    /// `anchor_from_trusted_cert` refuses it. That is exactly the shape of
+    /// certificate that used to fail the whole `ClientBuilder::build()`.
+    #[cfg(feature = "rustls")]
+    fn unusable_cert(der: &[u8]) -> CertificateDer<'static> {
+        const EXPLICIT_V3: [u8; 5] = [0xA0, 0x03, 0x02, 0x01, 0x02];
+        let mut out = der.to_vec();
+        let pos = out
+            .windows(EXPLICIT_V3.len())
+            .take(40)
+            .position(|window| window == EXPLICIT_V3)
+            .expect("explicit version field near the start of the TBSCertificate");
+        out[pos + 4] = 0x00;
+        CertificateDer::from(out)
+    }
+
+    #[cfg(feature = "rustls")]
+    #[test]
+    fn filter_invalid_drops_only_the_unusable_certificate() {
+        let valid: Vec<CertificateDer<'static>> = webpki_root_certs::TLS_SERVER_ROOT_CERTS
+            .iter()
+            .take(3)
+            .map(|cert| cert.clone().into_owned())
+            .collect();
+        let mut input = valid.clone();
+        input.push(unusable_cert(
+            webpki_root_certs::TLS_SERVER_ROOT_CERTS[5].as_ref(),
+        ));
+
+        // Unfiltered, the single bad certificate takes down the whole client.
+        assert!(
+            reqwest::Client::builder()
+                .use_rustls_tls()
+                .tls_certs_only(Certificates(input.clone()).to_reqwest_certs())
+                .build()
+                .is_err(),
+            "expected the unusable certificate to break the client build"
+        );
+
+        let filtered = Certificates(input)
+            .filter_invalid(&CertificateSource::SslCertFile(PathBuf::from("bundle.pem")));
+
+        assert_eq!(
+            filtered.0, valid,
+            "only the unusable certificate should be dropped"
+        );
+        assert!(
+            reqwest::Client::builder()
+                .use_rustls_tls()
+                .tls_certs_only(filtered.to_reqwest_certs())
+                .build()
+                .is_ok(),
+            "the client should build once the unusable certificate is dropped"
+        );
+    }
+
+    #[test]
+    fn ssl_cert_file_empty_value_is_not_a_source() {
+        assert!(Certificates::from_ssl_cert_file(std::ffi::OsStr::new("")).is_none());
+    }
+
+    #[test]
+    fn ssl_cert_file_nonexistent_path_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.pem");
+        assert!(Certificates::from_ssl_cert_file(missing.as_os_str()).is_none());
+    }
+
+    #[test]
+    fn ssl_cert_file_without_certificates_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.pem");
+        fs_err::write(&path, "not a certificate").unwrap();
+        assert!(Certificates::from_ssl_cert_file(path.as_os_str()).is_none());
+    }
+
+    #[test]
+    fn ssl_cert_dir_empty_value_is_not_a_source() {
+        assert!(Certificates::from_ssl_cert_dir(std::ffi::OsStr::new("")).is_none());
+    }
+
+    #[test]
+    fn ssl_cert_dir_nonexistent_path_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = env::join_paths([dir.path().join("missing")]).unwrap();
+        assert!(Certificates::from_ssl_cert_dir(missing.as_os_str()).is_none());
+    }
+
+    /// The case that made pixi warn on every command: the directory exists and
+    /// holds no certificates, which is how the `openssl` package ships it.
+    #[test]
+    fn ssl_cert_dir_that_exists_but_is_empty_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        fs_err::write(dir.path().join(".keep"), "").unwrap();
+        let dirs = env::join_paths([dir.path()]).unwrap();
+        assert!(Certificates::from_ssl_cert_dir(dirs.as_os_str()).is_none());
+    }
+
+    /// A configured source is a deliberate choice about what to trust, so it
+    /// must not silently widen back out to the default roots when it turns out
+    /// to be unusable.
+    #[test]
+    fn explicit_cert_file_is_authoritative_even_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.pem");
+
+        temp_env::with_vars(
+            [
+                ("SSL_CERT_FILE", Some(missing.as_os_str())),
+                ("SSL_CERT_DIR", None),
+            ],
+            || {
+                let certs = Certificates::from_env()
+                    .expect("a configured `SSL_CERT_FILE` must not fall back to the defaults");
+                assert!(
+                    certs.is_empty(),
+                    "nothing was loadable, so nothing is trusted"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn explicit_cert_dir_is_authoritative_even_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+
+        temp_env::with_vars(
+            [
+                ("SSL_CERT_FILE", None),
+                ("SSL_CERT_DIR", Some(dir.path().as_os_str())),
+            ],
+            || {
+                let certs = Certificates::from_env()
+                    .expect("a configured `SSL_CERT_DIR` must not fall back to the defaults");
+                assert!(certs.is_empty());
+            },
+        );
+    }
+
+    #[test]
+    fn unset_cert_vars_leave_the_configured_mode_alone() {
+        temp_env::with_vars(
+            [
+                ("SSL_CERT_FILE", None::<&std::ffi::OsStr>),
+                ("SSL_CERT_DIR", None),
+            ],
+            || assert!(Certificates::from_env().is_none()),
+        );
+    }
+
+    #[test]
+    fn merge_deduplicates() {
+        let one = Certificates(
+            webpki_root_certs::TLS_SERVER_ROOT_CERTS
+                .iter()
+                .take(2)
+                .map(|cert| cert.clone().into_owned())
+                .collect(),
+        );
+        let mut merged = one.clone();
+        merged.merge(one);
+        assert_eq!(
+            merged.0.len(),
+            2,
+            "merging a set with itself changes nothing"
+        );
+    }
+
+    #[test]
+    fn webpki_roots_are_not_empty() {
+        assert!(!Certificates::webpki_roots().is_empty());
     }
 }

--- a/crates/pixi_utils/tests/tls_certs.rs
+++ b/crates/pixi_utils/tests/tls_certs.rs
@@ -1,0 +1,208 @@
+//! End-to-end checks that the certificates pixi loads decide what it trusts.
+//!
+//! Each test starts a throwaway TLS server presenting a generated certificate,
+//! points `SSL_CERT_FILE` or `SSL_CERT_DIR` at some combination of authorities,
+//! and asks whether pixi's client is willing to talk to it.
+
+#![cfg(feature = "rustls")]
+
+use std::{
+    ffi::OsStr,
+    path::Path,
+    sync::{Arc, Once},
+};
+
+use rcgen::{BasicConstraints, CertificateParams, CustomExtension, IsCa, Issuer, KeyPair};
+use rustls::{
+    ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer},
+};
+use tempfile::TempDir;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+use tokio_rustls::TlsAcceptor;
+
+/// A generated certificate authority, plus a leaf it has signed.
+struct Authority {
+    pem: String,
+    leaf: CertificateDer<'static>,
+    leaf_key: PrivateKeyDer<'static>,
+}
+
+impl Authority {
+    /// A perfectly ordinary authority.
+    fn usable() -> Self {
+        Self::new(Vec::new())
+    }
+
+    /// An authority carrying `basicConstraints` twice.
+    ///
+    /// It is well-formed DER and parses as a certificate, but a trust anchor is
+    /// only allowed to carry each extension once, so it is refused. This is the
+    /// shape that used to take down the whole client.
+    fn unusable() -> Self {
+        Self::new(vec![CustomExtension::from_oid_content(
+            &[2, 5, 29, 19],
+            vec![0x30, 0x00],
+        )])
+    }
+
+    fn new(custom_extensions: Vec<CustomExtension>) -> Self {
+        let ca_key = KeyPair::generate().expect("key pair");
+        let mut ca_params = CertificateParams::new(Vec::<String>::new()).expect("parameters");
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.custom_extensions = custom_extensions;
+        let pem = ca_params.self_signed(&ca_key).expect("authority").pem();
+        let issuer = Issuer::new(ca_params, ca_key);
+
+        let leaf_key = KeyPair::generate().expect("key pair");
+        let leaf = CertificateParams::new(vec!["localhost".to_owned()])
+            .expect("parameters")
+            .signed_by(&leaf_key, &issuer)
+            .expect("leaf certificate");
+
+        Self {
+            pem,
+            leaf: leaf.der().clone(),
+            leaf_key: PrivateKeyDer::try_from(leaf_key.serialize_der()).expect("private key"),
+        }
+    }
+
+    fn write_pem(&self, path: &Path) {
+        fs_err::write(path, &self.pem).expect("write certificate");
+    }
+}
+/// Pick a crypto provider for the test server.
+///
+/// Feature unification pulls in more than one provider on some platforms, and
+/// rustls refuses to guess between them, so say which one to use.
+fn install_crypto_provider() {
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+/// Serve HTTPS on a loopback port until the test ends.
+async fn serve(authority: &Authority) -> u16 {
+    install_crypto_provider();
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![authority.leaf.clone()], authority.leaf_key.clone_key())
+        .expect("server config");
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("listener");
+    let port = listener.local_addr().expect("local address").port();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                if let Ok(mut tls) = acceptor.accept(stream).await {
+                    let _ = tls.read(&mut [0u8; 1024]).await;
+                    let _ = tls
+                        .write_all(b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\n\r\nok")
+                        .await;
+                    let _ = tls.shutdown().await;
+                }
+            });
+        }
+    });
+
+    port
+}
+
+/// Build a client the way pixi builds its own, with the given environment.
+fn client(ssl_cert_file: Option<&Path>, ssl_cert_dir: Option<&OsStr>) -> reqwest::Client {
+    temp_env::with_vars(
+        [
+            ("SSL_CERT_FILE", ssl_cert_file.map(Path::as_os_str)),
+            ("SSL_CERT_DIR", ssl_cert_dir),
+        ],
+        || {
+            pixi_utils::reqwest::reqwest_client_builder(None)
+                .expect("client builder")
+                .build()
+                .expect("client")
+        },
+    )
+}
+
+async fn can_reach(client: &reqwest::Client, port: u16) -> bool {
+    match client
+        .get(format!("https://localhost:{port}/"))
+        .send()
+        .await
+    {
+        Ok(_) => true,
+        Err(err) => {
+            eprintln!("request failed: {err:?}");
+            false
+        }
+    }
+}
+
+#[tokio::test]
+async fn a_bundle_keeps_working_when_one_certificate_is_unusable() {
+    let server = Authority::usable();
+    let port = serve(&server).await;
+    let dir = TempDir::new().expect("temp dir");
+    let bundle = dir.path().join("bundle.pem");
+    fs_err::write(
+        &bundle,
+        format!("{}{}", Authority::unusable().pem, server.pem),
+    )
+    .expect("bundle");
+
+    assert!(can_reach(&client(Some(&bundle), None), port).await);
+}
+
+#[tokio::test]
+async fn a_directory_keeps_working_when_one_certificate_is_unusable() {
+    let server = Authority::usable();
+    let port = serve(&server).await;
+    let dir = TempDir::new().expect("temp dir");
+    server.write_pem(&dir.path().join("good.pem"));
+    Authority::unusable().write_pem(&dir.path().join("bad.pem"));
+
+    assert!(can_reach(&client(None, Some(dir.path().as_os_str())), port).await);
+}
+
+#[tokio::test]
+async fn nothing_is_trusted_when_every_certificate_is_unusable() {
+    let server = Authority::usable();
+    let port = serve(&server).await;
+    let dir = TempDir::new().expect("temp dir");
+    let bundle = dir.path().join("bundle.pem");
+    Authority::unusable().write_pem(&bundle);
+
+    assert!(!can_reach(&client(Some(&bundle), None), port).await);
+}
+
+#[tokio::test]
+async fn a_file_and_a_directory_are_combined() {
+    let server = Authority::usable();
+    let port = serve(&server).await;
+    let file_dir = TempDir::new().expect("temp dir");
+    let bundle = file_dir.path().join("other.pem");
+    Authority::usable().write_pem(&bundle);
+    let cert_dir = TempDir::new().expect("temp dir");
+    server.write_pem(&cert_dir.path().join("good.pem"));
+
+    let client = client(Some(&bundle), Some(cert_dir.path().as_os_str()));
+    assert!(can_reach(&client, port).await);
+}
+
+#[tokio::test]
+async fn missing_directory_entries_are_skipped() {
+    let server = Authority::usable();
+    let port = serve(&server).await;
+    let dir = TempDir::new().expect("temp dir");
+    server.write_pem(&dir.path().join("good.pem"));
+    let entries =
+        std::env::join_paths([dir.path().join("missing"), dir.path().to_path_buf()]).expect("dirs");
+
+    assert!(can_reach(&client(None, Some(entries.as_os_str())), port).await);
+}


### PR DESCRIPTION
﻿### Description

Every pixi command from a conda-forge shell prints this:

```
WARN ignoring `SSL_CERT_DIR`: no certificates found in ...\Library\ssl\certs
```

`openssl` points `SSL_CERT_DIR` at a directory holding only a `.keep` placeholder while the real bundle sits in `SSL_CERT_FILE`. Nothing is lost, so it is a debug log now. A directory that did hold certificates and lost all of them still warns.

Digging into that turned up worse. On rustls builds `reqwest::Certificate::from_der` never looks at the DER; rustls only checks it in `ClientBuilder::build()`, which we call behind an `.expect()`. So one unparseable certificate anywhere in your trust sources panics pixi at first network use:

```
thread 'main2' panicked at crates\pixi_utils\src\reqwest.rs:326:22:
failed to create reqwest Client: ... InvalidCertificate(BadEncoding)
```

Those are dropped now, with the subject and reason at debug. Skipped on native-tls, where the platform verifier accepts anchors rustls rejects (#6229).

One behavior change worth a look: `SSL_CERT_FILE`/`SSL_CERT_DIR` now replace the default roots even when missing or empty, instead of falling back. Falling back widens trust to the public web PKI for someone who set the variable to narrow it.

Fixes #6615

### How Has This Been Tested?

12 unit tests, plus 5 integration tests that run a throwaway TLS server and check what the client will actually talk to: a bundle or directory keeps working when one certificate is unusable, nothing is trusted when they all are, and file and directory sources combine. `rcgen`, `rustls` and `tokio-rustls` are new dev-dependencies; `cargo deny` is happy with them.

fmt, clippy `-D warnings` and the tests pass under the default features and `--no-default-features --features native-tls`. Also checked end to end on Windows against a locally built binary.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
