### PR TITLE
fix: honor CONDA_OVERRIDE_* in the publish build and host solves

### DIFF
--- a/crates/pixi_cli/src/publish/mod.rs
+++ b/crates/pixi_cli/src/publish/mod.rs
@@ -24,7 +24,9 @@ use pixi_command_dispatcher::{
 };
 use pixi_config::{ConfigCli, PackageFormatAndCompression};
 use pixi_core::{
-    Workspace, WorkspaceLocator, environment::sanity_check_workspace, workspace::DiscoveryStart,
+    Workspace, WorkspaceLocator,
+    environment::sanity_check_workspace,
+    workspace::{DiscoveryStart, apply_environment_variable_overrides},
 };
 use pixi_manifest::{FeaturesExt, S3Options};
 use pixi_path::AbsPathBuf;
@@ -651,19 +653,21 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         variant_files.extend(resolve_variant_config_paths(&args.variant_config, &cwd));
     }
 
-    let build_virtual_packages: Vec<GenericVirtualPackage> = workspace
+    let mut build_virtual_packages: Vec<GenericVirtualPackage> = workspace
         .default_environment()
         .virtual_packages(&build_pixi_platform)
         .into_iter()
         .map(GenericVirtualPackage::from)
         .collect();
+    apply_environment_variable_overrides(&mut build_virtual_packages, build_pixi_platform.subdir());
 
-    let host_virtual_packages: Vec<GenericVirtualPackage> = workspace
+    let mut host_virtual_packages: Vec<GenericVirtualPackage> = workspace
         .default_environment()
         .virtual_packages(&target_pixi_platform)
         .into_iter()
         .map(GenericVirtualPackage::from)
         .collect();
+    apply_environment_variable_overrides(&mut host_virtual_packages, target_pixi_platform.subdir());
 
     let build_environment = BuildEnvironment {
         host_platform: args.target_platform,

--- a/tests/integration_python/pixi_build/test_build.py
+++ b/tests/integration_python/pixi_build/test_build.py
@@ -44,6 +44,42 @@ def test_build_conda_package(
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(
+    CURRENT_PLATFORM not in {"linux-64", "win-64"},
+    reason="virtual_packages channel ships the cuda package only for linux-64 and win-64",
+)
+def test_build_honors_cuda_override(
+    pixi: Path,
+    simple_workspace: Workspace,
+    test_data: Path,
+) -> None:
+    """`CONDA_OVERRIDE_CUDA` must reach the host solve, so a machine without a
+    GPU can build a package whose host requirements need `__cuda`."""
+    channel = test_data.joinpath("channels", "channels", "virtual_packages").as_uri()
+    simple_workspace.workspace_manifest["workspace"]["channels"].insert(0, channel)
+    simple_workspace.recipe["requirements"] = {"host": ["cuda"]}
+    simple_workspace.write_files()
+
+    command = [
+        pixi,
+        "publish",
+        "--target-dir",
+        str(simple_workspace.workspace_dir),
+        "--path",
+        simple_workspace.package_dir,
+    ]
+
+    # An empty override disables `__cuda`, so this fails on a GPU machine too.
+    verify_cli_command(
+        command,
+        expected_exit_code=ExitCode.FAILURE,
+        env={"CONDA_OVERRIDE_CUDA": ""},
+        stderr_contains="__cuda",
+    )
+    verify_cli_command(command, env={"CONDA_OVERRIDE_CUDA": "12.0"})
+
+
+@pytest.mark.slow
 def test_no_change_should_be_fully_cached(pixi: Path, simple_workspace: Workspace) -> None:
     simple_workspace.write_files()
     verify_cli_command(


### PR DESCRIPTION
### Description

`pixi publish` builds its build/host virtual packages from the declared platforms alone, so `CONDA_OVERRIDE_*` never reaches the solve. A GPU-less runner cannot build a package whose host needs `__cuda`, although `docs/workspace/system_requirements.md` says these overrides "apply regardless of how the platform is declared in `pixi.toml`", and they already work for `pixi lock` and for plain `rattler-build` on the same recipe.

This applies them on top of the declared platforms via `apply_environment_variable_overrides` (#6820), as `Workspace::host_platform` already does. Only the solved virtual packages change; platform identity, derived build variants and the build string stay as declared.

Related to #6653, which also asks that `-t/--target-platform` accept a rich platform name; that part is unaddressed here.

### How Has This Been Tested?

- New `test_build_honors_cuda_override` builds a package whose host requires `cuda` (`__cuda >=12`, from the in-repo `virtual_packages` channel) on a machine with no GPU. It fails without this change and passes with it.
- The reproducer from #6653 now builds and emits `cuda-pkg-0.1.0-hb0f4dca_0.conda`, the same build hash bare `rattler-build` produces. With `CONDA_OVERRIDE_CUDA=""` it still fails as before.
- `cargo nextest run -p pixi_cli -p pixi_core` and the `pixi_build` integration suite.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Claude Opus 5)

This was an interactive session rather than a single prompt, so the task as given, rather than a verbatim prompt:

```plaintext
Investigate why `pixi publish` ignores CONDA_OVERRIDE_CUDA (#6653), which is
blocking a CUDA PyTorch extension from building on a GPU-less CI runner, and
write a minimal upstream fix.

Constraints: match pixi's existing style exactly; no comments unless comparable
call sites carry an equivalent comment; verify against the issue's own
reproducer before proposing anything.
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
