### PR TITLE
fix: enable `pixi_build_types` feature on `pixi_spec` in type conversions

### DIFF
--- a/crates/pixi_build_type_conversions/Cargo.toml
+++ b/crates/pixi_build_type_conversions/Cargo.toml
@@ -14,7 +14,7 @@ itertools = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 pixi_build_types = { workspace = true }
 pixi_manifest = { workspace = true }
-pixi_spec = { workspace = true }
+pixi_spec = { workspace = true, features = ["pixi_build_types"] }
 pixi_spec_containers = { workspace = true }
 rattler_conda_types = { workspace = true }
 


### PR DESCRIPTION
`pixi_build_type_conversions` uses the `From<&Pin>` impls gated behind `pixi_spec`'s `pixi_build_types` feature without enabling it. Workspace builds pass via feature unification, but the isolated `cargo install --locked --path crates/pixi_build_ros` on the feedstock fails to compile.

Needs a pixi-build-ros 0.7.4 release afterwards, the 0.7.3 tag is broken.
