### PR TITLE
refactor: Use matchspecs for requirements in rich platforms

### DIFF
--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -219,13 +219,13 @@ pub async fn add_auto_detected<I: Interface>(
 
 /// Pointers shown after adding a fresh auto-detected platform: it is shared via
 /// the manifest, it is usually more specific than needed, and `pixi info`
-/// reveals which virtual packages are actually required.
+/// reveals what the installed packages actually require.
 fn auto_detected_hint(name: &PixiPlatformName) -> String {
     format!(
         "\n  This platform is written to pixi.toml and shared with everyone using the workspace.\n  \
          Auto-detection captures your machine exactly, which is often more specific than needed.\n\n  \
-         After installing, `pixi info` shows each environment's \"Minimum platform\" -- the\n  \
-         virtual packages actually required -- so you can see which ones are safe to drop.\n\n  \
+         After installing, `pixi info` shows each environment's \"Minimum platform\" -- what the\n  \
+         installed packages actually require -- so you can see which ones are safe to drop.\n\n  \
          Refine it:\n    \
          pixi workspace platform edit {name} ...   # rename / drop virtual packages\n    \
          pixi workspace platform move {name} ...   # change its priority"

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use miette::IntoDiagnostic;
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
-use pixi_core::environment::PlatformData;
+use pixi_core::environment::{PlatformData, RequiredPlatform};
 use pixi_global::{BinDir, EnvRoot};
 use pixi_manifest::platform::subdir_default_virtual_packages;
 use pixi_manifest::toml::inline_virtual_package_specs;
@@ -88,16 +88,25 @@ impl From<&pixi_manifest::PixiPlatform> for PlatformInfo {
     }
 }
 
-/// Built from a marker-file [`PlatformData`], which records the platform's
-/// composition but not its name; the subdir stands in as the display name.
 impl From<&PlatformData> for PlatformInfo {
     fn from(data: &PlatformData) -> Self {
         Self {
             name: data.subdir().into(),
             subdir: data.subdir().to_string(),
-            // Resolved/minimum is a computed set, not a declaration: don't filter,
-            // so a requirement that equals a subdir default still shows.
             virtual_packages: friendly_virtual_packages(data.virtual_packages(), None),
+        }
+    }
+}
+
+/// Built from a marker-file [`RequiredPlatform`]. Its entries are match specs
+/// rather than concrete virtual packages, so they are shown as written -- a
+/// requirement is a constraint, and there is no friendly manifest key for one.
+impl From<&RequiredPlatform> for PlatformInfo {
+    fn from(data: &RequiredPlatform) -> Self {
+        Self {
+            name: data.subdir().into(),
+            subdir: data.subdir().to_string(),
+            virtual_packages: data.requirement_strings(),
         }
     }
 }

--- a/crates/pixi_command_dispatcher/Cargo.toml
+++ b/crates/pixi_command_dispatcher/Cargo.toml
@@ -19,7 +19,6 @@ derive_more = { workspace = true, features = ["display", "from", "try_into"] }
 dunce = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
-indexmap = { workspace = true }
 itertools = { workspace = true }
 miette = { workspace = true }
 nanoid = { workspace = true }

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -15,7 +15,10 @@ pub use pixi_python_status::PythonStatus;
 use pixi_spec::{GitSpec, PixiSpec};
 use pixi_utils::EnvironmentFingerprint;
 use pixi_utils::{prefix::Prefix, rlimit::try_increase_rlimit_to_sensible};
-use rattler_conda_types::{GenericVirtualPackage, Platform};
+use rattler_conda_types::{
+    GenericVirtualPackage, MatchSpec, PackageNameMatcher, ParseMatchSpecError, ParseStrictness,
+    Platform, StringMatcher, Version, VersionSpec, version_spec::RangeOperator,
+};
 use rattler_lock::{LockFile, LockedPackage};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
@@ -117,7 +120,7 @@ impl EnvironmentHash {
     /// Used for **task** caching: a task's cached result is keyed on
     /// inputs the user can change without going through an install
     /// (manifest, lock file, env vars, activation scripts), so this
-    /// flavour folds locked package URLs into the hash directly.
+    /// flavor folds locked package URLs into the hash directly.
     ///
     /// The activation cache uses [`Self::for_activation`] instead --
     /// see the docs there for why URL-based hashing is too coarse for
@@ -343,17 +346,119 @@ impl From<&PixiPlatform> for PlatformData {
 
 impl Display for PlatformData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.subdir)?;
-        if !self.virtual_packages.is_empty() {
-            let packages = self
-                .virtual_packages
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ");
-            write!(f, " [{packages}]")?;
+        write_platform(f, self.subdir, &self.virtual_packages)
+    }
+}
+
+/// Render a platform as `<subdir>` or `<subdir> [entry, entry]`.
+fn write_platform(
+    f: &mut Formatter<'_>,
+    subdir: Platform,
+    entries: &[impl Display],
+) -> std::fmt::Result {
+    write!(f, "{subdir}")?;
+    if !entries.is_empty() {
+        let entries = entries
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, " [{entries}]")?;
+    }
+    Ok(())
+}
+
+/// The requirements the installed packages place on the machine: the conda
+/// subdir plus the virtual-package specs some resolved dependency depends on.
+#[derive(Serialize, Deserialize)]
+#[serde(try_from = "RequiredPlatformRaw", into = "RequiredPlatformRaw")]
+#[derive(Clone)]
+pub struct RequiredPlatform {
+    subdir: Platform,
+    requirements: Vec<MatchSpec>,
+}
+
+impl RequiredPlatform {
+    /// A requirement set from a subdir and the specs resolved dependencies
+    pub fn new(subdir: Platform, requirements: Vec<MatchSpec>) -> Self {
+        Self {
+            subdir,
+            requirements,
         }
-        Ok(())
+    }
+
+    /// The conda subdir these requirements were resolved for.
+    pub fn subdir(&self) -> Platform {
+        self.subdir
+    }
+
+    /// The virtual-package specs resolved dependencies require.
+    pub fn requirements(&self) -> &[MatchSpec] {
+        &self.requirements
+    }
+
+    /// The requirements as conda match-spec strings: how they are written to the
+    /// marker file and shown by `pixi info`, and the only form that round-trips.
+    pub fn requirement_strings(&self) -> Vec<String> {
+        self.requirements.iter().map(ToString::to_string).collect()
+    }
+}
+
+impl Display for RequiredPlatform {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write_platform(f, self.subdir, &self.requirements)
+    }
+}
+
+/// On-disk representation of [`RequiredPlatform`]. Specs are stored as conda match-spec
+/// strings, matching how [`GenericVirtualPackage`] renders itself in this file
+#[derive(Serialize, Deserialize)]
+struct RequiredPlatformRaw {
+    subdir: Platform,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    requirements: Vec<String>,
+    /// Written by pixi versions that recorded requirements as concrete virtual
+    /// packages. Read for migration, never written.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    virtual_packages: Vec<GenericVirtualPackage>,
+}
+
+impl From<RequiredPlatform> for RequiredPlatformRaw {
+    fn from(platform: RequiredPlatform) -> Self {
+        Self {
+            subdir: platform.subdir,
+            requirements: platform.requirement_strings(),
+            virtual_packages: Vec::new(),
+        }
+    }
+}
+
+impl TryFrom<RequiredPlatformRaw> for RequiredPlatform {
+    type Error = ParseMatchSpecError;
+
+    fn try_from(raw: RequiredPlatformRaw) -> Result<Self, Self::Error> {
+        let mut requirements = raw
+            .requirements
+            .iter()
+            .map(|spec| MatchSpec::from_str(spec, ParseStrictness::Lenient))
+            .collect::<Result<Vec<_>, _>>()?;
+        // Migrate a marker written before requirements were specs.
+        requirements.extend(raw.virtual_packages.iter().map(legacy_requirement));
+        Ok(Self::new(raw.subdir, requirements))
+    }
+}
+
+/// Reinterpret a legacy marker's concrete virtual package as the requirement it
+/// stood for: at least this version, with version 0 meaning "any version".
+fn legacy_requirement(package: &GenericVirtualPackage) -> MatchSpec {
+    let version = (package.version != Version::major(0))
+        .then(|| VersionSpec::Range(RangeOperator::GreaterEquals, package.version.clone()));
+    MatchSpec {
+        name: PackageNameMatcher::Exact(package.name.clone()),
+        version,
+        build: (!package.build_string.is_empty())
+            .then(|| StringMatcher::Exact(package.build_string.clone())),
+        ..MatchSpec::default()
     }
 }
 
