### PR TITLE
fix: treat corrupt task-cache JSON as a cache miss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7265,6 +7265,7 @@ dependencies = [
  "pixi_glob",
  "pixi_manifest",
  "pixi_progress",
+ "pixi_utils",
  "rattler_conda_types",
  "rattler_lock",
  "rayon",

--- a/crates/pixi_task/Cargo.toml
+++ b/crates/pixi_task/Cargo.toml
@@ -23,6 +23,7 @@ pixi_core = { workspace = true }
 pixi_glob = { workspace = true }
 pixi_manifest = { workspace = true, features = ["rattler_lock"] }
 pixi_progress = { workspace = true }
+pixi_utils = { workspace = true }
 rattler_conda_types = { workspace = true }
 rattler_lock = { workspace = true }
 rayon = { workspace = true }

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -24,6 +24,7 @@ use pixi_manifest::{
     task::{ArgValues, TaskRenderContext, TemplateStringError},
 };
 use pixi_progress::await_in_progress;
+use pixi_utils::atomic_write::atomic_write;
 use rattler_lock::LockFile;
 use thiserror::Error;
 use tokio::task::JoinHandle;
@@ -466,31 +467,7 @@ impl<'p> ExecutableTask<'p> {
         let cache = TaskCache {
             hash: new_hash.computation_hash(),
         };
-        Ok(replace_file_atomically(&cache_file, serde_json::to_string(&cache)?).await?)
-    }
-}
-
-/// Persist `contents` at `path` via a sibling temp file and rename.
-/// An interrupted write then leaves a `.json.tmp`, not a truncated cache.
-async fn replace_file_atomically(
-    path: &std::path::Path,
-    contents: impl AsRef<[u8]>,
-) -> std::io::Result<()> {
-    let tmp_file = match path.file_name() {
-        Some(name) => {
-            let mut tmp_name = name.to_os_string();
-            tmp_name.push(".tmp");
-            path.with_file_name(tmp_name)
-        }
-        None => path.with_extension("tmp"),
-    };
-    tokio::fs::write(&tmp_file, contents).await?;
-    match tokio::fs::rename(&tmp_file, path).await {
-        Ok(()) => Ok(()),
-        Err(_) => {
-            let _ = tokio::fs::remove_file(path).await;
-            tokio::fs::rename(&tmp_file, path).await
-        }
+        Ok(atomic_write(&cache_file, serde_json::to_string(&cache)?).await?)
     }
 }
 
