### PR TITLE
fix(pixi-build-mojo): fall back to `mojo package` when `precompile` is unavailable

### DIFF
--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -12,5 +12,12 @@ mojo build {{ bin.extra_args | join(" ")  }} "{{ bin.path }}" -o {{ library_pref
 
 {#- Build pkg -#}
 {% if pkg %}
-mojo precompile {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
+# Mojo v1.0 renamed `mojo package` to `mojo precompile`; probe which subcommand the installed compiler supports
+if mojo precompile --help >/dev/null 2>&1; then
+    MOJO_PKG_CMD=precompile
+else
+    MOJO_PKG_CMD=package
+fi
+mkdir -p {{ library_prefix }}/lib/mojo
+mojo $MOJO_PKG_CMD {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
 {% endif %}

--- a/crates/pixi_build_mojo/src/build_script.rs
+++ b/crates/pixi_build_mojo/src/build_script.rs
@@ -25,3 +25,33 @@ impl BuildScriptContext {
             .to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkg_probes_for_precompile_with_package_fallback() {
+        let script = BuildScriptContext {
+            bins: None,
+            pkg: Some(MojoPkgConfig {
+                name: Some(String::from("mylib")),
+                path: Some(String::from("/src/mylib")),
+                extra_args: None,
+            }),
+        }
+        .render();
+
+        insta::assert_snapshot!(script, @r#"
+        mojo --version
+        # Mojo v1.0 renamed `mojo package` to `mojo precompile`; probe which subcommand the installed compiler supports
+        if mojo precompile --help >/dev/null 2>&1; then
+            MOJO_PKG_CMD=precompile
+        else
+            MOJO_PKG_CMD=package
+        fi
+        mkdir -p $PREFIX/lib/mojo
+        mojo $MOJO_PKG_CMD  "/src/mylib" -o $PREFIX/lib/mojo/mylib.mojopkg
+        "#);
+    }
+}


### PR DESCRIPTION
### Description

#6833 switched the build script to `mojo precompile`, but compilers older than Mojo v1.0 don't have that subcommand yet, so their builds would break with the next backend release. The build script now probes `mojo precompile --help` and falls back to `mojo package` when it isn't available. Thanks @wolfv for the suggestion!

While testing the clanker noticed that pkg-only builds fail on old and new compilers alike because `$PREFIX/lib/mojo` doesn't exist; the script now creates it before packaging.

### How Has This Been Tested?

- Inline snapshot test for the rendered build script
- Built a minimal pkg-only Mojo project with `pixi build` and a locally built backend, once with `mojo-compiler==0.25.7.0` (picks `mojo package`) and once with `==1.0.0` (picks `mojo precompile`); both produce `lib/mojo/<name>.mojopkg`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