@@ -377,15 +482,15 @@ pub struct EnvironmentFile {
     /// file, so they record [`LockedEnvironmentHash::invalid`] here.
     pub environment_lock_file_hash: LockedEnvironmentHash,
     /// The platform the environment was resolved with (subdir + the virtual
-    /// packages the workspace declared for it). `None` on environments written
-    /// by an older pixi, or when no declared platform runs on this machine.
+    /// packages the workspace declared for it). `None` for older pixi versions.
     #[serde(default)]
     pub resolved_platform: Option<PlatformData>,
-    /// The minimum platform the installed packages actually require (the subdir
-    /// plus only the virtual packages some resolved dependency depends on). Can
-    /// be weaker than [`Self::resolved_platform`]. `None` as above.
+    /// The minimum the installed packages actually require (the subdir plus
+    /// only the virtual-package specs some resolved dependency depends on). Can
+    /// be weaker than [`Self::resolved_platform`]. `None` for older pixi
+    /// versions.
     #[serde(default)]
-    pub minimum_supported_platform: Option<PlatformData>,
+    pub minimum_supported_platform: Option<RequiredPlatform>,
     /// Fingerprints of the manifest's source dependencies at install time,
     /// keyed by package name: a hash of the source spec plus any inline
     /// package definition. Only written by `pixi global`, which has no lock
@@ -983,5 +1088,147 @@ mod tests {
         let restored: PlatformData = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.subdir, Platform::Linux64);
         assert!(restored.virtual_packages.contains(&cuda));
+    }
+
+    #[test]
+    fn required_platform_round_trips_pattern_requirements() {
+        let archspec = "__archspec[version='1.*', build='^(x86_64_v3|haswell|skylake)$']";
+        let requirements = vec![
+            MatchSpec::from_str(archspec, ParseStrictness::Lenient).unwrap(),
+            MatchSpec::from_str("__glibc >=2.17", ParseStrictness::Lenient).unwrap(),
+        ];
+        let platform = RequiredPlatform::new(Platform::Linux64, requirements);
+
+        let json = serde_json::to_string(&platform).unwrap();
+        // Stored as strings, like the concrete virtual packages beside them,
+        // rather than serde's field-wise form for a match spec.
+        assert!(json.contains("x86_64_v3|haswell|skylake"), "{json}");
+        assert!(!json.contains("\"build\":{"), "{json}");
+
+        let restored: RequiredPlatform = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.subdir(), Platform::Linux64);
+        let archspec_spec = restored
+            .requirements()
+            .iter()
+            .find(|spec| {
+                spec.name
+                    .as_exact()
+                    .is_some_and(|name| name.as_normalized() == "__archspec")
+            })
+            .expect("__archspec requirement");
+        // The build matcher survives as a regex, not as a literal name.
+        assert!(
+            matches!(archspec_spec.build, Some(StringMatcher::Regex(_))),
+            "{:?}",
+            archspec_spec.build
+        );
+    }
+
+    #[test]
+    fn legacy_marker_requirements_migrate_to_match_specs() {
+        let legacy = r#"{
+            "subdir": "linux-64",
+            "virtual_packages": ["__glibc=2.17", "__cuda=0"]
+        }"#;
+        let restored: RequiredPlatform = serde_json::from_str(legacy).unwrap();
+        assert_eq!(restored.subdir(), Platform::Linux64);
+        // A recorded version becomes a lower bound; version 0 meant "any".
+        assert_eq!(
+            restored
+                .requirements()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["__glibc >=2.17", "__cuda"]
+        );
+
+        // Re-serializing writes the modern field and drops the legacy one.
+        let json = serde_json::to_string(&restored).unwrap();
+        assert!(json.contains("requirements"), "{json}");
+        assert!(!json.contains("virtual_packages"), "{json}");
+    }
+
+    #[test]
+    fn required_platform_reads_modern_and_legacy_keys_together() {
+        let both = r#"{
+            "subdir": "linux-64",
+            "requirements": ["__glibc >=2.28"],
+            "virtual_packages": ["__cuda=99"]
+        }"#;
+        let restored: RequiredPlatform = serde_json::from_str(both).unwrap();
+        assert_eq!(
+            restored
+                .requirements()
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["__glibc >=2.28", "__cuda >=99"]
+        );
+    }
+
+    #[test]
+    fn malformed_required_platform_markers_are_rejected_not_misread() {
+        // A requirement that is not a parseable match spec.
+        assert!(
+            serde_json::from_str::<RequiredPlatform>(
+                r#"{"subdir": "linux-64", "requirements": ["@@@ not a spec @@@"]}"#
+            )
+            .is_err()
+        );
+        // A legacy entry that is not a parseable virtual package.
+        assert!(
+            serde_json::from_str::<RequiredPlatform>(
+                r#"{"subdir": "linux-64", "virtual_packages": ["not a vp"]}"#
+            )
+            .is_err()
+        );
+        // Wrong shape for the list, and a missing subdir.
+        assert!(
+            serde_json::from_str::<RequiredPlatform>(
+                r#"{"subdir": "linux-64", "requirements": "__cuda >=12"}"#
+            )
+            .is_err()
+        );
+        assert!(
+            serde_json::from_str::<RequiredPlatform>(r#"{"requirements": ["__cuda >=12"]}"#)
+                .is_err()
+        );
+
+        // These are tolerated: no requirements at all is a real state
+        let empty: RequiredPlatform =
+            serde_json::from_str(r#"{"subdir": "linux-64"}"#).expect("no requirements is valid");
+        assert!(empty.requirements().is_empty());
+        // An empty list round-trips to the same thing, and omits the key.
+        let json = serde_json::to_string(&empty).unwrap();
+        assert!(!json.contains("requirements"), "{json}");
+        assert!(
+            serde_json::from_str::<RequiredPlatform>(
+                r#"{"subdir": "linux-64", "requirements": [], "future_key": 3}"#
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn requirement_specs_survive_the_marker_round_trip() {
+        for raw in [
+            "__cuda >=12",
+            "__cuda",
+            "__glibc >=2.17,<3.0.a0",
+            "__unix",
+            "__archspec 1 x86_64",
+            "__archspec 1.* ^(x86_64_v3|haswell|skylake)$",
+        ] {
+            let spec = MatchSpec::from_str(raw, ParseStrictness::Lenient).unwrap();
+            let platform = RequiredPlatform::new(Platform::Linux64, vec![spec.clone()]);
+            let json = serde_json::to_string(&platform).unwrap();
+            let restored: RequiredPlatform = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("'{raw}' did not survive the round trip: {e}"));
+            assert_eq!(
+                restored.requirements(),
+                &[spec],
+                "'{raw}' changed meaning through the marker"
+            );
+        }
     }
 }

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -16,8 +16,8 @@ use pixi_spec::{GitSpec, PixiSpec};
 use pixi_utils::EnvironmentFingerprint;
 use pixi_utils::{prefix::Prefix, rlimit::try_increase_rlimit_to_sensible};
 use rattler_conda_types::{
-    GenericVirtualPackage, MatchSpec, PackageNameMatcher, ParseMatchSpecError, ParseStrictness,
-    Platform, StringMatcher, Version, VersionSpec, version_spec::RangeOperator,
+    GenericVirtualPackage, MatchSpec, PackageNameMatcher, ParseStrictness, Platform, StringMatcher,
+    Version, VersionSpec, version_spec::RangeOperator,
 };
 use rattler_lock::{LockFile, LockedPackage};
 use serde::{Deserialize, Serialize};
@@ -371,7 +371,7 @@ fn write_platform(
 /// The requirements the installed packages place on the machine: the conda
 /// subdir plus the virtual-package specs some resolved dependency depends on.
 #[derive(Serialize, Deserialize)]
-#[serde(try_from = "RequiredPlatformRaw", into = "RequiredPlatformRaw")]
+#[serde(from = "RequiredPlatformRaw", into = "RequiredPlatformRaw")]
 #[derive(Clone)]
 pub struct RequiredPlatform {
     subdir: Platform,
@@ -420,7 +420,7 @@ struct RequiredPlatformRaw {
     /// Written by pixi versions that recorded requirements as concrete virtual
     /// packages. Read for migration, never written.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    virtual_packages: Vec<GenericVirtualPackage>,
+    virtual_packages: Vec<String>,
 }
 
 impl From<RequiredPlatform> for RequiredPlatformRaw {
@@ -433,18 +433,35 @@ impl From<RequiredPlatform> for RequiredPlatformRaw {
     }
 }
 
-impl TryFrom<RequiredPlatformRaw> for RequiredPlatform {
-    type Error = ParseMatchSpecError;
-
-    fn try_from(raw: RequiredPlatformRaw) -> Result<Self, Self::Error> {
-        let mut requirements = raw
+impl From<RequiredPlatformRaw> for RequiredPlatform {
+    /// Read what can be read and drop the rest, loudly.
+    fn from(raw: RequiredPlatformRaw) -> Self {
+        let mut requirements: Vec<MatchSpec> = raw
             .requirements
             .iter()
-            .map(|spec| MatchSpec::from_str(spec, ParseStrictness::Lenient))
-            .collect::<Result<Vec<_>, _>>()?;
+            .filter_map(|spec| {
+                MatchSpec::from_str(spec, ParseStrictness::Lenient)
+                    .inspect_err(|error| {
+                        tracing::warn!(
+                            "Ignoring unreadable requirement '{spec}' recorded in {}: {error}",
+                            consts::ENVIRONMENT_FILE_NAME
+                        );
+                    })
+                    .ok()
+            })
+            .collect();
         // Migrate a marker written before requirements were specs.
-        requirements.extend(raw.virtual_packages.iter().map(legacy_requirement));
-        Ok(Self::new(raw.subdir, requirements))
+        requirements.extend(raw.virtual_packages.iter().filter_map(|entry| {
+            let package = pixi_manifest::platform::parse_locked_virtual_package(entry);
+            if package.is_none() {
+                tracing::warn!(
+                    "Ignoring unreadable virtual package '{entry}' recorded in {}",
+                    consts::ENVIRONMENT_FILE_NAME
+                );
+            }
+            package.as_ref().map(legacy_requirement)
+        }));
+        Self::new(raw.subdir, requirements)
     }
 }
 
@@ -1168,21 +1185,19 @@ mod tests {
 
     #[test]
     fn malformed_required_platform_markers_are_rejected_not_misread() {
-        // A requirement that is not a parseable match spec.
-        assert!(
-            serde_json::from_str::<RequiredPlatform>(
-                r#"{"subdir": "linux-64", "requirements": ["@@@ not a spec @@@"]}"#
-            )
-            .is_err()
-        );
-        // A legacy entry that is not a parseable virtual package.
-        assert!(
-            serde_json::from_str::<RequiredPlatform>(
-                r#"{"subdir": "linux-64", "virtual_packages": ["not a vp"]}"#
-            )
-            .is_err()
-        );
-        // Wrong shape for the list, and a missing subdir.
+        // An entry pixi cannot read costs that entry and nothing more, in
+        // either the modern or the legacy field.
+        let unreadable: RequiredPlatform = serde_json::from_str(
+            r#"{"subdir": "linux-64", "requirements": ["@@@ not a spec @@@"]}"#,
+        )
+        .expect("one unreadable requirement must not reject the platform");
+        assert!(unreadable.requirements().is_empty());
+        let unreadable: RequiredPlatform =
+            serde_json::from_str(r#"{"subdir": "linux-64", "virtual_packages": ["not a vp"]}"#)
+                .expect("one unreadable legacy entry must not reject the platform");
+        assert!(unreadable.requirements().is_empty());
+
+        // A structurally wrong file is still a rejection.
         assert!(
             serde_json::from_str::<RequiredPlatform>(
                 r#"{"subdir": "linux-64", "requirements": "__cuda >=12"}"#
@@ -1230,5 +1245,54 @@ mod tests {
                 "'{raw}' changed meaning through the marker"
             );
         }
+    }
+
+    /// A version literal too large to represent.
+    const UNPARSABLE_REQUIREMENT: &str = "__cuda >=99999999999999999999";
+
+    #[test]
+    fn the_unparsable_requirement_fixture_really_is_unparsable() {
+        assert!(MatchSpec::from_str(UNPARSABLE_REQUIREMENT, ParseStrictness::Lenient).is_err());
+    }
+
+    #[test]
+    fn one_unparsable_requirement_does_not_discard_the_readable_ones() {
+        let json = format!(
+            r#"{{"subdir": "linux-64", "requirements": ["__cuda >=12", "{UNPARSABLE_REQUIREMENT}"]}}"#
+        );
+        let restored: RequiredPlatform = serde_json::from_str(&json)
+            .expect("a requirement pixi cannot read must not void the ones it can");
+        assert!(
+            restored
+                .requirements()
+                .iter()
+                .any(|spec| spec.to_string() == "__cuda >=12"),
+            "the readable requirement was dropped: {:?}",
+            restored.requirements()
+        );
+    }
+
+    #[test]
+    fn an_unparsable_requirement_does_not_void_the_whole_environment_file() {
+        let json = format!(
+            r#"{{
+                "manifest_path": "/ws/pixi.toml",
+                "environment_name": "default",
+                "pixi_version": "0.1.0",
+                "environment_lock_file_hash": "deadbeef",
+                "source_fingerprints": {{"some-source-package": 42}},
+                "minimum_supported_platform": {{
+                    "subdir": "linux-64",
+                    "requirements": ["{UNPARSABLE_REQUIREMENT}"]
+                }}
+            }}"#
+        );
+        let parsed: EnvironmentFile = serde_json::from_str(&json)
+            .expect("an unreadable minimum must not invalidate the rest of the marker");
+        assert_eq!(
+            parsed.source_fingerprints.get("some-source-package"),
+            Some(&42),
+            "the rest of the marker was lost with the unreadable requirement"
+        );
     }
 }

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -69,14 +69,14 @@ use crate::{
     activation::CurrentEnvVarBehavior,
     environment::{
         CondaPrefixUpdated, EnvironmentFile, InstallFilter, LockFileUsage, LockedEnvironmentHash,
-        PerEnvironmentAndPlatform, PerGroup, PerGroupAndPlatform, PlatformData,
+        PerEnvironmentAndPlatform, PerGroup, PerGroupAndPlatform, PlatformData, RequiredPlatform,
         read_environment_file, write_environment_file,
     },
     lock_file::{
         self,
         reporter::SolveProgressBar,
         virtual_packages::{
-            compute_minimal_required_platforms, validate_system_meets_environment_requirements,
+            compute_required_virtual_package_specs, validate_system_meets_environment_requirements,
         },
     },
     workspace::{
@@ -769,24 +769,26 @@ impl<'p> LockFileDerivedData<'p> {
     }
 
     /// The platform data recorded in the `conda-meta/pixi` marker file for the
-    /// installed prefix: the platform the environment was resolved with, and
-    /// the minimum platform its resolved packages actually require. `None` when
-    /// no declared platform runs on this machine.
+    /// installed prefix.
+    /// `None` when no declared platform runs on this machine.
     fn installed_platform_data(
         &self,
         environment: &Environment<'p>,
-    ) -> Option<(PlatformData, PlatformData)> {
+    ) -> Option<(PlatformData, RequiredPlatform)> {
         let resolved = self.install_platform(environment)?;
-        let minimal =
-            compute_minimal_required_platforms(&self.lock_file, environment.name(), &[resolved]);
+        let requirements = compute_required_virtual_package_specs(
+            &self.lock_file,
+            environment.name(),
+            &[resolved],
+        );
         // A subdir whose lock entry has no conda packages is absent from the
-        // map; the minimum is then the subdir with no required virtual packages.
-        let minimum = minimal.get(&resolved.subdir()).map_or_else(
-            || PlatformData {
-                subdir: resolved.subdir(),
-                virtual_packages: Vec::new(),
-            },
-            PlatformData::from,
+        // map; the minimum is then the subdir with no requirements at all.
+        let minimum = RequiredPlatform::new(
+            resolved.subdir(),
+            requirements
+                .get(&resolved.subdir())
+                .cloned()
+                .unwrap_or_default(),
         );
         Some((PlatformData::from(resolved), minimum))
     }

--- a/crates/pixi_core/src/lock_file/virtual_packages.rs
+++ b/crates/pixi_core/src/lock_file/virtual_packages.rs
@@ -33,11 +33,13 @@ pub struct VirtualPackageNotFoundError {
 }
 
 impl VirtualPackageNotFoundError {
+    /// `target` is the subdir the environment is being validated for.
     pub fn new(
         required_package: &MatchSpec,
         system_virtual_packages: &[GenericVirtualPackage],
+        target: Platform,
     ) -> Self {
-        let help = spec_override_hint(required_package).map(|hint| {
+        let help = spec_override_hint(required_package, target).map(|hint| {
             format!(
                 " You can mock the virtual package by overriding the environment variable, e.g.: '`{hint}`'"
             )
@@ -294,7 +296,12 @@ pub(crate) fn validate_system_meets_environment_requirements(
     if let Some(unmet) =
         unmet_requirements(&required_virtual_packages, &system_capabilities).first()
     {
-        return Err(VirtualPackageNotFoundError::new(unmet, &system_capabilities).into());
+        return Err(VirtualPackageNotFoundError::new(
+            unmet,
+            &system_capabilities,
+            platform.subdir(),
+        )
+        .into());
     }
 
     // Check if the wheel tags match the system virtual packages if there are any
@@ -701,11 +708,13 @@ packages:
         };
         let system_virtual_packages = vec![libc, cuda, osx];
 
-        let error1 = VirtualPackageNotFoundError::new(&spec, &system_virtual_packages);
+        let error1 =
+            VirtualPackageNotFoundError::new(&spec, &system_virtual_packages, Platform::Linux64);
 
         // Create a test MatchSpec for unix which doesn't have an override
         let spec = MatchSpec::from_str("__unix >= 1.2.3", ParseStrictness::Strict).unwrap();
-        let error2 = VirtualPackageNotFoundError::new(&spec, &system_virtual_packages);
+        let error2 =
+            VirtualPackageNotFoundError::new(&spec, &system_virtual_packages, Platform::Linux64);
 
         assert_snapshot!(format!(
             "With override:\n{}\nWithout override:\n{}",
@@ -715,22 +724,44 @@ packages:
     }
     #[test]
     fn test_virtual_package_not_found_error_with_overrides() {
-        // Check all overrides
+        // Each override is checked on a target that honors it.
         let overrides = vec![
-            ("__glibc >= 2.17", "`CONDA_OVERRIDE_GLIBC=2.17`"),
-            ("__cuda >= 12.0", "`CONDA_OVERRIDE_CUDA=12.0`"),
-            ("__osx >= 10.15", "`CONDA_OVERRIDE_OSX=10.15`"),
+            (
+                "__glibc >= 2.17",
+                Platform::Linux64,
+                "`CONDA_OVERRIDE_GLIBC=2.17`",
+            ),
+            (
+                "__cuda >= 12.0",
+                Platform::Linux64,
+                "`CONDA_OVERRIDE_CUDA=12.0`",
+            ),
+            (
+                "__osx >= 10.15",
+                Platform::Osx64,
+                "`CONDA_OVERRIDE_OSX=10.15`",
+            ),
         ];
 
         let system_virtual_packages: Vec<GenericVirtualPackage> = vec![];
 
-        for (spec, msg) in overrides {
+        for (spec, target, msg) in overrides {
             let error = VirtualPackageNotFoundError::new(
                 &MatchSpec::from_str(spec, ParseStrictness::Strict).unwrap(),
                 &system_virtual_packages,
+                target,
             );
             assert!(error.help.unwrap().contains(msg));
         }
+
+        // The same `__osx` requirement on a linux target suggests nothing:
+        // CEP 30 has `CONDA_OVERRIDE_OSX` ignored unless the target is `osx-*`.
+        let error = VirtualPackageNotFoundError::new(
+            &MatchSpec::from_str("__osx >= 10.15", ParseStrictness::Strict).unwrap(),
+            &system_virtual_packages,
+            Platform::Linux64,
+        );
+        assert!(error.help.is_none(), "{:?}", error.help);
     }
 
     #[test]

--- a/crates/pixi_core/src/lock_file/virtual_packages.rs
+++ b/crates/pixi_core/src/lock_file/virtual_packages.rs
@@ -1,4 +1,4 @@
-use crate::workspace::errors::conda_override_hint;
+use crate::workspace::errors::spec_override_hint;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use miette::Diagnostic;
@@ -7,7 +7,7 @@ use pypi_modifiers::pypi_tags::{PyPITagError, get_tags_from_machine, is_python_r
 use rattler_conda_types::ParseMatchSpecError;
 use rattler_conda_types::ParseStrictness::Lenient;
 use rattler_conda_types::{
-    GenericVirtualPackage, MatchSpec, Matches, PackageName, Platform, Version, VersionSpec,
+    GenericVirtualPackage, MatchSpec, Matches, Platform, Version, VersionSpec,
 };
 use rattler_lock::{CondaPackageData, ConversionError, LockFile, PypiPackageData};
 use rattler_virtual_packages::{
@@ -35,18 +35,13 @@ pub struct VirtualPackageNotFoundError {
 impl VirtualPackageNotFoundError {
     pub fn new(
         required_package: &MatchSpec,
-        system_virtual_packages: &Vec<&GenericVirtualPackage>,
+        system_virtual_packages: &[GenericVirtualPackage],
     ) -> Self {
-        let required_version = required_package.version.as_ref().and_then(spec_version);
-        let help = required_package
-            .name
-            .as_exact()
-            .and_then(|name| conda_override_hint(name.as_normalized(), required_version))
-            .map(|hint| {
-                format!(
-                    " You can mock the virtual package by overriding the environment variable, e.g.: '`{hint}`'"
-                )
-            });
+        let help = spec_override_hint(required_package).map(|hint| {
+            format!(
+                " You can mock the virtual package by overriding the environment variable, e.g.: '`{hint}`'"
+            )
+        });
 
         let msg = format!(
             "Virtual package '{}' does not match any of the available virtual packages on your machine: [{}]",
@@ -106,38 +101,52 @@ pub(crate) fn get_required_virtual_packages_from_depends(
         .map_err(MachineValidationError::DependencyParsingError)
 }
 
-/// The single version a virtual-package match spec carries. Virtual-package
-/// dependencies are always pinned to one exact version (`__cuda 12` /
-/// `__cuda >=12` both mean version `12`), so the operator is irrelevant -- we
-/// just read the version. Specs with no version (a bare `__cuda`) yield `None`.
-fn spec_version(spec: &VersionSpec) -> Option<&Version> {
+/// The requirements in `specs` that `system` does not satisfy, in order.
+pub(crate) fn unmet_requirements(
+    specs: &[MatchSpec],
+    system: &[GenericVirtualPackage],
+) -> Vec<MatchSpec> {
+    let (checked, skipped): (Vec<&MatchSpec>, Vec<&MatchSpec>) = specs.iter().partition(|spec| {
+        spec.name
+            .as_exact()
+            .is_some_and(|name| ACCEPTED_VIRTUAL_PACKAGES.contains(&name.as_normalized()))
+    });
+    if !skipped.is_empty() {
+        tracing::debug!(
+            "Not checking virtual-package requirements pixi cannot evaluate: {}",
+            skipped.iter().map(ToString::to_string).join(", ")
+        );
+    }
+
+    checked
+        .into_iter()
+        .filter(|spec| !system.iter().any(|provided| spec.matches(provided)))
+        .cloned()
+        .collect()
+}
+
+/// The version literal a virtual-package match spec mentions, ignoring its
+/// operator. Specs with no version (a bare `__cuda`) yield `None`.
+pub(crate) fn spec_version(spec: &VersionSpec) -> Option<&Version> {
     match spec {
         VersionSpec::Range(_, version) | VersionSpec::Exact(_, version) => Some(version),
         _ => None,
     }
 }
 
-/// Compute the minimal-required platform for each subdir the environment was
-/// resolved for: the subdir plus exactly the virtual packages that some resolved
-/// dependency requires, each at the highest version seen across all packages.
-///
-/// The result is keyed by subdir; `declared_platforms` that share a subdir are
-/// unioned. Only `depends` is considered, mirroring
-/// [`validate_system_meets_environment_requirements`]. A subdir whose lock-file
-/// entry has no conda packages is omitted (the caller falls back to the declared
-/// platform); a subdir with packages but no virtual-package requirements yields a
-/// platform with an empty declared set.
-pub(crate) fn compute_minimal_required_platforms(
+/// Compute the virtual-package requirements for each subdir the environment was
+/// resolved for: exactly the specs that some resolved dependency requires.
+pub(crate) fn compute_required_virtual_package_specs(
     lock_file: &LockFile,
     environment_name: &EnvironmentName,
     declared_platforms: &[&PixiPlatform],
-) -> HashMap<Platform, PixiPlatform> {
+) -> HashMap<Platform, Vec<MatchSpec>> {
     let Some(environment) = lock_file.environment(environment_name.as_str()) else {
         return HashMap::new();
     };
 
-    // subdir -> all `depends` strings of its resolved conda packages, unioned
-    // across the declared platforms that share a subdir.
+    // subdir -> all `depends` strings of its resolved conda packages, across the
+    // declared platforms that share a subdir.
     let mut depends_by_subdir: HashMap<Platform, Vec<String>> = HashMap::new();
 
     for platform in declared_platforms {
@@ -157,58 +166,31 @@ pub(crate) fn compute_minimal_required_platforms(
         .into_iter()
         .map(|(subdir, depends)| {
             let depends: Vec<&str> = depends.iter().map(String::as_str).collect_vec();
-            (
-                subdir,
-                PixiPlatform::from_required_virtual_packages(
-                    subdir,
-                    minimal_required_virtual_packages(&depends),
-                ),
-            )
+            (subdir, required_virtual_package_specs(&depends))
         })
         .collect()
 }
 
-/// The virtual packages that some dependency in `depends` requires: each
-/// accepted virtual package at the highest version seen across all `depends`,
-/// with a version-less requirement (bare `__cuda`) pinned to version 0 so it
-/// survives but loses to any versioned one. The result is sorted by name.
+/// The virtual-package requirements some dependency in `depends` places on the
+/// machine: the specs themselves, deduplicated and sorted so the recorded set is
+/// stable.
 ///
-/// This is the per-subdir core of `compute_minimal_required_platforms`,
-/// shared with `pixi global` which derives the same minimum from an installed
-/// environment's records rather than a lock file.
-pub fn minimal_required_virtual_packages(depends: &[&str]) -> Vec<GenericVirtualPackage> {
+/// The specs are kept verbatim rather than folded into one concrete virtual
+/// package per name.
+pub fn required_virtual_package_specs(depends: &[&str]) -> Vec<MatchSpec> {
     let Ok(specs) = get_required_virtual_packages_from_depends(depends) else {
         return Vec::new();
     };
 
-    let mut aggregated: HashMap<PackageName, GenericVirtualPackage> = HashMap::new();
-    for spec in specs {
-        let Some(name) = spec.name.as_exact() else {
-            continue;
-        };
-        let version = spec
-            .version
-            .as_ref()
-            .and_then(spec_version)
-            .cloned()
-            .unwrap_or_else(|| Version::major(0));
-        aggregated
-            .entry(name.clone())
-            .and_modify(|existing| {
-                if version > existing.version {
-                    existing.version = version.clone();
-                }
-            })
-            .or_insert_with(|| GenericVirtualPackage {
-                name: name.clone(),
-                version,
-                build_string: String::new(),
-            });
-    }
-
-    let mut vps: Vec<GenericVirtualPackage> = aggregated.into_values().collect();
-    vps.sort_by(|a, b| a.name.as_normalized().cmp(b.name.as_normalized()));
-    vps
+    specs
+        .into_iter()
+        // A spec with a non-exact name matches nothing we can check.
+        .filter(|spec| spec.name.as_exact().is_some())
+        .map(|spec| (spec.to_string(), spec))
+        .sorted_by(|(a, _), (b, _)| a.cmp(b))
+        .dedup_by(|(a, _), (b, _)| a == b)
+        .map(|(_, spec)| spec)
+        .collect()
 }
 
 /// Get the wheel filenames from the lock file pypi package data
@@ -293,62 +275,26 @@ pub(crate) fn validate_system_meets_environment_requirements(
 
     // Get the virtual packages available on the system
     let system_virtual_packages = VirtualPackage::detect(&virtual_package_overrides)?;
-    let generic_system_virtual_packages = system_virtual_packages
+    let system_capabilities: Vec<GenericVirtualPackage> = system_virtual_packages
         .iter()
         .cloned()
         .map(GenericVirtualPackage::from)
-        .map(|vpkg| (vpkg.name.clone(), vpkg))
-        .collect::<HashMap<_, _>>();
+        .collect();
 
     tracing::debug!(
         "Generic system virtual packages for env: '{}' : [{}]",
         environment_name.fancy_display(),
-        generic_system_virtual_packages
+        system_capabilities
             .iter()
-            .map(|(name, vpkg)| format!("{}: {}", name.as_normalized(), vpkg))
+            .map(ToString::to_string)
             .join(", ")
     );
 
-    // Check if all the required virtual conda packages match the system virtual packages
-    for required in required_virtual_packages {
-        // Check if the package name is in our accepted list
-        let is_accepted = required
-            .name
-            .as_exact()
-            .map(|n| ACCEPTED_VIRTUAL_PACKAGES.contains(&n.as_normalized()))
-            .unwrap_or(false);
-
-        // Skip if not in accepted packages
-        if !is_accepted {
-            tracing::debug!(
-                "Skipping virtual package: {} as it's not in the accepted packages",
-                required
-            );
-            continue;
-        }
-
-        let name = if let Some(name_exact) = required.name.as_exact() {
-            name_exact
-        } else {
-            continue;
-        };
-
-        if let Some(local_vpkg) = generic_system_virtual_packages.get(name) {
-            if !required.matches(local_vpkg) {
-                return Err(VirtualPackageNotFoundError::new(
-                    &required,
-                    &generic_system_virtual_packages.values().collect(),
-                )
-                .into());
-            }
-            tracing::debug!("Required virtual package: {} matches the system", required);
-        } else {
-            return Err(VirtualPackageNotFoundError::new(
-                &required,
-                &generic_system_virtual_packages.values().collect(),
-            )
-            .into());
-        }
+    // Check if all the required virtual conda packages match the system virtual packages.
+    if let Some(unmet) =
+        unmet_requirements(&required_virtual_packages, &system_capabilities).first()
+    {
+        return Err(VirtualPackageNotFoundError::new(unmet, &system_capabilities).into());
     }
 
     // Check if the wheel tags match the system virtual packages if there are any
@@ -386,7 +332,7 @@ mod test {
     use insta::assert_snapshot;
     use pixi_test_utils::format_diagnostic;
     use rattler_conda_types::package::DistArchiveIdentifier;
-    use rattler_conda_types::{PackageRecord, ParseStrictness, Platform};
+    use rattler_conda_types::{PackageName, PackageRecord, ParseStrictness, Platform};
     use rattler_lock::{CondaBinaryData, PlatformData, PlatformName, UrlOrPath};
     use rattler_virtual_packages::Override;
     use std::path::Path;
@@ -435,48 +381,33 @@ mod test {
     }
 
     #[test]
-    fn test_compute_minimal_required_platforms() {
+    fn test_compute_required_virtual_package_specs() {
         let root_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let lock_file_path =
             root_dir.join("../../tests/data/lock_files/cuda_virtual_dependency.lock");
         let lock_file = LockFile::from_path(&lock_file_path).unwrap();
         let declared = PixiPlatform::from_subdir(Platform::Linux64);
 
-        let minimal = compute_minimal_required_platforms(
+        let required = compute_required_virtual_package_specs(
             &lock_file,
             &EnvironmentName::default(),
             &[&declared],
         );
 
-        let platform = minimal
+        let specs = required
             .get(&Platform::Linux64)
-            .expect("linux-64 minimal platform");
-        assert_eq!(platform.subdir(), Platform::Linux64);
-
-        // The resolved packages require `__cuda` at the highest version seen.
-        let cuda = platform
-            .declared_virtual_packages()
-            .iter()
-            .find(|vp| vp.name.as_normalized() == "__cuda")
-            .expect("__cuda is required");
-        assert_eq!(cuda.version, Version::from_str("12").unwrap());
-
-        // Only depended-on VPs are present; subdir defaults are not padded in
-        // (`__archspec` is a linux-64 default but never appears in `depends`).
-        assert!(
-            !platform
-                .declared_virtual_packages()
-                .iter()
-                .any(|vp| vp.name.as_normalized() == "__archspec")
+            .expect("linux-64 requirements");
+        // Only depended-on virtual packages are present; subdir defaults are
+        // not padded in (`__archspec` is a linux-64 default but never appears
+        // in `depends`).
+        assert_eq!(
+            specs.iter().map(ToString::to_string).collect_vec(),
+            vec!["__cuda >=12"]
         );
     }
 
-    /// A version-less virtual-package dependency (bare `__cuda`) still
-    /// requires the package to be present. It used to be dropped from the
-    /// minimal platform, making machines without the package look compatible
-    /// while `validate_system_meets_environment_requirements` rejected them.
     #[test]
-    fn test_compute_minimal_required_platforms_versionless_spec() {
+    fn test_required_specs_keep_a_versionless_spec_unconstrained() {
         let lock_source = r#"version: 7
 platforms:
 - name: linux-64
@@ -495,21 +426,122 @@ packages:
         let lock_file = LockFile::from_str_with_base_directory(lock_source, None).unwrap();
         let declared = PixiPlatform::from_subdir(Platform::Linux64);
 
-        let minimal = compute_minimal_required_platforms(
+        let required = compute_required_virtual_package_specs(
             &lock_file,
             &EnvironmentName::default(),
             &[&declared],
         );
 
-        let platform = minimal
+        let specs = required
             .get(&Platform::Linux64)
-            .expect("linux-64 minimal platform");
-        let cuda = platform
-            .declared_virtual_packages()
-            .iter()
-            .find(|vp| vp.name.as_normalized() == "__cuda")
-            .expect("bare __cuda must survive into the minimal platform");
-        assert_eq!(cuda.version, Version::major(0));
+            .expect("linux-64 requirements");
+        assert_eq!(
+            specs.iter().map(ToString::to_string).collect_vec(),
+            vec!["__cuda"]
+        );
+        assert!(specs[0].version.is_none());
+    }
+
+    #[test]
+    fn test_required_specs_keep_every_distinct_constraint() {
+        let depends = [
+            "__glibc >=2.17",
+            "__glibc >=2.28",
+            "__archspec 1.* ^(x86_64_v3|skylake)$",
+            // A duplicate of the first: recorded once.
+            "__glibc >=2.17",
+            // Not a virtual package: ignored entirely.
+            "python >=3.12",
+        ];
+        let specs = required_virtual_package_specs(&depends);
+
+        assert_eq!(
+            specs.iter().map(ToString::to_string).collect_vec(),
+            vec![
+                "__archspec 1.* ^(x86_64_v3|skylake)$",
+                "__glibc >=2.17",
+                "__glibc >=2.28",
+            ]
+        );
+        // The build-string pattern survives as a pattern, not as a literal.
+        assert!(matches!(
+            specs[0].build,
+            Some(rattler_conda_types::StringMatcher::Regex(_))
+        ));
+    }
+
+    #[test]
+    fn unmet_requirements_matches_the_spec_not_just_its_version() {
+        let spec = |raw: &str| {
+            MatchSpec::from_str(raw, rattler_conda_types::ParseStrictness::Lenient).unwrap()
+        };
+        let cuda = |v: &str| {
+            vec![GenericVirtualPackage {
+                name: rattler_conda_types::PackageName::try_from("__cuda").unwrap(),
+                version: rattler_conda_types::Version::from_str(v).unwrap(),
+                build_string: String::new(),
+            }]
+        };
+
+        // A lower bound behaves as before: any newer machine satisfies it.
+        assert!(unmet_requirements(&[spec("__cuda >=12")], &cuda("12.4")).is_empty());
+        assert_eq!(
+            unmet_requirements(&[spec("__cuda >=12")], &cuda("11")).len(),
+            1
+        );
+
+        // An exact pin is honored as a pin. The old `>=`-only comparison called
+        // this satisfied.
+        assert_eq!(
+            unmet_requirements(&[spec("__cuda ==12")], &cuda("12.4")).len(),
+            1
+        );
+
+        // A bare requirement only asks for presence.
+        assert!(unmet_requirements(&[spec("__cuda")], &cuda("11")).is_empty());
+        assert_eq!(unmet_requirements(&[spec("__cuda")], &[]).len(), 1);
+    }
+
+    #[test]
+    fn unmet_requirements_only_checks_accepted_virtual_packages() {
+        let spec = |raw: &str| {
+            MatchSpec::from_str(raw, rattler_conda_types::ParseStrictness::Lenient).unwrap()
+        };
+        let host = |microarchitecture: &str| {
+            vec![GenericVirtualPackage {
+                name: rattler_conda_types::PackageName::try_from("__archspec").unwrap(),
+                version: rattler_conda_types::Version::major(1),
+                build_string: microarchitecture.to_string(),
+            }]
+        };
+
+        // A specific host satisfies a baseline requirement...
+        assert!(unmet_requirements(&[spec("__archspec 1 x86_64")], &host("zen5")).is_empty());
+        // ...including through the CEP-29 regex spelling conda-forge's microarch
+        // metapackages use, whose enumeration cannot know future CPUs.
+        assert!(
+            unmet_requirements(
+                &[spec("__archspec 1.* ^(x86_64_v3|skylake)$")],
+                &host("zen5")
+            )
+            .is_empty()
+        );
+        // A host that reports no microarchitecture at all is not a reason to
+        // refuse either.
+        assert!(unmet_requirements(&[spec("__archspec 1 x86_64")], &host("0")).is_empty());
+        // The same goes for any other name off the list -- pixi has never failed
+        // an install over `__unix`, and the fallback path must not either.
+        assert!(unmet_requirements(&[spec("__unix")], &[]).is_empty());
+        // Every accepted virtual package has its build string compared.
+        let cuda = vec![GenericVirtualPackage {
+            name: rattler_conda_types::PackageName::try_from("__cuda").unwrap(),
+            version: rattler_conda_types::Version::major(12),
+            build_string: "real".to_string(),
+        }];
+        assert_eq!(
+            unmet_requirements(&[spec("__cuda 12 other")], &cuda).len(),
+            1
+        );
     }
 
     #[test]
@@ -667,7 +699,7 @@ packages:
             version: "10.14".parse().unwrap(),
             build_string: "".to_string(),
         };
-        let system_virtual_packages = vec![&libc, &cuda, &osx];
+        let system_virtual_packages = vec![libc, cuda, osx];
 
         let error1 = VirtualPackageNotFoundError::new(&spec, &system_virtual_packages);
 
@@ -690,7 +722,7 @@ packages:
             ("__osx >= 10.15", "`CONDA_OVERRIDE_OSX=10.15`"),
         ];
 
-        let system_virtual_packages = vec![];
+        let system_virtual_packages: Vec<GenericVirtualPackage> = vec![];
 
         for (spec, msg) in overrides {
             let error = VirtualPackageNotFoundError::new(

--- a/crates/pixi_core/src/workspace/environment.rs
+++ b/crates/pixi_core/src/workspace/environment.rs
@@ -105,14 +105,12 @@ impl<'p> Environment<'p> {
             .join(self.environment.name.as_str())
     }
 
-    /// The platforms recorded in this environment's `conda-meta/pixi` marker
-    /// file: `(resolved, minimum_supported)`. Both are `None` when the
-    /// environment isn't installed yet or was written by an older pixi.
+    /// What this environment's `conda-meta/pixi` marker file records
     pub fn installed_platforms(
         &self,
     ) -> (
         Option<crate::environment::PlatformData>,
-        Option<crate::environment::PlatformData>,
+        Option<crate::environment::RequiredPlatform>,
     ) {
         match crate::environment::read_environment_file(&self.dir()) {
             Ok(Some(file)) => (file.resolved_platform, file.minimum_supported_platform),
@@ -285,6 +283,9 @@ impl<'p> Environment<'p> {
             environment: self.name().clone(),
             platform: current,
             unsatisfied_requirements,
+            // Filled in by the caller that has a lock file to derive them from;
+            // this diagnosis only knows the declared platforms.
+            unmet_requirements: Vec::new(),
             platform_diagnostics,
         }
     }
@@ -362,7 +363,7 @@ impl<'p> Environment<'p> {
     pub fn tasks(
         &self,
         platform: Option<&'p PixiPlatform>,
-    ) -> Result<IndexMap<&'p TaskName, &'p Task>, UnsupportedPlatformError> {
+    ) -> Result<IndexMap<&'p TaskName, &'p Task>, Box<UnsupportedPlatformError>> {
         self.validate_platform_support(platform)?;
         let result = self
             .features()
@@ -460,17 +461,18 @@ impl<'p> Environment<'p> {
     fn validate_platform_support(
         &self,
         platform: Option<&PixiPlatform>,
-    ) -> Result<(), UnsupportedPlatformError> {
+    ) -> Result<(), Box<UnsupportedPlatformError>> {
         if let Some(platform) = platform
             && !self.platforms().contains(platform.name())
         {
-            return Err(UnsupportedPlatformError {
+            return Err(Box::new(UnsupportedPlatformError {
                 environments_platforms: self.platforms().into_iter().collect(),
                 environment: self.name().clone(),
                 platform: platform.subdir(),
                 unsatisfied_requirements: Vec::new(),
+                unmet_requirements: Vec::new(),
                 platform_diagnostics: Vec::new(),
-            });
+            }));
         }
 
         Ok(())

--- a/crates/pixi_core/src/workspace/errors.rs
+++ b/crates/pixi_core/src/workspace/errors.rs
@@ -1,9 +1,10 @@
 use crate::Workspace;
+use crate::lock_file::virtual_packages::spec_version;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use miette::{Diagnostic, LabeledSpan};
 use pixi_manifest::{EnvironmentName, PixiPlatformName, PlatformMatchDiagnosis, TaskName};
-use rattler_conda_types::{GenericVirtualPackage, Platform, Version};
+use rattler_conda_types::{GenericVirtualPackage, MatchSpec, Platform, Version};
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
@@ -26,7 +27,21 @@ pub struct UnsupportedPlatformError {
     /// platform mismatch isn't caused by missing virtual packages -- for
     /// example, when the user explicitly asked for a platform the
     /// environment doesn't declare at all.
+    ///
+    /// These are capabilities a manifest declares, so they stay
+    /// [`GenericVirtualPackage`]. What the *resolved packages* require lives in
+    /// [`Self::unmet_requirements`], which is a different kind of thing.
     pub unsatisfied_requirements: Vec<GenericVirtualPackage>,
+
+    /// Virtual-package requirements the resolved packages place on the machine
+    /// that it does not meet, read from the lock file. Set only once the
+    /// declared platforms have already been ruled out, so it explains why the
+    /// lock-derived fallback failed too.
+    ///
+    /// Match specs rather than concrete virtual packages: a `depends` entry
+    /// carries a version range and a build-string pattern, and reporting one as
+    /// a value it never had misleads.
+    pub unmet_requirements: Vec<MatchSpec>,
 
     /// Why each platform the environment declares does not run on this
     /// machine (unrunnable subdir or missing virtual packages). Empty when no
@@ -57,7 +72,10 @@ impl Display for UnsupportedPlatformError {
             .collect();
 
         // Nothing to elaborate: keep the terse legacy message.
-        if breakdown.is_empty() && self.unsatisfied_requirements.is_empty() {
+        if breakdown.is_empty()
+            && self.unsatisfied_requirements.is_empty()
+            && self.unmet_requirements.is_empty()
+        {
             return match &self.environment {
                 EnvironmentName::Default => write!(
                     f,
@@ -88,6 +106,14 @@ impl Display for UnsupportedPlatformError {
                 f,
                 "\n\nUnsatisfied requirements: {}",
                 format_requirements(&self.unsatisfied_requirements),
+            )?;
+        }
+
+        if !self.unmet_requirements.is_empty() {
+            write!(
+                f,
+                "\n\nThe installed packages also require: {}",
+                format_specs(&self.unmet_requirements),
             )?;
         }
 
@@ -136,11 +162,17 @@ impl Diagnostic for UnsupportedPlatformError {
     }
 
     fn help(&self) -> Option<Box<dyn Display + '_>> {
-        let overrides: Vec<String> = self
+        // Both kinds can be mocked the same way, so the hints are pooled --
+        // but each reads its own shape to find the name and version.
+        let declared = self
             .unsatisfied_requirements
             .iter()
-            .filter_map(|req| conda_override_hint(req.name.as_normalized(), Some(&req.version)))
-            .collect();
+            .filter_map(|req| conda_override_hint(req.name.as_normalized(), Some(&req.version)));
+        let required = self
+            .unmet_requirements
+            .iter()
+            .filter_map(spec_override_hint);
+        let overrides: Vec<String> = declared.chain(required).unique().collect();
 
         let base = if overrides.is_empty() {
             format!(
@@ -179,6 +211,20 @@ fn format_requirements(reqs: &[GenericVirtualPackage]) -> String {
             }
         })
         .join(", ")
+}
+
+/// Render lock-derived requirements.
+pub(crate) fn format_specs(specs: &[MatchSpec]) -> String {
+    specs.iter().map(ToString::to_string).join(", ")
+}
+
+/// `CONDA_OVERRIDE_*` hint for an unmet requirement, `None` when the spec names
+/// no single virtual package or that package has no override.
+pub(crate) fn spec_override_hint(spec: &MatchSpec) -> Option<String> {
+    conda_override_hint(
+        spec.name.as_exact()?.as_normalized(),
+        spec.version.as_ref().and_then(spec_version),
+    )
 }
 
 /// `CONDA_OVERRIDE_*` hint for a missing virtual package: the required
@@ -261,8 +307,13 @@ mod tests {
             environment: EnvironmentName::Default,
             platform: Platform::Linux64,
             unsatisfied_requirements: unsatisfied,
+            unmet_requirements: vec![],
             platform_diagnostics: vec![],
         }
+    }
+
+    fn spec(raw: &str) -> MatchSpec {
+        MatchSpec::from_str(raw, rattler_conda_types::ParseStrictness::Lenient).unwrap()
     }
 
     #[test]
@@ -299,6 +350,43 @@ mod tests {
             display.contains("Unsatisfied requirements: __cuda >= 11"),
             "{display}"
         );
+    }
+
+    #[test]
+    fn lock_derived_requirements_render_as_specs() {
+        let mut e = err(vec![]);
+        e.unmet_requirements = vec![
+            spec("__glibc >=2.28"),
+            spec("__archspec 1.* ^(x86_64_v3|skylake)$"),
+        ];
+        let display = e.to_string();
+        assert!(
+            display.contains("The installed packages also require: __glibc >=2.28"),
+            "{display}"
+        );
+        // The build-string pattern is shown as written, not flattened.
+        assert!(display.contains("^(x86_64_v3|skylake)$"), "{display}");
+
+        let help = e.help().unwrap().to_string();
+        assert!(help.contains("CONDA_OVERRIDE_GLIBC=2.28"), "{help}");
+    }
+
+    #[test]
+    fn declared_and_lock_derived_sections_coexist() {
+        let mut e = err(vec![vp("__cuda", "12.0")]);
+        e.unmet_requirements = vec![spec("__glibc >=2.28")];
+        let display = e.to_string();
+        assert!(
+            display.contains("Unsatisfied requirements: __cuda >= 12.0"),
+            "{display}"
+        );
+        assert!(
+            display.contains("The installed packages also require: __glibc >=2.28"),
+            "{display}"
+        );
+        let help = e.help().unwrap().to_string();
+        assert!(help.contains("CONDA_OVERRIDE_CUDA=12"), "{help}");
+        assert!(help.contains("CONDA_OVERRIDE_GLIBC=2.28"), "{help}");
     }
 
     fn diagnosis(

--- a/crates/pixi_core/src/workspace/errors.rs
+++ b/crates/pixi_core/src/workspace/errors.rs
@@ -164,14 +164,13 @@ impl Diagnostic for UnsupportedPlatformError {
     fn help(&self) -> Option<Box<dyn Display + '_>> {
         // Both kinds can be mocked the same way, so the hints are pooled --
         // but each reads its own shape to find the name and version.
-        let declared = self
-            .unsatisfied_requirements
-            .iter()
-            .filter_map(|req| conda_override_hint(req.name.as_normalized(), Some(&req.version)));
+        let declared = self.unsatisfied_requirements.iter().filter_map(|req| {
+            conda_override_hint(req.name.as_normalized(), Some(&req.version), self.platform)
+        });
         let required = self
             .unmet_requirements
             .iter()
-            .filter_map(spec_override_hint);
+            .filter_map(|spec| spec_override_hint(spec, self.platform));
         let overrides: Vec<String> = declared.chain(required).unique().collect();
 
         let base = if overrides.is_empty() {
@@ -219,29 +218,46 @@ pub(crate) fn format_specs(specs: &[MatchSpec]) -> String {
 }
 
 /// `CONDA_OVERRIDE_*` hint for an unmet requirement, `None` when the spec names
-/// no single virtual package or that package has no override.
-pub(crate) fn spec_override_hint(spec: &MatchSpec) -> Option<String> {
+/// no single virtual package or that package has no override `target` honors.
+pub(crate) fn spec_override_hint(spec: &MatchSpec, target: Platform) -> Option<String> {
     conda_override_hint(
         spec.name.as_exact()?.as_normalized(),
         spec.version.as_ref().and_then(spec_version),
+        target,
     )
 }
 
 /// `CONDA_OVERRIDE_*` hints for a set of unmet requirements, deduplicated and
-/// in the order the requirements appear. Requirements with no known override
-/// (e.g. `__unix`) contribute nothing.
-pub(crate) fn spec_override_hints(specs: &[MatchSpec]) -> Vec<String> {
+/// in the order the requirements appear.
+pub(crate) fn spec_override_hints(specs: &[MatchSpec], target: Platform) -> Vec<String> {
     specs
         .iter()
-        .filter_map(spec_override_hint)
+        .filter_map(|spec| spec_override_hint(spec, target))
         .unique()
         .collect()
 }
 
-/// `CONDA_OVERRIDE_*` hint for a missing virtual package: the required
-/// version when known, a realistic example otherwise. `None` for virtual
-/// packages without a known override (e.g. `__unix`).
-pub(crate) fn conda_override_hint(name: &str, version: Option<&Version>) -> Option<String> {
+/// Whether setting `CONDA_OVERRIDE_*` for `name` has any effect when the target
+/// platform is `target` (as defined in CEP-30).
+fn override_applies_to(name: &str, target: Platform) -> bool {
+    match name {
+        "__glibc" | "__linux" => target.is_linux(),
+        "__osx" => target.is_osx(),
+        "__win" => target.is_windows(),
+        _ => true,
+    }
+}
+
+/// `CONDA_OVERRIDE_*` hint for a virtual package the machine does not provide:
+/// the required version when known, a realistic example otherwise.
+///
+/// `None` when there is no such variable (e.g. `__unix`), or when `target` is a
+/// platform that ignores it
+pub(crate) fn conda_override_hint(
+    name: &str,
+    version: Option<&Version>,
+    target: Platform,
+) -> Option<String> {
     let env_var = match name {
         "__glibc" => "CONDA_OVERRIDE_GLIBC",
         "__cuda" => "CONDA_OVERRIDE_CUDA",
@@ -251,6 +267,9 @@ pub(crate) fn conda_override_hint(name: &str, version: Option<&Version>) -> Opti
         "__archspec" => "CONDA_OVERRIDE_ARCHSPEC",
         _ => return None,
     };
+    if !override_applies_to(name, target) {
+        return None;
+    }
     // A version-0 requirement means "any version"; "=0" reads like nonsense,
     // so suggest a realistic value instead.
     let example = match version.filter(|v| **v != Version::major(0)) {

--- a/crates/pixi_core/src/workspace/errors.rs
+++ b/crates/pixi_core/src/workspace/errors.rs
@@ -227,6 +227,17 @@ pub(crate) fn spec_override_hint(spec: &MatchSpec) -> Option<String> {
     )
 }
 
+/// `CONDA_OVERRIDE_*` hints for a set of unmet requirements, deduplicated and
+/// in the order the requirements appear. Requirements with no known override
+/// (e.g. `__unix`) contribute nothing.
+pub(crate) fn spec_override_hints(specs: &[MatchSpec]) -> Vec<String> {
+    specs
+        .iter()
+        .filter_map(spec_override_hint)
+        .unique()
+        .collect()
+}
+
 /// `CONDA_OVERRIDE_*` hint for a missing virtual package: the required
 /// version when known, a realistic example otherwise. `None` for virtual
 /// packages without a known override (e.g. `__unix`).

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -396,6 +396,12 @@ pub fn verify_run_platform(
     environment: &Environment<'_>,
     target_platform: Option<&PixiPlatformName>,
 ) -> Result<(), RunPlatformUnsupportedError> {
+    // An explicit platform override means the user vouches for the machine, so
+    // host validation is skipped.
+    if std::env::var(pixi_consts::consts::PIXI_OVERRIDE_PLATFORM).is_ok() {
+        return Ok(());
+    }
+
     let (Some(resolved), Some(minimum)) = environment.installed_platforms() else {
         // No marker (older pixi or not installed) -- nothing to validate.
         return Ok(());

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -17,6 +17,7 @@ use rattler_conda_types::{GenericVirtualPackage, MatchSpec, Platform};
 use rattler_lock::LockFile;
 use rattler_virtual_packages::{Cuda, CudaArch, LibC, Linux, Osx, VirtualPackage};
 use std::collections::HashSet;
+use std::fmt::Display;
 use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
 use thiserror::Error;
@@ -220,16 +221,34 @@ pub fn minimum_compatible_declared_platform<'p>(
 
 /// The platform the environment was installed for cannot run the installed
 /// packages: they require virtual packages this platform does not provide.
-#[derive(Debug, Error, Diagnostic)]
+#[derive(Debug, Error)]
 #[error("the installed environment '{environment}' cannot run on platform '{platform}'")]
-#[diagnostic(help(
-    "The installed packages require virtual packages this platform does not provide: [{}]. Reinstall for this machine with 'pixi install', or select a compatible platform with '--platform'.",
-    format_specs(.unmet)
-))]
 pub struct RunPlatformUnsupportedError {
     environment: EnvironmentName,
     platform: PixiPlatformName,
     unmet: Vec<MatchSpec>,
+}
+
+impl Diagnostic for RunPlatformUnsupportedError {
+    /// Names the unmet requirements and, for the ones that have a
+    /// `CONDA_OVERRIDE_*`, a value that would satisfy them.
+    fn help(&self) -> Option<Box<dyn Display + '_>> {
+        let requirements = format_specs(&self.unmet);
+        let base = format!(
+            "The installed packages require virtual packages this platform does not provide: \
+             [{requirements}]. Reinstall for this machine with 'pixi install', or select a \
+             compatible platform with '--platform'."
+        );
+        let overrides = crate::workspace::errors::spec_override_hints(&self.unmet);
+        Some(Box::new(if overrides.is_empty() {
+            base
+        } else {
+            format!(
+                "{base}\nOr mock them via the environment, e.g.:\n  {}",
+                overrides.join("\n  ")
+            )
+        }))
+    }
 }
 
 /// How a base platform compares to the resolved/minimum platforms an
@@ -1009,6 +1028,53 @@ packages: []
             }
             other => panic!("expected BelowMinimum, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn run_platform_refusal_suggests_overrides_from_the_requirements() {
+        let spec = |raw: &str| {
+            MatchSpec::from_str(raw, rattler_conda_types::ParseStrictness::Lenient).unwrap()
+        };
+        let error = RunPlatformUnsupportedError {
+            environment: EnvironmentName::Default,
+            platform: PixiPlatformName::from(Platform::Linux64),
+            unmet: vec![spec("__glibc >=2.28"), spec("__cuda >=12"), spec("__unix")],
+        };
+        let help = error
+            .help()
+            .expect("a refusal always explains itself")
+            .to_string();
+
+        // The requirements themselves, as written.
+        assert!(
+            help.contains("[__glibc >=2.28, __cuda >=12, __unix]"),
+            "{help}"
+        );
+        // The remedies that actually fix the environment come first.
+        assert!(help.contains("pixi install"), "{help}");
+        // A value drawn from each requirement that has an override.
+        assert!(help.contains("CONDA_OVERRIDE_GLIBC=2.28"), "{help}");
+        assert!(help.contains("CONDA_OVERRIDE_CUDA=12"), "{help}");
+        // `__unix` has no override, so it is named but not suggested.
+        assert!(!help.contains("CONDA_OVERRIDE_UNIX"), "{help}");
+    }
+
+    #[test]
+    fn run_platform_refusal_omits_the_override_section_when_useless() {
+        let error = RunPlatformUnsupportedError {
+            environment: EnvironmentName::Default,
+            platform: PixiPlatformName::from(Platform::Linux64),
+            unmet: vec![
+                MatchSpec::from_str("__unix", rattler_conda_types::ParseStrictness::Lenient)
+                    .unwrap(),
+            ],
+        };
+        let help = error
+            .help()
+            .expect("a refusal always explains itself")
+            .to_string();
+        assert!(!help.contains("e.g."), "{help}");
+        assert!(help.contains("pixi install"), "{help}");
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -219,35 +219,52 @@ pub fn minimum_compatible_declared_platform<'p>(
     Err(unmet.unwrap_or_default())
 }
 
+/// Why the platform the environment was installed for cannot run here.
+#[derive(Debug)]
+enum RunPlatformFailure {
+    /// The machine can run the subdir, but does not meet these requirements the
+    /// installed packages place on it.
+    UnmetRequirements(Vec<MatchSpec>),
+    /// The environment was installed for a subdir, which the machine cannot run.
+    UnrunnableSubdir(Platform),
+}
+
 /// The platform the environment was installed for cannot run the installed
-/// packages: they require virtual packages this platform does not provide.
+/// packages.
 #[derive(Debug, Error)]
 #[error("the installed environment '{environment}' cannot run on platform '{platform}'")]
 pub struct RunPlatformUnsupportedError {
     environment: EnvironmentName,
     platform: PixiPlatformName,
-    unmet: Vec<MatchSpec>,
+    failure: RunPlatformFailure,
 }
 
 impl Diagnostic for RunPlatformUnsupportedError {
-    /// Names the unmet requirements and, for the ones that have a
-    /// `CONDA_OVERRIDE_*`, a value that would satisfy them.
+    /// Generate a good help text for the `RunPlatformUnsupportedError`
     fn help(&self) -> Option<Box<dyn Display + '_>> {
-        let requirements = format_specs(&self.unmet);
-        let base = format!(
-            "The installed packages require virtual packages this platform does not provide: \
-             [{requirements}]. Reinstall for this machine with 'pixi install', or select a \
-             compatible platform with '--platform'."
-        );
-        let overrides = crate::workspace::errors::spec_override_hints(&self.unmet);
-        Some(Box::new(if overrides.is_empty() {
-            base
-        } else {
-            format!(
-                "{base}\nOr mock them via the environment, e.g.:\n  {}",
-                overrides.join("\n  ")
-            )
-        }))
+        match &self.failure {
+            RunPlatformFailure::UnrunnableSubdir(subdir) => Some(Box::new(format!(
+                "It was installed for subdir '{subdir}', which this machine cannot run. \
+                 Reinstall for this machine with 'pixi install'."
+            ))),
+            RunPlatformFailure::UnmetRequirements(unmet) => {
+                let requirements = format_specs(unmet);
+                let base = format!(
+                    "The installed packages require virtual packages this platform does not \
+                     provide: [{requirements}]. Reinstall for this machine with 'pixi install', \
+                     or select a compatible platform with '--platform'."
+                );
+                let overrides = crate::workspace::errors::spec_override_hints(unmet);
+                Some(Box::new(if overrides.is_empty() {
+                    base
+                } else {
+                    format!(
+                        "{base}\nOr mock them via the environment, e.g.:\n  {}",
+                        overrides.join("\n  ")
+                    )
+                }))
+            }
+        }
     }
 }
 
@@ -265,13 +282,12 @@ enum RunPlatformVerdict {
     /// The base is below the minimum: the installed packages cannot run, with
     /// the requirements it fails to meet.
     BelowMinimum(Vec<MatchSpec>),
+    /// The environment was installed for a subdir the base cannot run at all.
+    UnrunnableSubdir(Platform),
 }
 
 /// Classify a base platform against the resolution platform and the
-/// requirements an environment was installed with (read from `conda-meta/pixi`).
-/// `base_subdirs` are the subdirs the base can run (a single subdir for an
-/// explicit `--platform`, or the host's candidate subdirs incl. architecture
-/// fallbacks); a subdir outside that set never satisfies.
+/// requirements an environment was installed with.
 fn classify_run_platform(
     base_subdirs: &[Platform],
     base_capabilities: &[GenericVirtualPackage],
@@ -290,7 +306,7 @@ fn classify_run_platform(
     } else if base_subdirs.contains(&minimum.subdir()) {
         RunPlatformVerdict::BelowMinimum(unmet_minimum)
     } else {
-        RunPlatformVerdict::BelowMinimum(minimum.requirements().to_vec())
+        RunPlatformVerdict::UnrunnableSubdir(minimum.subdir())
     }
 }
 
@@ -485,7 +501,12 @@ pub fn verify_run_platform(
         RunPlatformVerdict::BelowMinimum(unmet) => Err(RunPlatformUnsupportedError {
             environment: environment.name().clone(),
             platform: base_name,
-            unmet,
+            failure: RunPlatformFailure::UnmetRequirements(unmet),
+        }),
+        RunPlatformVerdict::UnrunnableSubdir(subdir) => Err(RunPlatformUnsupportedError {
+            environment: environment.name().clone(),
+            platform: base_name,
+            failure: RunPlatformFailure::UnrunnableSubdir(subdir),
         }),
     }
 }
@@ -1038,7 +1059,11 @@ packages: []
         let error = RunPlatformUnsupportedError {
             environment: EnvironmentName::Default,
             platform: PixiPlatformName::from(Platform::Linux64),
-            unmet: vec![spec("__glibc >=2.28"), spec("__cuda >=12"), spec("__unix")],
+            failure: RunPlatformFailure::UnmetRequirements(vec![
+                spec("__glibc >=2.28"),
+                spec("__cuda >=12"),
+                spec("__unix"),
+            ]),
         };
         let help = error
             .help()
@@ -1064,10 +1089,10 @@ packages: []
         let error = RunPlatformUnsupportedError {
             environment: EnvironmentName::Default,
             platform: PixiPlatformName::from(Platform::Linux64),
-            unmet: vec![
+            failure: RunPlatformFailure::UnmetRequirements(vec![
                 MatchSpec::from_str("__unix", rattler_conda_types::ParseStrictness::Lenient)
                     .unwrap(),
-            ],
+            ]),
         };
         let help = error
             .help()
@@ -1078,12 +1103,38 @@ packages: []
     }
 
     #[test]
-    fn classify_below_minimum_on_subdir_mismatch() {
-        // A subdir outside the base's candidates can never satisfy.
+    fn classify_reports_an_unrunnable_subdir_rather_than_its_requirements() {
         let resolved = platform_data(Platform::Osx64, vec![]);
-        let minimum = required_platform(Platform::Osx64, &[]);
-        let verdict = classify_run_platform(&[Platform::Linux64], &[], &resolved, &minimum);
-        assert!(matches!(verdict, RunPlatformVerdict::BelowMinimum(_)));
+        let minimum = required_platform(Platform::Osx64, &["__osx >=11.0"]);
+        let verdict = classify_run_platform(
+            &[Platform::Linux64],
+            &[gvp("__osx", "13.0")],
+            &resolved,
+            &minimum,
+        );
+        assert_eq!(
+            verdict,
+            RunPlatformVerdict::UnrunnableSubdir(Platform::Osx64)
+        );
+    }
+
+    #[test]
+    fn run_platform_refusal_for_a_subdir_mismatch_names_the_subdir() {
+        let error = RunPlatformUnsupportedError {
+            environment: EnvironmentName::Default,
+            platform: PixiPlatformName::from(Platform::Linux64),
+            failure: RunPlatformFailure::UnrunnableSubdir(Platform::Osx64),
+        };
+        let help = error
+            .help()
+            .expect("a refusal always explains itself")
+            .to_string();
+        assert!(help.contains("installed for subdir 'osx-64'"), "{help}");
+        assert!(help.contains("pixi install"), "{help}");
+        // No virtual package is named, and no remedy that cannot work.
+        assert!(!help.contains("virtual packages"), "{help}");
+        assert!(!help.contains("CONDA_OVERRIDE"), "{help}");
+        assert!(!help.contains("--platform"), "{help}");
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -236,6 +236,9 @@ enum RunPlatformFailure {
 pub struct RunPlatformUnsupportedError {
     environment: EnvironmentName,
     platform: PixiPlatformName,
+    /// The subdir behind `platform`. Kept alongside the name because a
+    /// `CONDA_OVERRIDE_*` suggestion is only useful on the platforms that honor it
+    subdir: Platform,
     failure: RunPlatformFailure,
 }
 
@@ -254,7 +257,7 @@ impl Diagnostic for RunPlatformUnsupportedError {
                      provide: [{requirements}]. Reinstall for this machine with 'pixi install', \
                      or select a compatible platform with '--platform'."
                 );
-                let overrides = crate::workspace::errors::spec_override_hints(unmet);
+                let overrides = crate::workspace::errors::spec_override_hints(unmet, self.subdir);
                 Some(Box::new(if overrides.is_empty() {
                     base
                 } else {
@@ -442,7 +445,7 @@ pub fn verify_run_platform(
         return Ok(());
     };
 
-    let (base_subdirs, base_capabilities, base_name) = match target_platform {
+    let (base_subdirs, base_capabilities, base_name, base_subdir) = match target_platform {
         // Explicit `--platform`: trust the named platform's declared capabilities.
         Some(name) => {
             let Some(platform) = environment.named_or_best_declared_platform(Some(name)) else {
@@ -453,6 +456,7 @@ pub fn verify_run_platform(
                 vec![platform.subdir()],
                 platform.declared_virtual_packages().to_vec(),
                 name.clone(),
+                platform.subdir(),
             )
         }
         // Auto-detected machine: its real virtual packages, and the subdirs it
@@ -480,6 +484,7 @@ pub fn verify_run_platform(
                     .declared_virtual_packages()
                     .to_vec(),
                 PixiPlatformName::from(current),
+                current,
             )
         }
     };
@@ -501,11 +506,13 @@ pub fn verify_run_platform(
         RunPlatformVerdict::BelowMinimum(unmet) => Err(RunPlatformUnsupportedError {
             environment: environment.name().clone(),
             platform: base_name,
+            subdir: base_subdir,
             failure: RunPlatformFailure::UnmetRequirements(unmet),
         }),
         RunPlatformVerdict::UnrunnableSubdir(subdir) => Err(RunPlatformUnsupportedError {
             environment: environment.name().clone(),
             platform: base_name,
+            subdir: base_subdir,
             failure: RunPlatformFailure::UnrunnableSubdir(subdir),
         }),
     }
@@ -1059,6 +1066,7 @@ packages: []
         let error = RunPlatformUnsupportedError {
             environment: EnvironmentName::Default,
             platform: PixiPlatformName::from(Platform::Linux64),
+            subdir: Platform::Linux64,
             failure: RunPlatformFailure::UnmetRequirements(vec![
                 spec("__glibc >=2.28"),
                 spec("__cuda >=12"),
@@ -1089,6 +1097,7 @@ packages: []
         let error = RunPlatformUnsupportedError {
             environment: EnvironmentName::Default,
             platform: PixiPlatformName::from(Platform::Linux64),
+            subdir: Platform::Linux64,
             failure: RunPlatformFailure::UnmetRequirements(vec![
                 MatchSpec::from_str("__unix", rattler_conda_types::ParseStrictness::Lenient)
                     .unwrap(),
@@ -1100,6 +1109,47 @@ packages: []
             .to_string();
         assert!(!help.contains("e.g."), "{help}");
         assert!(help.contains("pixi install"), "{help}");
+    }
+
+    #[test]
+    fn run_platform_refusal_omits_overrides_the_host_platform_ignores() {
+        // Requirements whose override this host ignores, per CEP 30.
+        let ignored_here: &[(&str, &str)] = if cfg!(target_os = "windows") {
+            &[
+                ("__osx", "CONDA_OVERRIDE_OSX"),
+                ("__linux", "CONDA_OVERRIDE_LINUX"),
+            ]
+        } else if cfg!(target_os = "macos") {
+            &[
+                ("__win", "CONDA_OVERRIDE_WIN"),
+                ("__linux", "CONDA_OVERRIDE_LINUX"),
+            ]
+        } else {
+            &[
+                ("__win", "CONDA_OVERRIDE_WIN"),
+                ("__osx", "CONDA_OVERRIDE_OSX"),
+            ]
+        };
+
+        for (name, env_var) in ignored_here {
+            let error = RunPlatformUnsupportedError {
+                environment: EnvironmentName::Default,
+                platform: PixiPlatformName::from(Platform::current()),
+                subdir: Platform::current(),
+                failure: RunPlatformFailure::UnmetRequirements(vec![
+                    MatchSpec::from_str(name, rattler_conda_types::ParseStrictness::Lenient)
+                        .unwrap(),
+                ]),
+            };
+            let help = error
+                .help()
+                .expect("a refusal always explains itself")
+                .to_string();
+            assert!(
+                !help.contains(env_var),
+                "{env_var} does nothing on this host, so suggesting it is a dead end:\n{help}"
+            );
+        }
     }
 
     #[test]
@@ -1123,6 +1173,7 @@ packages: []
         let error = RunPlatformUnsupportedError {
             environment: EnvironmentName::Default,
             platform: PixiPlatformName::from(Platform::Linux64),
+            subdir: Platform::Linux64,
             failure: RunPlatformFailure::UnrunnableSubdir(Platform::Osx64),
         };
         let help = error

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -1,19 +1,19 @@
-use crate::environment::PlatformData;
+use crate::environment::{PlatformData, RequiredPlatform};
 use crate::lock_file::virtual_packages::{
-    MachineValidationError, compute_minimal_required_platforms,
+    MachineValidationError, compute_required_virtual_package_specs, unmet_requirements,
     validate_system_meets_environment_requirements,
 };
 use crate::workspace::{
     Environment, HasWorkspaceRef, PlatformOverrides, PlatformSource,
-    errors::UnsupportedPlatformError,
+    errors::{UnsupportedPlatformError, format_specs},
 };
 use fancy_display::FancyDisplay;
 use miette::Diagnostic;
 use pixi_manifest::{
     EnvironmentName, FeaturesExt, HasWorkspaceManifest, PixiPlatform, PixiPlatformName,
-    platform::archspec_from_build_string,
+    platform::{archspec_from_build_string, unsatisfied_capabilities},
 };
-use rattler_conda_types::{GenericVirtualPackage, Platform};
+use rattler_conda_types::{GenericVirtualPackage, MatchSpec, Platform};
 use rattler_lock::LockFile;
 use rattler_virtual_packages::{Cuda, CudaArch, LibC, Linux, Osx, VirtualPackage};
 use std::collections::HashSet;
@@ -95,13 +95,13 @@ pub enum VerifyCurrentPlatformError {
 ///    platforms match this machine (subdir + declared virtual packages)? This
 ///    is [`Environment::best_declared_platform`].
 /// 2. *Resolution compatibility* -- if (1) fails and a resolution is available,
-///    fall back to the minimal-required platform derived from the resolved
-///    dependencies (a declared platform may promise virtual packages the
-///    resolved packages don't actually need). If the machine satisfies that
-///    minimal set, the environment can run.
+///    fall back to the virtual-package requirements the resolved dependencies
+///    actually place on the machine (a declared platform may promise virtual
+///    packages they don't need). If the machine meets those, the environment can
+///    run.
 ///
 /// Outcomes: (1) holds -> ok; (1) fails but (2) holds -> ok with a warning;
-/// both fail -> error listing the unmet minimal requirements.
+/// both fail -> error listing the unmet requirements.
 pub fn verify_current_platform_can_run_environment(
     environment: &Environment<'_>,
     lock_file: Option<&LockFile>,
@@ -112,7 +112,7 @@ pub fn verify_current_platform_can_run_environment(
         return Ok(());
     }
 
-    // Check 1: a declared platform matches this machine.
+    // Check 1:
     if let Some(current_platform) = environment.best_declared_platform() {
         // Declared-compatible. Keep validating the resolved requirements
         // (conda virtual packages + pypi wheel tags) against the lock file.
@@ -127,16 +127,13 @@ pub fn verify_current_platform_can_run_environment(
         return Ok(());
     }
 
-    // Check 1 failed. Without a resolution there is nothing to fall back on, so
-    // keep the original "platform not supported" error.
     let Some(lock_file) = lock_file else {
         return Err(VerifyCurrentPlatformError::from(Box::new(
             environment.unsupported_platform_error(),
         )));
     };
 
-    // Check 2: does the machine satisfy the minimal-required platform for a
-    // subdir it can run (the current subdir or an architecture fallback)?
+    // Check 2:
     match minimum_compatible_declared_platform(environment, lock_file) {
         Ok(_) => {
             // Check 1 failed but the resolution is compatible -- continue.
@@ -146,11 +143,10 @@ pub fn verify_current_platform_can_run_environment(
             );
             Ok(())
         }
-        // Both checks failed. Reuse the declared-platform diagnosis but swap
-        // in the resolution-derived requirements the machine actually lacks.
+        // Both checks failed:
         Err(unmet) => {
             let mut error = environment.unsupported_platform_error();
-            error.unsatisfied_requirements = unmet;
+            error.unmet_requirements = unmet;
             Err(VerifyCurrentPlatformError::from(Box::new(error)))
         }
     }
@@ -164,7 +160,7 @@ pub fn verify_current_platform_can_run_environment(
 pub fn minimum_compatible_declared_platform<'p>(
     environment: &Environment<'p>,
     lock_file: &LockFile,
-) -> Result<&'p PixiPlatform, Vec<GenericVirtualPackage>> {
+) -> Result<&'p PixiPlatform, Vec<MatchSpec>> {
     let current = environment
         .workspace()
         .host_platform(
@@ -195,17 +191,17 @@ pub fn minimum_compatible_declared_platform<'p>(
         .iter()
         .filter(|platform| env_platform_names.contains(platform.name()))
         .collect();
-    let minimal =
-        compute_minimal_required_platforms(lock_file, environment.name(), &declared_platforms);
+    let required =
+        compute_required_virtual_package_specs(lock_file, environment.name(), &declared_platforms);
 
-    let mut unmet: Option<Vec<GenericVirtualPackage>> = None;
+    let mut unmet: Option<Vec<MatchSpec>> = None;
     for subdir in &candidate_subdirs {
         // A subdir with no resolved packages requires no virtual packages, so
         // the machine trivially satisfies it -- e.g. an empty environment whose
         // only content is tasks still runs under an unsatisfiable requirement.
-        let unsatisfied = minimal
+        let unsatisfied = required
             .get(subdir)
-            .map(|platform| unsatisfied_virtual_packages(platform, &system_virtual_packages))
+            .map(|specs| unmet_requirements(specs, &system_virtual_packages))
             .unwrap_or_default();
         if unsatisfied.is_empty() {
             if let Some(declared) = declared_platforms
@@ -222,36 +218,18 @@ pub fn minimum_compatible_declared_platform<'p>(
     Err(unmet.unwrap_or_default())
 }
 
-/// The declared virtual packages of `platform` that the machine does not
-/// provide (missing entirely, or present at a lower version).
-fn unsatisfied_virtual_packages(
-    platform: &PixiPlatform,
-    system: &[GenericVirtualPackage],
-) -> Vec<GenericVirtualPackage> {
-    platform
-        .declared_virtual_packages()
-        .iter()
-        .filter(|required| {
-            !system
-                .iter()
-                .any(|sys| sys.name == required.name && sys.version >= required.version)
-        })
-        .cloned()
-        .collect()
-}
-
 /// The platform the environment was installed for cannot run the installed
 /// packages: they require virtual packages this platform does not provide.
 #[derive(Debug, Error, Diagnostic)]
 #[error("the installed environment '{environment}' cannot run on platform '{platform}'")]
 #[diagnostic(help(
     "The installed packages require virtual packages this platform does not provide: [{}]. Reinstall for this machine with 'pixi install', or select a compatible platform with '--platform'.",
-    .unmet.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ")
+    format_specs(.unmet)
 ))]
 pub struct RunPlatformUnsupportedError {
     environment: EnvironmentName,
     platform: PixiPlatformName,
-    unmet: Vec<GenericVirtualPackage>,
+    unmet: Vec<MatchSpec>,
 }
 
 /// How a base platform compares to the resolved/minimum platforms an
@@ -266,47 +244,34 @@ enum RunPlatformVerdict {
     /// (empty when only the resolution subdir is out of reach).
     OnlyMinimum(Vec<GenericVirtualPackage>),
     /// The base is below the minimum: the installed packages cannot run, with
-    /// the virtual packages it fails to provide.
-    BelowMinimum(Vec<GenericVirtualPackage>),
+    /// the requirements it fails to meet.
+    BelowMinimum(Vec<MatchSpec>),
 }
 
-/// The virtual packages `required` needs that `base_capabilities` does not
-/// provide (missing, or present at a lower version). Subdir-agnostic.
-fn unmet_virtual_packages(
-    required: &PlatformData,
-    base_capabilities: &[GenericVirtualPackage],
-) -> Vec<GenericVirtualPackage> {
-    let required_platform = PixiPlatform::from_required_virtual_packages(
-        required.subdir(),
-        required.virtual_packages().to_vec(),
-    );
-    unsatisfied_virtual_packages(&required_platform, base_capabilities)
-}
-
-/// Classify a base platform against the resolution and minimum platforms an
-/// environment was installed for (read from `conda-meta/pixi`). `base_subdirs`
-/// are the subdirs the base can run (a single subdir for an explicit
-/// `--platform`, or the host's candidate subdirs incl. architecture
-/// fallbacks); a required subdir outside that set never satisfies.
+/// Classify a base platform against the resolution platform and the
+/// requirements an environment was installed with (read from `conda-meta/pixi`).
+/// `base_subdirs` are the subdirs the base can run (a single subdir for an
+/// explicit `--platform`, or the host's candidate subdirs incl. architecture
+/// fallbacks); a subdir outside that set never satisfies.
 fn classify_run_platform(
     base_subdirs: &[Platform],
     base_capabilities: &[GenericVirtualPackage],
     resolved: &PlatformData,
-    minimum: &PlatformData,
+    minimum: &RequiredPlatform,
 ) -> RunPlatformVerdict {
-    let satisfies = |required: &PlatformData| {
-        base_subdirs.contains(&required.subdir())
-            && unmet_virtual_packages(required, base_capabilities).is_empty()
-    };
+    let unmet_resolved = unsatisfied_capabilities(resolved.virtual_packages(), base_capabilities);
+    let unmet_minimum = unmet_requirements(minimum.requirements(), base_capabilities);
+    let meets_resolved = base_subdirs.contains(&resolved.subdir()) && unmet_resolved.is_empty();
+    let meets_minimum = base_subdirs.contains(&minimum.subdir()) && unmet_minimum.is_empty();
 
-    if satisfies(resolved) {
+    if meets_resolved {
         RunPlatformVerdict::Compatible
-    } else if satisfies(minimum) {
-        RunPlatformVerdict::OnlyMinimum(unmet_virtual_packages(resolved, base_capabilities))
+    } else if meets_minimum {
+        RunPlatformVerdict::OnlyMinimum(unmet_resolved)
     } else if base_subdirs.contains(&minimum.subdir()) {
-        RunPlatformVerdict::BelowMinimum(unmet_virtual_packages(minimum, base_capabilities))
+        RunPlatformVerdict::BelowMinimum(unmet_minimum)
     } else {
-        RunPlatformVerdict::BelowMinimum(minimum.virtual_packages().to_vec())
+        RunPlatformVerdict::BelowMinimum(minimum.requirements().to_vec())
     }
 }
 
@@ -748,7 +713,11 @@ packages:
             &lock("  depends:\n  - __cuda >=9999\n"),
         )
         .expect_err("an unsatisfiable resolved requirement has no fallback");
-        assert!(unmet.iter().any(|vp| vp.name.as_normalized() == "__cuda"));
+        // Reported as the spec the package carries, not as a bare version.
+        assert_eq!(
+            unmet.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            vec!["__cuda >=9999"]
+        );
     }
 
     /// An environment that resolved no packages at all (its subdir is absent
@@ -892,38 +861,6 @@ packages: []
     }
 
     #[test]
-    fn unsatisfied_virtual_packages_reports_missing_and_lower() {
-        use rattler_conda_types::{PackageName, Version};
-
-        let platform = pixi_manifest::PixiPlatform::from_required_virtual_packages(
-            Platform::Linux64,
-            vec![GenericVirtualPackage {
-                name: PackageName::try_from("__cuda").unwrap(),
-                version: Version::from_str("12").unwrap(),
-                build_string: String::new(),
-            }],
-        );
-        let cuda = |v: &str| {
-            vec![GenericVirtualPackage {
-                name: PackageName::try_from("__cuda").unwrap(),
-                version: Version::from_str(v).unwrap(),
-                build_string: String::new(),
-            }]
-        };
-
-        // Machine provides cuda 12 -> the requirement is met.
-        assert!(unsatisfied_virtual_packages(&platform, &cuda("12")).is_empty());
-        // A higher machine version still satisfies the minimum.
-        assert!(unsatisfied_virtual_packages(&platform, &cuda("12.4")).is_empty());
-        // A lower machine version leaves the requirement unmet.
-        let unmet = unsatisfied_virtual_packages(&platform, &cuda("11"));
-        assert_eq!(unmet.len(), 1);
-        assert_eq!(unmet[0].name.as_normalized(), "__cuda");
-        // No cuda at all -> unmet.
-        assert_eq!(unsatisfied_virtual_packages(&platform, &[]).len(), 1);
-    }
-
-    #[test]
     fn declared_libc_picks_family_and_version() {
         let pp = pixi_manifest::PixiPlatform::new(
             pixi_manifest::PixiPlatformName::try_from("musl-host").unwrap(),
@@ -961,11 +898,25 @@ packages: []
         }
     }
 
+    /// The requirement side: match specs as a resolved package's `depends`
+    /// spells them, not concrete virtual packages.
+    fn required_platform(subdir: Platform, specs: &[&str]) -> RequiredPlatform {
+        RequiredPlatform::new(
+            subdir,
+            specs
+                .iter()
+                .map(|raw| {
+                    MatchSpec::from_str(raw, rattler_conda_types::ParseStrictness::Lenient).unwrap()
+                })
+                .collect(),
+        )
+    }
+
     #[test]
     fn classify_compatible_when_base_meets_resolution() {
         // Base provides cuda 12.4; resolution needs 12.0 and minimum 12.0.
         let resolved = platform_data(Platform::Linux64, vec![gvp("__cuda", "12.0")]);
-        let minimum = platform_data(Platform::Linux64, vec![gvp("__cuda", "12.0")]);
+        let minimum = required_platform(Platform::Linux64, &["__cuda >=12.0"]);
         let verdict = classify_run_platform(
             &[Platform::Linux64],
             &[gvp("__cuda", "12.4")],
@@ -981,7 +932,7 @@ packages: []
         // base provides 2.17 -- it runs, but by accident. The verdict carries
         // the resolution requirement the base misses.
         let resolved = platform_data(Platform::Linux64, vec![gvp("__glibc", "2.28")]);
-        let minimum = platform_data(Platform::Linux64, vec![gvp("__glibc", "2.17")]);
+        let minimum = required_platform(Platform::Linux64, &["__glibc >=2.17"]);
         let verdict = classify_run_platform(
             &[Platform::Linux64],
             &[gvp("__glibc", "2.17")],
@@ -1036,7 +987,7 @@ packages: []
     fn classify_below_minimum_reports_unmet() {
         // Base glibc 2.12 is below the 2.17 floor the installed packages need.
         let resolved = platform_data(Platform::Linux64, vec![gvp("__glibc", "2.28")]);
-        let minimum = platform_data(Platform::Linux64, vec![gvp("__glibc", "2.17")]);
+        let minimum = required_platform(Platform::Linux64, &["__glibc >=2.17"]);
         let verdict = classify_run_platform(
             &[Platform::Linux64],
             &[gvp("__glibc", "2.12")],
@@ -1045,8 +996,10 @@ packages: []
         );
         match verdict {
             RunPlatformVerdict::BelowMinimum(unmet) => {
-                assert_eq!(unmet.len(), 1);
-                assert_eq!(unmet[0].name.as_normalized(), "__glibc");
+                assert_eq!(
+                    unmet.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                    vec!["__glibc >=2.17"]
+                );
             }
             other => panic!("expected BelowMinimum, got {other:?}"),
         }
@@ -1056,7 +1009,7 @@ packages: []
     fn classify_below_minimum_on_subdir_mismatch() {
         // A subdir outside the base's candidates can never satisfy.
         let resolved = platform_data(Platform::Osx64, vec![]);
-        let minimum = platform_data(Platform::Osx64, vec![]);
+        let minimum = required_platform(Platform::Osx64, &[]);
         let verdict = classify_run_platform(&[Platform::Linux64], &[], &resolved, &minimum);
         assert!(matches!(verdict, RunPlatformVerdict::BelowMinimum(_)));
     }
@@ -1066,7 +1019,7 @@ packages: []
         // An emulated subdir (osx-64 among an osx-arm64 host's candidates) with
         // satisfied virtual packages is compatible.
         let resolved = platform_data(Platform::Osx64, vec![gvp("__osx", "11.0")]);
-        let minimum = platform_data(Platform::Osx64, vec![]);
+        let minimum = required_platform(Platform::Osx64, &[]);
         let verdict = classify_run_platform(
             &[Platform::OsxArm64, Platform::Osx64],
             &[gvp("__osx", "13.0")],

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -31,9 +31,9 @@ use pixi_command_dispatcher::{
 use pixi_config::{Config, RunPostLinkScripts, default_channel_config, pixi_home};
 use pixi_consts::consts::{self};
 use pixi_core::environment::{
-    EnvironmentFile, LockedEnvironmentHash, PlatformData, write_environment_file,
+    EnvironmentFile, LockedEnvironmentHash, PlatformData, RequiredPlatform, write_environment_file,
 };
-use pixi_core::lock_file::virtual_packages::minimal_required_virtual_packages;
+use pixi_core::lock_file::virtual_packages::required_virtual_package_specs;
 use pixi_core::repodata::Repodata;
 use pixi_core::workspace::stdlib_variants::{StdlibVersionPin, derive_stdlib_variants};
 use pixi_manifest::{InlinePackageManifest, PixiPlatform, PrioritizedChannel, WorkspaceManifest};
@@ -848,13 +848,9 @@ impl Project {
         Ok(EnvironmentUpdate::new(install_changes, dependencies_names))
     }
 
-    /// Record the resolved and minimum-supported platforms in the environment's
-    /// `conda-meta/pixi` marker file, mirroring what non-global environments
-    /// write. The resolved platform is the subdir plus the virtual packages the
-    /// solve ran against (machine detection honoring `CONDA_OVERRIDE_*`); the
-    /// minimum-supported platform keeps only the virtual packages some installed
-    /// record actually depends on. `source_fingerprints` records the source
-    /// dependency specifications so `pixi global sync` can detect edits.
+    /// Record the resolved platform and the installed packages' requirements in
+    /// the environment's `conda-meta/pixi` marker file, mirroring what non-global
+    /// environments write.
     fn write_environment_file(
         &self,
         env_name: &EnvironmentName,
@@ -867,7 +863,7 @@ impl Project {
         let resolved_platform = PlatformData::new(platform, resolved_virtual_packages);
         let depends: Vec<&str> = resolved_depends.iter().map(String::as_str).collect();
         let minimum_supported_platform =
-            PlatformData::new(platform, minimal_required_virtual_packages(&depends));
+            RequiredPlatform::new(platform, required_virtual_package_specs(&depends));
 
         write_environment_file(
             prefix.root(),

--- a/crates/pixi_manifest/src/platform.rs
+++ b/crates/pixi_manifest/src/platform.rs
@@ -462,12 +462,7 @@ impl PixiPlatform {
 
     /// Build a runtime-only `PixiPlatform` for `subdir` declaring *exactly*
     /// `virtual_packages` -- no subdir defaults are merged in. The name is
-    /// synthesised from the contents.
-    ///
-    /// Reserved for computed, in-memory platforms (e.g. an environment's
-    /// minimal-required-platform set). These are never registered in a workspace
-    /// or written to disk, so the subdir-platform invariant enforced by
-    /// [`Self::new`] does not apply.
+    /// synthesized from the contents.
     pub fn from_required_virtual_packages(
         subdir: Platform,
         virtual_packages: Vec<GenericVirtualPackage>,
@@ -800,7 +795,8 @@ pub fn subdir_default_virtual_packages(subdir: Platform) -> Vec<GenericVirtualPa
 }
 
 /// Returns `true` if `gvp` is exactly the value `subdir_default_virtual_packages`
-/// would emit for `subdir`. Used by the TOML layer to elide default-matching
+/// would emit for `subdir`.
+///  Used by the TOML layer to elide default-matching
 /// virtual packages from synthesized names and on-disk serialization, and by
 /// the lock-file satisfiability check to compare only the user-customized
 /// virtual packages.
@@ -808,6 +804,29 @@ pub fn is_subdir_default(gvp: &GenericVirtualPackage, subdir: Platform) -> bool 
     subdir_default_virtual_packages(subdir).iter().any(|d| {
         d.name == gvp.name && d.version == gvp.version && d.build_string == gvp.build_string
     })
+}
+
+/// Returns `true` when `system` provides the capability `required` names: a
+/// virtual package of the same name at a version at least as high.
+pub fn capability_satisfied_by(
+    required: &GenericVirtualPackage,
+    system: &[GenericVirtualPackage],
+) -> bool {
+    system
+        .iter()
+        .any(|provided| provided.name == required.name && provided.version >= required.version)
+}
+
+/// The entries of `required` that `system` does not provide, in order.
+pub fn unsatisfied_capabilities(
+    required: &[GenericVirtualPackage],
+    system: &[GenericVirtualPackage],
+) -> Vec<GenericVirtualPackage> {
+    required
+        .iter()
+        .filter(|required| !capability_satisfied_by(required, system))
+        .cloned()
+        .collect()
 }
 
 /// The microarchitecture named by an `__archspec` build string, or `None` when
@@ -1163,6 +1182,23 @@ mod tests {
         // With no required VPs the platform carries an empty declared set.
         let empty = PixiPlatform::from_required_virtual_packages(Platform::Linux64, vec![]);
         assert!(empty.declared_virtual_packages().is_empty());
+    }
+
+    #[test]
+    fn unsatisfied_capabilities_reports_missing_and_lower() {
+        let required = [gvp("__cuda", "12")];
+
+        assert!(unsatisfied_capabilities(&required, &[gvp("__cuda", "12")]).is_empty());
+        assert!(unsatisfied_capabilities(&required, &[gvp("__cuda", "12.4")]).is_empty());
+
+        let unmet = unsatisfied_capabilities(&required, &[gvp("__cuda", "11")]);
+        assert_eq!(unmet, vec![gvp("__cuda", "12")]);
+        // A machine reporting nothing for the name leaves it unmet too.
+        assert_eq!(
+            unsatisfied_capabilities(&required, &[gvp("__glibc", "2.28")]),
+            vec![gvp("__cuda", "12")]
+        );
+        assert_eq!(unsatisfied_capabilities(&required, &[]).len(), 1);
     }
 
     #[test]

--- a/crates/pixi_manifest/src/workspace.rs
+++ b/crates/pixi_manifest/src/workspace.rs
@@ -17,6 +17,7 @@ use url::Url;
 use super::pypi::pypi_options::PypiOptions;
 use crate::{
     PixiPlatform, PixiPlatformName, PrioritizedChannel, S3Options, TargetSelector, Targets,
+    platform::{capability_satisfied_by, is_subdir_default},
     preview::Preview,
 };
 use minijinja::{AutoEscape, Environment, UndefinedBehavior};
@@ -167,8 +168,8 @@ impl Workspace {
         let satisfies_system = |p: &&PixiPlatform| {
             p.declared_virtual_packages()
                 .iter()
-                .filter(|declared| !crate::platform::is_subdir_default(declared, p.subdir()))
-                .all(|declared| satisfied_by_system(declared, system_virtual_packages))
+                .filter(|declared| !is_subdir_default(declared, p.subdir()))
+                .all(|declared| capability_satisfied_by(declared, system_virtual_packages))
         };
 
         let mut result: Vec<&PixiPlatform> = Vec::new();
@@ -263,8 +264,8 @@ impl Workspace {
                 let unsatisfied_virtual_packages = p
                     .declared_virtual_packages()
                     .iter()
-                    .filter(|declared| !crate::platform::is_subdir_default(declared, subdir))
-                    .filter(|declared| !satisfied_by_system(declared, system_virtual_packages))
+                    .filter(|declared| !is_subdir_default(declared, subdir))
+                    .filter(|declared| !capability_satisfied_by(declared, system_virtual_packages))
                     .cloned()
                     .collect();
                 PlatformMatchDiagnosis {
@@ -304,16 +305,6 @@ impl PlatformMatchDiagnosis {
     pub fn matches_host(&self) -> bool {
         self.subdir_matches_host && self.unsatisfied_virtual_packages.is_empty()
     }
-}
-
-/// Returns true if `declared` is provided by the system: the system must list
-/// a virtual package of the same name with a version at least as high as the
-/// declared one.
-fn satisfied_by_system(declared: &GenericVirtualPackage, system: &[GenericVirtualPackage]) -> bool {
-    system
-        .iter()
-        .find(|s| s.name == declared.name)
-        .is_some_and(|s| s.version >= declared.version)
 }
 
 /// A source that contributes additional build variant definitions.

--- a/docs/advanced/explain_info_command.md
+++ b/docs/advanced/explain_info_command.md
@@ -108,6 +108,6 @@ Only present once the environment has been installed.
 
 ### Minimum platform
 
-The minimum platform the installed packages actually require: the same subdir with only the virtual packages that some installed package depends on.
+What the installed packages actually require: the same subdir with only the virtual-package requirements that some installed package depends on, shown as match specs the way the packages spell them (`__glibc >=2.17`).
 This can be weaker than the resolved platform and tells you how portable the installed environment is.
 Only present once the environment has been installed.

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -156,7 +156,7 @@ Adding a platform whose definition already exists under a *different* name is re
 
 !!! tip "Trim it for portability"
     Auto-detection captures your machine exactly, which is usually more specific than your packages actually need.
-    After installing, `pixi info` reports each environment's **Minimum platform** (the virtual packages some resolved dependency really requires), so you can see which ones are safe to drop with `pixi workspace platform edit`.
+    After installing, `pixi info` reports each environment's **Minimum platform** (the virtual-package requirements some resolved dependency really places on the machine), so you can see which ones are safe to drop with `pixi workspace platform edit`.
 
 ### Managing platforms from the CLI
 

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -111,7 +111,12 @@ cuda = "*"
         [pixi, "install", "--manifest-path", manifest],
         ExitCode.FAILURE,
         env={"CONDA_OVERRIDE_CUDA": "10"},
-        stderr_contains="__cuda >= 12",
+        stderr_contains=[
+            # The declared platform, reported as the capability it declares...
+            "__cuda >= 42",
+            # ...and the package's own floor, reported as the spec it depends on.
+            "__cuda >=12",
+        ],
     )
 
 

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -120,6 +120,58 @@ cuda = "*"
     )
 
 
+@linux_only
+@requires_cuda_channel
+def test_run_honours_platform_override_for_the_marker_check(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """``PIXI_OVERRIDE_PLATFORM`` must skip the ``conda-meta/pixi`` marker check.
+
+    The override moves the subdir pixi pretends to be on but leaves the detected
+    virtual packages alone, so the check used to compare a pretended ``win-64``
+    against a marker recorded for ``linux-64`` and report every requirement as
+    unmet -- naming ``__cuda``, which the machine does provide. Every sibling
+    platform check already bails on the override.
+    """
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "override-run"
+channels = ["{virtual_packages_channel}"]
+platforms = [{{ platform = "linux-64", cuda = "13" }}]
+
+[dependencies]
+cuda = "*"
+
+[tasks]
+hello = "echo marker-check-skipped"
+""",
+    )
+    verify_cli_command(
+        [pixi, "install", "--manifest-path", manifest],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "13"},
+    )
+
+    # Pretending to be win-64 must not resurrect the linux-64 marker.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "hello"],
+        ExitCode.SUCCESS,
+        env={"PIXI_OVERRIDE_PLATFORM": "win-64", "CONDA_OVERRIDE_CUDA": "13"},
+        stdout_contains="marker-check-skipped",
+    )
+
+    # Without the override the check still bites: a host below the package floor
+    # cannot run what was installed.
+    verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "hello"],
+        ExitCode.FAILURE,
+        env={"CONDA_OVERRIDE_CUDA": "1"},
+        stderr_contains="__cuda >=12",
+    )
+
+
 @requires_cuda_channel
 def test_run_without_environment_flag_does_not_leak_base_platform(
     pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -4,13 +4,15 @@ Each test asserts the intended behaviour for a bug that pixi used to get
 wrong; they guard against regressions now that those bugs are fixed.
 
 All tests stay network-free: they use the in-repo ``virtual_packages`` channel
-(its ``cuda`` package depends on ``__cuda >=12``) and gate themselves on the
-host platform where the requirement only makes sense.
+(its ``cuda`` package depends on ``__cuda >=12``) or ``dummy_channel_1``, and
+gate themselves on the host platform where the requirement only makes sense.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -32,6 +34,59 @@ linux_only = pytest.mark.skipif(
 def _write(manifest: Path, body: str) -> Path:
     manifest.write_text(body)
     return manifest
+
+
+# A resolved platform no machine satisfies. `classify_run_platform` answers on
+# the resolved platform first and never consults the recorded minimum when that
+# one matches, so tests about a requirement must make it unsatisfiable first.
+_UNSATISFIABLE_RESOLVED: dict[str, Any] = {
+    "subdir": CURRENT_PLATFORM,
+    "virtual_packages": ["__cuda=99999"],
+}
+
+
+def _bare_manifest(workspace: Path, channel: str, *, deps: str = 'no-deps = "*"') -> Path:
+    """A workspace on a bare subdir platform, so the declared-platform check
+    always passes and the ``conda-meta/pixi`` marker check is what decides."""
+    return _write(
+        workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "marker-check"
+channels = ["{channel}"]
+platforms = ["{CURRENT_PLATFORM}"]
+
+[dependencies]
+{deps}
+
+[tasks]
+hello = "echo TASK-RAN"
+""",
+    )
+
+
+def _marker(workspace: Path, environment: str = "default") -> Path:
+    return workspace / ".pixi" / "envs" / environment / "conda-meta" / "pixi"
+
+
+def _read_marker(workspace: Path, environment: str = "default") -> dict[str, Any]:
+    return json.loads(_marker(workspace, environment).read_text())
+
+
+def _patch_marker(workspace: Path, **fields: Any) -> None:
+    """Overwrite marker fields in place, to reach states a solve cannot produce."""
+    path = _marker(workspace)
+    data = json.loads(path.read_text())
+    data.update(fields)
+    path.write_text(json.dumps(data))
+
+
+def _install(pixi: Path, manifest: Path, **kwargs: Any) -> None:
+    verify_cli_command([pixi, "install", "--manifest-path", manifest], ExitCode.SUCCESS, **kwargs)
+
+
+def _run(pixi: Path, manifest: Path, expected: ExitCode, **kwargs: Any) -> None:
+    verify_cli_command([pixi, "run", "--manifest-path", manifest, "hello"], expected, **kwargs)
 
 
 @requires_cuda_channel
@@ -328,3 +383,47 @@ restricted = {{ features = ["x86-only"] }}
         [pixi, "lock", "--check", "--dry-run", "--manifest-path", manifest],
         ExitCode.SUCCESS,
     )
+
+
+def test_unreadable_requirement_costs_only_that_requirement(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    """A requirement pixi cannot parse must not disable the whole check.
+
+    Rejecting the platform means ``read_environment_file`` deletes the marker,
+    which silently reinstalls the prefix and skips the very check the marker
+    exists for -- so an unreadable entry would turn a refusal into a pass.
+    """
+    manifest = _bare_manifest(tmp_pixi_workspace, dummy_channel_1, deps='dummy-a = "*"')
+    _install(pixi, manifest)
+    _patch_marker(
+        tmp_pixi_workspace,
+        resolved_platform=_UNSATISFIABLE_RESOLVED,
+        minimum_supported_platform={
+            "subdir": CURRENT_PLATFORM,
+            # Too large for a conda version component, so it cannot be read.
+            "requirements": ["__cuda >=99999999999999999999", "__cuda >=12"],
+        },
+    )
+    _run(pixi, manifest, ExitCode.FAILURE, stderr_contains="__cuda >=12")
+    # The marker survives, so the readable requirement is still enforced next time.
+    assert "requirements" in _read_marker(tmp_pixi_workspace)["minimum_supported_platform"]
+
+
+def test_unreadable_requirement_alone_does_not_discard_the_marker(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    """The rest of the marker -- lock hash, resolved platform, fingerprints --
+    must outlive an entry pixi cannot read."""
+    manifest = _bare_manifest(tmp_pixi_workspace, dummy_channel_1, deps='dummy-a = "*"')
+    _install(pixi, manifest)
+    _patch_marker(
+        tmp_pixi_workspace,
+        minimum_supported_platform={
+            "subdir": CURRENT_PLATFORM,
+            "requirements": [f"__cuda >={'9' * 200}"],
+        },
+    )
+    before = _read_marker(tmp_pixi_workspace)["environment_lock_file_hash"]
+    _run(pixi, manifest, ExitCode.SUCCESS, stdout_contains="TASK-RAN")
+    assert _read_marker(tmp_pixi_workspace)["environment_lock_file_hash"] == before

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -11,12 +11,14 @@ gate themselves on the host platform where the requirement only makes sense.
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from .common import CURRENT_PLATFORM, ExitCode, verify_cli_command
+from .common import CURRENT_PLATFORM, ExitCode, Output, verify_cli_command
 
 # The virtual_packages channel only ships the cuda package for these subdirs.
 CUDA_CHANNEL_SUBDIRS = {"linux-64", "win-64"}
@@ -87,6 +89,23 @@ def _install(pixi: Path, manifest: Path, **kwargs: Any) -> None:
 
 def _run(pixi: Path, manifest: Path, expected: ExitCode, **kwargs: Any) -> None:
     verify_cli_command([pixi, "run", "--manifest-path", manifest, "hello"], expected, **kwargs)
+
+
+def _run_unchecked(pixi: Path, manifest: Path) -> Output:
+    """Run the task without asserting an exit code: a host that happens to
+    provide the requirement under test is not refused at all."""
+    command = [pixi, "run", "--manifest-path", manifest, "hello"]
+    process = subprocess.run(
+        [str(part) for part in command],
+        capture_output=True,
+        env=dict(os.environ) | {"PIXI_NO_WRAP": "1"},
+    )
+    return Output(
+        command,
+        process.stdout.decode("utf-8", errors="replace"),
+        process.stderr.decode("utf-8", errors="replace"),
+        process.returncode,
+    )
 
 
 @requires_cuda_channel
@@ -427,3 +446,66 @@ def test_unreadable_requirement_alone_does_not_discard_the_marker(
     before = _read_marker(tmp_pixi_workspace)["environment_lock_file_hash"]
     _run(pixi, manifest, ExitCode.SUCCESS, stdout_contains="TASK-RAN")
     assert _read_marker(tmp_pixi_workspace)["environment_lock_file_hash"] == before
+
+
+# A requirement whose `CONDA_OVERRIDE_*` variable this host ignores, per CEP 30.
+_GATED_OFF_PLATFORM = "__osx >=99999" if CURRENT_PLATFORM.startswith("win") else "__win >=99999"
+
+
+def test_refusal_omits_an_override_the_host_platform_ignores(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    """A hint for a variable the target platform ignores is a dead end: the user
+    spends a round trip discovering the value they were handed does nothing."""
+    manifest = _bare_manifest(tmp_pixi_workspace, dummy_channel_1, deps='dummy-a = "*"')
+    _install(pixi, manifest)
+    _patch_marker(
+        tmp_pixi_workspace,
+        resolved_platform=_UNSATISFIABLE_RESOLVED,
+        minimum_supported_platform={
+            "subdir": CURRENT_PLATFORM,
+            "requirements": [_GATED_OFF_PLATFORM],
+        },
+    )
+    output = verify_cli_command(
+        [pixi, "run", "--manifest-path", manifest, "hello"], ExitCode.FAILURE
+    )
+    assert "CONDA_OVERRIDE" not in output.stderr, output.stderr
+
+
+@pytest.mark.parametrize(
+    ("name", "env_var"),
+    [
+        pytest.param("__cuda", "CONDA_OVERRIDE_CUDA", id="cuda"),
+        pytest.param("__glibc", "CONDA_OVERRIDE_GLIBC", id="glibc"),
+        pytest.param("__linux", "CONDA_OVERRIDE_LINUX", id="linux"),
+        pytest.param("__osx", "CONDA_OVERRIDE_OSX", id="osx"),
+        pytest.param("__win", "CONDA_OVERRIDE_WIN", id="win"),
+    ],
+)
+def test_every_suggested_override_is_actionable(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str, name: str, env_var: str
+) -> None:
+    """A hint pixi prints must unblock the run when followed.
+
+    CEP 30 gates several of these on the target platform: `CONDA_OVERRIDE_WIN`
+    "MUST be ignored when the target platform is not win-*", and the same for
+    `__osx` and `__linux`. Suggesting one off its platform hands the user a
+    value that cannot work, so off-platform there must be no hint at all.
+    """
+    manifest = _bare_manifest(tmp_pixi_workspace, dummy_channel_1, deps='dummy-a = "*"')
+    _install(pixi, manifest)
+    _patch_marker(
+        tmp_pixi_workspace,
+        resolved_platform=_UNSATISFIABLE_RESOLVED,
+        minimum_supported_platform={
+            "subdir": CURRENT_PLATFORM,
+            "requirements": [name],
+        },
+    )
+    refusal = _run_unchecked(pixi, manifest)
+    if env_var not in refusal.stderr:
+        pytest.skip(f"no {env_var} hint is offered here, so there is none to follow")
+    suggested = next(line.strip() for line in refusal.stderr.splitlines() if env_var in line)
+    key, _, value = suggested.partition("=")
+    _run(pixi, manifest, ExitCode.SUCCESS, env={key: value}, stdout_contains="TASK-RAN")


### PR DESCRIPTION
### Description

Use matchspecs to describe requirements in rich platforms. That is more expressive and avoids (potentially lossy) conversions from matchspecs to virtual packages and back.

This does introduce backward incompatibility: Running an older pixi with environments installed with a newer one is going to lose information on the requirements used to set up the that environment. I think this is OK, who would ever want to downgrade the pixi version they use to create environments with?

### How Has This Been Tested?

Unit tests plus manual testing. Lots of fixes on top of the actual change were added due to edge cases showing up during testing.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