@@ -637,10 +614,9 @@ mod tests {
     async fn can_skip_treats_empty_cache_file_as_miss_and_removes_it() {
         let tmp = tempfile::tempdir().unwrap();
         let manifest = tmp.path().join("pixi.toml");
-        let file_contents = format!(
-            "{PROJECT_BOILERPLATE}\n[tasks]\nrepro = {{ cmd = \"echo task-ran\" }}\n"
-        );
-        std::fs::write(&manifest, &file_contents).unwrap();
+        let file_contents =
+            format!("{PROJECT_BOILERPLATE}\n[tasks]\nrepro = {{ cmd = \"echo task-ran\" }}\n");
+        fs_err::write(&manifest, &file_contents).unwrap();
         let workspace = Workspace::from_str(&manifest, &file_contents).unwrap();
         let task = task_from_snippet(&workspace, "repro");
         let args_hash = TaskHash::task_args_hash(&task).unwrap_or_default();
@@ -660,24 +636,6 @@ mod tests {
         assert!(
             !cache_file.exists(),
             "corrupt cache file must be removed so later runs can recover"
-        );
-    }
-
-    #[tokio::test]
-    async fn replace_file_atomically_overwrites_without_leaving_truncated_json() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("default-repro-.json");
-        tokio::fs::write(&path, "").await.unwrap();
-        replace_file_atomically(&path, "{\"hash\":\"abc\"}")
-            .await
-            .unwrap();
-        let written = tokio::fs::read_to_string(&path).await.unwrap();
-        assert_eq!(written, "{\"hash\":\"abc\"}");
-        let mut tmp_name = path.file_name().unwrap().to_os_string();
-        tmp_name.push(".tmp");
-        assert!(
-            !path.with_file_name(tmp_name).exists(),
-            "successful replace must not leave the temp sibling"
         );
     }
 

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -404,30 +404,34 @@ impl<'p> ExecutableTask<'p> {
         let args_hash = TaskHash::task_args_hash(self).unwrap_or_default();
         let cache_name = self.cache_name(args_hash);
         let cache_file = self.project().task_cache_folder().join(cache_name);
-        if cache_file.exists() {
-            let cache = tokio_fs::read_to_string(&cache_file).await?;
-            let cache: TaskCache = match serde_json::from_str(&cache) {
-                Ok(cache) => cache,
-                Err(err) => {
-                    // A truncated or corrupt cache is a miss, not a hard failure.
-                    // Disk-full writes have left zero-byte files that then
-                    // blocked every later `pixi run` with a generic JSON EOF.
-                    tracing::warn!(
-                        path = %cache_file.display(),
-                        error = %err,
-                        "ignoring corrupt task-cache entry"
-                    );
-                    let _ = tokio_fs::remove_file(&cache_file).await;
-                    return Ok(CanSkip::No(None));
-                }
-            };
-            let hash = TaskHash::from_task(self, lock_file).await;
-            if let Ok(Some(hash)) = hash {
-                if hash.computation_hash() != cache.hash {
-                    return Ok(CanSkip::No(Some(hash)));
-                } else {
-                    return Ok(CanSkip::Yes);
-                }
+        let cache = match tokio_fs::read_to_string(&cache_file).await {
+            Ok(cache) => cache,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(CanSkip::No(None));
+            }
+            Err(err) => return Err(err),
+        };
+        let cache: TaskCache = match serde_json::from_str(&cache) {
+            Ok(cache) => cache,
+            Err(err) => {
+                // A truncated or corrupt cache is a miss, not a hard failure.
+                // Disk-full writes have left zero-byte files that then
+                // blocked every later `pixi run` with a generic JSON EOF.
+                tracing::warn!(
+                    path = %cache_file.display(),
+                    error = %err,
+                    "ignoring corrupt task-cache entry"
+                );
+                let _ = tokio_fs::remove_file(&cache_file).await;
+                return Ok(CanSkip::No(None));
+            }
+        };
+        let hash = TaskHash::from_task(self, lock_file).await;
+        if let Ok(Some(hash)) = hash {
+            if hash.computation_hash() != cache.hash {
+                return Ok(CanSkip::No(Some(hash)));
+            } else {
+                return Ok(CanSkip::Yes);
             }
         }
         Ok(CanSkip::No(None))
@@ -613,11 +617,7 @@ mod tests {
     #[tokio::test]
     async fn can_skip_treats_empty_cache_file_as_miss_and_removes_it() {
         let tmp = tempfile::tempdir().unwrap();
-        let manifest = tmp.path().join("pixi.toml");
-        let file_contents =
-            format!("{PROJECT_BOILERPLATE}\n[tasks]\nrepro = {{ cmd = \"echo task-ran\" }}\n");
-        fs_err::write(&manifest, &file_contents).unwrap();
-        let workspace = Workspace::from_str(&manifest, &file_contents).unwrap();
+        let workspace = workspace_at(tmp.path(), "repro = { cmd = \"echo task-ran\" }");
         let task = task_from_snippet(&workspace, "repro");
         let args_hash = TaskHash::task_args_hash(&task).unwrap_or_default();
         let cache_file = workspace
@@ -637,6 +637,63 @@ mod tests {
             !cache_file.exists(),
             "corrupt cache file must be removed so later runs can recover"
         );
+    }
+
+    #[tokio::test]
+    async fn can_skip_treats_missing_cache_file_as_miss() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = workspace_at(tmp.path(), "repro = { cmd = \"echo task-ran\" }");
+        let task = task_from_snippet(&workspace, "repro");
+
+        let result = task.can_skip(&LockFile::default()).await.unwrap();
+
+        assert!(matches!(result, CanSkip::No(None)));
+    }
+
+    #[tokio::test]
+    async fn save_cache_atomically_overwrites_existing_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = workspace_at(
+            tmp.path(),
+            "repro = { cmd = \"echo task-ran\", outputs = [\"output.txt\"] }",
+        );
+        let output = tmp.path().join("output.txt");
+        tokio_fs::write(&output, "first").await.unwrap();
+        let task = task_from_snippet(&workspace, "repro");
+        let lock_file = LockFile::default();
+
+        let first_hash = TaskHash::from_task(&task, &lock_file)
+            .await
+            .unwrap()
+            .unwrap();
+        task.save_cache(Some(first_hash)).await.unwrap();
+        let cache_file = workspace
+            .task_cache_folder()
+            .join(task.cache_name(TaskHash::task_args_hash(&task).unwrap_or_default()));
+        let first_cache: TaskCache =
+            serde_json::from_str(&tokio_fs::read_to_string(&cache_file).await.unwrap()).unwrap();
+
+        tokio_fs::write(&output, "second-version").await.unwrap();
+        let second_hash = TaskHash::from_task(&task, &lock_file)
+            .await
+            .unwrap()
+            .unwrap();
+        let expected_hash = second_hash.computation_hash();
+        task.save_cache(Some(second_hash)).await.unwrap();
+
+        let second_cache: TaskCache =
+            serde_json::from_str(&tokio_fs::read_to_string(&cache_file).await.unwrap()).unwrap();
+        assert_ne!(first_cache.hash, second_cache.hash);
+        assert_eq!(second_cache.hash, expected_hash);
+
+        let mut entries = tokio_fs::read_dir(workspace.task_cache_folder())
+            .await
+            .unwrap();
+        assert_eq!(
+            entries.next_entry().await.unwrap().unwrap().path(),
+            cache_file
+        );
+        assert!(entries.next_entry().await.unwrap().is_none());
     }
 
     const PROJECT_BOILERPLATE: &str = r#"
@@ -786,6 +843,13 @@ mod tests {
             args: ArgValues::default(),
             init_cwd: None,
         }
+    }
+
+    fn workspace_at(root: &Path, task_definition: &str) -> Workspace {
+        let manifest = root.join("pixi.toml");
+        let file_contents = format!("{PROJECT_BOILERPLATE}\n[tasks]\n{task_definition}\n");
+        fs_err::write(&manifest, &file_contents).unwrap();
+        Workspace::from_str(&manifest, &file_contents).unwrap()
     }
 
     fn workspace_with(file_contents: &str) -> Workspace {

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -405,7 +405,21 @@ impl<'p> ExecutableTask<'p> {
         let cache_file = self.project().task_cache_folder().join(cache_name);
         if cache_file.exists() {
             let cache = tokio_fs::read_to_string(&cache_file).await?;
-            let cache: TaskCache = serde_json::from_str(&cache)?;
+            let cache: TaskCache = match serde_json::from_str(&cache) {
+                Ok(cache) => cache,
+                Err(err) => {
+                    // A truncated or corrupt cache is a miss, not a hard failure.
+                    // Disk-full writes have left zero-byte files that then
+                    // blocked every later `pixi run` with a generic JSON EOF.
+                    tracing::warn!(
+                        path = %cache_file.display(),
+                        error = %err,
+                        "ignoring corrupt task-cache entry"
+                    );
+                    let _ = tokio_fs::remove_file(&cache_file).await;
+                    return Ok(CanSkip::No(None));
+                }
+            };
             let hash = TaskHash::from_task(self, lock_file).await;
             if let Ok(Some(hash)) = hash {
                 if hash.computation_hash() != cache.hash {
@@ -452,8 +466,31 @@ impl<'p> ExecutableTask<'p> {
         let cache = TaskCache {
             hash: new_hash.computation_hash(),
         };
-        let cache = serde_json::to_string(&cache)?;
-        Ok(tokio::fs::write(&cache_file, cache).await?)
+        Ok(replace_file_atomically(&cache_file, serde_json::to_string(&cache)?).await?)
+    }
+}
+
+/// Persist `contents` at `path` via a sibling temp file and rename.
+/// An interrupted write then leaves a `.json.tmp`, not a truncated cache.
+async fn replace_file_atomically(
+    path: &std::path::Path,
+    contents: impl AsRef<[u8]>,
+) -> std::io::Result<()> {
+    let tmp_file = match path.file_name() {
+        Some(name) => {
+            let mut tmp_name = name.to_os_string();
+            tmp_name.push(".tmp");
+            path.with_file_name(tmp_name)
+        }
+        None => path.with_extension("tmp"),
+    };
+    tokio::fs::write(&tmp_file, contents).await?;
+    match tokio::fs::rename(&tmp_file, path).await {
+        Ok(()) => Ok(()),
+        Err(_) => {
+            let _ = tokio::fs::remove_file(path).await;
+            tokio::fs::rename(&tmp_file, path).await
+        }
     }
 }
 
@@ -573,8 +610,76 @@ pub async fn get_task_env(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task_hash::ComputationHash;
     use pixi_manifest::task::{ArgValues, TypedArg};
     use std::path::Path;
+
+    #[test]
+    fn empty_task_cache_json_is_a_parse_error() {
+        let err = serde_json::from_str::<TaskCache>("").expect_err("empty cache must not parse");
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("eof") || err.is_eof(),
+            "expected an EOF-class parse error, got {err}"
+        );
+    }
+
+    #[test]
+    fn valid_task_cache_json_roundtrips() {
+        let cache = TaskCache {
+            hash: ComputationHash::from("abc123".to_string()),
+        };
+        let encoded = serde_json::to_string(&cache).expect("encode");
+        let decoded: TaskCache = serde_json::from_str(&encoded).expect("decode");
+        assert_eq!(decoded.hash, cache.hash);
+    }
+
+    #[tokio::test]
+    async fn can_skip_treats_empty_cache_file_as_miss_and_removes_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifest = tmp.path().join("pixi.toml");
+        let file_contents = format!(
+            "{PROJECT_BOILERPLATE}\n[tasks]\nrepro = {{ cmd = \"echo task-ran\" }}\n"
+        );
+        std::fs::write(&manifest, &file_contents).unwrap();
+        let workspace = Workspace::from_str(&manifest, &file_contents).unwrap();
+        let task = task_from_snippet(&workspace, "repro");
+        let args_hash = TaskHash::task_args_hash(&task).unwrap_or_default();
+        let cache_file = workspace
+            .task_cache_folder()
+            .join(task.cache_name(args_hash));
+        tokio::fs::create_dir_all(cache_file.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&cache_file, "").await.unwrap();
+
+        let result = task.can_skip(&LockFile::default()).await.unwrap();
+        assert!(
+            matches!(result, CanSkip::No(None)),
+            "empty cache must be a miss"
+        );
+        assert!(
+            !cache_file.exists(),
+            "corrupt cache file must be removed so later runs can recover"
+        );
+    }
+
+    #[tokio::test]
+    async fn replace_file_atomically_overwrites_without_leaving_truncated_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("default-repro-.json");
+        tokio::fs::write(&path, "").await.unwrap();
+        replace_file_atomically(&path, "{\"hash\":\"abc\"}")
+            .await
+            .unwrap();
+        let written = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(written, "{\"hash\":\"abc\"}");
+        let mut tmp_name = path.file_name().unwrap().to_os_string();
+        tmp_name.push(".tmp");
+        assert!(
+            !path.with_file_name(tmp_name).exists(),
+            "successful replace must not leave the temp sibling"
+        );
+    }
 
     const PROJECT_BOILERPLATE: &str = r#"
         [project]

--- a/crates/pixi_task/src/executable_task.rs
+++ b/crates/pixi_task/src/executable_task.rs
@@ -422,7 +422,9 @@ impl<'p> ExecutableTask<'p> {
                     error = %err,
                     "ignoring corrupt task-cache entry"
                 );
-                let _ = tokio_fs::remove_file(&cache_file).await;
+                // Leave the rejected entry in place until a successful run
+                // replaces it. Removing it here could unlink a valid entry
+                // concurrently written after this process read the bad bytes.
                 return Ok(CanSkip::No(None));
             }
         };
@@ -615,7 +617,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn can_skip_treats_empty_cache_file_as_miss_and_removes_it() {
+    async fn can_skip_treats_empty_cache_file_as_miss_without_unlinking_it() {
         let tmp = tempfile::tempdir().unwrap();
         let workspace = workspace_at(tmp.path(), "repro = { cmd = \"echo task-ran\" }");
         let task = task_from_snippet(&workspace, "repro");
@@ -634,8 +636,8 @@ mod tests {
             "empty cache must be a miss"
         );
         assert!(
-            !cache_file.exists(),
-            "corrupt cache file must be removed so later runs can recover"
+            cache_file.exists(),
+            "leave the rejected entry for a successful run to replace atomically"
         );
     }
 
@@ -685,6 +687,10 @@ mod tests {
             serde_json::from_str(&tokio_fs::read_to_string(&cache_file).await.unwrap()).unwrap();
         assert_ne!(first_cache.hash, second_cache.hash);
         assert_eq!(second_cache.hash, expected_hash);
+        assert!(matches!(
+            task.can_skip(&lock_file).await.unwrap(),
+            CanSkip::Yes
+        ));
 
         let mut entries = tokio_fs::read_dir(workspace.task_cache_folder())
             .await


### PR DESCRIPTION
### Description

Fixes #6823.

A truncated `.pixi/task-cache-v0/*.json` file (for example, after the filesystem runs out of space during a write) currently makes every later `pixi run` fail with `EOF while parsing a value`.

Missing, empty, or otherwise invalid cache entries are now treated as cache misses so the task runs normally. Rejected entries are left in place until a successful task run replaces them atomically; this avoids one process unlinking a valid cache entry concurrently written by another process.

Cache writes now use the shared `pixi_utils::atomic_write` helper, which writes through a unique temporary file and atomically persists the completed JSON.

### How Has This Been Tested?

- `cargo clippy --all-targets --workspace -- -D warnings`
- `cargo test -p pixi_task --lib` (54 passed)
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- Regression coverage for missing and corrupt cache entries, preservation of rejected entries, and atomic overwrite without temporary-file leftovers.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Google Antigravity (Gemini) and OpenAI Codex

```plaintext
Diagnose and repair #6823 so missing or corrupt task-cache JSON is a safe cache miss, cache writes are atomic, concurrent runs cannot delete valid replacements, and regression and lint checks cover the behavior.
```

### Checklist:

- [x] I have performed a self-review of my own code.
- [x] I have added sufficient tests to cover my changes.
