### PR TITLE
fix(pixi-build-mojo): use .mojoc with precompile

### DIFF
--- a/crates/pixi_build_mojo/src/build_script.j2
+++ b/crates/pixi_build_mojo/src/build_script.j2
@@ -15,9 +15,11 @@ mojo build {{ bin.extra_args | join(" ")  }} "{{ bin.path }}" -o {{ library_pref
 # Mojo v1.0 renamed `mojo package` to `mojo precompile`; probe which subcommand the installed compiler supports
 if mojo precompile --help >/dev/null 2>&1; then
     MOJO_PKG_CMD=precompile
+    MOJO_PKG_EXT=mojoc
 else
     MOJO_PKG_CMD=package
+    MOJO_PKG_EXT=mojopkg
 fi
 mkdir -p {{ library_prefix }}/lib/mojo
-mojo $MOJO_PKG_CMD {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name}}.mojopkg
+mojo $MOJO_PKG_CMD {{ pkg.extra_args | join(" ") }} "{{ pkg.path }}" -o {{ library_prefix }}/lib/mojo/{{ pkg.name }}.$MOJO_PKG_EXT
 {% endif %}

--- a/crates/pixi_build_mojo/src/build_script.rs
+++ b/crates/pixi_build_mojo/src/build_script.rs
@@ -31,7 +31,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pkg_probes_for_precompile_with_package_fallback() {
+    fn pkg_selects_matching_command_and_extension() {
         let script = BuildScriptContext {
             bins: None,
             pkg: Some(MojoPkgConfig {
@@ -47,11 +47,13 @@ mod tests {
         # Mojo v1.0 renamed `mojo package` to `mojo precompile`; probe which subcommand the installed compiler supports
         if mojo precompile --help >/dev/null 2>&1; then
             MOJO_PKG_CMD=precompile
+            MOJO_PKG_EXT=mojoc
         else
             MOJO_PKG_CMD=package
+            MOJO_PKG_EXT=mojopkg
         fi
         mkdir -p $PREFIX/lib/mojo
-        mojo $MOJO_PKG_CMD  "/src/mylib" -o $PREFIX/lib/mojo/mylib.mojopkg
+        mojo $MOJO_PKG_CMD  "/src/mylib" -o $PREFIX/lib/mojo/mylib.$MOJO_PKG_EXT
         "#);
     }
 }

--- a/crates/pixi_build_mojo/src/config.rs
+++ b/crates/pixi_build_mojo/src/config.rs
@@ -305,7 +305,7 @@ impl MojoBinConfig {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct MojoPkgConfig {
-    /// Name to give the mojo package (.mojopkg suffix will be added).
+    /// Name to give the Mojo package (`.mojoc` for current compilers, `.mojopkg` for legacy compilers).
     ///
     /// This will default to the name of the project, any dashes will
     /// be replaced with `_`.

--- a/docs/build/backends/pixi-build-mojo.md
+++ b/docs/build/backends/pixi-build-mojo.md
@@ -274,7 +274,9 @@ Package configuration for creating Mojo package. The created Mojo package will b
 - **Type**: `String`
 - **Default**: Project name (with dashes converted to underscores)
 
-The name to give the Mojo package. The `.mojopkg` suffix will be added automatically. If not specified, defaults to the project name.
+The name to give the Mojo package. The backend adds the `.mojoc` suffix when using
+`mojo precompile`, or `.mojopkg` when falling back to the legacy `mojo package`
+command. If not specified, the name defaults to the project name.
 
 ```toml
 [package.build.config.pkg]


### PR DESCRIPTION
### Description

Mojo 1.0 renamed `mojo package` to `mojo precompile` and replaced the legacy `.mojopkg` extension with `.mojoc`. The backend already probed for the available subcommand, but always wrote a `.mojopkg` file, so current Mojo builds still emitted an extension deprecation warning.

This follow-up to #6833 and #6841 selects the command and extension together:

| Compiler capability | Command | Output extension |
| --- | --- | --- |
| `precompile` available | `mojo precompile` | `.mojoc` |
| Legacy fallback | `mojo package` | `.mojopkg` |

This removes the warning for Mojo 1.0 while preserving compatibility with older compilers. The rendered-script snapshot, Rust configuration documentation, and backend user documentation are updated accordingly.

### How Has This Been Tested?

- `cargo test -p pixi-build-mojo` (31 tests passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p pixi-build-mojo --all-targets -- -D warnings`
- built `mojopt` end-to-end with Mojo 1.0.0 through the overridden local backend; the generated Conda package contained `lib/mojo/mojopt.mojoc` and emitted neither package deprecation warning

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

Prompt:

```plaintext
Inspect the local pixi-build-mojo backend and fix the Mojo 1.0 package warning by pairing mojo precompile with .mojoc while preserving the legacy mojo package/.mojopkg fallback; update tests and documentation, then verify the fix end-to-end.
```

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
