### PR TITLE
fix(pixi-build-mojo): change `mojo package` command to `mojo precompile`

### DIFF
--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -12,5 +12,5 @@ mojo build {{ bin.extra_args | join(" ")  }} "{{ bin.path }}" -o {{ library_pref
 
 {#- Build pkg -#}
 {% if pkg %}
-mojo package {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
+mojo precompile {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
 {% endif %}


### PR DESCRIPTION
### Description

Fixes #6832 

### How Has This Been Tested?

I have tested this locally. Per the issue report, you can see the effect of this when you call the old function in the shell; there is a warning that `package` has been deprecated in favor of `precompile`

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
- [ ] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
