### PR TITLE
feat: Add some extra mappings to `pixi-build-ros` 

### DIFF
--- a/crates/pixi_build_ros/robostack.yaml
+++ b/crates/pixi_build_ros/robostack.yaml
@@ -1,4 +1,3 @@
-# This file is part of the RoboStack noetic project. for testing purposes.
 acl:
   robostack:
     linux: [libacl]
@@ -76,6 +75,8 @@ draco:
   robostack: [draco]
 eigen:
   robostack: [eigen]
+libdraco-dev:
+  robostack: [draco]
 emacs:
   # Wait until https://github.com/robostack-forge/gtk3-feedstock/pull/74 is resolved
   # and emacs is rebuilt for harfbuzz=10
@@ -318,6 +319,8 @@ libglew-dev:
   robostack: [glew]
 libglfw3-dev:
   robostack: [glfw 3.*]
+libgmock-dev:
+  robostack: [gmock]
 libglu-dev:
   robostack:
     linux: [libglu]
@@ -461,6 +464,8 @@ libsqlite3-dev:
   robostack: [sqlite 3.*]
 libssl-dev:
   robostack: [openssl]
+libsystemd-dev:
+  robostack: [libsystemd]
 libtheora:
   robostack: [libtheora]
 libtool:
@@ -767,6 +772,8 @@ python3-flask:
   robostack: [flask]
 python3-flask-cors:
   robostack: [flask-cors]
+python3-fastapi:
+  robostack: [fastapi]
 python3-fiona:
   robostack: [fiona]
 python3-future:
@@ -847,6 +854,8 @@ python3-pycodestyle:
   robostack: [pycodestyle]
 python3-pycryptodome:
   robostack: [pycryptodome, pycryptodomex]
+python3-pydantic:
+  robostack: [pydantic]
 python3-pydot:
   robostack: [pydot]
 python3-pygraphviz:
@@ -931,6 +940,8 @@ python3-unidiff:
   robostack: [unidiff]
 python3-usb:
   robostack: [pyusb]
+python3-uvicorn:
+  robostack: [uvicorn]
 python3-vcstool:
   robostack: [vcstool]
 python3-flake8-docstrings:
@@ -961,6 +972,8 @@ roboticstoolbox-python:
   robostack: [roboticstoolbox-python]
 rsync:
   robostack: [rsync]
+range-v3:
+  robostack: [range-v3]
 rti-connext-dds-5.3.1:
   robostack: []
 ruby:
@@ -994,6 +1007,8 @@ subversion:
   robostack: [subversion]
 suitesparse:
   robostack: [suitesparse]
+sophus:
+  robostack: [sophus]
 sqlite3:
   robostack: [sqlite 3.*]
 swig:


### PR DESCRIPTION
### Description

These mappings are long part of robostack: https://github.com/RoboStack/ros-kilted/blob/b51c0355ea9d6ccbcaedce2382f9ad7fa815337a/robostack.yaml#L331
But somehow I still need to supply them using:

```toml
[package.build]
backend = { name = "pixi-build-ros", version = "*" }

[[package.build.config.extra-package-mappings]]
libgmock-dev = { conda = ["gmock"] }
```

My current understanding is that we are still using this file then? If so, please add these missing ones.

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
