### PR TITLE
fix(script): solve scripts against the host's virtual packages

### DIFF
--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -130,6 +130,10 @@ pub async fn add_auto_detected<I: Interface>(
     feature_name: FeatureName,
     lock_file_usage: LockFileUsage,
 ) -> miette::Result<()> {
+    // A script's implicit platforms are pixi's own guess, not a declaration;
+    // dedup against them would make this a guaranteed no-op.
+    workspace.forget_implicit_script_platforms();
+
     // Content-based dedup: an existing platform with the same definition *is*
     // this machine, regardless of name.
     let existing = workspace

--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -130,8 +130,8 @@ pub async fn add_auto_detected<I: Interface>(
     feature_name: FeatureName,
     lock_file_usage: LockFileUsage,
 ) -> miette::Result<()> {
-    // A script's implicit platforms are pixi's own guess, not a declaration;
-    // dedup against them would make this a guaranteed no-op.
+    // A script's implicit platforms are pixi's own guess, not a declaration,
+    // so deduplicating against them would make this a guaranteed no-op.
     workspace.forget_implicit_script_platforms();
 
     // Content-based dedup: an existing platform with the same definition *is*

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -85,7 +85,8 @@ use crate::{
         get_activated_environment_variables,
         grouped_environment::{GroupedEnvironment, GroupedEnvironmentName},
         virtual_packages::{
-            minimum_compatible_declared_platform, verify_current_platform_can_run_environment,
+            environment_has_dependencies_for_platform, minimum_compatible_declared_platform,
+            verify_current_platform_can_run_environment,
         },
     },
 };
@@ -757,10 +758,41 @@ impl<'p> LockFileDerivedData<'p> {
         let lock_file_path = self.workspace.persistent_lock_file_path().ok_or_else(|| {
             miette::miette!("transient script workspaces cannot write lock files")
         })?;
+        self.warn_if_locking_an_implicit_host_platform(&lock_file_path);
         self.lock_file
             .to_path(&lock_file_path)
             .into_diagnostic()
             .context("failed to write lock file to disk")
+    }
+
+    /// Warn when a script that declares no `platforms` is about to persist a
+    /// lock file describing this machine.
+    ///
+    /// `pixi run --script` reaches here only when a sidecar already exists (it
+    /// resolves in memory otherwise), so this is about the `pixi lock --script`
+    /// that deliberately creates a portable-looking artifact that is not
+    /// portable, and about the runs that keep it up to date afterwards.
+    fn warn_if_locking_an_implicit_host_platform(&self, lock_file_path: &Path) {
+        if !self.workspace.script_platforms_are_implicit() {
+            return;
+        }
+        let manifest = self.workspace.workspace_manifest();
+        if manifest
+            .workspace
+            .platforms
+            .iter()
+            .all(|platform| platform.customised_virtual_packages().is_empty())
+        {
+            return;
+        }
+        let script = self.workspace.workspace.provenance.absolute_path();
+        tracing::warn!(
+            "the script declares no platforms, so {} records this machine's virtual packages.\n\
+             Run `pixi workspace platform add --script {} --auto-detect` to declare it explicitly, \
+             or add `platforms` to the script metadata.",
+            lock_file_path.display(),
+            script.display(),
+        );
     }
 
     /// Consumes this instance, dropping any resources that are not needed
@@ -1035,6 +1067,26 @@ impl<'p> LockFileDerivedData<'p> {
                     platform.name(),
                     environment.workspace_manifest(),
                 );
+                // No row for the platform being installed means nothing to
+                // install. That is the right answer whenever the environment
+                // declares nothing for this platform, which is ordinary for a
+                // workspace whose dependencies all sit under another
+                // `[target]`, and for a lock file old enough to carry rows only
+                // for the platforms that had packages. When it does declare
+                // something, an empty prefix would silently hand the run
+                // whatever is on `PATH`. Mostly reached through `--frozen`,
+                // which consumes the lock file without checking that it still
+                // covers this machine.
+                if lock_platform.is_none()
+                    && environment_has_dependencies_for_platform(environment, platform)
+                {
+                    return Err(miette::miette!(
+                        help = "Run `pixi lock` to resolve it for this platform. Without `--frozen` or `--locked`, pixi updates the lock file itself.",
+                        "the lock file has no entry for platform '{}' in environment '{}'",
+                        platform.name().as_str(),
+                        environment.name().fancy_display(),
+                    ));
+                }
                 let result = subset.filter(lock_platform.and_then(|p| locked_env.packages(p)))?;
                 let packages = result.install;
                 let ignored = result.ignore;

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -768,10 +768,9 @@ impl<'p> LockFileDerivedData<'p> {
     /// Warn when a script that declares no `platforms` is about to persist a
     /// lock file describing this machine.
     ///
-    /// `pixi run --script` reaches here only when a sidecar already exists (it
-    /// resolves in memory otherwise), so this is about the `pixi lock --script`
-    /// that deliberately creates a portable-looking artifact that is not
-    /// portable, and about the runs that keep it up to date afterwards.
+    /// Reached from `pixi lock --script`, which creates a portable-looking
+    /// artifact that is not portable, and from the runs that keep it up to date
+    /// afterwards.
     fn warn_if_locking_an_implicit_host_platform(&self, lock_file_path: &Path) {
         if !self.workspace.script_platforms_are_implicit() {
             return;
@@ -1067,16 +1066,14 @@ impl<'p> LockFileDerivedData<'p> {
                     platform.name(),
                     environment.workspace_manifest(),
                 );
-                // No row for the platform being installed means nothing to
-                // install. That is the right answer whenever the environment
-                // declares nothing for this platform, which is ordinary for a
-                // workspace whose dependencies all sit under another
-                // `[target]`, and for a lock file old enough to carry rows only
-                // for the platforms that had packages. When it does declare
-                // something, an empty prefix would silently hand the run
-                // whatever is on `PATH`. Mostly reached through `--frozen`,
-                // which consumes the lock file without checking that it still
-                // covers this machine.
+                // No row for the platform means nothing to install, which is
+                // right whenever the environment declares nothing for it: all
+                // dependencies sit under another `[target]`, or the lock file
+                // only carries rows for platforms that had packages. When it
+                // does declare something, an empty prefix would silently hand
+                // the run whatever is on `PATH`. Mostly reached through
+                // `--frozen`, which consumes the lock file without checking
+                // that it still covers this machine.
                 if lock_platform.is_none()
                     && environment_has_dependencies_for_platform(environment, platform)
                 {

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -55,12 +55,17 @@ use pixi_utils::{
     variants::{VariantConfig, VariantValue},
 };
 use pypi_mapping::PurlDerivationMode;
-use rattler_conda_types::{ChannelConfig, ChannelUrl, MatchSpec, PackageName, Platform};
+use rattler_conda_types::{
+    ChannelConfig, ChannelUrl, GenericVirtualPackage, MatchSpec, PackageName, Platform,
+};
 use rattler_lock::LockFile;
 use thiserror::Error;
 
 use crate::lock_file::LockedPackageKind;
-use pixi_manifest::platform::host::{host_capabilities, host_subdir};
+use pixi_manifest::platform::host::{
+    detect_host, host_capabilities, host_subdir, platform_from_detected,
+};
+use pixi_manifest::platform::unsatisfied_capabilities;
 use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
 pub use registry::{WorkspaceRegistry, WorkspaceRegistryError};
@@ -206,6 +211,16 @@ pub enum ScriptWorkspaceError {
 
     #[error("failed to resolve the script environment cache directory: {0}")]
     CacheDirectory(String),
+
+    #[error("failed to determine the virtual packages of this machine for '{subdir}'")]
+    #[diagnostic(help(
+        "a script without `platforms` is resolved for this machine. Declare the platforms in the script metadata to resolve it for a fixed target instead."
+    ))]
+    HostDetection {
+        subdir: Platform,
+        #[source]
+        source: pixi_manifest::platform::host::HostDetectionError,
+    },
 }
 
 fn script_cache_name(path: &Path) -> String {
@@ -231,6 +246,174 @@ fn script_cache_name(path: &Path) -> String {
     } else {
         format!("{name}-{digest}")
     }
+}
+
+/// Install the platforms picked for a script that declares none.
+///
+/// `use_platform_composition` is decided while the manifest is parsed, and a
+/// script's synthetic manifest is parsed with an empty `platforms`, which reads
+/// as "every platform is a bare subdir". Composition then resolves an
+/// environment's platform by *subdir name*, so it would look for `linux-64` and
+/// never find the rich platform injected afterwards. Recompute the flag for the
+/// platforms actually installed, which is what the parser would have done had
+/// they been written in the metadata.
+///
+/// `must_migrate` is deliberately left alone. It records that the script still
+/// carries a legacy `[system-requirements]` table, which is a fact about the
+/// document rather than about the platforms picked here, and clearing it stops
+/// `commit_if_needed` from dropping that table when a rich platform is written
+/// next to it. The two cannot coexist, so the manifest would no longer parse.
+fn set_implicit_script_platforms(
+    workspace: &mut pixi_manifest::Workspace,
+    platforms: IndexSet<PixiPlatform>,
+) {
+    workspace.use_platform_composition = platforms.iter().all(PixiPlatform::is_subdir_platform);
+    workspace.platforms = platforms;
+}
+
+/// The platforms a script that declares none is resolved for.
+///
+/// A script has no `[workspace] platforms`, so pixi picks one on its behalf.
+/// Unlike a workspace -- where "the current platform" means the subdir with
+/// pixi's assumed defaults, written down in the manifest for you to see and
+/// edit -- a script is resolved for the machine it is run on, the same as its
+/// no-manifest siblings `pixi exec` and `pixi global`. Otherwise a script on a
+/// machine with CUDA, or with a glibc newer than pixi's 2.28 floor, is solved
+/// against packages that machine does not need to be limited to.
+///
+/// An adjacent sidecar lock wins while it is usable, so a `pixi lock --script`
+/// keeps reproducing rather than being re-solved for a marginally different
+/// host on the next run. The platforms it recorded are rebuilt in full,
+/// virtual packages included: reading them back as bare subdirs would lose the
+/// machine they were locked for, and pixi would re-solve every run, quietly
+/// overwriting the sidecar with the defaults. Their names are synthesized from
+/// their contents rather than taken from the lock, which stores rich platforms
+/// under short `p1`/`p2` aliases; `align_platform_names` maps the rows back on
+/// by identity.
+///
+/// A recorded platform is only worth keeping when it says something this
+/// machine can honour. One this machine cannot run, and one that records
+/// nothing beyond pixi's defaults for the subdir, both give way to the host and
+/// a re-solve, rather than failing on a platform the user never declared or
+/// pinning the script below the machine it runs on. Rows for other subdirs are
+/// dropped outright. Each of those is worth a word, since the next write to the
+/// lock file makes it permanent, so all three warn.
+///
+/// A lock file that does not parse is left to the loader to report, so it is
+/// not mistaken here for one recording an unrunnable platform.
+fn implicit_script_platforms(
+    lock_file_path: Option<&Path>,
+) -> Result<IndexSet<PixiPlatform>, ScriptWorkspaceError> {
+    let subdir = host_subdir();
+    let host = detect_host(subdir).map_err(|error| ScriptWorkspaceError::HostDetection {
+        subdir,
+        source: error,
+    })?;
+
+    // A lock file that does not parse says nothing about which platform this
+    // machine can run, so it is passed over silently: the loader reads the same
+    // file moments later and reports why it is unusable, with the position in
+    // the file that this function does not have.
+    let Some(lock_file) = lock_file_path
+        .filter(|path| path.is_file())
+        .and_then(|path| LockFile::from_path(path).ok())
+    else {
+        return Ok(IndexSet::from([host]));
+    };
+
+    // A row carrying nothing beyond the subdir baseline records no machine at
+    // all: it is what an older pixi wrote for a script without `platforms`, or
+    // what was locked while the script still declared a bare subdir. Adopting
+    // it would pin the script to pixi's defaults and quietly undo the point of
+    // resolving a script for the host it runs on. When the host is itself
+    // baseline the two are the same platform, so there is nothing to reject and
+    // no re-solve to trigger on every run.
+    let host_is_baseline = host.customised_virtual_packages().is_empty();
+
+    let mut foreign_subdirs: IndexSet<Platform> = IndexSet::new();
+    let mut rejected_baseline = false;
+    let mut rejected_unrunnable = false;
+    let mut locked: IndexSet<PixiPlatform> = IndexSet::new();
+    for row in lock_file.platforms() {
+        // A lock can hold rows for other subdirs (a script that declared
+        // `platforms` once and had the line removed since); keeping those would
+        // make every later run solve and lock for a platform the script no
+        // longer asks for.
+        if row.subdir() != subdir {
+            foreign_subdirs.insert(row.subdir());
+            continue;
+        }
+        let Ok(recorded) = platform_from_detected(row.subdir(), locked_virtual_packages(&row))
+        else {
+            continue;
+        };
+        if !host_is_baseline && recorded.customised_virtual_packages().is_empty() {
+            rejected_baseline = true;
+            continue;
+        }
+        if !unsatisfied_capabilities(
+            &recorded.customised_virtual_packages(),
+            host.declared_virtual_packages(),
+        )
+        .is_empty()
+        {
+            rejected_unrunnable = true;
+            continue;
+        }
+        locked.insert(recorded);
+    }
+
+    // Whether the file on disk actually changes is up to the lock file usage the
+    // command was given: `--frozen` and `--locked` consume it without writing,
+    // so none of these may claim the lock file *is* rewritten.
+    if !foreign_subdirs.is_empty() {
+        tracing::warn!(
+            "the lock file next to this script also records {}, which a script without \
+             `platforms` does not ask for, so the next write to the lock file drops those \
+             rows.\n\
+             Declare `platforms` in the script metadata to keep locking for them.",
+            foreign_subdirs
+                .iter()
+                .map(|subdir| format!("'{}'", subdir.as_str()))
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+    }
+
+    if locked.is_empty() {
+        if rejected_unrunnable {
+            tracing::warn!(
+                "the lock file next to this script records a platform this machine cannot run, \
+                 so the script is resolved for '{}' instead, and the next write to the lock file \
+                 replaces what it records.\n\
+                 Declare `platforms` in the script metadata to keep locking for a fixed target.",
+                host.name().as_str(),
+            );
+        } else if rejected_baseline {
+            tracing::warn!(
+                "the lock file next to this script records pixi's defaults for '{}' rather than \
+                 the machine it was locked on, so the script is resolved for '{}' instead, and \
+                 the next write to the lock file replaces what it records.\n\
+                 Declare `platforms` in the script metadata to keep locking for a fixed target.",
+                subdir.as_str(),
+                host.name().as_str(),
+            );
+        }
+        return Ok(IndexSet::from([host]));
+    }
+
+    Ok(locked)
+}
+
+/// The virtual packages a lock-file platform row records, as the typed form.
+/// Entries the current pixi cannot parse are dropped; they can only have come
+/// from a newer pixi, and a platform is defined by what we can compare.
+fn locked_virtual_packages(platform: &rattler_lock::Platform<'_>) -> Vec<GenericVirtualPackage> {
+    platform
+        .virtual_packages()
+        .iter()
+        .filter_map(|raw| pixi_manifest::platform::parse_locked_virtual_package(raw))
+        .collect()
 }
 
 fn script_lock_file_path(path: &Path) -> PathBuf {
@@ -355,19 +538,10 @@ impl Workspace {
                 .collect();
         }
         if !script_config.platforms_explicit {
-            let locked_platforms = LockFile::from_path(&lock_file_path)
-                .ok()
-                .map(|lock_file| {
-                    lock_file
-                        .platforms()
-                        .map(|platform| PixiPlatform::from_subdir(platform.subdir()))
-                        .collect::<IndexSet<_>>()
-                })
-                .filter(|platforms| !platforms.is_empty());
-
-            manifest.workspace.platforms = locked_platforms.unwrap_or_else(|| {
-                IndexSet::from([PixiPlatform::from_subdir(Platform::current())])
-            });
+            set_implicit_script_platforms(
+                &mut manifest.workspace,
+                implicit_script_platforms(Some(&lock_file_path))?,
+            );
         }
 
         let root = script_path
@@ -416,8 +590,12 @@ impl Workspace {
                 .collect();
         }
         if !script_config.platforms_explicit {
-            manifest.workspace.platforms =
-                IndexSet::from([PixiPlatform::from_subdir(Platform::current())]);
+            // A transient script has nowhere to keep a lock file, so the host
+            // is the only platform it can be resolved for.
+            set_implicit_script_platforms(
+                &mut manifest.workspace,
+                implicit_script_platforms(None)?,
+            );
         }
 
         let digest = format!("{:016x}", xxh3_64(cache_key));
@@ -566,6 +744,18 @@ impl Workspace {
         }
         self.detached_environments_path()
             .unwrap_or_else(|| self.default_pixi_dir())
+    }
+
+    /// `true` when this is a script that declares no `platforms`, so the
+    /// platform it resolves for was picked from the machine rather than from
+    /// the script metadata.
+    pub fn script_platforms_are_implicit(&self) -> bool {
+        let WorkspaceStorage::Script { manifest, .. } = &self.storage else {
+            return false;
+        };
+        manifest
+            .workspace_config()
+            .is_ok_and(|config| !config.platforms_explicit)
     }
 
     /// Create the detached-environments path for this project if it is set in
@@ -1307,6 +1497,54 @@ mod tests {
     use xxhash_rust::xxh3::xxh3_64;
 
     use super::*;
+
+    /// A lock file's platform row is not pixi's own input: it carries whatever
+    /// package names were written into it, and a long enough one spells out
+    /// past the platform-name limit. Such a row has no platform, so it is
+    /// skipped -- the rest of the lock still counts, and nothing panics.
+    #[test]
+    fn an_unnameable_locked_platform_is_skipped() {
+        let subdir = host_subdir();
+        // `MAX_PLATFORM_NAME_BYTES` is private to `pixi_manifest`, so this is
+        // simply longer than any cap that crate would plausibly carry.
+        let unnameable = format!("__{}", "a".repeat(1024));
+        let lock_source = format!(
+            r#"version: 7
+platforms:
+- name: {subdir}
+  subdir: {subdir}
+- name: unnameable
+  subdir: {subdir}
+  virtual-packages:
+  - {unnameable}=1
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages: {{}}
+packages: []
+"#
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let lock_file_path = dir.path().join("script.py.pixi.lock");
+        fs_err::write(&lock_file_path, lock_source).unwrap();
+
+        let platforms = implicit_script_platforms(Some(&lock_file_path))
+            .expect("an unnameable row must not fail the whole lookup");
+
+        // The bare-subdir row came through, so the lock really was read.
+        assert!(
+            platforms.iter().any(|p| p.subdir() == subdir),
+            "got {:?}",
+            platforms.iter().map(|p| p.name().as_str()).collect_vec()
+        );
+        assert!(
+            !platforms.iter().any(|p| p.name().as_str().contains("aaaa")),
+            "the unnameable row should have been skipped, got {:?}",
+            platforms.iter().map(|p| p.name().as_str()).collect_vec()
+        );
+    }
 
     const PROJECT_BOILERPLATE: &str = r#"
         [project]
@@ -2084,12 +2322,21 @@ print("hello")
     }
 
     #[test]
-    fn script_workspace_reuses_platforms_from_an_existing_sidecar_lock() {
+    fn script_workspace_drops_foreign_subdirs_from_a_sidecar_lock() {
         let root = tempfile::tempdir().unwrap();
         let cache = tempfile::tempdir().unwrap();
+        let host = host_subdir();
+        // A subdir this machine cannot run. A sidecar can hold one when the
+        // script declared `platforms` at some point and the line was removed
+        // since; adopting it would make every later run solve for it too.
+        let foreign = if host.is_windows() {
+            Platform::Linux64
+        } else {
+            Platform::Win64
+        };
         let lock_file = LockFile::builder()
             .with_platforms(
-                [Platform::Linux64, Platform::OsxArm64]
+                [host, foreign]
                     .into_iter()
                     .map(|subdir| rattler_lock::PlatformData {
                         name: rattler_lock::PlatformName::try_from(subdir.as_str()).unwrap(),
@@ -2119,8 +2366,97 @@ print("hello")
                 .iter()
                 .map(PixiPlatform::subdir)
                 .collect::<Vec<_>>(),
-            [Platform::Linux64, Platform::OsxArm64]
+            [host]
         );
+    }
+
+    /// A row carrying nothing beyond the subdir baseline records no machine:
+    /// it is what an older pixi wrote for a script without `platforms`, or what
+    /// was locked while the script still declared a bare subdir. Adopting it
+    /// would pin the script to pixi's defaults on a machine that offers more.
+    #[test]
+    fn a_baseline_locked_platform_gives_way_to_the_host() {
+        let subdir = host_subdir();
+        let host = detect_host(subdir).unwrap();
+        if host.customised_virtual_packages().is_empty() {
+            // This machine is itself the baseline, so the recorded row already
+            // is the host and there is nothing to prefer over it.
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let lock_file_path = dir.path().join("script.py.pixi.lock");
+        fs_err::write(&lock_file_path, baseline_lock_source(subdir)).unwrap();
+
+        assert_eq!(
+            implicit_script_platforms(Some(&lock_file_path)).unwrap(),
+            IndexSet::from([host])
+        );
+    }
+
+    /// A row this machine satisfies is reused exactly as recorded, so a
+    /// `pixi lock --script` keeps reproducing rather than being re-solved for a
+    /// marginally different host on the next run.
+    #[test]
+    fn a_locked_platform_the_host_satisfies_is_reused() {
+        let subdir = host_subdir();
+        let host = detect_host(subdir).unwrap();
+        // One of the machine's own virtual packages: customised, so it is not
+        // the baseline, and satisfied, so it survives the capability check.
+        let Some(recorded) = host.customised_virtual_packages().first().cloned() else {
+            return;
+        };
+        let build = if recorded.build_string.is_empty() {
+            "0"
+        } else {
+            recorded.build_string.as_str()
+        };
+        let lock_source = format!(
+            r#"version: 7
+platforms:
+- name: recorded
+  subdir: {subdir}
+  virtual-packages:
+  - {name}={version}={build}
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages: {{}}
+packages: []
+"#,
+            name = recorded.name.as_normalized(),
+            version = recorded.version,
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let lock_file_path = dir.path().join("script.py.pixi.lock");
+        fs_err::write(&lock_file_path, lock_source).unwrap();
+
+        let platforms = implicit_script_platforms(Some(&lock_file_path)).unwrap();
+        assert_eq!(
+            platforms
+                .iter()
+                .map(PixiPlatform::customised_virtual_packages)
+                .collect::<Vec<_>>(),
+            [vec![recorded]],
+        );
+    }
+
+    fn baseline_lock_source(subdir: Platform) -> String {
+        format!(
+            r#"version: 7
+platforms:
+- name: {subdir}
+  subdir: {subdir}
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages: {{}}
+packages: []
+"#
+        )
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -2290,6 +2290,43 @@ print("hello")
         assert!(workspace.workspace.value.workspace.platforms.is_empty());
     }
 
+    /// Declaring `platforms` opts a script out of host detection, so it keeps
+    /// the bare subdir it asks for instead of this machine's virtual packages.
+    #[test]
+    fn script_workspace_keeps_explicitly_declared_platforms() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let subdir = host_subdir();
+        let workspace = script_workspace(
+            &format!(
+                r#"# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = []
+# platforms = ["{subdir}"]
+# ///
+"#
+            ),
+            root.path(),
+            cache.path(),
+        );
+
+        assert!(!workspace.script_platforms_are_implicit());
+        let platforms = &workspace.workspace.value.workspace.platforms;
+        assert_eq!(
+            platforms.iter().map(PixiPlatform::subdir).collect_vec(),
+            [subdir]
+        );
+        assert!(
+            platforms
+                .iter()
+                .all(|platform| platform.customised_virtual_packages().is_empty()),
+            "host detection leaked into an explicitly declared platform: {:?}",
+            platforms
+        );
+    }
+
     #[test]
     fn script_workspace_cache_identity_includes_the_absolute_path() {
         let first_root = tempfile::tempdir().unwrap();
@@ -2422,6 +2459,41 @@ packages: []
                 .map(PixiPlatform::customised_virtual_packages)
                 .collect::<Vec<_>>(),
             [vec![recorded]],
+        );
+    }
+
+    /// A row for this subdir that demands more than the machine offers gives
+    /// way to the host, rather than failing on a platform the script never
+    /// declared.
+    #[test]
+    fn a_locked_platform_the_host_cannot_run_gives_way_to_the_host() {
+        let subdir = host_subdir();
+        let host = detect_host(subdir).unwrap();
+        // No machine reports a CUDA driver this new, so the recorded platform
+        // is customised (not the baseline) and unsatisfiable.
+        let lock_source = format!(
+            r#"version: 7
+platforms:
+- name: recorded
+  subdir: {subdir}
+  virtual-packages:
+  - __cuda=99=0
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages: {{}}
+packages: []
+"#
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let lock_file_path = dir.path().join("script.py.pixi.lock");
+        fs_err::write(&lock_file_path, lock_source).unwrap();
+
+        assert_eq!(
+            implicit_script_platforms(Some(&lock_file_path)).unwrap(),
+            IndexSet::from([host])
         );
     }
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -250,19 +250,17 @@ fn script_cache_name(path: &Path) -> String {
 
 /// Install the platforms picked for a script that declares none.
 ///
-/// `use_platform_composition` is decided while the manifest is parsed, and a
-/// script's synthetic manifest is parsed with an empty `platforms`, which reads
-/// as "every platform is a bare subdir". Composition then resolves an
-/// environment's platform by *subdir name*, so it would look for `linux-64` and
-/// never find the rich platform injected afterwards. Recompute the flag for the
-/// platforms actually installed, which is what the parser would have done had
-/// they been written in the metadata.
+/// `use_platform_composition` is decided while parsing, and a script's
+/// synthetic manifest parses with an empty `platforms`, which reads as "every
+/// platform is a bare subdir". Composition would then resolve an environment's
+/// platform by *subdir name* and never find the rich platform injected here, so
+/// the flag is recomputed for the platforms actually installed.
 ///
-/// `must_migrate` is deliberately left alone. It records that the script still
-/// carries a legacy `[system-requirements]` table, which is a fact about the
-/// document rather than about the platforms picked here, and clearing it stops
+/// `must_migrate` is deliberately left alone: it records that the script still
+/// carries a legacy `[system-requirements]` table, a fact about the document
+/// rather than about the platforms picked here. Clearing it would keep
 /// `commit_if_needed` from dropping that table when a rich platform is written
-/// next to it. The two cannot coexist, so the manifest would no longer parse.
+/// next to it, and the two cannot coexist.
 fn set_implicit_script_platforms(
     workspace: &mut pixi_manifest::Workspace,
     platforms: IndexSet<PixiPlatform>,
@@ -273,34 +271,27 @@ fn set_implicit_script_platforms(
 
 /// The platforms a script that declares none is resolved for.
 ///
-/// A script has no `[workspace] platforms`, so pixi picks one on its behalf.
-/// Unlike a workspace -- where "the current platform" means the subdir with
-/// pixi's assumed defaults, written down in the manifest for you to see and
-/// edit -- a script is resolved for the machine it is run on, the same as its
-/// no-manifest siblings `pixi exec` and `pixi global`. Otherwise a script on a
-/// machine with CUDA, or with a glibc newer than pixi's 2.28 floor, is solved
-/// against packages that machine does not need to be limited to.
+/// Such a script is resolved for the machine it runs on, like its no-manifest
+/// siblings `pixi exec` and `pixi global`, while a workspace takes "the current
+/// platform" to mean the bare subdir with pixi's assumed defaults. Otherwise a
+/// script on a machine with CUDA, or with a glibc newer than pixi's 2.28 floor,
+/// is solved against packages that machine does not need to be limited to.
 ///
 /// An adjacent sidecar lock wins while it is usable, so a `pixi lock --script`
 /// keeps reproducing rather than being re-solved for a marginally different
-/// host on the next run. The platforms it recorded are rebuilt in full,
-/// virtual packages included: reading them back as bare subdirs would lose the
-/// machine they were locked for, and pixi would re-solve every run, quietly
-/// overwriting the sidecar with the defaults. Their names are synthesized from
-/// their contents rather than taken from the lock, which stores rich platforms
-/// under short `p1`/`p2` aliases; `align_platform_names` maps the rows back on
-/// by identity.
+/// host. Its platforms are rebuilt in full, virtual packages included, since
+/// bare subdirs would lose the machine they were locked for. Their names are
+/// synthesized from their contents rather than taken from the lock, so a lock
+/// written by an older pixi under `p1`/`p2` aliases still maps on;
+/// `align_platform_names` matches the rows by identity either way.
 ///
-/// A recorded platform is only worth keeping when it says something this
-/// machine can honour. One this machine cannot run, and one that records
-/// nothing beyond pixi's defaults for the subdir, both give way to the host and
-/// a re-solve, rather than failing on a platform the user never declared or
-/// pinning the script below the machine it runs on. Rows for other subdirs are
-/// dropped outright. Each of those is worth a word, since the next write to the
-/// lock file makes it permanent, so all three warn.
+/// A recorded platform is kept only when it says something this machine can
+/// honour. One this machine cannot run, and one that records nothing beyond
+/// pixi's defaults for the subdir, both give way to the host and a re-solve.
+/// Rows for other subdirs are dropped. All three warn, since the next write to
+/// the lock file makes them permanent.
 ///
-/// A lock file that does not parse is left to the loader to report, so it is
-/// not mistaken here for one recording an unrunnable platform.
+/// A lock file that does not parse is left to the loader to report.
 fn implicit_script_platforms(
     lock_file_path: Option<&Path>,
 ) -> Result<IndexSet<PixiPlatform>, ScriptWorkspaceError> {
@@ -310,10 +301,9 @@ fn implicit_script_platforms(
         source: error,
     })?;
 
-    // A lock file that does not parse says nothing about which platform this
-    // machine can run, so it is passed over silently: the loader reads the same
-    // file moments later and reports why it is unusable, with the position in
-    // the file that this function does not have.
+    // A lock file that does not parse is passed over silently: the loader reads
+    // the same file moments later and reports why it is unusable, with a
+    // position in the file that is not available here.
     let Some(lock_file) = lock_file_path
         .filter(|path| path.is_file())
         .and_then(|path| LockFile::from_path(path).ok())
@@ -322,12 +312,9 @@ fn implicit_script_platforms(
     };
 
     // A row carrying nothing beyond the subdir baseline records no machine at
-    // all: it is what an older pixi wrote for a script without `platforms`, or
-    // what was locked while the script still declared a bare subdir. Adopting
-    // it would pin the script to pixi's defaults and quietly undo the point of
-    // resolving a script for the host it runs on. When the host is itself
-    // baseline the two are the same platform, so there is nothing to reject and
-    // no re-solve to trigger on every run.
+    // all, and adopting it would pin the script to pixi's defaults. When the
+    // host is itself baseline the two are the same platform, so there is
+    // nothing to reject and no re-solve to trigger on every run.
     let host_is_baseline = host.customised_virtual_packages().is_empty();
 
     let mut foreign_subdirs: IndexSet<Platform> = IndexSet::new();
@@ -335,10 +322,9 @@ fn implicit_script_platforms(
     let mut rejected_unrunnable = false;
     let mut locked: IndexSet<PixiPlatform> = IndexSet::new();
     for row in lock_file.platforms() {
-        // A lock can hold rows for other subdirs (a script that declared
-        // `platforms` once and had the line removed since); keeping those would
-        // make every later run solve and lock for a platform the script no
-        // longer asks for.
+        // A lock can hold rows for other subdirs, from a script that declared
+        // `platforms` and had the line removed since. Keeping those would make
+        // every later run solve and lock for a platform it no longer asks for.
         if row.subdir() != subdir {
             foreign_subdirs.insert(row.subdir());
             continue;
@@ -363,9 +349,8 @@ fn implicit_script_platforms(
         locked.insert(recorded);
     }
 
-    // Whether the file on disk actually changes is up to the lock file usage the
-    // command was given: `--frozen` and `--locked` consume it without writing,
-    // so none of these may claim the lock file *is* rewritten.
+    // `--frozen` and `--locked` consume the lock file without writing, so none
+    // of these warnings may claim that it *is* rewritten.
     if !foreign_subdirs.is_empty() {
         tracing::warn!(
             "the lock file next to this script also records {}, which a script without \
@@ -1498,10 +1483,9 @@ mod tests {
 
     use super::*;
 
-    /// A lock file's platform row is not pixi's own input: it carries whatever
-    /// package names were written into it, and a long enough one spells out
-    /// past the platform-name limit. Such a row has no platform, so it is
-    /// skipped -- the rest of the lock still counts, and nothing panics.
+    /// A platform row carries whatever package names were written into it, and
+    /// a long enough one spells out past the platform-name limit. Such a row is
+    /// skipped: the rest of the lock still counts, and nothing panics.
     #[test]
     fn an_unnameable_locked_platform_is_skipped() {
         let subdir = host_subdir();
@@ -2327,8 +2311,7 @@ print("hello")
         let cache = tempfile::tempdir().unwrap();
         let host = host_subdir();
         // A subdir this machine cannot run. A sidecar can hold one when the
-        // script declared `platforms` at some point and the line was removed
-        // since; adopting it would make every later run solve for it too.
+        // script declared `platforms` and had the line removed since.
         let foreign = if host.is_windows() {
             Platform::Linux64
         } else {
@@ -2370,10 +2353,9 @@ print("hello")
         );
     }
 
-    /// A row carrying nothing beyond the subdir baseline records no machine:
-    /// it is what an older pixi wrote for a script without `platforms`, or what
-    /// was locked while the script still declared a bare subdir. Adopting it
-    /// would pin the script to pixi's defaults on a machine that offers more.
+    /// A row carrying nothing beyond the subdir baseline records no machine,
+    /// so adopting it would pin the script to pixi's defaults on a machine that
+    /// offers more.
     #[test]
     fn a_baseline_locked_platform_gives_way_to_the_host() {
         let subdir = host_subdir();
@@ -2396,7 +2378,7 @@ print("hello")
 
     /// A row this machine satisfies is reused exactly as recorded, so a
     /// `pixi lock --script` keeps reproducing rather than being re-solved for a
-    /// marginally different host on the next run.
+    /// marginally different host.
     #[test]
     fn a_locked_platform_the_host_satisfies_is_reused() {
         let subdir = host_subdir();

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -255,12 +255,6 @@ fn script_cache_name(path: &Path) -> String {
 /// platform is a bare subdir". Composition would then resolve an environment's
 /// platform by *subdir name* and never find the rich platform injected here, so
 /// the flag is recomputed for the platforms actually installed.
-///
-/// `must_migrate` is deliberately left alone: it records that the script still
-/// carries a legacy `[system-requirements]` table, a fact about the document
-/// rather than about the platforms picked here. Clearing it would keep
-/// `commit_if_needed` from dropping that table when a rich platform is written
-/// next to it, and the two cannot coexist.
 fn set_implicit_script_platforms(
     workspace: &mut pixi_manifest::Workspace,
     platforms: IndexSet<PixiPlatform>,

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -496,6 +496,26 @@ pub(crate) fn environment_has_dependencies(environment: &Environment<'_>) -> boo
         .any(|platform| has_conda_dependencies(Some(platform)))
 }
 
+/// Whether `environment` declares anything to install for `platform` in
+/// particular.
+///
+/// [`environment_has_dependencies`] answers the same question for the
+/// environment as a whole, which is the wrong question when the answer decides
+/// what a single platform's prefix should hold: a `[target.win-64.dependencies]`
+/// table says nothing about what belongs in a linux-64 prefix. Resolving the
+/// targets for one platform covers both the platform-independent tables and
+/// that platform's own.
+pub(crate) fn environment_has_dependencies_for_platform(
+    environment: &Environment<'_>,
+    platform: &PixiPlatform,
+) -> bool {
+    !environment.combined_dependencies(Some(platform)).is_empty()
+        || !environment
+            .combined_dev_dependencies(Some(platform))
+            .is_empty()
+        || !environment.pypi_dependencies(Some(platform)).is_empty()
+}
+
 /// Classify how the current machine (including virtual-package overrides)
 /// runs `environment`:
 ///

--- a/crates/pixi_core/src/workspace/virtual_packages.rs
+++ b/crates/pixi_core/src/workspace/virtual_packages.rs
@@ -500,11 +500,9 @@ pub(crate) fn environment_has_dependencies(environment: &Environment<'_>) -> boo
 /// particular.
 ///
 /// [`environment_has_dependencies`] answers the same question for the
-/// environment as a whole, which is the wrong question when the answer decides
-/// what a single platform's prefix should hold: a `[target.win-64.dependencies]`
-/// table says nothing about what belongs in a linux-64 prefix. Resolving the
-/// targets for one platform covers both the platform-independent tables and
-/// that platform's own.
+/// environment as a whole, which is too coarse to decide what a single
+/// platform's prefix should hold: a `[target.win-64.dependencies]` table says
+/// nothing about what belongs in a linux-64 prefix.
 pub(crate) fn environment_has_dependencies_for_platform(
     environment: &Environment<'_>,
     platform: &PixiPlatform,

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -175,6 +175,44 @@ impl WorkspaceMut {
         self.workspace_manifest_document.kind()
     }
 
+    /// Forget the platforms pixi picked for a script that declares none, so an
+    /// edit sees the empty list the script actually has.
+    ///
+    /// A script's `platforms` are injected into the parsed manifest at load
+    /// time, which makes them look declared to every mutation: an add finds the
+    /// platform "already there" and writes nothing, which is exactly the
+    /// no-op `pixi workspace platform add --script <PATH> --auto-detect` used
+    /// to be. Nothing is lost by dropping them, since they are recomputed on
+    /// the next load.
+    pub fn forget_implicit_script_platforms(&mut self) {
+        if !self
+            .workspace
+            .as_ref()
+            .expect("workspace is not available")
+            .script_platforms_are_implicit()
+        {
+            return;
+        }
+        self.workspace
+            .as_mut()
+            .expect("workspace is not available")
+            .workspace
+            .value
+            .workspace
+            .platforms
+            .clear();
+        // `use_platform_composition` was set from the injected platforms; with
+        // none left, an environment resolves its platform by subdir name again,
+        // which is what an empty `platforms` parses to.
+        self.workspace
+            .as_mut()
+            .expect("workspace is not available")
+            .workspace
+            .value
+            .workspace
+            .use_platform_composition = true;
+    }
+
     /// Returns a [`WorkspaceManifestMut`] which implements methods to modify a
     /// workspace manifest both in memory and on-disk.
     #[must_use]

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -179,11 +179,9 @@ impl WorkspaceMut {
     /// edit sees the empty list the script actually has.
     ///
     /// A script's `platforms` are injected into the parsed manifest at load
-    /// time, which makes them look declared to every mutation: an add finds the
-    /// platform "already there" and writes nothing, which is exactly the
-    /// no-op `pixi workspace platform add --script <PATH> --auto-detect` used
-    /// to be. Nothing is lost by dropping them, since they are recomputed on
-    /// the next load.
+    /// time, which makes them look declared to every mutation: an add would
+    /// find the platform "already there" and write nothing. Nothing is lost by
+    /// dropping them, since they are recomputed on the next load.
     pub fn forget_implicit_script_platforms(&mut self) {
         if !self
             .workspace
@@ -201,9 +199,9 @@ impl WorkspaceMut {
             .workspace
             .platforms
             .clear();
-        // `use_platform_composition` was set from the injected platforms; with
-        // none left, an environment resolves its platform by subdir name again,
-        // which is what an empty `platforms` parses to.
+        // `use_platform_composition` was set from the injected platforms. With
+        // none left, an environment resolves its platform by subdir name, which
+        // is what an empty `platforms` parses to.
         self.workspace
             .as_mut()
             .expect("workspace is not available")

--- a/crates/pixi_manifest/src/script.rs
+++ b/crates/pixi_manifest/src/script.rs
@@ -423,32 +423,21 @@ impl ScriptManifest {
             .and_then(Item::as_table_like_mut)
             .and_then(|tool| tool.get_mut("pixi"))
             .and_then(Item::as_table_like_mut);
-        let (updated_conda, updated_pypi, updated_targets, updated_system_requirements) =
-            if let Some(pixi) = updated_pixi {
-                (
-                    pixi.remove("dependencies")
-                        .and_then(|item| item.into_table().ok()),
-                    pixi.remove("pypi-dependencies")
-                        .and_then(|item| item.into_table().ok()),
-                    pixi.remove("target")
-                        .and_then(|item| item.into_table().ok()),
-                    pixi.remove("system-requirements")
-                        .and_then(|item| item.into_table().ok()),
-                )
-            } else {
-                (None, None, None, None)
-            };
+        let (updated_conda, updated_pypi, updated_targets) = if let Some(pixi) = updated_pixi {
+            (
+                pixi.remove("dependencies")
+                    .and_then(|item| item.into_table().ok()),
+                pixi.remove("pypi-dependencies")
+                    .and_then(|item| item.into_table().ok()),
+                pixi.remove("target")
+                    .and_then(|item| item.into_table().ok()),
+            )
+        } else {
+            (None, None, None)
+        };
         sync_pixi_table(&mut metadata, updated_conda, "dependencies")?;
         sync_pixi_table(&mut metadata, updated_pypi, "pypi-dependencies")?;
         sync_pixi_table(&mut metadata, updated_targets, "target")?;
-        // The legacy `[system-requirements]` table has to be able to *leave*
-        // the script: adding a rich platform commits the migration away from
-        // it, and the two cannot coexist, so its removal has to be synced too.
-        sync_pixi_table(
-            &mut metadata,
-            updated_system_requirements,
-            "system-requirements",
-        )?;
 
         Ok(format!(
             "{}{}{}",
@@ -686,6 +675,13 @@ fn validate_subset(metadata: &DocumentMut) -> Result<(), ScriptManifestError> {
         return Ok(());
     };
 
+    // Reported on its own, ahead of the generic sweep: the machine's virtual
+    // packages already reach a script that declares no `platforms`, and a
+    // script that declares them carries its requirements on the platform.
+    if pixi.contains_key("system-requirements") {
+        return Err(ScriptManifestError::SystemRequirementsUnsupported);
+    }
+
     let mut unsupported = unsupported_keys(
         pixi,
         "tool.pixi",
@@ -694,7 +690,6 @@ fn validate_subset(metadata: &DocumentMut) -> Result<(), ScriptManifestError> {
             "constraints",
             "dependencies",
             "pypi-dependencies",
-            "system-requirements",
             "target",
             "workspace",
         ],
@@ -791,6 +786,12 @@ pub enum ScriptManifestError {
     #[error("PEP 723 scripts do not support: {}", .0.join(", "))]
     #[diagnostic(help("A script represents one implicit default environment."))]
     UnsupportedFields(Vec<String>),
+
+    #[error("PEP 723 scripts do not support `[tool.pixi.system-requirements]`")]
+    #[diagnostic(help(
+        "a script without `platforms` is resolved for the virtual packages of the machine it runs on. To pin a target instead, run `pixi workspace platform add --script <PATH> --auto-detect`"
+    ))]
+    SystemRequirementsUnsupported,
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -1262,6 +1263,29 @@ print("hello")
                 "tool.pixi.target.linux-64.tasks",
                 "tool.pixi.workspace.description"
             ]
+        );
+    }
+
+    #[test]
+    fn rejects_system_requirements() {
+        let (_directory, path) = script(
+            r#"# /// script
+# dependencies = []
+#
+# [tool.pixi.system-requirements]
+# cuda = "12"
+# ///
+"#,
+        );
+
+        let error = ScriptManifest::from_path(path)
+            .unwrap()
+            .unwrap()
+            .into_workspace_manifest()
+            .unwrap_err();
+        assert!(
+            matches!(error, ScriptManifestError::SystemRequirementsUnsupported),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/pixi_manifest/src/script.rs
+++ b/crates/pixi_manifest/src/script.rs
@@ -443,8 +443,7 @@ impl ScriptManifest {
         sync_pixi_table(&mut metadata, updated_targets, "target")?;
         // The legacy `[system-requirements]` table has to be able to *leave*
         // the script: adding a rich platform commits the migration away from
-        // it, and the two cannot coexist. Without this the removal is dropped
-        // on the floor here and the script no longer parses.
+        // it, and the two cannot coexist, so its removal has to be synced too.
         sync_pixi_table(
             &mut metadata,
             updated_system_requirements,

--- a/crates/pixi_manifest/src/script.rs
+++ b/crates/pixi_manifest/src/script.rs
@@ -423,21 +423,33 @@ impl ScriptManifest {
             .and_then(Item::as_table_like_mut)
             .and_then(|tool| tool.get_mut("pixi"))
             .and_then(Item::as_table_like_mut);
-        let (updated_conda, updated_pypi, updated_targets) = if let Some(pixi) = updated_pixi {
-            (
-                pixi.remove("dependencies")
-                    .and_then(|item| item.into_table().ok()),
-                pixi.remove("pypi-dependencies")
-                    .and_then(|item| item.into_table().ok()),
-                pixi.remove("target")
-                    .and_then(|item| item.into_table().ok()),
-            )
-        } else {
-            (None, None, None)
-        };
+        let (updated_conda, updated_pypi, updated_targets, updated_system_requirements) =
+            if let Some(pixi) = updated_pixi {
+                (
+                    pixi.remove("dependencies")
+                        .and_then(|item| item.into_table().ok()),
+                    pixi.remove("pypi-dependencies")
+                        .and_then(|item| item.into_table().ok()),
+                    pixi.remove("target")
+                        .and_then(|item| item.into_table().ok()),
+                    pixi.remove("system-requirements")
+                        .and_then(|item| item.into_table().ok()),
+                )
+            } else {
+                (None, None, None, None)
+            };
         sync_pixi_table(&mut metadata, updated_conda, "dependencies")?;
         sync_pixi_table(&mut metadata, updated_pypi, "pypi-dependencies")?;
         sync_pixi_table(&mut metadata, updated_targets, "target")?;
+        // The legacy `[system-requirements]` table has to be able to *leave*
+        // the script: adding a rich platform commits the migration away from
+        // it, and the two cannot coexist. Without this the removal is dropped
+        // on the floor here and the script no longer parses.
+        sync_pixi_table(
+            &mut metadata,
+            updated_system_requirements,
+            "system-requirements",
+        )?;
 
         Ok(format!(
             "{}{}{}",

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -260,6 +260,29 @@ and `move` operations. Platform order determines selection priority. Declared
 platforms are also the platforms consumed by `pixi lock --script`; the lock
 command does not take a separate platform override.
 
+### Scripts without declared platforms
+
+A script does not have to declare `platforms`.
+When it doesn't, Pixi resolves it for the machine you run it on, using the [virtual packages](../workspace/multi_platform_configuration.md#declaring-virtual-packages-per-platform) it detects there.
+This is what `pixi exec` and `pixi global` do as well, and it means a script that needs your CUDA driver or a glibc newer than Pixi's `2.28` floor resolves without you having to write the platform down.
+
+A workspace behaves differently.
+There, the current platform means the conda subdir with Pixi's assumed defaults, written into `pixi.toml` where you can see and edit it.
+
+Declare `platforms` to opt out and resolve for a fixed target instead:
+
+```console
+pixi workspace platform add --script analysis.py --auto-detect
+```
+
+The environment itself lives in Pixi's cache and is never shared between machines, so this only matters once you create a sidecar lock file.
+`pixi run --script` does not create one, but `pixi lock --script` does, and on a script without declared platforms it records the machine that ran it.
+Pixi warns when that happens.
+A sidecar keeps being reused as long as the machine still satisfies the platform it was locked for; otherwise the script is resolved for the current machine again.
+A sidecar that records only the plain conda subdir does not count as a machine, so it is re-solved too.
+That is what an older Pixi wrote, and what you get when a script declared `platforms` and the line was later removed; keeping it would pin the script to Pixi's defaults on a machine that offers more.
+Pixi warns before it happens, and again before it drops any rows for other subdirs the script no longer asks for.
+
 ## Supported command surface
 
 The script-capable commands are:

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -113,7 +113,7 @@ pixi add --script analysis.py --pypi --editable \
 Relative paths in metadata are resolved from the script's directory.
 
 When no adjacent lock file exists, dependency mutations solve for validation
-but write only the inline metadata. If a sidecar lock already exists, it is
+but write only the inline metadata. If a lock file already exists, it is
 updated as part of the mutation.
 
 ## Run the script
@@ -214,25 +214,28 @@ and reuse Pixi's caches:
 pixi run --script earthquakes.py
 ```
 
-Create a sidecar when exact versions need to travel with the script:
+Create a lock file when exact versions need to travel with the script:
 
 ```console
 pixi lock --script earthquakes.py
 ```
 
 This writes `earthquakes.py.pixi.lock` next to the file. Subsequent commands
-reuse the sidecar, and metadata mutations keep it up to date.
+reuse the lock file, and metadata mutations keep it up to date.
 
-To lock more than the current platform, declare the platforms first:
+When the script declares no platforms, Pixi locks the versions for your
+machine. On a machine that does not meet it, Pixi resolves the script again
+instead of using the lock file. Declare the platforms first to lock versions
+that everyone reuses:
 
 ```console
 pixi workspace platform add --script earthquakes.py linux-64 osx-arm64
 pixi lock --script earthquakes.py
 ```
 
-Use `--locked` to require an existing, up-to-date sidecar. Use `--frozen` to
-consume an existing sidecar without updating it. Both options report an error
-when the script has no adjacent lock file.
+Use `--locked` to require an existing, up-to-date lock file. Use `--frozen`
+to consume an existing lock file without updating it. Both options report an
+error when the script has no adjacent lock file.
 
 ## Manage channels and platforms
 
@@ -263,25 +266,14 @@ command does not take a separate platform override.
 ### Scripts without declared platforms
 
 A script does not have to declare `platforms`.
-When it doesn't, Pixi resolves it for the machine you run it on, using the [virtual packages](../workspace/multi_platform_configuration.md#declaring-virtual-packages-per-platform) it detects there.
-This is what `pixi exec` and `pixi global` do as well, and it means a script that needs your CUDA driver or a glibc newer than Pixi's `2.28` floor resolves without you having to write the platform down.
+When it doesn't, Pixi resolves it for the machine you run it on, using the [virtual packages](../workspace/multi_platform_configuration.md#declaring-virtual-packages-per-platform) it detects there: your CUDA driver, your glibc version, your macOS version.
+A script that needs a glibc newer than Pixi's `2.28` default resolves without you writing anything down.
 
-A workspace behaves differently.
-There, the current platform means the conda subdir with Pixi's assumed defaults, written into `pixi.toml` where you can see and edit it.
-
-Declare `platforms` to opt out and resolve for a fixed target instead:
+To resolve for a fixed target instead:
 
 ```console
 pixi workspace platform add --script analysis.py --auto-detect
 ```
-
-The environment itself lives in Pixi's cache and is never shared between machines, so this only matters once you create a sidecar lock file.
-`pixi run --script` does not create one, but `pixi lock --script` does, and on a script without declared platforms it records the machine that ran it.
-Pixi warns when that happens.
-A sidecar keeps being reused as long as the machine still satisfies the platform it was locked for; otherwise the script is resolved for the current machine again.
-A sidecar that records only the plain conda subdir does not count as a machine, so it is re-solved too.
-That is what an older Pixi wrote, and what you get when a script declared `platforms` and the line was later removed; keeping it would pin the script to Pixi's defaults on a machine that offers more.
-Pixi warns before it happens, and again before it drops any rows for other subdirs the script no longer asks for.
 
 ## Supported command surface
 

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -627,3 +627,51 @@ def test_exec_honours_the_platform_override(
         stderr_contains="No candidates were found for dummy-f",
     )
     verify_cli_command(command, ExitCode.SUCCESS)
+
+
+def test_a_lock_without_a_row_for_this_platform_installs_nothing(
+    pixi: Path, tmp_pixi_workspace: Path, dummy_channel_1: str
+) -> None:
+    """A lock file that carries no row for the platform being installed is only
+    a problem when the environment declares something to install there.
+
+    A v6 lock records rows per platform that had packages, so a workspace whose
+    dependencies all sit under another ``[target]`` legitimately has none for
+    this one. Treating that as fatal broke every such workspace, on a plain
+    ``pixi run`` as much as under ``--frozen``.
+    """
+    other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
+    manifest = _write(
+        tmp_pixi_workspace / "pixi.toml",
+        f"""
+[workspace]
+name = "no-row"
+channels = ["{dummy_channel_1}"]
+platforms = ["{CURRENT_PLATFORM}", "{other}"]
+
+[target.{other}.dependencies]
+dummy-a = "*"
+
+[tasks]
+hello = "echo TASK-RAN"
+""",
+    )
+    _write(
+        tmp_pixi_workspace / "pixi.lock",
+        f"""version: 6
+environments:
+  default:
+    channels:
+    - url: {dummy_channel_1}/
+    packages:
+      {other}: []
+packages: []
+""",
+    )
+
+    for extra in ([], ["--frozen"]):
+        verify_cli_command(
+            [pixi, "run", *extra, "--manifest-path", manifest, "hello"],
+            ExitCode.SUCCESS,
+            stdout_contains="TASK-RAN",
+        )

--- a/tests/integration_python/test_richer_platform_bugs.py
+++ b/tests/integration_python/test_richer_platform_bugs.py
@@ -637,8 +637,7 @@ def test_a_lock_without_a_row_for_this_platform_installs_nothing(
 
     A v6 lock records rows per platform that had packages, so a workspace whose
     dependencies all sit under another ``[target]`` legitimately has none for
-    this one. Treating that as fatal broke every such workspace, on a plain
-    ``pixi run`` as much as under ``--frozen``.
+    this one, on a plain ``pixi run`` as much as under ``--frozen``.
     """
     other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
     manifest = _write(

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -1350,35 +1350,6 @@ def test_script_without_platforms_respects_a_machine_below_the_floor(
 
 @pytest.mark.slow
 @requires_cuda_channel
-def test_script_with_explicit_platforms_is_left_alone(
-    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
-) -> None:
-    """Declaring `platforms` opts out of host detection, so the same script
-    resolves against the subdir defaults, which carry no ``__cuda`` at all."""
-    script = tmp_pixi_workspace / "gpu.py"
-    script.write_text(
-        f"""# /// script
-# dependencies = []
-#
-# [tool.pixi.workspace]
-# channels = ["{virtual_packages_channel}", "{CONDA_FORGE_CHANNEL}"]
-# platforms = ["{CURRENT_PLATFORM}"]
-#
-# [tool.pixi.dependencies]
-# cuda = "*"
-# ///
-print("SCRIPT-RAN")
-"""
-    )
-    verify_cli_command(
-        [pixi, "run", "--script", script],
-        ExitCode.FAILURE,
-        env={"CONDA_OVERRIDE_CUDA": "12"},
-    )
-
-
-@pytest.mark.slow
-@requires_cuda_channel
 def test_script_sidecar_round_trips_without_resolving_again(
     pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
 ) -> None:
@@ -1415,34 +1386,6 @@ def test_script_sidecar_round_trips_without_resolving_again(
         stdout_contains="SCRIPT-RAN",
     )
     assert lock.read_text() == before
-
-
-@pytest.mark.slow
-def test_script_sidecar_for_another_subdir_falls_back_to_the_machine(
-    pixi: Path, tmp_pixi_workspace: Path
-) -> None:
-    """A sidecar locked for a subdir this machine cannot run is re-resolved.
-
-    The script declares no platforms, so erroring out on one would blame the
-    user for a platform they never wrote down.
-    """
-    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
-    other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
-
-    verify_cli_command(
-        [pixi, "lock", "--script", script],
-        ExitCode.SUCCESS,
-        env={"PIXI_OVERRIDE_PLATFORM": other},
-    )
-    # Re-resolving replaces the sidecar, so say so rather than discarding a
-    # deliberate lock in silence. Its only row is for another subdir, which is
-    # what gets reported.
-    verify_cli_command(
-        [pixi, "run", "--script", script],
-        ExitCode.SUCCESS,
-        stdout_contains="SCRIPT-RAN",
-        stderr_contains=[f"'{other}'", "does not ask for"],
-    )
 
 
 @pytest.mark.slow
@@ -1577,27 +1520,4 @@ print("SCRIPT-RAN")
         ExitCode.SUCCESS,
         stdout_contains="SCRIPT-RAN",
         stderr_contains=[f"'{other}'", "does not ask for"],
-    )
-
-
-@pytest.mark.slow
-def test_script_sidecar_this_machine_cannot_run_falls_back_to_the_host(
-    pixi: Path, tmp_pixi_workspace: Path
-) -> None:
-    """A sidecar row for this subdir that demands more than the machine offers
-    gives way to the host, rather than failing on a platform the script never
-    declared."""
-    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
-
-    # Locked on a machine claiming a CUDA driver, run on one without it.
-    verify_cli_command(
-        [pixi, "lock", "--script", script],
-        ExitCode.SUCCESS,
-        env={"CONDA_OVERRIDE_CUDA": "99"},
-    )
-    verify_cli_command(
-        [pixi, "run", "--script", script],
-        ExitCode.SUCCESS,
-        stdout_contains="SCRIPT-RAN",
-        stderr_contains=["cannot run", "replaces what it records"],
     )

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -1272,3 +1272,333 @@ print("hello")
     assert script_lock.read_text() != original_lock
     assert not (tmp_pixi_workspace / "pixi.lock").exists()
     assert_no_workspace_state_created(tmp_pixi_workspace)
+
+
+# The virtual_packages channel only ships the cuda package for these subdirs.
+_CUDA_CHANNEL_SUBDIRS = {"linux-64", "win-64"}
+
+requires_cuda_channel = pytest.mark.skipif(
+    CURRENT_PLATFORM not in _CUDA_CHANNEL_SUBDIRS,
+    reason="virtual_packages channel ships the cuda package only for linux-64 and win-64",
+)
+
+
+def _script_without_platforms(path: Path, extra_channel: str | None, dependency: str) -> Path:
+    """A script with no `platforms`, so pixi picks one for it.
+
+    Every script needs `python`, so conda-forge is always in the list; a test
+    channel goes in front of it when the test needs a package from one.
+    """
+    channels = [f'"{extra_channel}"'] if extra_channel else []
+    channels.append(f'"{CONDA_FORGE_CHANNEL}"')
+    path.write_text(
+        f"""# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = [{", ".join(channels)}]
+#
+# [tool.pixi.dependencies]
+# {dependency}
+# ///
+print("SCRIPT-RAN")
+"""
+    )
+    return path
+
+
+@pytest.mark.slow
+@requires_cuda_channel
+def test_script_without_platforms_solves_against_the_machine(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """A script that declares no platforms is resolved for the machine it runs
+    on, not for pixi's per-subdir defaults.
+
+    The in-repo ``cuda`` package needs ``__cuda >=12``, and ``__cuda`` is never
+    a subdir default, so it can only resolve if the host's virtual packages
+    reached the solver.
+    """
+    script = _script_without_platforms(
+        tmp_pixi_workspace / "gpu.py", virtual_packages_channel, 'cuda = "*"'
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "12"},
+        stdout_contains="SCRIPT-RAN",
+    )
+
+
+@pytest.mark.slow
+@requires_cuda_channel
+def test_script_without_platforms_respects_a_machine_below_the_floor(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """The guard rail for the test above: below the package's ``__cuda >=12``
+    floor the same script must fail, so the success there cannot come from the
+    requirement being ignored."""
+    script = _script_without_platforms(
+        tmp_pixi_workspace / "gpu.py", virtual_packages_channel, 'cuda = "*"'
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.FAILURE,
+        env={"CONDA_OVERRIDE_CUDA": "10"},
+    )
+
+
+@pytest.mark.slow
+@requires_cuda_channel
+def test_script_with_explicit_platforms_is_left_alone(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """Declaring `platforms` opts out of host detection, so the same script
+    resolves against the subdir defaults, which carry no ``__cuda`` at all."""
+    script = tmp_pixi_workspace / "gpu.py"
+    script.write_text(
+        f"""# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["{virtual_packages_channel}", "{CONDA_FORGE_CHANNEL}"]
+# platforms = ["{CURRENT_PLATFORM}"]
+#
+# [tool.pixi.dependencies]
+# cuda = "*"
+# ///
+print("SCRIPT-RAN")
+"""
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.FAILURE,
+        env={"CONDA_OVERRIDE_CUDA": "12"},
+    )
+
+
+@pytest.mark.slow
+@requires_cuda_channel
+def test_script_sidecar_round_trips_without_resolving_again(
+    pixi: Path, tmp_pixi_workspace: Path, virtual_packages_channel: str
+) -> None:
+    """``pixi lock --script`` records the host platform, and the next run reuses
+    it.
+
+    The sidecar's platform used to be read back as a bare subdir, which dropped
+    the virtual packages it was locked with. The environment then looked absent,
+    every run re-resolved, and the sidecar was quietly rewritten with pixi's
+    defaults -- undoing the fix for anyone who created one.
+    """
+    script = _script_without_platforms(
+        tmp_pixi_workspace / "gpu.py", virtual_packages_channel, 'cuda = "*"'
+    )
+    lock = tmp_pixi_workspace / "gpu.py.pixi.lock"
+    env = {"CONDA_OVERRIDE_CUDA": "12"}
+
+    verify_cli_command([pixi, "lock", "--script", script], ExitCode.SUCCESS, env=env)
+    locked = json.loads(
+        verify_cli_command(
+            [pixi, "workspace", "platform", "list", "--script", script, "--json"],
+            ExitCode.SUCCESS,
+            env=env,
+        ).stdout
+    )
+    declared = [row for row in locked["platforms"] if not row.get("is_autodetected")]
+    assert declared, locked
+    assert any("cuda=12" in row["virtual_packages"] for row in declared), declared
+
+    before = lock.read_text()
+    verify_cli_command(
+        [pixi, "run", "--script", script, "--locked"],
+        ExitCode.SUCCESS,
+        env=env,
+        stdout_contains="SCRIPT-RAN",
+    )
+    assert lock.read_text() == before
+
+
+@pytest.mark.slow
+def test_script_sidecar_for_another_subdir_falls_back_to_the_machine(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """A sidecar locked for a subdir this machine cannot run is re-resolved.
+
+    The script declares no platforms, so erroring out on one would blame the
+    user for a platform they never wrote down. It used to do exactly that.
+    """
+    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
+    other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
+
+    verify_cli_command(
+        [pixi, "lock", "--script", script],
+        ExitCode.SUCCESS,
+        env={"PIXI_OVERRIDE_PLATFORM": other},
+    )
+    # Re-resolving replaces the sidecar, so say so rather than discarding a
+    # deliberate lock in silence. The only row it holds is for another subdir,
+    # which is what gets reported.
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.SUCCESS,
+        stdout_contains="SCRIPT-RAN",
+        stderr_contains=[f"'{other}'", "does not ask for"],
+    )
+
+
+@pytest.mark.slow
+def test_script_frozen_refuses_a_sidecar_without_an_entry_for_this_machine(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """`--frozen` consumes the lock without checking it, so a sidecar with no
+    row for the platform we run on used to produce an empty environment and run
+    the script against whatever `python` was on `PATH`."""
+    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, 'python = "3.12.*"')
+    other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
+
+    verify_cli_command(
+        [pixi, "lock", "--script", script],
+        ExitCode.SUCCESS,
+        env={"PIXI_OVERRIDE_PLATFORM": other},
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", script, "--frozen"],
+        ExitCode.FAILURE,
+        stderr_contains="has no entry for platform",
+    )
+
+
+@pytest.mark.slow
+def test_lock_script_without_platforms_warns_that_it_records_this_machine(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """``pixi lock --script`` is the only command that persists the picked
+    platform, so it says so once rather than leaving a machine-specific lock
+    looking portable."""
+    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
+    verify_cli_command(
+        [pixi, "lock", "--script", script],
+        ExitCode.SUCCESS,
+        stderr_contains=[
+            "declares no platforms",
+            "--auto-detect",
+        ],
+    )
+
+
+@pytest.mark.slow
+def test_script_with_an_unparsable_sidecar_does_not_blame_the_platform(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """A sidecar that does not parse says nothing about the platform it was
+    locked for, so the platform pick stays quiet and lets the loader report the
+    parse error it can point at a line of."""
+    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
+    (tmp_pixi_workspace / "plain.py.pixi.lock").write_text("this is not yaml: [ }\n")
+
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.FAILURE,
+        stderr_excludes="cannot run",
+    )
+
+
+@pytest.mark.slow
+def test_script_platform_add_migrates_away_from_system_requirements(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """Adding a detected platform to a script commits the migration off the
+    legacy ``[system-requirements]`` table.
+
+    The two cannot coexist, so a script keeping both no longer parses, and the
+    command that produced it is the one the lock warning recommends.
+    """
+    script = tmp_pixi_workspace / "sr.py"
+    script.write_text(
+        f"""# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+#
+# [tool.pixi.system-requirements]
+# libc = "2.17"
+# ///
+print("SCRIPT-RAN")
+"""
+    )
+
+    verify_cli_command(
+        [pixi, "workspace", "platform", "add", "--script", script, "--auto-detect", "--no-install"],
+        ExitCode.SUCCESS,
+    )
+    assert "system-requirements" not in script.read_text()
+
+    # The script has to still load, which is what the stale table prevented.
+    verify_cli_command(
+        [pixi, "workspace", "platform", "list", "--script", script],
+        ExitCode.SUCCESS,
+    )
+
+
+@pytest.mark.slow
+def test_script_warns_before_dropping_foreign_subdirs_from_a_sidecar(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """A script that declares no platforms asks for one platform, the one it
+    runs on, so rows for other subdirs go. They take their packages with them,
+    which is too much of a checked-in lock file to lose in silence."""
+    script = tmp_pixi_workspace / "multi.py"
+    other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
+    script.write_text(
+        f"""# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# platforms = ["{CURRENT_PLATFORM}", "{other}"]
+#
+# [tool.pixi.dependencies]
+# python = "3.12.*"
+# ///
+print("SCRIPT-RAN")
+"""
+    )
+    verify_cli_command([pixi, "lock", "--script", script], ExitCode.SUCCESS)
+
+    # Dropping the `platforms` line is what leaves the foreign rows behind.
+    script.write_text(
+        "\n".join(
+            line for line in script.read_text().splitlines() if not line.startswith("# platforms")
+        )
+        + "\n"
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.SUCCESS,
+        stdout_contains="SCRIPT-RAN",
+        stderr_contains=[f"'{other}'", "does not ask for"],
+    )
+
+
+@pytest.mark.slow
+def test_script_sidecar_this_machine_cannot_run_falls_back_to_the_host(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """A sidecar row for this subdir that demands more than the machine offers
+    gives way to the host, rather than failing on a platform the script never
+    declared."""
+    script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
+
+    # Locked on a machine claiming a CUDA driver, run on one without it.
+    verify_cli_command(
+        [pixi, "lock", "--script", script],
+        ExitCode.SUCCESS,
+        env={"CONDA_OVERRIDE_CUDA": "99"},
+    )
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.SUCCESS,
+        stdout_contains="SCRIPT-RAN",
+        stderr_contains=["cannot run", "replaces what it records"],
+    )

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -1446,44 +1446,6 @@ def test_script_with_an_unparsable_sidecar_does_not_blame_the_platform(
 
 
 @pytest.mark.slow
-def test_script_platform_add_migrates_away_from_system_requirements(
-    pixi: Path, tmp_pixi_workspace: Path
-) -> None:
-    """Adding a detected platform to a script commits the migration off the
-    legacy ``[system-requirements]`` table.
-
-    The two cannot coexist, so a script keeping both no longer parses, and the
-    command that produced it is the one the lock warning recommends.
-    """
-    script = tmp_pixi_workspace / "sr.py"
-    script.write_text(
-        f"""# /// script
-# dependencies = []
-#
-# [tool.pixi.workspace]
-# channels = ["{CONDA_FORGE_CHANNEL}"]
-#
-# [tool.pixi.system-requirements]
-# libc = "2.17"
-# ///
-print("SCRIPT-RAN")
-"""
-    )
-
-    verify_cli_command(
-        [pixi, "workspace", "platform", "add", "--script", script, "--auto-detect", "--no-install"],
-        ExitCode.SUCCESS,
-    )
-    assert "system-requirements" not in script.read_text()
-
-    # The script has to still load, which a leftover table would prevent.
-    verify_cli_command(
-        [pixi, "workspace", "platform", "list", "--script", script],
-        ExitCode.SUCCESS,
-    )
-
-
-@pytest.mark.slow
 def test_script_warns_before_dropping_foreign_subdirs_from_a_sidecar(
     pixi: Path, tmp_pixi_workspace: Path
 ) -> None:

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -1385,10 +1385,9 @@ def test_script_sidecar_round_trips_without_resolving_again(
     """``pixi lock --script`` records the host platform, and the next run reuses
     it.
 
-    The sidecar's platform used to be read back as a bare subdir, which dropped
-    the virtual packages it was locked with. The environment then looked absent,
-    every run re-resolved, and the sidecar was quietly rewritten with pixi's
-    defaults -- undoing the fix for anyone who created one.
+    The sidecar's platform has to be read back with the virtual packages it was
+    locked with. As a bare subdir the environment would look absent, every run
+    would re-resolve, and the sidecar would be rewritten with pixi's defaults.
     """
     script = _script_without_platforms(
         tmp_pixi_workspace / "gpu.py", virtual_packages_channel, 'cuda = "*"'
@@ -1425,7 +1424,7 @@ def test_script_sidecar_for_another_subdir_falls_back_to_the_machine(
     """A sidecar locked for a subdir this machine cannot run is re-resolved.
 
     The script declares no platforms, so erroring out on one would blame the
-    user for a platform they never wrote down. It used to do exactly that.
+    user for a platform they never wrote down.
     """
     script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, "")
     other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
@@ -1436,8 +1435,8 @@ def test_script_sidecar_for_another_subdir_falls_back_to_the_machine(
         env={"PIXI_OVERRIDE_PLATFORM": other},
     )
     # Re-resolving replaces the sidecar, so say so rather than discarding a
-    # deliberate lock in silence. The only row it holds is for another subdir,
-    # which is what gets reported.
+    # deliberate lock in silence. Its only row is for another subdir, which is
+    # what gets reported.
     verify_cli_command(
         [pixi, "run", "--script", script],
         ExitCode.SUCCESS,
@@ -1451,8 +1450,8 @@ def test_script_frozen_refuses_a_sidecar_without_an_entry_for_this_machine(
     pixi: Path, tmp_pixi_workspace: Path
 ) -> None:
     """`--frozen` consumes the lock without checking it, so a sidecar with no
-    row for the platform we run on used to produce an empty environment and run
-    the script against whatever `python` was on `PATH`."""
+    row for the platform we run on has to be refused here rather than yielding
+    an empty environment that runs against whatever `python` is on `PATH`."""
     script = _script_without_platforms(tmp_pixi_workspace / "plain.py", None, 'python = "3.12.*"')
     other = "win-64" if not CURRENT_PLATFORM.startswith("win") else "linux-64"
 
@@ -1534,7 +1533,7 @@ print("SCRIPT-RAN")
     )
     assert "system-requirements" not in script.read_text()
 
-    # The script has to still load, which is what the stale table prevented.
+    # The script has to still load, which a leftover table would prevent.
     verify_cli_command(
         [pixi, "workspace", "platform", "list", "--script", script],
         ExitCode.SUCCESS,


### PR DESCRIPTION
### Description

Stacked on #6864.

A PEP 723 script declares no `platforms`, so Pixi picks one for it, and it
picked the wrong one: the current subdir with Pixi's assumed defaults. The host
was detected, printed in the debug log, and then thrown away.

```
DEBUG selecting best platform for environment 'default' on host subdir 'linux-aarch64'
      (host virtual packages: [__unix=0, __linux=6.8.12, __glibc=2.39, __cuda=13.2, __archspec=1])
Error: × failed to solve requirements of environment 'default' for platform 'linux-aarch64'
  ╰─▶ tensorrt 10.16.2.10 would require __glibc >=2.38, for which no candidates were found.
```

A script without declared platforms is resolved for the machine it runs on
now, like `pixi exec` and `pixi global`. Declaring `platforms` opts out. 
A workspace is unaffected: there the current platform
still means the subdir with Pixi's defaults, written into `pixi.toml` where you
can see and edit it.

An adjacent `<script>.py.pixi.lock` still wins while it is usable, so a
deliberate `pixi lock --script` keeps reproducing rather than being re-solved
for a marginally different host.

`pixi lock --script` warns that the lock describes this machine and points at
`pixi workspace platform add --script <PATH> --auto-detect`. That command was
a guaranteed no-op on a script, since the platform Pixi picked already looked
declared; an edit forgets the implicit platforms first now.

Fixes PFX-1870.

### How Has This Been Tested?

Added tests

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
