### PR TITLE
fix: remove backends channel from pixi repo

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -659,7 +659,6 @@ source = { path = "crates/pixi" }
 
 [package.build.backend]
 channels = [
-  "https://prefix.dev/pixi-build-backends",
   "https://prefix.dev/conda-forge",
 ]
 name = "pixi-build-rust"


### PR DESCRIPTION
At the moment backends on our backend channel don't work with newest Pixi, so we can't use them