### PR TITLE
feat(platform): Honor CONDA_OVERRIDE_ARCHSPEC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,7 +257,7 @@ rattler_upload = { version = "0.10", default-features = false, features = [
   "s3",
   "sigstore-sign",
 ] }
-rattler_virtual_packages = { version = "4.0", default-features = false }
+rattler_virtual_packages = { version = "4.1", default-features = false }
 simple_spawn_blocking = { version = "1.1.0", default-features = false }
 
 # Rattler build crates

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -776,16 +776,19 @@ async fn execute_list(
     }
 
     if args.json {
+        // Same snapshot the human output renders, so the two views of one
+        // command cannot disagree about the host.
+        let machine = HostMachine::detect(workspace);
         let mut platforms: Vec<serde_json::Value> =
             Vec::with_capacity(workspace_platforms.len() + 1);
-        platforms.push(autodetected_to_json());
+        platforms.push(autodetected_to_json(&machine));
         for p in &workspace_platforms {
             let users = environments_and_features_using(workspace, p);
             platforms.push(show_to_json(p, &users));
         }
 
         let value = serde_json::json!({
-            "current_subdir": Platform::current().as_str(),
+            "current_subdir": machine.subdir.as_str(),
             "platforms": platforms,
         });
         let _ = writeln!(
@@ -1208,15 +1211,11 @@ fn show_to_json(platform: &PixiPlatform, users: &PlatformUsers) -> serde_json::V
 /// JSON counterpart to [`print_autodetected_host`]. Carries the same data
 /// shape as a real platform entry plus an `is_autodetected: true` marker so
 /// downstream tooling can tell synthetic rows apart from declared ones.
-fn autodetected_to_json() -> serde_json::Value {
-    let host = PixiPlatform::auto_detected(Platform::current());
-    let detected: Vec<String> = match host.virtual_packages() {
-        Ok(d) => render_friendly(&d.into_generic_virtual_packages().collect::<Vec<_>>(), None),
-        Err(_) => Vec::new(),
-    };
+fn autodetected_to_json(machine: &HostMachine) -> serde_json::Value {
+    let detected: Vec<String> = render_friendly(&machine.detected, None);
     serde_json::json!({
         "name": "current",
-        "subdir": Platform::current().as_str(),
+        "subdir": machine.subdir.as_str(),
         "virtual_packages": Vec::<String>::new(),
         "detected_virtual_packages": detected,
         "features": Vec::<String>::new(),

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -964,7 +964,7 @@ impl HostMachine {
             }
         };
 
-        pixi_core::workspace::apply_environment_variable_overrides(&mut detected);
+        pixi_core::workspace::apply_environment_variable_overrides(&mut detected, subdir);
         HostMachine {
             subdir,
             candidate_subdirs,

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -12,7 +12,7 @@ use pixi_manifest::{
     PixiPlatformName, PlatformEdit, PlatformMove, platform::subdir_default_virtual_packages,
 };
 use rattler_conda_types::{GenericVirtualPackage, PackageName, Platform, Version};
-use rattler_virtual_packages::{VirtualPackageOverrides, VirtualPackages};
+use rattler_virtual_packages::{Archspec, Override, VirtualPackageOverrides, VirtualPackages};
 
 use crate::{cli_config::ScriptWorkspaceConfig, cli_interface::CliInterface};
 
@@ -944,17 +944,26 @@ impl HostMachine {
         // Avoid rattler's `CONDA_OVERRIDE_*` handling: it fails the whole
         // detection on a value it can't parse, which would leave every row empty.
         // Apply overrides per slot instead.
-        let mut detected =
-            match VirtualPackages::detect_for_platform(subdir, &VirtualPackageOverrides::default())
-            {
-                Ok(detected) => detected.into_generic_virtual_packages().collect::<Vec<_>>(),
-                Err(error) => {
-                    tracing::warn!(
-                        "Could not detect the virtual packages of this machine: {error}"
-                    );
-                    Vec::new()
-                }
-            };
+        let mut overrides = VirtualPackageOverrides::default();
+        if subdir != Platform::current() {
+            // An unset slot means "no override" everywhere except rattler's
+            // cross-compile branch, which reads `CONDA_OVERRIDE_ARCHSPEC`
+            // anyway and aborts the whole detection on a bad value.
+            overrides.archspec = Some(Override::String(
+                Archspec::from_platform(subdir).map_or_else(
+                    || String::from("0"),
+                    |archspec| archspec.as_str().to_string(),
+                ),
+            ));
+        }
+        let mut detected = match VirtualPackages::detect_for_platform(subdir, &overrides) {
+            Ok(detected) => detected.into_generic_virtual_packages().collect::<Vec<_>>(),
+            Err(error) => {
+                tracing::warn!("Could not detect the virtual packages of this machine: {error}");
+                Vec::new()
+            }
+        };
+
         pixi_core::workspace::apply_environment_variable_overrides(&mut detected);
         HostMachine {
             subdir,

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -935,22 +935,27 @@ struct HostMachine {
 
 impl HostMachine {
     fn detect(workspace: &pixi_core::Workspace) -> Self {
-        let subdir = workspace
-            .host_platform(
-                PlatformSource::Defaults,
-                PlatformOverrides::EnvironmentVariableOverrides,
-            )
-            .subdir();
+        let subdir =
+            pixi_core::workspace::host_subdir(PlatformOverrides::EnvironmentVariableOverrides);
         let candidate_subdirs = workspace
             .workspace_manifest()
             .workspace
             .candidate_subdirs(subdir);
-        // `VirtualPackageOverrides::from_env()` applies the `CONDA_OVERRIDE_*`
-        // family, so this detection matches what the workspace rows are tested against.
-        let detected =
-            VirtualPackages::detect_for_platform(subdir, &VirtualPackageOverrides::from_env())
-                .map(|d| d.into_generic_virtual_packages().collect::<Vec<_>>())
-                .unwrap_or_default();
+        // Avoid rattler's `CONDA_OVERRIDE_*` handling: it fails the whole
+        // detection on a value it can't parse, which would leave every row empty.
+        // Apply overrides per slot instead.
+        let mut detected =
+            match VirtualPackages::detect_for_platform(subdir, &VirtualPackageOverrides::default())
+            {
+                Ok(detected) => detected.into_generic_virtual_packages().collect::<Vec<_>>(),
+                Err(error) => {
+                    tracing::warn!(
+                        "Could not detect the virtual packages of this machine: {error}"
+                    );
+                    Vec::new()
+                }
+            };
+        pixi_core::workspace::apply_environment_variable_overrides(&mut detected);
         HostMachine {
             subdir,
             candidate_subdirs,

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -797,12 +797,12 @@ async fn execute_list(
     }
 
     let mut stdout = std::io::stdout();
-    print_autodetected_host(workspace);
+    let machine = HostMachine::detect(workspace);
+    print_autodetected_host(&mut stdout, &machine);
 
     if !workspace_platforms.is_empty() {
         let _ = writeln!(stdout, "\n{}", console::style("Platforms:").bold().bright());
     }
-    let machine = HostMachine::detect(workspace);
     let _ = write!(
         stdout,
         "{}",
@@ -866,27 +866,14 @@ async fn execute_remove(
 }
 
 /// Pretty-print rattler's host detection as a "diagnostic" header rather
-/// than another `<name>:` row -- the host has no manifest-side identity, so
-/// labelling it `current:` was misleading. The body is the same
-/// `platform=...[, ...]` payload the workspace rows use; subdir defaults
-/// filter out so it only mentions where the host diverges from pixi's
-/// baseline. Both `PIXI_OVERRIDE_PLATFORM` and the `CONDA_OVERRIDE_*`
-/// virtual-package overrides are respected here so the header agrees
-/// with what the workspace rows are matched against.
-fn print_autodetected_host(workspace: &pixi_core::Workspace) {
-    let subdir = workspace
-        .host_platform(
-            PlatformSource::Defaults,
-            PlatformOverrides::EnvironmentVariableOverrides,
-        )
-        .subdir();
-    let detected: Vec<GenericVirtualPackage> =
-        VirtualPackages::detect_for_platform(subdir, &VirtualPackageOverrides::from_env())
-            .map(|d| d.into_generic_virtual_packages().collect())
-            .unwrap_or_default();
-    let mut stdout = std::io::stdout();
+/// than another `<name>:` row
+fn print_autodetected_host(stdout: &mut std::io::Stdout, machine: &HostMachine) {
     let _ = writeln!(stdout, "Your current machine was detected as:");
-    let _ = writeln!(stdout, "    {}", inline_entry_body(subdir, &detected));
+    let _ = writeln!(
+        stdout,
+        "    {}",
+        inline_entry_body(machine.subdir, &machine.detected)
+    );
 }
 
 /// Walk all environments + features in the workspace and collect the names of
@@ -937,17 +924,18 @@ struct PlatformUsers {
     environments: Vec<String>,
 }
 
-/// Snapshot of the local machine used to colour platform rows in `list`:
-/// which subdirs we can run packages from (current + arch fallbacks) and
-/// which virtual packages rattler detected on the host.
+/// Snapshot of the local machine used to color platform rows in `list`:
+/// the subdir we target, which subdirs we can run packages from (that one plus
+/// arch fallbacks) and which virtual packages rattler detected on the host.
 struct HostMachine {
+    subdir: Platform,
     candidate_subdirs: Vec<Platform>,
     detected: Vec<GenericVirtualPackage>,
 }
 
 impl HostMachine {
     fn detect(workspace: &pixi_core::Workspace) -> Self {
-        let current = workspace
+        let subdir = workspace
             .host_platform(
                 PlatformSource::Defaults,
                 PlatformOverrides::EnvironmentVariableOverrides,
@@ -956,14 +944,15 @@ impl HostMachine {
         let candidate_subdirs = workspace
             .workspace_manifest()
             .workspace
-            .candidate_subdirs(current);
+            .candidate_subdirs(subdir);
         // `VirtualPackageOverrides::from_env()` applies the `CONDA_OVERRIDE_*`
         // family, so this detection matches what the workspace rows are tested against.
         let detected =
-            VirtualPackages::detect_for_platform(current, &VirtualPackageOverrides::from_env())
+            VirtualPackages::detect_for_platform(subdir, &VirtualPackageOverrides::from_env())
                 .map(|d| d.into_generic_virtual_packages().collect::<Vec<_>>())
                 .unwrap_or_default();
         HostMachine {
+            subdir,
             candidate_subdirs,
             detected,
         }
@@ -987,8 +976,8 @@ impl HostMachine {
 
     /// Does the current machine support running this platform? Combines
     /// the subdir check with the per-VP satisfaction check on the user-
-    /// customised virtual packages (subdir defaults are pixi's baseline
-    /// and not considered host requirements). Used to colour both the
+    /// customized virtual packages (subdir defaults are pixi's baseline
+    /// and not considered host requirements). Used to color both the
     /// row itself and the env/feature names that reference it.
     fn supports(&self, platform: &PixiPlatform) -> bool {
         let subdir = platform.subdir();
@@ -1260,6 +1249,7 @@ mod tests {
     /// A host that runs linux-64 with no customised virtual packages.
     fn linux_machine() -> HostMachine {
         HostMachine {
+            subdir: Platform::Linux64,
             candidate_subdirs: vec![Platform::Linux64],
             detected: Vec::new(),
         }

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -66,7 +66,7 @@ use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
 use rattler_virtual_packages::{
     Archspec, Cuda, CudaArch, EnvOverride, LibC, Linux, Osx, Override, VirtualPackageOverrides,
-    VirtualPackages,
+    VirtualPackages, Windows,
 };
 pub use registry::{WorkspaceRegistry, WorkspaceRegistryError};
 pub use solve_group::SolveGroup;
@@ -365,6 +365,9 @@ pub fn apply_environment_variable_overrides(
     let linux = version_override::<Linux>(|linux| linux.version);
     let osx = version_override::<Osx>(|osx| osx.version);
     let cuda_arch = version_override::<CudaArch>(|arch| arch.version);
+    // `Windows::parse_version` always fills the version in, so the fallback
+    // only covers the unreachable `None` arm of rattler's optional field.
+    let win = version_override::<Windows>(|win| win.version.unwrap_or_else(|| Version::major(0)));
 
     packages.retain_mut(|package| {
         let outcome = match package.name.as_normalized() {
@@ -372,6 +375,7 @@ pub fn apply_environment_variable_overrides(
             "__cuda_arch" => cuda_arch.clone(),
             "__linux" => linux.clone(),
             "__osx" => osx.clone(),
+            "__win" => win.clone(),
             // The libc family is handled by `apply_glibc_override` below, since
             // the single glibc env var must not rewrite `__musl`/`__eglibc`.
             _ => None,
@@ -412,6 +416,7 @@ pub fn apply_environment_variable_overrides(
     add_missing("__cuda_arch", cuda_arch.flatten());
     add_missing("__osx", osx.flatten());
     add_missing("__linux", linux.flatten());
+    add_missing("__win", win.flatten());
 
     // CEP couples the two CUDA slots: `__cuda_arch` is meaningless without a
     // driver, and rattler drops it the same way in `VirtualPackages::detect`.

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -310,6 +310,24 @@ pub fn host_subdir(overrides: PlatformOverrides) -> Platform {
         .unwrap_or_else(Platform::current)
 }
 
+/// Read one `CONDA_OVERRIDE_*` variable: `None` when it is unset or holds a
+/// value rattler can't parse, `Some(None)` when it is set empty ("disable this
+/// package"), `Some(Some(version))` otherwise.
+///
+/// An unusable value is warned about rather than dropped on the floor -- pixi
+/// applies these itself now, so nothing else would ever tell the user their
+/// override was ignored.
+fn version_override<T: EnvOverride>(to_version: impl Fn(T) -> Version) -> Option<Option<Version>> {
+    std::env::var_os(T::DEFAULT_ENV_NAME)?;
+    match T::detect_with_fallback(&Override::DefaultEnvVar, || Ok(None)) {
+        Ok(value) => Some(value.map(to_version)),
+        Err(error) => {
+            tracing::warn!("Ignoring {}: {error}", T::DEFAULT_ENV_NAME);
+            None
+        }
+    }
+}
+
 /// Whether `subdir` can carry the OS-specific virtual package `name` at all.
 /// Mirrors the per-platform gating in rattler's `detect_for_platform`; every
 /// other slot (`__cuda`, `__archspec`, ...) is valid on any subdir.
@@ -341,37 +359,32 @@ pub fn apply_environment_variable_overrides(
     packages: &mut Vec<GenericVirtualPackage>,
     subdir: Platform,
 ) {
-    let env = Override::DefaultEnvVar;
+    // Read each variable once, so a bad value is reported once rather than
+    // per pass below.
+    let cuda = version_override::<Cuda>(|cuda| cuda.version);
+    let linux = version_override::<Linux>(|linux| linux.version);
+    let osx = version_override::<Osx>(|osx| osx.version);
+    let cuda_arch = version_override::<CudaArch>(|arch| arch.version);
+
     packages.retain_mut(|package| {
-        let base = package.version.clone();
-        let outcome: Option<Option<Version>> = match package.name.as_normalized() {
-            "__cuda" => Cuda::detect_with_fallback(&env, || Ok(Some(Cuda { version: base })))
-                .ok()
-                .map(|cuda| cuda.map(|cuda| cuda.version)),
-            "__linux" => Linux::detect_with_fallback(&env, || Ok(Some(Linux { version: base })))
-                .ok()
-                .map(|linux| linux.map(|linux| linux.version)),
-            "__osx" => Osx::detect_with_fallback(&env, || Ok(Some(Osx { version: base })))
-                .ok()
-                .map(|osx| osx.map(|osx| osx.version)),
-            "__cuda_arch" => {
-                CudaArch::detect_with_fallback(&env, || Ok(Some(CudaArch { version: base })))
-                    .ok()
-                    .map(|arch| arch.map(|arch| arch.version))
-            }
+        let outcome = match package.name.as_normalized() {
+            "__cuda" => cuda.clone(),
+            "__cuda_arch" => cuda_arch.clone(),
+            "__linux" => linux.clone(),
+            "__osx" => osx.clone(),
             // The libc family is handled by `apply_glibc_override` below, since
             // the single glibc env var must not rewrite `__musl`/`__eglibc`.
             _ => None,
         };
         match outcome {
-            // Override (or unset fallback) produced a version: keep it.
+            // Override produced a version: use it.
             Some(Some(version)) => {
                 package.version = version;
                 true
             }
             // Variable was set empty: disable the package.
             Some(None) => false,
-            // Not env-overridable, or detection failed: leave untouched.
+            // Not env-overridable, unset, or unusable: leave untouched.
             None => true,
         }
     });
@@ -394,34 +407,11 @@ pub fn apply_environment_variable_overrides(
             build_string: "0".to_string(),
         });
     };
-    add_missing(
-        "__cuda",
-        Cuda::detect_with_fallback(&env, || Ok(None))
-            .ok()
-            .flatten()
-            .map(|cuda| cuda.version),
-    );
-    add_missing(
-        "__cuda_arch",
-        CudaArch::detect_with_fallback(&env, || Ok(None))
-            .ok()
-            .flatten()
-            .map(|arch| arch.version),
-    );
-    add_missing(
-        "__osx",
-        Osx::detect_with_fallback(&env, || Ok(None))
-            .ok()
-            .flatten()
-            .map(|osx| osx.version),
-    );
-    add_missing(
-        "__linux",
-        Linux::detect_with_fallback(&env, || Ok(None))
-            .ok()
-            .flatten()
-            .map(|linux| linux.version),
-    );
+
+    add_missing("__cuda", cuda.flatten());
+    add_missing("__cuda_arch", cuda_arch.flatten());
+    add_missing("__osx", osx.flatten());
+    add_missing("__linux", linux.flatten());
 
     // CEP couples the two CUDA slots: `__cuda_arch` is meaningless without a
     // driver, and rattler drops it the same way in `VirtualPackages::detect`.
@@ -503,8 +493,10 @@ fn apply_glibc_override(packages: &mut Vec<GenericVirtualPackage>, subdir: Platf
                 });
             }
         }
-        // Unparsable value: leave the detected packages untouched.
-        Err(_) => {}
+        // Unusable value: leave the detected packages untouched, but say so.
+        Err(error) => {
+            tracing::warn!("Ignoring {}: {error}", LibC::DEFAULT_ENV_NAME);
+        }
     }
 }
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -310,12 +310,37 @@ pub fn host_subdir(overrides: PlatformOverrides) -> Platform {
         .unwrap_or_else(Platform::current)
 }
 
+/// Whether `subdir` can carry the OS-specific virtual package `name` at all.
+/// Mirrors the per-platform gating in rattler's `detect_for_platform`; every
+/// other slot (`__cuda`, `__archspec`, ...) is valid on any subdir.
+fn carried_by_subdir(name: &str, subdir: Platform) -> bool {
+    match name {
+        "__osx" => subdir.is_osx(),
+        "__win" => subdir.is_windows(),
+        "__linux" | "__glibc" | "__musl" | "__eglibc" => subdir.is_linux(),
+        _ => true,
+    }
+}
+
 /// Apply `CONDA_OVERRIDE_*` env vars to `packages`, matching upstream rattler
 /// semantics: unset keeps the current version, non-empty replaces it (adding
 /// the package if it wasn't detected at all), and empty removes the package
 /// entirely. Rattler drives this per slot via `detect_with_fallback`;
 /// `Ok(Some(v))` = use v, `Ok(None)` = disabled, error = leave untouched.
-pub fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage>) {
+///
+/// Detect with [`VirtualPackageOverrides::default`] and apply this instead of
+/// detecting with [`VirtualPackageOverrides::from_env`]: rattler errors out of
+/// the whole detection on an unparsable override value, where this validates
+/// per slot and warns.
+///
+/// `subdir` is the platform being described. An override only introduces a
+/// package the subdir can actually carry, so `CONDA_OVERRIDE_OSX` does not put
+/// `__osx` on a win-64 target -- rattler's `detect_for_platform` filters the
+/// same way.
+pub fn apply_environment_variable_overrides(
+    packages: &mut Vec<GenericVirtualPackage>,
+    subdir: Platform,
+) {
     let env = Override::DefaultEnvVar;
     packages.retain_mut(|package| {
         let base = package.version.clone();
@@ -353,8 +378,13 @@ pub fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPac
 
     // Overrides can introduce packages the machine lacks (`CONDA_OVERRIDE_CUDA`
     // without a GPU), matching rattler; the `Ok(None)` fallback adds only set vars.
+    // `carried_by_subdir` keeps an override from inventing an OS package the
+    // target can't have, the way rattler gates the same slots on the platform.
     let mut add_missing = |name: &str, version: Option<Version>| {
         let Some(version) = version else { return };
+        if !carried_by_subdir(name, subdir) {
+            return;
+        }
         if packages.iter().any(|p| p.name.as_normalized() == name) {
             return;
         }
@@ -399,7 +429,7 @@ pub fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPac
         packages.retain(|p| p.name.as_normalized() != "__cuda_arch");
     }
 
-    apply_glibc_override(packages);
+    apply_glibc_override(packages, subdir);
     apply_archspec_override(packages);
 }
 
@@ -443,11 +473,14 @@ fn apply_archspec_override(packages: &mut Vec<GenericVirtualPackage>) {
 /// empty value removes `__glibc`, and a concrete version pins
 /// `__glibc=<version>=0` and drops `__musl`/`__eglibc` (one libc family
 /// applies).
-fn apply_glibc_override(packages: &mut Vec<GenericVirtualPackage>) {
+fn apply_glibc_override(packages: &mut Vec<GenericVirtualPackage>, subdir: Platform) {
     // Read the variable rattler would and reuse its empty-vs-version parsing.
     let Ok(value) = std::env::var(LibC::DEFAULT_ENV_NAME) else {
         return;
     };
+    if !carried_by_subdir("__glibc", subdir) {
+        return;
+    }
     match LibC::parse_version_opt(&value) {
         // `CONDA_OVERRIDE_GLIBC=""`: drop `__glibc`, leave `__musl`/`__eglibc`.
         Ok(None) => packages.retain(|p| p.name.as_normalized() != "__glibc"),
@@ -1256,7 +1289,7 @@ impl Workspace {
         };
 
         if let PlatformOverrides::EnvironmentVariableOverrides = overrides {
-            apply_environment_variable_overrides(&mut virtual_packages);
+            apply_environment_variable_overrides(&mut virtual_packages, subdir);
         }
 
         PixiPlatform::from_required_virtual_packages(subdir, virtual_packages)
@@ -1563,7 +1596,7 @@ mod tests {
     fn override_adds_undetected_virtual_package() {
         let packages = temp_env::with_var("CONDA_OVERRIDE_CUDA", Some("12.0"), || {
             let mut packages = Vec::new();
-            apply_environment_variable_overrides(&mut packages);
+            apply_environment_variable_overrides(&mut packages, Platform::Linux64);
             packages
         });
 
@@ -1596,7 +1629,7 @@ mod tests {
                 libc_package("__glibc", "2.28"),
                 libc_package("__musl", "1.2"),
             ];
-            apply_environment_variable_overrides(&mut packages);
+            apply_environment_variable_overrides(&mut packages, Platform::Linux64);
             packages
         });
 
@@ -1613,7 +1646,7 @@ mod tests {
                 libc_package("__musl", "1.2"),
                 libc_package("__eglibc", "2.30"),
             ];
-            apply_environment_variable_overrides(&mut packages);
+            apply_environment_variable_overrides(&mut packages, Platform::Linux64);
             packages
         });
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -65,7 +65,8 @@ use crate::lock_file::LockedPackageKind;
 use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
 use rattler_virtual_packages::{
-    Cuda, EnvOverride, LibC, Linux, Osx, Override, VirtualPackageOverrides, VirtualPackages,
+    Archspec, Cuda, EnvOverride, LibC, Linux, Osx, Override, VirtualPackageOverrides,
+    VirtualPackages,
 };
 pub use registry::{WorkspaceRegistry, WorkspaceRegistryError};
 pub use solve_group::SolveGroup;
@@ -360,6 +361,42 @@ fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage
     );
 
     apply_glibc_override(packages);
+    apply_archspec_override(packages);
+}
+
+/// Apply `CONDA_OVERRIDE_ARCHSPEC` to `packages`: unset leaves the detected
+/// `__archspec` untouched, an empty value removes it, and a microarchitecture
+/// name (or `0` for "unknown") replaces or inserts it.
+///
+/// Unknown names are rejected by [`Archspec::parse_version`] and ignored with a
+/// warning
+fn apply_archspec_override(packages: &mut Vec<GenericVirtualPackage>) {
+    if std::env::var_os(Archspec::DEFAULT_ENV_NAME).is_none() {
+        return;
+    }
+    let overridden = match Archspec::detect_with_fallback(&Override::DefaultEnvVar, || Ok(None)) {
+        Ok(overridden) => overridden,
+        Err(error) => {
+            tracing::warn!("Ignoring {}: {error}", Archspec::DEFAULT_ENV_NAME);
+            return;
+        }
+    };
+
+    // Set empty: no `__archspec` at all.
+    let Some(overridden) = overridden else {
+        packages.retain(|p| p.name.as_normalized() != "__archspec");
+        return;
+    };
+    // CEP 30 reserves version 0 for a build string that echoes the subdir
+    // architecture. So replace version as well as build string.
+    let overridden = GenericVirtualPackage::from(overridden);
+    match packages
+        .iter_mut()
+        .find(|p| p.name.as_normalized() == "__archspec")
+    {
+        Some(existing) => *existing = overridden,
+        None => packages.push(overridden),
+    }
 }
 
 /// Apply `CONDA_OVERRIDE_GLIBC` (rattler's only libc slot) to `packages`. The

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -65,7 +65,7 @@ use crate::lock_file::LockedPackageKind;
 use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
 use rattler_virtual_packages::{
-    Archspec, Cuda, EnvOverride, LibC, Linux, Osx, Override, VirtualPackageOverrides,
+    Archspec, Cuda, CudaArch, EnvOverride, LibC, Linux, Osx, Override, VirtualPackageOverrides,
     VirtualPackages,
 };
 pub use registry::{WorkspaceRegistry, WorkspaceRegistryError};
@@ -289,12 +289,33 @@ pub enum PlatformOverrides {
     EnvironmentVariableOverrides,
 }
 
+/// The subdir pixi treats as this machine's, honoring `PIXI_OVERRIDE_PLATFORM`
+/// when `overrides` allows it.
+///
+/// This function does not apply `CONDA_OVERRIDE_*`, so it does not trigger
+/// warnings when those are invalid.
+pub fn host_subdir(overrides: PlatformOverrides) -> Platform {
+    let PlatformOverrides::EnvironmentVariableOverrides = overrides else {
+        return Platform::current();
+    };
+    std::env::var(consts::PIXI_OVERRIDE_PLATFORM)
+        .ok()
+        .and_then(|value| match value.parse::<Platform>() {
+            Ok(platform) => Some(platform),
+            Err(_) => {
+                tracing::warn!("Invalid value for PIXI_OVERRIDE_PLATFORM='{value}', ignoring.");
+                None
+            }
+        })
+        .unwrap_or_else(Platform::current)
+}
+
 /// Apply `CONDA_OVERRIDE_*` env vars to `packages`, matching upstream rattler
 /// semantics: unset keeps the current version, non-empty replaces it (adding
 /// the package if it wasn't detected at all), and empty removes the package
 /// entirely. Rattler drives this per slot via `detect_with_fallback`;
 /// `Ok(Some(v))` = use v, `Ok(None)` = disabled, error = leave untouched.
-fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage>) {
+pub fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage>) {
     let env = Override::DefaultEnvVar;
     packages.retain_mut(|package| {
         let base = package.version.clone();
@@ -308,6 +329,11 @@ fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage
             "__osx" => Osx::detect_with_fallback(&env, || Ok(Some(Osx { version: base })))
                 .ok()
                 .map(|osx| osx.map(|osx| osx.version)),
+            "__cuda_arch" => {
+                CudaArch::detect_with_fallback(&env, || Ok(Some(CudaArch { version: base })))
+                    .ok()
+                    .map(|arch| arch.map(|arch| arch.version))
+            }
             // The libc family is handled by `apply_glibc_override` below, since
             // the single glibc env var must not rewrite `__musl`/`__eglibc`.
             _ => None,
@@ -346,6 +372,13 @@ fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage
             .map(|cuda| cuda.version),
     );
     add_missing(
+        "__cuda_arch",
+        CudaArch::detect_with_fallback(&env, || Ok(None))
+            .ok()
+            .flatten()
+            .map(|arch| arch.version),
+    );
+    add_missing(
         "__osx",
         Osx::detect_with_fallback(&env, || Ok(None))
             .ok()
@@ -359,6 +392,12 @@ fn apply_environment_variable_overrides(packages: &mut Vec<GenericVirtualPackage
             .flatten()
             .map(|linux| linux.version),
     );
+
+    // CEP couples the two CUDA slots: `__cuda_arch` is meaningless without a
+    // driver, and rattler drops it the same way in `VirtualPackages::detect`.
+    if !packages.iter().any(|p| p.name.as_normalized() == "__cuda") {
+        packages.retain(|p| p.name.as_normalized() != "__cuda_arch");
+    }
 
     apply_glibc_override(packages);
     apply_archspec_override(packages);
@@ -1203,23 +1242,7 @@ impl Workspace {
         source: PlatformSource,
         overrides: PlatformOverrides,
     ) -> PixiPlatform {
-        let subdir = match overrides {
-            PlatformOverrides::NoOverrides => Platform::current(),
-            PlatformOverrides::EnvironmentVariableOverrides => {
-                std::env::var(consts::PIXI_OVERRIDE_PLATFORM)
-                    .ok()
-                    .and_then(|value| match value.parse::<Platform>() {
-                        Ok(platform) => Some(platform),
-                        Err(_) => {
-                            tracing::warn!(
-                                "Invalid value for PIXI_OVERRIDE_PLATFORM='{value}', ignoring."
-                            );
-                            None
-                        }
-                    })
-                    .unwrap_or_else(Platform::current)
-            }
-        };
+        let subdir = host_subdir(overrides);
 
         let mut virtual_packages = match source {
             PlatformSource::Defaults => PixiPlatform::from_subdir(subdir)

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -11,10 +11,11 @@ use fancy_display::FancyDisplay;
 use miette::Diagnostic;
 use pixi_manifest::{
     EnvironmentName, FeaturesExt, HasWorkspaceManifest, PixiPlatform, PixiPlatformName,
+    platform::archspec_from_build_string,
 };
 use rattler_conda_types::{GenericVirtualPackage, Platform};
 use rattler_lock::LockFile;
-use rattler_virtual_packages::{Archspec, Cuda, CudaArch, LibC, Linux, Osx, VirtualPackage};
+use rattler_virtual_packages::{Cuda, CudaArch, LibC, Linux, Osx, VirtualPackage};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
@@ -67,17 +68,9 @@ fn generic_to_virtual_package(gvp: &GenericVirtualPackage) -> Option<VirtualPack
         "__cuda_arch" => Some(VirtualPackage::CudaArch(CudaArch {
             version: gvp.version.clone(),
         })),
-        "__archspec" => {
-            // Rattler maps an archspec string through a microarch database
-            // lookup; an empty/"0" build-string means "unknown microarch"
-            // and `from_name` returns the generic catch-all in that case.
-            if gvp.build_string.is_empty() || gvp.build_string == "0" {
-                return Some(VirtualPackage::Archspec(Archspec::Unknown));
-            }
-            Some(VirtualPackage::Archspec(Archspec::from_name(
-                gvp.build_string.as_str(),
-            )))
-        }
+        "__archspec" => Some(VirtualPackage::Archspec(archspec_from_build_string(
+            &gvp.build_string,
+        ))),
         _ => None,
     }
 }

--- a/crates/pixi_manifest/src/platform.rs
+++ b/crates/pixi_manifest/src/platform.rs
@@ -794,8 +794,8 @@ pub fn subdir_default_virtual_packages(subdir: Platform) -> Vec<GenericVirtualPa
 
 /// Returns `true` if `gvp` is exactly the value `subdir_default_virtual_packages`
 /// would emit for `subdir`. Used by the TOML layer to elide default-matching
-/// virtual packages from synthesised names and on-disk serialisation, and by
-/// the lock-file satisfiability check to compare only the user-customised
+/// virtual packages from synthesized names and on-disk serialization, and by
+/// the lock-file satisfiability check to compare only the user-customized
 /// virtual packages.
 pub fn is_subdir_default(gvp: &GenericVirtualPackage, subdir: Platform) -> bool {
     subdir_default_virtual_packages(subdir).iter().any(|d| {
@@ -813,6 +813,14 @@ pub fn archspec_microarchitecture(build_string: &str) -> Option<&str> {
     } else {
         Some(build_string)
     }
+}
+
+/// Map an `__archspec` build string to rattler's typed [`Archspec`]. A name the
+/// archspec database doesn't know maps to [`Archspec::Unknown`].
+pub fn archspec_from_build_string(build_string: &str) -> Archspec {
+    archspec_microarchitecture(build_string)
+        .and_then(Archspec::from_known_name)
+        .unwrap_or(Archspec::Unknown)
 }
 
 /// Validate a declared `__archspec` microarchitecture name against the archspec


### PR DESCRIPTION
This PR introduces CONDA_OVERRIDE_ARCHSPEC support and fixes a couple of small things I noticed testing this. All of it is related to handling CONDA_OVERRIDE_* in general or reporting the results of these overrides.

It does not do anything with that override now, but the feature is super useful to actually test with that it makes sense to land this first first :-)

### How Has This Been Tested?

Mostly by testing the work on top of this one :-)

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
