### PR TITLE
fix: help users with better help messages

### DIFF
--- a/crates/pixi_manifest/src/platform.rs
+++ b/crates/pixi_manifest/src/platform.rs
@@ -379,6 +379,17 @@ impl PixiPlatform {
         self.subdir.as_str() == self.name.as_str()
     }
 
+    /// True when this entry has no `name` of its own and its name was derived
+    /// from the subdir plus its virtual packages. Also decides whether a
+    /// `name` key is written back out.
+    pub fn has_derived_name(&self) -> bool {
+        self.name.as_str()
+            == crate::toml::platform::synthesize_name_string(
+                self.subdir,
+                &self.declared_virtual_packages,
+            )
+    }
+
     /// Returns true if a feature's `platforms` reference `name` selects this
     /// platform. A reference matches by exact name or by bare subdir, so a
     /// feature constrained to `linux-64` also applies to a synthesised
@@ -617,11 +628,7 @@ impl PixiPlatform {
         // A subdir platform and a synthesised platform both carry the
         // auto-derived name; only an explicit custom name differs from it, and
         // such a name is preserved across the edit.
-        let was_auto = self.name.as_str()
-            == crate::toml::platform::synthesize_name_string(
-                self.subdir,
-                &self.declared_virtual_packages,
-            );
+        let was_auto = self.has_derived_name();
         // The subdir might be about to change. Capture it so we can strip
         // the old subdir's defaults from `declared` before merging the new
         // subdir's defaults -- otherwise a Linux64 → Osx64 set_subdir

--- a/crates/pixi_manifest/src/system_requirements.rs
+++ b/crates/pixi_manifest/src/system_requirements.rs
@@ -190,6 +190,19 @@ pub fn virtual_package_applies_to_subdir(name: &str, subdir: Platform) -> bool {
     }
 }
 
+/// Narrow `candidates` to the packages that apply on `subdir`. Shared by the
+/// migration and the deprecation warning that suggests its replacement.
+pub fn virtual_packages_for_subdir(
+    candidates: &[GenericVirtualPackage],
+    subdir: Platform,
+) -> Vec<GenericVirtualPackage> {
+    candidates
+        .iter()
+        .filter(|c| virtual_package_applies_to_subdir(c.name.as_normalized(), subdir))
+        .cloned()
+        .collect()
+}
+
 #[derive(Debug, Clone, Error, Diagnostic)]
 pub enum SystemRequirementsUnionError {
     #[error("two different libc families were specified: '{0}' and '{1}'")]

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -10,8 +10,8 @@ use crate::{
     pypi::pypi_options::PypiOptions,
     toml::{
         PlatformSpan, TomlPrioritizedChannel, TomlTarget, TomlWorkspace,
-        WorkspacePackageProperties, create_unsupported_selector_warning, preview::TomlPreview,
-        task::TomlTask,
+        WorkspacePackageProperties, create_unsupported_selector_warning,
+        platform::system_requirements_as_platforms, preview::TomlPreview, task::TomlTask,
     },
     utils::{
         PixiSpanned, inheritable_package_map::InheritablePackageMap, package_map::DependencyTable,
@@ -245,9 +245,13 @@ impl<'de> toml_span::Deserialize<'de> for TomlFeature {
             && !system_requirements.value.is_empty()
         {
             warnings.push(
-                Deprecation::system_requirements(Some(
-                    system_requirements.span.start..system_requirements.span.end,
-                ))
+                Deprecation::system_requirements(
+                    // A feature is parsed without workspace context, so there
+                    // are no subdirs to write entries for and the example falls
+                    // back to a generic one.
+                    system_requirements_as_platforms(&system_requirements.value, &[]),
+                    Some(system_requirements.span.start..system_requirements.span.end),
+                )
                 .into(),
             );
         }

--- a/crates/pixi_manifest/src/toml/feature.rs
+++ b/crates/pixi_manifest/src/toml/feature.rs
@@ -246,9 +246,7 @@ impl<'de> toml_span::Deserialize<'de> for TomlFeature {
         {
             warnings.push(
                 Deprecation::system_requirements(
-                    // A feature is parsed without workspace context, so there
-                    // are no subdirs to write entries for and the example falls
-                    // back to a generic one.
+                    // No workspace context here, so no subdirs to write.
                     system_requirements_as_platforms(&system_requirements.value, &[]),
                     Some(system_requirements.span.start..system_requirements.span.end),
                 )

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -30,6 +30,7 @@ use crate::{
         PackageDefaults, PlatformSpan, TomlFeature, TomlPackage, TomlTarget, TomlWorkspace,
         WorkspacePackageProperties, create_unsupported_selector_warning,
         environment::{TomlEnvironment, TomlEnvironmentList},
+        platform::{synthesize_name_string, system_requirements_as_platforms},
         task::TomlTask,
     },
     utils::{
@@ -264,8 +265,20 @@ impl TomlManifest {
         if let Some(system_requirements) = &self.system_requirements
             && !system_requirements.value.is_empty()
         {
-            warnings
-                .push(Deprecation::system_requirements(system_requirements.span.clone()).into());
+            let subdirs: Vec<Platform> = workspace
+                .value
+                .platforms
+                .value
+                .iter()
+                .map(PixiPlatform::subdir)
+                .collect();
+            warnings.push(
+                Deprecation::system_requirements(
+                    system_requirements_as_platforms(&system_requirements.value, &subdirs),
+                    system_requirements.span.clone(),
+                )
+                .into(),
+            );
         }
         let default_sysreqs = self
             .system_requirements
@@ -705,6 +718,55 @@ fn extend_originals_with_referenced_subdirs(
     Ok(())
 }
 
+/// True when `platform` has no `name` of its own, so the name a feature has to
+/// reference was derived from the entry itself: its bare subdir, or a slug
+/// built from its virtual packages (e.g. `linux-64-cuda-12-9`). This is the
+/// same comparison the serializer makes to decide whether to write a `name`
+/// key back out.
+fn has_derived_name(platform: &PixiPlatform) -> bool {
+    platform.name().as_str()
+        == synthesize_name_string(platform.subdir(), platform.declared_virtual_packages())
+}
+
+/// The error for a feature that references a platform name the workspace does
+/// not declare, listing the names that are actually available.
+///
+/// When no entry carries a name of its own, the reference the user has to write
+/// is one the manifest derived for them, so the help also suggests naming the
+/// entries. It stays quiet as soon as one entry is explicitly named: past that
+/// point the naming convention is established and repeating the suggestion is
+/// just noise.
+fn undeclared_platform_error(
+    declared: &IndexSet<PixiPlatform>,
+    feature: &Feature,
+    name: &PixiPlatformName,
+) -> TomlError {
+    let help = if declared.is_empty() {
+        "the workspace does not declare any platforms".to_string()
+    } else {
+        let names = declared
+            .iter()
+            .map(|p| p.name().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if declared.iter().all(has_derived_name) {
+            format!(
+                "the workspace declares: {names}. no platform entry sets a `name`, so those names were derived for you; add `name = \"...\"` to an entry to choose your own"
+            )
+        } else {
+            format!("the workspace declares: {names}")
+        }
+    };
+    TomlError::from(
+        GenericError::new(format!(
+            "{} references platform '{}' which is not declared in the workspace",
+            feature.name.user_facing(),
+            name,
+        ))
+        .with_help(help),
+    )
+}
+
 /// Error if any name in `feature.platforms` does not resolve to a platform
 /// declared in the workspace.
 fn validate_referenced_platforms(
@@ -716,11 +778,7 @@ fn validate_referenced_platforms(
     };
     for name in names {
         if !platforms.iter().any(|p| p.name() == name) {
-            return Err(TomlError::from(GenericError::new(format!(
-                "{} references platform '{}' which is not declared in the workspace",
-                feature.name.user_facing(),
-                name,
-            ))));
+            return Err(undeclared_platform_error(platforms, feature, name));
         }
     }
     Ok(())
@@ -737,13 +795,10 @@ fn register_referenced_originals(
         return Ok(());
     };
     for name in names {
-        let original = originals.iter().find(|p| p.name() == name).ok_or_else(|| {
-            TomlError::from(GenericError::new(format!(
-                "{} references platform '{}' which is not declared in the workspace",
-                feature.name.user_facing(),
-                name,
-            )))
-        })?;
+        let original = originals
+            .iter()
+            .find(|p| p.name() == name)
+            .ok_or_else(|| undeclared_platform_error(originals, feature, name))?;
         target.insert(original.clone());
     }
     Ok(())
@@ -2667,9 +2722,49 @@ mod test {
           · ╰──── declare these on the `platforms` entries instead
         9 │
           ╰────
-         help: e.g. platforms = [{ platform = "linux-64", cuda = "12" }]
+         help: e.g. platforms = [{ name = "my-linux-64", platform = "linux-64", cuda = "12" }]
         "#
         );
+    }
+
+    /// Every declared requirement makes it into the example, and the example
+    /// is written for a platform the workspace declares rather than a generic
+    /// `linux-64`. Each entry carries only the requirements that apply to its
+    /// own subdir: `macos` lands on the mac entry, `cuda` and `glibc` on the
+    /// linux one.
+    #[test]
+    fn test_system_requirements_deprecation_warning_lists_all_requirements() {
+        assert_snapshot!(expect_parse_warnings(
+            r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ['osx-arm64', 'linux-64']
+
+        [system-requirements]
+        cuda = "12.9"
+        macos = "13.0"
+        libc = { family = "glibc", version = "2.28" }
+        archspec = "x86_64_v3"
+        "#,
+        ));
+    }
+
+    /// A subdir that none of the declared requirements applies to needs no
+    /// customisation, so it stays a plain bare-string entry.
+    #[test]
+    fn test_system_requirements_deprecation_warning_skips_inapplicable_platforms() {
+        assert_snapshot!(expect_parse_warnings(
+            r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ['win-64', 'osx-64', 'linux-64']
+
+        [system-requirements]
+        libc = { family = "glibc", version = "2.28" }
+        "#,
+        ));
     }
 
     #[test]
@@ -2698,9 +2793,80 @@ mod test {
           · ╰──── declare these on the `platforms` entries instead
         9 │
           ╰────
-         help: e.g. platforms = [{ platform = "linux-64", cuda = "12" }]
+         help: e.g. platforms = [{ name = "my-linux-64", platform = "linux-64", cuda = "12" }]
         "#
         );
+    }
+
+    /// A workspace with named platforms and no `[system-requirements]` takes
+    /// the validate-only branch, so an unknown name is rejected outright.
+    #[test]
+    fn test_feature_references_undeclared_platform() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = [
+            { name = "cpu-linux-64", platform = "linux-64" },
+            { name = "cuda-linux-64", platform = "linux-64", cuda = "12" },
+        ]
+
+        [feature.gpu]
+        platforms = ["linux-64-cuda"]
+
+        [environments]
+        gpu = ["gpu"]
+        "#,
+        ));
+    }
+
+    /// No platform entry carries a `name`, so the name the feature has to
+    /// reference is a slug derived from the virtual packages. The help adds
+    /// the suggestion to name the entries.
+    #[test]
+    fn test_feature_references_undeclared_platform_suggests_naming() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = ["linux-64", { platform = "linux-64", cuda = "12.9" }]
+
+        [feature.gpu]
+        platforms = ["linux-64-cuda-13-0"]
+
+        [environments]
+        gpu = ["gpu"]
+        "#,
+        ));
+    }
+
+    /// The same reference reached through the legacy migration path: another
+    /// feature still carries `[system-requirements]`, so the platform list is
+    /// rebuilt and each reference is resolved against the originals instead.
+    #[test]
+    fn test_feature_references_undeclared_platform_with_system_requirements() {
+        assert_snapshot!(expect_parse_failure(
+            r#"
+        [workspace]
+        name = "test"
+        channels = []
+        platforms = [
+            { name = "cpu-linux-64", platform = "linux-64" },
+        ]
+
+        [feature.gpu]
+        platforms = ["linux-64-cuda"]
+
+        [feature.legacy.system-requirements]
+        cuda = "12"
+
+        [environments]
+        gpu = ["gpu"]
+        legacy = ["legacy"]
+        "#,
+        ));
     }
 
     #[test]

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -720,10 +720,6 @@ fn extend_originals_with_referenced_subdirs(
     Ok(())
 }
 
-/// Only appended when no platform entry is explicitly named.
-const NAME_YOUR_PLATFORMS_HELP: &str = ". no platform entry sets a `name`, so those names were \
-     derived for you; add `name = \"...\"` to an entry to choose your own";
-
 /// The error for a feature that references an undeclared platform name.
 fn undeclared_platform_error(
     declared: &IndexSet<PixiPlatform>,
@@ -734,8 +730,10 @@ fn undeclared_platform_error(
         "the workspace does not declare any platforms".to_string()
     } else {
         let names = declared.iter().map(PixiPlatform::name).format(", ");
+        // Only mention naming when no platform entry is explicitly named.
         let suggestion = if declared.iter().all(PixiPlatform::has_derived_name) {
-            NAME_YOUR_PLATFORMS_HELP
+            ". no platform entry sets a `name`, so those names were derived for you; \
+             add `name = \"...\"` to an entry to choose your own"
         } else {
             ""
         };

--- a/crates/pixi_manifest/src/toml/manifest.rs
+++ b/crates/pixi_manifest/src/toml/manifest.rs
@@ -6,11 +6,12 @@ use std::{
 };
 
 use indexmap::{IndexMap, IndexSet};
+use itertools::Itertools;
 use miette::LabeledSpan;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 use pixi_spec::ExcludeNewer;
 use pixi_toml::{Same, TomlFromStr, TomlHashMap, TomlIndexMap, TomlWith};
-use rattler_conda_types::{GenericVirtualPackage, PackageName, Platform, Version};
+use rattler_conda_types::{PackageName, Platform, Version};
 use toml_span::{
     DeserError, Spanned, Value,
     de_helpers::{TableHelper, expected},
@@ -26,6 +27,7 @@ use crate::{
     error::{FeatureNotEnabled, GenericError},
     manifests::PackageManifest,
     pypi::pypi_options::PypiOptions,
+    system_requirements::virtual_packages_for_subdir,
     toml::{
         PackageDefaults, PlatformSpan, TomlFeature, TomlPackage, TomlTarget, TomlWorkspace,
         WorkspacePackageProperties, create_unsupported_selector_warning,
@@ -718,24 +720,11 @@ fn extend_originals_with_referenced_subdirs(
     Ok(())
 }
 
-/// True when `platform` has no `name` of its own, so the name a feature has to
-/// reference was derived from the entry itself: its bare subdir, or a slug
-/// built from its virtual packages (e.g. `linux-64-cuda-12-9`). This is the
-/// same comparison the serializer makes to decide whether to write a `name`
-/// key back out.
-fn has_derived_name(platform: &PixiPlatform) -> bool {
-    platform.name().as_str()
-        == synthesize_name_string(platform.subdir(), platform.declared_virtual_packages())
-}
+/// Only appended when no platform entry is explicitly named.
+const NAME_YOUR_PLATFORMS_HELP: &str = ". no platform entry sets a `name`, so those names were \
+     derived for you; add `name = \"...\"` to an entry to choose your own";
 
-/// The error for a feature that references a platform name the workspace does
-/// not declare, listing the names that are actually available.
-///
-/// When no entry carries a name of its own, the reference the user has to write
-/// is one the manifest derived for them, so the help also suggests naming the
-/// entries. It stays quiet as soon as one entry is explicitly named: past that
-/// point the naming convention is established and repeating the suggestion is
-/// just noise.
+/// The error for a feature that references an undeclared platform name.
 fn undeclared_platform_error(
     declared: &IndexSet<PixiPlatform>,
     feature: &Feature,
@@ -744,18 +733,13 @@ fn undeclared_platform_error(
     let help = if declared.is_empty() {
         "the workspace does not declare any platforms".to_string()
     } else {
-        let names = declared
-            .iter()
-            .map(|p| p.name().to_string())
-            .collect::<Vec<_>>()
-            .join(", ");
-        if declared.iter().all(has_derived_name) {
-            format!(
-                "the workspace declares: {names}. no platform entry sets a `name`, so those names were derived for you; add `name = \"...\"` to an entry to choose your own"
-            )
+        let names = declared.iter().map(PixiPlatform::name).format(", ");
+        let suggestion = if declared.iter().all(PixiPlatform::has_derived_name) {
+            NAME_YOUR_PLATFORMS_HELP
         } else {
-            format!("the workspace declares: {names}")
-        }
+            ""
+        };
+        format!("the workspace declares: {names}{suggestion}")
     };
     TomlError::from(
         GenericError::new(format!(
@@ -833,17 +817,8 @@ fn synthesise_for_feature(
     let candidates = sysreqs.to_declared_virtual_packages();
     let mut synthesised_names: IndexSet<PixiPlatformName> = IndexSet::new();
     for subdir in subdirs {
-        let declared: Vec<GenericVirtualPackage> = candidates
-            .iter()
-            .filter(|c| {
-                crate::system_requirements::virtual_package_applies_to_subdir(
-                    c.name.as_normalized(),
-                    subdir,
-                )
-            })
-            .cloned()
-            .collect();
-        let name_str = crate::toml::platform::synthesize_name_string(subdir, &declared);
+        let declared = virtual_packages_for_subdir(&candidates, subdir);
+        let name_str = synthesize_name_string(subdir, &declared);
         // A sysreq that matches the subdir defaults collapses the name to the
         // bare subdir. Such a platform would be indistinguishable from the
         // bare subdir platform for solving and for lock-file identity
@@ -1409,32 +1384,6 @@ mod test {
                 .unwrap()
                 .as_str(),
             "linux-64",
-        );
-    }
-
-    #[test]
-    fn test_rich_workspace_feature_references_undeclared_platform_errors() {
-        // No system-requirements, so `extend_originals_with_referenced_subdirs`
-        // doesn't run for this rich-platform workspace; a feature naming a
-        // platform the workspace never declares must still be rejected.
-        let result = WorkspaceManifest::from_toml_str_with_base_dir(
-            r#"
-            [workspace]
-            name = "test"
-            channels = []
-            platforms = ["linux-64", { platform = "linux-64", cuda = "12.9" }]
-
-            [feature.gpu]
-            platforms = ["linux-64-cuda-13-0"]
-            "#,
-            Path::new(""),
-        );
-        let err = result.expect_err("undeclared feature platform must error");
-        assert!(
-            err.error
-                .to_string()
-                .contains("references platform 'linux-64-cuda-13-0' which is not declared"),
-            "unexpected error: {err:?}",
         );
     }
 
@@ -2727,11 +2676,8 @@ mod test {
         );
     }
 
-    /// Every declared requirement makes it into the example, and the example
-    /// is written for a platform the workspace declares rather than a generic
-    /// `linux-64`. Each entry carries only the requirements that apply to its
-    /// own subdir: `macos` lands on the mac entry, `cuda` and `glibc` on the
-    /// linux one.
+    /// Each entry carries only the requirements that apply to its own subdir.
+    /// `archspec` is not carried over.
     #[test]
     fn test_system_requirements_deprecation_warning_lists_all_requirements() {
         assert_snapshot!(expect_parse_warnings(
@@ -2750,8 +2696,7 @@ mod test {
         ));
     }
 
-    /// A subdir that none of the declared requirements applies to needs no
-    /// customisation, so it stays a plain bare-string entry.
+    /// A subdir nothing applies to stays a bare-string entry.
     #[test]
     fn test_system_requirements_deprecation_warning_skips_inapplicable_platforms() {
         assert_snapshot!(expect_parse_warnings(
@@ -2798,8 +2743,7 @@ mod test {
         );
     }
 
-    /// A workspace with named platforms and no `[system-requirements]` takes
-    /// the validate-only branch, so an unknown name is rejected outright.
+    /// Covers the `validate_referenced_platforms` path.
     #[test]
     fn test_feature_references_undeclared_platform() {
         assert_snapshot!(expect_parse_failure(
@@ -2821,9 +2765,7 @@ mod test {
         ));
     }
 
-    /// No platform entry carries a `name`, so the name the feature has to
-    /// reference is a slug derived from the virtual packages. The help adds
-    /// the suggestion to name the entries.
+    /// No entry is named, so the help suggests naming them.
     #[test]
     fn test_feature_references_undeclared_platform_suggests_naming() {
         assert_snapshot!(expect_parse_failure(
@@ -2842,9 +2784,7 @@ mod test {
         ));
     }
 
-    /// The same reference reached through the legacy migration path: another
-    /// feature still carries `[system-requirements]`, so the platform list is
-    /// rebuilt and each reference is resolved against the originals instead.
+    /// Covers the `register_referenced_originals` path.
     #[test]
     fn test_feature_references_undeclared_platform_with_system_requirements() {
         assert_snapshot!(expect_parse_failure(

--- a/crates/pixi_manifest/src/toml/platform.rs
+++ b/crates/pixi_manifest/src/toml/platform.rs
@@ -1,5 +1,8 @@
 use std::{collections::HashSet, str::FromStr};
 
+use indexmap::IndexSet;
+use itertools::Itertools;
+
 use pixi_toml::TomlEnum;
 use rattler_conda_types::{GenericVirtualPackage, PackageName, Platform, Version};
 use serde::{Serialize, ser::SerializeMap};
@@ -12,7 +15,7 @@ use toml_span::{
 use crate::{
     PixiPlatform, PixiPlatformName,
     platform::subdir_default_virtual_packages,
-    system_requirements::{SystemRequirements, virtual_package_applies_to_subdir},
+    system_requirements::{SystemRequirements, virtual_packages_for_subdir},
 };
 
 /// This type is used to represent the platform in the manifest file. The
@@ -331,8 +334,7 @@ impl Serialize for TomlPixiPlatform {
             return serializer.serialize_str(name);
         }
 
-        let auto_name = synthesize_name_string(platform.subdir(), declared);
-        let emit_name = name != auto_name;
+        let emit_name = !platform.has_derived_name();
 
         let count = 1 + usize::from(emit_name) + entries.len();
         let mut map = serializer.serialize_map(Some(count))?;
@@ -933,69 +935,50 @@ fn platform_inline_entries(
 }
 
 /// Render the `platforms` array that replaces a legacy `[system-requirements]`
-/// table: one entry per subdir the workspace declares, each carrying only the
-/// virtual packages that apply there. A requirement that names a different
-/// operating system is dropped from the entries it cannot apply to, so the
-/// result is a `platforms` array that can be pasted in as written.
+/// table: one entry per subdir, each carrying only the requirements that apply
+/// there.
 ///
-/// Built from the same two helpers the migration in
-/// `rebuild_platforms_from_system_requirements` uses, so the suggestion and
-/// what pixi would synthesise cannot drift apart. `subdirs` may be empty (a
-/// feature is parsed with no workspace context), in which case the example
-/// falls back to a single `linux-64` entry.
+/// A requirement equal to the subdir's default is still written out, where the
+/// serializer would drop it. `subdirs` may be empty, which falls back to a
+/// single `linux-64` entry.
 pub(crate) fn system_requirements_as_platforms(
     sysreqs: &SystemRequirements,
     subdirs: &[Platform],
 ) -> String {
-    // Two declared platforms can share a subdir (`linux-64` alongside a
-    // cuda-bearing variant); one entry per subdir is enough, and emitting the
-    // subdir twice would mint two entries with the same `my-` name.
-    let mut seen = HashSet::new();
-    let mut unique: Vec<Platform> = subdirs
-        .iter()
-        .copied()
-        .filter(|subdir| seen.insert(*subdir))
-        .collect();
-    if unique.is_empty() {
-        unique.push(Platform::Linux64);
-    }
+    // Two platforms can share a subdir; emitting it twice would give two
+    // entries the same `my-` name.
+    let unique: IndexSet<Platform> = if subdirs.is_empty() {
+        IndexSet::from([Platform::Linux64])
+    } else {
+        subdirs.iter().copied().collect()
+    };
 
     let candidates = sysreqs.to_declared_virtual_packages();
     let rendered = unique
         .iter()
-        .map(|&subdir| {
-            let declared: Vec<GenericVirtualPackage> = candidates
-                .iter()
-                .filter(|c| virtual_package_applies_to_subdir(c.name.as_normalized(), subdir))
-                .cloned()
-                .collect();
-            // No baseline: a requirement that happens to equal the subdir's
-            // default is still written out. Eliding it would be correct for
-            // serialization but wrong here, where the whole point is to show
-            // the user where each requirement they wrote ends up.
-            let entries = platform_inline_entries(&declared, None);
-            // Nothing the user declared applies to this subdir, so it needs no
-            // customisation and the plain bare-string form says exactly that.
-            if entries.is_empty() {
-                return format!("\"{subdir}\"");
-            }
-            let pairs = entries
-                .iter()
-                .map(|entry| match entry {
-                    InlinePlatformEntry::Scalar { key, value, .. } => {
-                        format!("{key} = \"{value}\"")
-                    }
-                    InlinePlatformEntry::CudaTable { driver, arch } => {
-                        format!("cuda = {{ driver = \"{driver}\", arch = \"{arch}\" }}")
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{{ name = \"my-{subdir}\", platform = \"{subdir}\", {pairs} }}")
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
+        .map(|&subdir| suggested_platform_entry(&candidates, subdir))
+        .format(", ");
     format!("platforms = [{rendered}]")
+}
+
+/// One suggested `platforms` entry for `subdir`.
+fn suggested_platform_entry(candidates: &[GenericVirtualPackage], subdir: Platform) -> String {
+    let declared = virtual_packages_for_subdir(candidates, subdir);
+    let entries = platform_inline_entries(&declared, None);
+    if entries.is_empty() {
+        return format!("\"{subdir}\"");
+    }
+    let pairs = entries
+        .iter()
+        .map(|entry| match entry {
+            InlinePlatformEntry::Scalar { key, value, .. } => format!("{key} = \"{value}\""),
+            InlinePlatformEntry::CudaTable { driver, arch } => render_cuda_table(driver, arch),
+        })
+        .format(", ");
+    // Without an explicit name, a requirement equal to the subdir default
+    // collapses the name back to the bare subdir, which is then rejected as
+    // `IsSubdirPlatform`.
+    format!("{{ name = \"my-{subdir}\", platform = \"{subdir}\", {pairs} }}")
 }
 
 /// Render a [`PixiPlatform`] as a [`toml_edit::Value`] using the same
@@ -1015,10 +998,8 @@ pub(crate) fn pixi_platform_to_toml_value(platform: &PixiPlatform) -> toml_edit:
         return toml_edit::Value::from(name);
     }
 
-    let auto_name = synthesize_name_string(platform.subdir(), declared);
-
     let mut table = toml_edit::InlineTable::new();
-    if name != auto_name {
+    if !platform.has_derived_name() {
         table.insert("name", name.into());
     }
     table.insert("platform", subdir_str.into());

--- a/crates/pixi_manifest/src/toml/platform.rs
+++ b/crates/pixi_manifest/src/toml/platform.rs
@@ -9,7 +9,11 @@ use toml_span::{
     value::ValueInner,
 };
 
-use crate::{PixiPlatform, PixiPlatformName, platform::subdir_default_virtual_packages};
+use crate::{
+    PixiPlatform, PixiPlatformName,
+    platform::subdir_default_virtual_packages,
+    system_requirements::{SystemRequirements, virtual_package_applies_to_subdir},
+};
 
 /// This type is used to represent the platform in the manifest file. The
 /// [`Platform`] type from rattler contains more platforms than we actually
@@ -926,6 +930,72 @@ fn platform_inline_entries(
         });
     }
     entries
+}
+
+/// Render the `platforms` array that replaces a legacy `[system-requirements]`
+/// table: one entry per subdir the workspace declares, each carrying only the
+/// virtual packages that apply there. A requirement that names a different
+/// operating system is dropped from the entries it cannot apply to, so the
+/// result is a `platforms` array that can be pasted in as written.
+///
+/// Built from the same two helpers the migration in
+/// `rebuild_platforms_from_system_requirements` uses, so the suggestion and
+/// what pixi would synthesise cannot drift apart. `subdirs` may be empty (a
+/// feature is parsed with no workspace context), in which case the example
+/// falls back to a single `linux-64` entry.
+pub(crate) fn system_requirements_as_platforms(
+    sysreqs: &SystemRequirements,
+    subdirs: &[Platform],
+) -> String {
+    // Two declared platforms can share a subdir (`linux-64` alongside a
+    // cuda-bearing variant); one entry per subdir is enough, and emitting the
+    // subdir twice would mint two entries with the same `my-` name.
+    let mut seen = HashSet::new();
+    let mut unique: Vec<Platform> = subdirs
+        .iter()
+        .copied()
+        .filter(|subdir| seen.insert(*subdir))
+        .collect();
+    if unique.is_empty() {
+        unique.push(Platform::Linux64);
+    }
+
+    let candidates = sysreqs.to_declared_virtual_packages();
+    let rendered = unique
+        .iter()
+        .map(|&subdir| {
+            let declared: Vec<GenericVirtualPackage> = candidates
+                .iter()
+                .filter(|c| virtual_package_applies_to_subdir(c.name.as_normalized(), subdir))
+                .cloned()
+                .collect();
+            // No baseline: a requirement that happens to equal the subdir's
+            // default is still written out. Eliding it would be correct for
+            // serialization but wrong here, where the whole point is to show
+            // the user where each requirement they wrote ends up.
+            let entries = platform_inline_entries(&declared, None);
+            // Nothing the user declared applies to this subdir, so it needs no
+            // customisation and the plain bare-string form says exactly that.
+            if entries.is_empty() {
+                return format!("\"{subdir}\"");
+            }
+            let pairs = entries
+                .iter()
+                .map(|entry| match entry {
+                    InlinePlatformEntry::Scalar { key, value, .. } => {
+                        format!("{key} = \"{value}\"")
+                    }
+                    InlinePlatformEntry::CudaTable { driver, arch } => {
+                        format!("cuda = {{ driver = \"{driver}\", arch = \"{arch}\" }}")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{ name = \"my-{subdir}\", platform = \"{subdir}\", {pairs} }}")
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("platforms = [{rendered}]")
 }
 
 /// Render a [`PixiPlatform`] as a [`toml_edit::Value`] using the same

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__feature_references_undeclared_platform.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__feature_references_undeclared_platform.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"test\"\n        channels = []\n        platforms = [\n            { name = \"cpu-linux-64\", platform = \"linux-64\" },\n            { name = \"cuda-linux-64\", platform = \"linux-64\", cuda = \"12\" },\n        ]\n\n        [feature.gpu]\n        platforms = [\"linux-64-cuda\"]\n\n        [environments]\n        gpu = [\"gpu\"]\n        \"#,)"
+---
+  × feature 'gpu' references platform 'linux-64-cuda' which is not declared in the workspace
+  help: the workspace declares: cpu-linux-64, cuda-linux-64

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__feature_references_undeclared_platform_suggests_naming.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__feature_references_undeclared_platform_suggests_naming.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"test\"\n        channels = []\n        platforms = [\"linux-64\", { platform = \"linux-64\", cuda = \"12.9\" }]\n\n        [feature.gpu]\n        platforms = [\"linux-64-cuda-13-0\"]\n\n        [environments]\n        gpu = [\"gpu\"]\n        \"#,)"
+---
+  × feature 'gpu' references platform 'linux-64-cuda-13-0' which is not declared in the workspace
+  help: the workspace declares: linux-64, linux-64-cuda-12-9. no platform entry sets a `name`, so those names were derived for you; add `name = "..."` to an entry to choose your own

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__feature_references_undeclared_platform_with_system_requirements.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__feature_references_undeclared_platform_with_system_requirements.snap
@@ -1,0 +1,6 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+expression: "expect_parse_failure(r#\"\n        [workspace]\n        name = \"test\"\n        channels = []\n        platforms = [\n            { name = \"cpu-linux-64\", platform = \"linux-64\" },\n        ]\n\n        [feature.gpu]\n        platforms = [\"linux-64-cuda\"]\n\n        [feature.legacy.system-requirements]\n        cuda = \"12\"\n\n        [environments]\n        gpu = [\"gpu\"]\n        legacy = [\"legacy\"]\n        \"#,)"
+---
+  × feature 'gpu' references platform 'linux-64-cuda' which is not declared in the workspace
+  help: the workspace declares: cpu-linux-64

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__system_requirements_deprecation_warning_lists_all_requirements.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__system_requirements_deprecation_warning_lists_all_requirements.snap
@@ -1,0 +1,17 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+assertion_line: 2737
+expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"test\"\n        channels = []\n        platforms = ['osx-arm64', 'linux-64']\n\n        [system-requirements]\n        cuda = \"12.9\"\n        macos = \"13.0\"\n        libc = { family = \"glibc\", version = \"2.28\" }\n        archspec = \"x86_64_v3\"\n        \"#,)"
+---
+  ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
+    ╭─[pixi.toml:7:9]
+  6 │
+  7 │ ╭─▶         [system-requirements]
+  8 │ │           cuda = "12.9"
+  9 │ │           macos = "13.0"
+ 10 │ │           libc = { family = "glibc", version = "2.28" }
+ 11 │ ├─▶         archspec = "x86_64_v3"
+    · ╰──── declare these on the `platforms` entries instead
+ 12 │
+    ╰────
+  help: e.g. platforms = [{ name = "my-osx-arm64", platform = "osx-arm64", macos = "13.0" }, { name = "my-linux-64", platform = "linux-64", cuda = "12.9", glibc = "2.28" }]

--- a/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__system_requirements_deprecation_warning_skips_inapplicable_platforms.snap
+++ b/crates/pixi_manifest/src/toml/snapshots/pixi_manifest__toml__manifest__test__system_requirements_deprecation_warning_skips_inapplicable_platforms.snap
@@ -1,0 +1,14 @@
+---
+source: crates/pixi_manifest/src/toml/manifest.rs
+assertion_line: 2757
+expression: "expect_parse_warnings(r#\"\n        [workspace]\n        name = \"test\"\n        channels = []\n        platforms = ['win-64', 'osx-64', 'linux-64']\n\n        [system-requirements]\n        libc = { family = \"glibc\", version = \"2.28\" }\n        \"#,)"
+---
+  ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
+   ╭─[pixi.toml:7:9]
+ 6 │
+ 7 │ ╭─▶         [system-requirements]
+ 8 │ ├─▶         libc = { family = "glibc", version = "2.28" }
+   · ╰──── declare these on the `platforms` entries instead
+ 9 │
+   ╰────
+  help: e.g. platforms = ["win-64", "osx-64", { name = "my-linux-64", platform = "linux-64", glibc = "2.28" }]

--- a/crates/pixi_manifest/src/warning/deprecation.rs
+++ b/crates/pixi_manifest/src/warning/deprecation.rs
@@ -29,9 +29,8 @@ impl Deprecation {
     /// Deprecation of the legacy `[system-requirements]` table in favor of
     /// virtual packages declared on the `platforms` entries.
     ///
-    /// `help` carries the tailored replacement, built by
-    /// [`crate::toml::platform::system_requirements_as_platforms`] so it spells
-    /// out the requirements actually declared, per platform.
+    /// `help` carries the replacement, built by
+    /// [`crate::toml::platform::system_requirements_as_platforms`].
     pub fn system_requirements(help: String, span: Option<Range<usize>>) -> Self {
         let labels = span
             .map(|span| {

--- a/crates/pixi_manifest/src/warning/deprecation.rs
+++ b/crates/pixi_manifest/src/warning/deprecation.rs
@@ -28,7 +28,11 @@ impl Deprecation {
 
     /// Deprecation of the legacy `[system-requirements]` table in favor of
     /// virtual packages declared on the `platforms` entries.
-    pub fn system_requirements(span: Option<Range<usize>>) -> Self {
+    ///
+    /// `help` carries the tailored replacement, built by
+    /// [`crate::toml::platform::system_requirements_as_platforms`] so it spells
+    /// out the requirements actually declared, per platform.
+    pub fn system_requirements(help: String, span: Option<Range<usize>>) -> Self {
         let labels = span
             .map(|span| {
                 vec![LabeledSpan::new_primary_with_span(
@@ -42,7 +46,7 @@ impl Deprecation {
                 "the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`"
                     .into(),
             labels,
-            help: Some(r#"e.g. platforms = [{ platform = "linux-64", cuda = "12" }]"#.into()),
+            help: Some(format!("e.g. {help}").into()),
         }
     }
 


### PR DESCRIPTION
### Description

Errors now help the user with the deprecation of system-requirements:

```
 WARN Encountered 1 warning while parsing the manifest:
  ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
   ╭─[/private/tmp/pixi-platform-errors/sysreq-deprecation/pixi.toml:6:1]
 5 │     
 6 │ ╭─▶ [system-requirements]
 7 │ │   cuda = "13"
 8 │ ├─▶ libc = { family = "glibc", version = "2.28" }
   · ╰──── declare these on the `platforms` entries instead
 9 │     
   ╰────
  help: e.g. platforms = [{ name = "my-win-64", platform = "win-64", cuda = "13" }, "osx-64", "osx-arm64", { name =
        "my-linux-64", platform = "linux-64", cuda = "13", glibc = "2.28" }]
```

And using an non existing platform will give you an helpful error too:

```
  × feature 'gpu' references platform 'linux-64-cuda' which is not declared in the workspace
  help: the workspace declares: cpu-linux-64, cuda-linux-64
```

Fixes prefix-dev/pixi#6814

### How Has This Been Tested?

I tested it manually on some of these examples but the integration tests do some tests with snapshots which also help with the review.

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added sufficient tests to cover my changes.
- [X] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.