### PR TITLE
feat(global): rework the terminal output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6912,6 +6912,7 @@ dependencies = [
  "fancy_display",
  "fs-err",
  "futures",
+ "human_bytes",
  "indexmap 2.14.0",
  "insta",
  "is_executable",

--- a/crates/pixi_cli/src/global/add.rs
+++ b/crates/pixi_cli/src/global/add.rs
@@ -4,7 +4,7 @@ use crate::global::revert_environment_after_error;
 use clap::Parser;
 use pixi_config::{Config, ConfigCli};
 use pixi_global::project::GlobalSpec;
-use pixi_global::{EnvironmentName, Mapping, Project, StateChange, StateChanges};
+use pixi_global::{EnvironmentName, Mapping, Project, StateChanges};
 use rattler_conda_types::NamedChannelOrUrl;
 
 /// Adds dependencies to an environment
@@ -73,31 +73,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let sync_changes = project.sync_environment(env_name, None).await?;
         project.clear_progress();
 
-        // Figure out added packages and their corresponding versions from EnvironmentUpdate
-        let requested_package_names: Vec<_> =
-            specs.iter().map(|spec| spec.name().clone()).collect();
-
-        // Extract EnvironmentUpdate from sync changes if present
-        if let Some(changes_for_env) = sync_changes.changes_for_env(env_name) {
-            for change in changes_for_env {
-                if let StateChange::UpdatedEnvironment(environment_update) = change {
-                    let user_requested_changes =
-                        environment_update.user_requested_changes(&requested_package_names);
-
-                    // Convert to StateChange::AddedPackage for packages that were installed or upgraded
-                    state_changes
-                        .add_packages_from_install_changes(
-                            env_name,
-                            user_requested_changes,
-                            project,
-                        )
-                        .await?;
-                    break;
-                }
-            }
-        }
-
-        // Add the sync changes
+        // The sync already carries the environment update describing every
+        // package that moved, so nothing has to be derived on top of it.
         state_changes |= sync_changes;
 
         state_changes |= project.sync_completions(env_name).await?;
@@ -128,7 +105,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     .await
     {
         Ok(state_changes) => {
-            state_changes.report();
+            state_changes.report(&project_modified).await;
             Ok(())
         }
         Err(err) => {

--- a/crates/pixi_cli/src/global/expose.rs
+++ b/crates/pixi_cli/src/global/expose.rs
@@ -4,7 +4,7 @@ use miette::Context;
 use pixi_config::{Config, ConfigCli};
 use pixi_global::{self, EnvironmentName, ExposedName, Mapping, StateChanges};
 
-use crate::global::revert_environment_after_error;
+use crate::global::{report_failed_environment, revert_environment_after_error};
 
 /// Add exposed binaries from an environment to your global environment
 ///
@@ -94,7 +94,7 @@ pub async fn add(args: AddArgs) -> miette::Result<()> {
     match apply_changes(&args, &mut project_modified).await {
         Ok(state_changes) => {
             project_modified.manifest.save().await?;
-            state_changes.report();
+            state_changes.report(&project_modified).await;
             Ok(())
         }
         Err(err) => {
@@ -141,6 +141,10 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
         })
         .collect_vec();
 
+    // Removing several names from one environment is one change to that
+    // environment, so the reports are collected and printed once at the end
+    // rather than repeating the header per name.
+    let mut all_changes = StateChanges::default();
     let mut last_updated_project = project_original;
     for mapping in exposed_mappings {
         let (exposed_name, env_name) = mapping?;
@@ -150,7 +154,7 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
             .wrap_err_with(|| format!("Couldn't remove exposed name {exposed_name}"))
         {
             Ok(state_changes) => {
-                state_changes.report();
+                all_changes |= state_changes;
             }
             Err(err) => {
                 if let Err(revert_err) =
@@ -159,10 +163,15 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
                     tracing::warn!("Reverting of the operation failed");
                     tracing::info!("Reversion error: {:?}", revert_err);
                 }
+                // The names before this one are already removed and saved, so
+                // they are still reported even though the command fails.
+                all_changes.report(&last_updated_project).await;
+                report_failed_environment(&env_name);
                 return Err(err);
             }
         }
         last_updated_project = project;
     }
+    all_changes.report(&last_updated_project).await;
     Ok(())
 }

--- a/crates/pixi_cli/src/global/install.rs
+++ b/crates/pixi_cli/src/global/install.rs
@@ -9,13 +9,12 @@ use rattler_conda_types::{MatchSpec, NamedChannelOrUrl, Platform};
 
 use crate::global::{
     EnvironmentAction, eventual_environment_channels, global_specs::GlobalSpecs,
-    report_failed_environments, revert_environment_after_error,
+    report_failed_environment, report_failed_environments, revert_environment_after_error,
 };
 use pixi_config::{self, Config, ConfigCli};
 use pixi_global::{
-    self, EnvChanges, EnvState, EnvironmentName, Mapping, Project, StateChange, StateChanges,
-    common::{NotChangedReason, contains_menuinst_document},
-    list::list_all_global_environments,
+    self, EnvironmentName, Mapping, Project, StateChange, StateChanges,
+    common::contains_menuinst_document,
     project::{ExposedType, GlobalSpec},
 };
 
@@ -134,7 +133,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         miette::bail!("Can't add packages with `--with` for more than one environment");
     }
 
-    let mut env_changes = EnvChanges::default();
     let mut last_updated_project = project_original;
     let mut errors: Vec<(EnvironmentName, Report)> = Vec::new();
     // Convert the packages into named global specs
@@ -143,16 +141,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let mut project = last_updated_project.clone();
         match setup_environment(env_name, &args, specs, &mut project).await {
             Ok(state_changes) => {
-                if state_changes.has_changed() {
-                    env_changes
-                        .changes
-                        .insert(env_name.clone(), EnvState::Installed)
-                } else {
-                    env_changes.changes.insert(
-                        env_name.clone(),
-                        EnvState::NotChanged(NotChangedReason::AlreadyInstalled),
-                    )
-                };
+                // The user named these environments, so they get a block even
+                // when nothing changed.
+                state_changes.report(&project).await;
                 // Only advance project on success
                 last_updated_project = project;
             }
@@ -163,20 +154,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     tracing::warn!("Reverting of the operation failed");
                     tracing::info!("Reversion error: {:?}", revert_err);
                 }
+                report_failed_environment(env_name);
                 errors.push((env_name.clone(), err));
             }
         }
     }
-
-    // After installing, we always want to list the changed environments
-    list_all_global_environments(
-        &last_updated_project,
-        Some(env_to_specs.into_keys().collect()),
-        Some(&env_changes),
-        None,
-        false,
-    )
-    .await?;
 
     report_failed_environments(EnvironmentAction::Install, errors)
 }
@@ -188,6 +170,10 @@ async fn setup_environment(
     project: &mut Project,
 ) -> miette::Result<StateChanges> {
     let mut state_changes = StateChanges::new_with_env(env_name.clone());
+
+    // The manifest as it was before this environment was touched, so the
+    // shortcut below can tell whether it still owes the file a write.
+    let manifest_before = project.manifest.document.to_string();
 
     if args.force_reinstall && project.environment(env_name).is_some() {
         state_changes |= project.remove_environment(env_name).await?;
@@ -239,8 +225,15 @@ async fn setup_environment(
         }
     }
 
+    // The prefix already satisfies the manifest, so there is nothing to solve,
+    // install or expose. The manifest itself can still have changed: it may
+    // have just gained the environment that the prefix was left over from, and
+    // that change still has to be written out.
     if project.environment_in_sync_internal(env_name, true).await? {
-        return Ok(StateChanges::new_with_env(env_name.clone()));
+        if project.manifest.document.to_string() != manifest_before {
+            project.manifest.save().await?;
+        }
+        return Ok(state_changes);
     }
 
     // Installing the environment to be able to find the bin paths later
@@ -264,18 +257,10 @@ async fn setup_environment(
         state_changes |= project.sync_shortcuts(env_name).await?;
     }
 
-    // Figure out added packages and their corresponding versions
-    let requested_package_names: Vec<_> = packages_to_add
-        .iter()
-        .map(|spec| spec.name().clone())
-        .collect();
-    let user_requested_changes =
-        environment_update.user_requested_changes(&requested_package_names);
-
-    // Convert to StateChange::AddedPackage for packages that were installed or upgraded
-    state_changes
-        .add_packages_from_install_changes(env_name, user_requested_changes, project)
-        .await?;
+    state_changes.insert_change(
+        env_name,
+        StateChange::UpdatedEnvironment(environment_update),
+    );
 
     // Expose executables of the new environment
     state_changes |= project

--- a/crates/pixi_cli/src/global/list.rs
+++ b/crates/pixi_cli/src/global/list.rs
@@ -11,10 +11,10 @@ use std::str::FromStr;
 ///
 /// All environments:
 ///
-/// - Yellow: the binaries that are exposed.
+/// - Magenta: the name of the environment.
 /// - Green: the packages that are explicit dependencies of the environment.
-/// - Blue: the version of the installed package.
-/// - Cyan: the name of the environment.
+/// - Yellow: the binaries that are exposed.
+/// - Dim: the version of the installed package.
 ///
 /// Per environment:
 ///
@@ -89,7 +89,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 "The environments are not in sync with the manifest, to sync run\n\tpixi global sync"
             );
         }
-        list_all_global_environments(&project, None, None, args.regex, true).await?;
+        list_all_global_environments(&project, args.regex).await?;
     }
 
     Ok(())

--- a/crates/pixi_cli/src/global/mod.rs
+++ b/crates/pixi_cli/src/global/mod.rs
@@ -1,10 +1,9 @@
 use clap::Parser;
-use fancy_display::FancyDisplay;
 use miette::{IntoDiagnostic, Report, WrapErr};
 use rattler_conda_types::NamedChannelOrUrl;
 use tokio::fs as tokio_fs;
 
-use pixi_global::EnvironmentName;
+use pixi_global::{EnvironmentName, report::EnvReport};
 
 mod add;
 mod edit;
@@ -86,7 +85,8 @@ pub async fn execute(cmd: Args) -> miette::Result<()> {
 enum EnvironmentAction {
     Sync,
     Install,
-    Remove,
+    Uninstall,
+    Update,
 }
 
 impl std::fmt::Display for EnvironmentAction {
@@ -94,15 +94,23 @@ impl std::fmt::Display for EnvironmentAction {
         let verb = match self {
             EnvironmentAction::Sync => "sync",
             EnvironmentAction::Install => "install",
-            EnvironmentAction::Remove => "remove",
+            EnvironmentAction::Uninstall => "uninstall",
+            EnvironmentAction::Update => "update",
         };
         write!(f, "{verb}")
     }
 }
 
-/// Warns about each failed environment with its full error, then returns a
-/// single error naming every environment the operation failed for. Returns
-/// `Ok(())` if there are no errors.
+/// Mark an environment as failed in place, so it keeps its position among the
+/// environments around it. Only the header line: the reason lands at the end of
+/// the run, with the other failures.
+fn report_failed_environment(env_name: &EnvironmentName) {
+    pixi_global::report::print(&EnvReport::failed(env_name.as_str()));
+}
+
+/// Print why each environment failed, then return a single error counting them.
+/// Collecting the reasons at the end of the run keeps them readable together,
+/// each attributed to its environment. Returns `Ok(())` if there are no errors.
 fn report_failed_environments(
     action: EnvironmentAction,
     errors: Vec<(EnvironmentName, Report)>,
@@ -110,19 +118,16 @@ fn report_failed_environments(
     if errors.is_empty() {
         return Ok(());
     }
+
+    let count = errors.len();
+    pixi_global::report::print_failure_heading(&action.to_string(), count);
     for (env_name, err) in &errors {
-        tracing::warn!(
-            "Couldn't {action} environment {}\n{err:?}",
-            env_name.fancy_display()
-        );
+        pixi_global::report::print(&EnvReport::reason(env_name.as_str(), format!("{err:?}")));
     }
-    let failed_envs = errors
-        .iter()
-        .map(|(env_name, _)| env_name.fancy_display().to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
+
+    let plural = if count == 1 { "" } else { "s" };
     Err(miette::miette!(
-        "Couldn't {action} the following environments: {failed_envs}"
+        "couldn't {action} {count} environment{plural}"
     ))
 }
 

--- a/crates/pixi_cli/src/global/remove.rs
+++ b/crates/pixi_cli/src/global/remove.rs
@@ -115,7 +115,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .wrap_err(format!("Couldn't remove packages from {env_name}"))
     {
         Ok(state_changes) => {
-            state_changes.report();
+            state_changes.report(&project).await;
         }
         Err(err) => {
             if let Err(revert_err) =

--- a/crates/pixi_cli/src/global/shortcut.rs
+++ b/crates/pixi_cli/src/global/shortcut.rs
@@ -1,4 +1,4 @@
-use crate::global::revert_environment_after_error;
+use crate::global::{report_failed_environment, revert_environment_after_error};
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use miette::Context;
@@ -78,7 +78,7 @@ pub async fn add(args: AddArgs) -> miette::Result<()> {
     match apply_changes(&args, &mut project_modified).await {
         Ok(state_changes) => {
             project_modified.manifest.save().await?;
-            state_changes.report();
+            state_changes.report(&project_modified).await;
             Ok(())
         }
         Err(err) => {
@@ -155,6 +155,7 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
         );
     }
 
+    let mut all_changes = StateChanges::default();
     let mut last_updated_project = project_original;
     for (env_name, shortcuts) in to_remove_shortcuts_map {
         let mut project = last_updated_project.clone();
@@ -167,7 +168,7 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
                 )
             }) {
             Ok(state_changes) => {
-                state_changes.report();
+                all_changes |= state_changes;
             }
             Err(err) => {
                 if let Err(revert_err) =
@@ -176,10 +177,16 @@ pub async fn remove(args: RemoveArgs) -> miette::Result<()> {
                     tracing::warn!("Reverting of the operation failed");
                     tracing::info!("Reversion error: {:?}", revert_err);
                 }
+                // The environments before this one are already changed and
+                // saved, so they are still reported even though the command
+                // fails.
+                all_changes.report(&last_updated_project).await;
+                report_failed_environment(&env_name);
                 return Err(err);
             }
         }
         last_updated_project = project;
     }
+    all_changes.report(&last_updated_project).await;
     Ok(())
 }

--- a/crates/pixi_cli/src/global/sync.rs
+++ b/crates/pixi_cli/src/global/sync.rs
@@ -1,7 +1,8 @@
-use crate::global::{EnvironmentAction, report_failed_environments};
+use crate::global::{EnvironmentAction, report_failed_environment, report_failed_environments};
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use pixi_config::{Config, ConfigCli};
+use pixi_global::report::EnvStatus;
 
 /// Sync global manifest with installed environments
 #[derive(Parser, Debug)]
@@ -17,8 +18,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .with_cli_config(config.clone());
 
-    let mut has_changed = false;
-
     // Prune environments that are not listed
     let state_change = project.prune_old_environments().await?;
 
@@ -30,8 +29,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     if state_change.has_changed() {
-        has_changed = true;
-        state_change.report();
+        state_change.report(&project).await;
     }
 
     // Remove broken files
@@ -55,12 +53,22 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // appearing frozen while executables are (re)exposed and trampolines rebuilt
     // (#6658). Reports use `pixi_progress::println!`, which suspends the spinner, so
     // change output stays readable above it.
-    let (expose_changed, errors) =
+    let total = env_names.len();
+    let (unchanged, errors) =
         pixi_progress::await_in_progress("Syncing global environments", |pb| async move {
-            let mut changed = false;
+            // `sync` sweeps every environment rather than the ones the user
+            // named, so the unchanged ones are counted instead of getting a
+            // block of their own.
+            let mut unchanged = 0;
             let mut errors = Vec::new();
-            for (env_name, install_result) in env_names.iter().zip(install_results) {
-                pb.set_message(format!("Syncing environment {}", env_name.fancy_display()));
+            for (index, (env_name, install_result)) in
+                env_names.iter().zip(install_results).enumerate()
+            {
+                pb.set_message(format!(
+                    "syncing {} ({}/{total})",
+                    env_name.fancy_display(),
+                    index + 1
+                ));
                 let result = match install_result {
                     Ok(mut state_changes) => {
                         match project.sync_environment_expose(env_name).await {
@@ -75,25 +83,26 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 };
                 match result {
                     Ok(state_change) => {
-                        if state_change.has_changed() {
-                            changed = true;
-                            state_change.report();
+                        for env_report in state_change.reports_or_warn(&project).await {
+                            if env_report.status == Some(EnvStatus::Unchanged) {
+                                unchanged += 1;
+                            } else {
+                                pixi_global::report::print(&env_report);
+                            }
                         }
                     }
-                    Err(err) => errors.push((env_name.clone(), err)),
+                    Err(err) => {
+                        report_failed_environment(env_name);
+                        errors.push((env_name.clone(), err));
+                    }
                 }
             }
-            (changed, errors)
+            (unchanged, errors)
         })
         .await;
-    has_changed |= expose_changed;
 
-    if !has_changed {
-        eprintln!(
-            "{}Nothing to do. The pixi global installation is already up-to-date.",
-            console::style(console::Emoji("✔ ", "")).green()
-        );
-    }
+    pixi_global::report::print_unchanged_summary(unchanged);
+    pixi_global::report::print_nothing_to_do();
 
     report_failed_environments(EnvironmentAction::Sync, errors)
 }

--- a/crates/pixi_cli/src/global/uninstall.rs
+++ b/crates/pixi_cli/src/global/uninstall.rs
@@ -1,5 +1,6 @@
 use crate::global::{
-    EnvironmentAction, report_failed_environments, revert_environment_after_error,
+    EnvironmentAction, report_failed_environment, report_failed_environments,
+    revert_environment_after_error,
 };
 use clap::Parser;
 use miette::Report;
@@ -44,7 +45,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         let mut project = last_updated_project.clone();
         match apply_changes(env_name, &mut project).await {
             Ok(state_changes) => {
-                state_changes.report();
+                state_changes.report(&project).await;
                 // Only advance the project when successful
                 last_updated_project = project;
             }
@@ -56,10 +57,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     tracing::warn!("Reverting of the operation failed");
                     tracing::info!("Reversion error: {:?}", revert_err);
                 }
+                report_failed_environment(env_name);
                 errors.push((env_name.clone(), err));
             }
         }
     }
 
-    report_failed_environments(EnvironmentAction::Remove, errors)
+    report_failed_environments(EnvironmentAction::Uninstall, errors)
 }

--- a/crates/pixi_cli/src/global/update.rs
+++ b/crates/pixi_cli/src/global/update.rs
@@ -1,11 +1,15 @@
-use crate::global::revert_environment_after_error;
+use crate::global::{
+    EnvironmentAction, report_failed_environment, report_failed_environments,
+    revert_environment_after_error,
+};
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use indexmap::IndexMap;
-use miette::WrapErr;
+use miette::{Report, WrapErr};
 use pixi_config::{Config, ConfigCli};
 use pixi_global::common::check_all_exposed;
 use pixi_global::project::ExposedType;
+use pixi_global::report::EnvStatus;
 use pixi_global::{EnvironmentName, Project};
 use pixi_global::{StateChange, StateChanges};
 use pixi_utils::prefix::Executable;
@@ -99,6 +103,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .with_cli_config(config.clone());
 
+    // Environments the user named get a block even when nothing changed;
+    // a sweep over all of them counts the unchanged ones instead.
+    let named_environments = args.environments.is_some();
     let env_names: Vec<EnvironmentName> = match args.environments {
         Some(env_names) => {
             let mut seen = indexmap::IndexSet::new();
@@ -109,7 +116,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
         None => {
             let state_changes = project_original.prune_old_environments().await?;
-            state_changes.report();
+            state_changes.report(&project_original).await;
             #[cfg(unix)]
             {
                 let completions_dir = pixi_global::completions::CompletionsDir::from_env().await?;
@@ -133,28 +140,37 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     let mut project = project_original;
     project.clear_progress();
-    for result in install_results {
-        match result {
-            Ok(env_result) => {
-                let env_name = env_result.env_name.clone();
-                match apply_manifest_changes(&mut project, env_result).await {
-                    Ok(state_changes) => state_changes.report(),
-                    Err(err) => {
-                        revert_environment_after_error(&env_name, &project).await?;
-                        return Err(err.wrap_err(format!(
-                            "Couldn't update environment {}",
-                            env_name.fancy_display()
-                        )));
+    let mut unchanged = 0;
+    let mut errors: Vec<(EnvironmentName, Report)> = Vec::new();
+    for (env_name, result) in env_names.iter().zip(install_results) {
+        let outcome = match result {
+            Ok(env_result) => apply_manifest_changes(&mut project, env_result).await,
+            Err(err) => Err(err),
+        };
+        match outcome {
+            Ok(state_changes) => {
+                for env_report in state_changes.reports_or_warn(&project).await {
+                    if !named_environments && env_report.status == Some(EnvStatus::Unchanged) {
+                        unchanged += 1;
+                    } else {
+                        pixi_global::report::print(&env_report);
                     }
                 }
             }
             Err(err) => {
-                let _ = project.manifest.save().await;
-                return Err(err);
+                if let Err(revert_err) = revert_environment_after_error(env_name, &project).await {
+                    tracing::warn!("Reverting of the operation failed");
+                    tracing::info!("Reversion error: {:?}", revert_err);
+                }
+                report_failed_environment(env_name);
+                errors.push((env_name.clone(), err));
             }
         }
     }
 
+    pixi_global::report::print_unchanged_summary(unchanged);
+    pixi_global::report::print_nothing_to_do();
+
     project.manifest.save().await?;
-    Ok(())
+    report_failed_environments(EnvironmentAction::Update, errors)
 }

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -152,6 +152,18 @@ impl Args {
     }
 }
 
+impl GlobalOptions {
+    /// How much detail the reports of `pixi global` show. This rides along with
+    /// the logging flags rather than having a knob of its own.
+    fn report_verbosity(&self) -> pixi_global::report::Verbosity {
+        match (self.quiet, self.verbose) {
+            (quiet, _) if quiet > 0 => pixi_global::report::Verbosity::Quiet,
+            (_, 0) => pixi_global::report::Verbosity::Normal,
+            _ => pixi_global::report::Verbosity::Detailed,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Command {
@@ -271,6 +283,10 @@ pub async fn execute() -> miette::Result<()> {
 
     // Setup logging for the application.
     setup_logging(&args, use_colors)?;
+
+    // The verbosity flags decide how much of a `pixi global` report is shown as
+    // well as how much is logged.
+    pixi_global::report::set_verbosity(args.global_options.report_verbosity());
 
     let (Some(command), global_options) = (args.command, args.global_options) else {
         // match CI expectations

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -153,13 +153,13 @@ impl Args {
 }
 
 impl GlobalOptions {
-    /// How much detail the reports of `pixi global` show. This rides along with
+    /// How much of the reports of `pixi global` is shown. This rides along with
     /// the logging flags rather than having a knob of its own.
     fn report_verbosity(&self) -> pixi_global::report::Verbosity {
-        match (self.quiet, self.verbose) {
-            (quiet, _) if quiet > 0 => pixi_global::report::Verbosity::Quiet,
-            (_, 0) => pixi_global::report::Verbosity::Normal,
-            _ => pixi_global::report::Verbosity::Detailed,
+        if self.quiet > 0 {
+            pixi_global::report::Verbosity::Quiet
+        } else {
+            pixi_global::report::Verbosity::Normal
         }
     }
 }
@@ -284,8 +284,8 @@ pub async fn execute() -> miette::Result<()> {
     // Setup logging for the application.
     setup_logging(&args, use_colors)?;
 
-    // The verbosity flags decide how much of a `pixi global` report is shown as
-    // well as how much is logged.
+    // The quiet flag silences the reports of `pixi global` as well as the
+    // logging.
     pixi_global::report::set_verbosity(args.global_options.report_verbosity());
 
     let (Some(command), global_options) = (args.command, args.global_options) else {

--- a/crates/pixi_core/src/environment/list.rs
+++ b/crates/pixi_core/src/environment/list.rs
@@ -65,6 +65,5 @@ pub fn print_package_table(packages: Vec<PackageToOutput>) -> Result<(), std::io
         )?;
     }
 
-    writeln!(writer, "\n")?;
     writer.flush()
 }

--- a/crates/pixi_global/Cargo.toml
+++ b/crates/pixi_global/Cargo.toml
@@ -16,6 +16,7 @@ dunce = { workspace = true }
 fancy_display = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
+human_bytes = { workspace = true }
 indexmap = { workspace = true }
 is_executable = { workspace = true }
 itertools = { workspace = true }

--- a/crates/pixi_global/src/common.rs
+++ b/crates/pixi_global/src/common.rs
@@ -409,42 +409,6 @@ impl StateChanges {
     }
 }
 
-/// How many packages an environment gained, changed and lost besides the ones
-/// named in its manifest.
-#[derive(Debug, Default)]
-struct TransitiveCounts {
-    added: usize,
-    changed: usize,
-    removed: usize,
-}
-
-impl TransitiveCounts {
-    fn add(&mut self, change: &InstallChange) {
-        match change {
-            InstallChange::Installed(_) => self.added += 1,
-            InstallChange::Removed => self.removed += 1,
-            InstallChange::Upgraded(_, _)
-            | InstallChange::TransitiveUpgraded(_, _)
-            | InstallChange::Reinstalled(_, _) => self.changed += 1,
-        }
-    }
-}
-
-impl std::fmt::Display for TransitiveCounts {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let parts = [
-            (self.added, "added"),
-            (self.changed, "changed"),
-            (self.removed, "removed"),
-        ]
-        .into_iter()
-        .filter(|(count, _)| *count > 0)
-        .map(|(count, what)| format!("{count} {what}"))
-        .join(", ");
-        write!(f, "{parts}")
-    }
-}
-
 /// The executable an exposed name points at, spelled out only when it differs
 /// from the name itself.
 fn exposed_target(name: &ExposedName, executable: Option<&str>) -> Option<String> {
@@ -569,14 +533,15 @@ async fn build_report(
     // that matters is that it ended up exposed. Changes are walked in the order
     // they were recorded, so the last one wins.
     let mut dependencies: BTreeMap<String, Item> = BTreeMap::new();
-    let mut transitive: BTreeMap<String, Item> = BTreeMap::new();
-    let mut transitive_counts = TransitiveCounts::default();
     let mut exposed: BTreeMap<String, Item> = BTreeMap::new();
     let mut shortcuts: BTreeMap<String, Item> = BTreeMap::new();
     let mut completions: BTreeMap<String, Item> = BTreeMap::new();
     // The last environment-level change wins: `--force-reinstall` removes the
     // environment and creates it again, and that reads as an install.
     let mut environment_change = None;
+    // Packages that aren't named in the manifest leave no row behind, but the
+    // environment did change and has to say so.
+    let mut transitive_change = false;
 
     for change in changes {
         match change {
@@ -608,15 +573,14 @@ async fn build_report(
                         left.as_normalized().cmp(right.as_normalized())
                     })
                 {
-                    let name = package_name.as_normalized().to_string();
-                    let item = install_change_item(&name, install_change);
                     // A package the manifest names is a dependency; everything
-                    // else came along with it.
+                    // else came along with it and is only counted.
                     if update.current_packages().contains(package_name) {
-                        dependencies.insert(name, item);
+                        let name = package_name.as_normalized().to_string();
+                        dependencies
+                            .insert(name.clone(), install_change_item(&name, install_change));
                     } else {
-                        transitive_counts.add(install_change);
-                        transitive.insert(name, item);
+                        transitive_change = true;
                     }
                 }
             }
@@ -645,23 +609,18 @@ async fn build_report(
 
     let mut rows = Vec::new();
     push_row(&mut rows, Label::Dependencies, dependencies);
-    if !transitive.is_empty() {
-        let items = if report::verbosity() == report::Verbosity::Detailed {
-            transitive.into_values().collect()
-        } else {
-            vec![Item::summary(transitive_counts.to_string())]
-        };
-        rows.push(Row::new(Label::Transitive, items));
-    }
     push_row(&mut rows, Label::Exposed, exposed);
     push_row(&mut rows, Label::Shortcuts, shortcuts);
     push_row(&mut rows, Label::Completions, completions);
 
     let status = match environment_change {
         Some(status) => status,
-        // The dependency that was lifted into the header still counts as a
-        // change, even though it left no row behind.
-        None if rows.is_empty() && own_dependency.is_none() => EnvStatus::Unchanged,
+        // The dependency that was lifted into the header and the packages that
+        // came along with it still count as changes, even though they left no
+        // row behind.
+        None if rows.is_empty() && own_dependency.is_none() && !transitive_change => {
+            EnvStatus::Unchanged
+        }
         None => EnvStatus::Updated,
     };
 

--- a/crates/pixi_global/src/common.rs
+++ b/crates/pixi_global/src/common.rs
@@ -1,8 +1,7 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     ffi::OsStr,
     io::Read,
-    iter::Peekable,
     ops::Not,
     path::{Path, PathBuf},
     str::FromStr,
@@ -10,7 +9,6 @@ use std::{
 
 use ahash::HashSet;
 use console::StyledObject;
-use fancy_display::FancyDisplay;
 use fs_err as fs;
 use fs_err::tokio as tokio_fs;
 use indexmap::{IndexMap, IndexSet};
@@ -18,17 +16,19 @@ use is_executable::IsExecutable;
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use pixi_config::pixi_home;
+use pixi_consts::consts;
 use pixi_manifest::PrioritizedChannel;
 use pixi_utils::{executable_from_path, prefix::Executable};
 use rattler::install::{Transaction, TransactionOperation};
 use rattler_conda_types::{
     Channel, ChannelConfig, HasArtifactIdentificationRefs, NamedChannelOrUrl, PackageName,
-    PackageRecord, PrefixRecord, Version,
+    PrefixRecord, Version,
 };
 use url::Url;
 
 use super::{
     EnvironmentName, ExposedName, Mapping,
+    report::{self, EnvReport, EnvStatus, Item, Label, Marker, Row},
     trampoline::{GlobalExecutable, Trampoline},
 };
 
@@ -216,65 +216,6 @@ pub async fn find_package_records(conda_meta: &Path) -> miette::Result<Vec<Prefi
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NotChangedReason {
-    AlreadyInstalled,
-}
-
-impl std::fmt::Display for NotChangedReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            NotChangedReason::AlreadyInstalled => {
-                write!(f, "{}", NotChangedReason::AlreadyInstalled.as_str())
-            }
-        }
-    }
-}
-
-impl NotChangedReason {
-    /// Returns the name of the environment.
-    pub fn as_str(&self) -> &str {
-        match self {
-            NotChangedReason::AlreadyInstalled => "already installed",
-        }
-    }
-}
-
-impl FancyDisplay for NotChangedReason {
-    fn fancy_display(&self) -> StyledObject<&str> {
-        console::style(self.as_str()).cyan()
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EnvState {
-    Installed,
-    NotChanged(NotChangedReason),
-}
-
-impl EnvState {
-    pub fn as_str(&self) -> &str {
-        match self {
-            EnvState::Installed => "installed",
-            EnvState::NotChanged(reason) => reason.as_str(),
-        }
-    }
-}
-
-impl FancyDisplay for EnvState {
-    fn fancy_display(&self) -> StyledObject<&str> {
-        match self {
-            EnvState::Installed => console::style(self.as_str()).green(),
-            EnvState::NotChanged(reason) => reason.fancy_display(),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct EnvChanges {
-    pub changes: HashMap<EnvironmentName, EnvState>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstallChange {
     Installed(Version),
     Upgraded(Version, Version),
@@ -353,29 +294,16 @@ impl EnvironmentUpdate {
     pub fn add_removed_packages(&mut self, packages: Vec<PackageName>) {
         self.current_packages.extend(packages);
     }
-
-    /// Get only the package changes that were explicitly requested by the user.
-    /// This filters out transitive dependency changes to focus on
-    /// user-installed packages.
-    pub fn user_requested_changes(
-        &self,
-        requested_packages: &[PackageName],
-    ) -> HashMap<PackageName, InstallChange> {
-        self.package_changes
-            .iter()
-            .filter(|(name, _)| requested_packages.contains(name))
-            .map(|(name, change)| (name.clone(), change.clone()))
-            .collect()
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[must_use]
 pub enum StateChange {
-    AddedExposed(ExposedName),
+    /// An executable was exposed, together with the executable it points at
+    /// when that is known.
+    AddedExposed(ExposedName, Option<String>),
     RemovedExposed(ExposedName),
-    UpdatedExposed(ExposedName),
-    AddedPackage(Box<PackageRecord>),
+    UpdatedExposed(ExposedName, Option<String>),
     AddedEnvironment,
     RemovedEnvironment,
     UpdatedEnvironment(EnvironmentUpdate),
@@ -418,60 +346,6 @@ impl StateChanges {
         self.changes
     }
 
-    /// Get changes for a specific environment
-    pub fn changes_for_env(&self, env_name: &EnvironmentName) -> Option<&Vec<StateChange>> {
-        self.changes.get(env_name)
-    }
-
-    /// Convert user-requested install changes to AddedPackage state changes
-    pub async fn add_packages_from_install_changes(
-        &mut self,
-        env_name: &EnvironmentName,
-        user_requested_changes: HashMap<PackageName, InstallChange>,
-        project: &super::Project,
-    ) -> miette::Result<()> {
-        // Convert to StateChange::AddedPackage for packages that were installed or
-        // upgraded
-        for (package_name, install_change) in user_requested_changes {
-            if matches!(
-                install_change,
-                InstallChange::Installed(_)
-                    | InstallChange::Upgraded(_, _)
-                    | InstallChange::Reinstalled(_, _)
-            ) {
-                // Get the package record from the environment prefix
-                let prefix = project.environment_prefix(env_name).await?;
-                if let Ok(prefix_record) = prefix.find_designated_package(&package_name).await {
-                    self.insert_change(
-                        env_name,
-                        StateChange::AddedPackage(Box::new(
-                            prefix_record.repodata_record.package_record,
-                        )),
-                    );
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn accumulate_changes<F, T>(
-        iter: &mut Peekable<std::slice::Iter<StateChange>>,
-        filter_fn: F,
-        init_value: Option<T>,
-    ) -> Vec<T>
-    where
-        F: Fn(Option<&StateChange>) -> Option<T>,
-    {
-        let mut changes = init_value.into_iter().collect::<Vec<T>>();
-
-        while let Some(next) = filter_fn(iter.peek().cloned()) {
-            changes.push(next);
-            iter.next();
-        }
-
-        changes
-    }
-
     /// Remove changes that cancel each other out
     fn prune(&mut self) {
         self.changes = self
@@ -488,360 +362,320 @@ impl StateChanges {
                 }
                 (env.clone(), pruned_changes)
             })
-            .collect()
+            .collect();
     }
 
-    pub fn report(mut self) {
+    /// Turn the recorded changes into one report per environment, sorted by
+    /// environment name so that the output doesn't depend on hash order.
+    pub async fn into_reports(
+        mut self,
+        project: &super::Project,
+    ) -> miette::Result<Vec<EnvReport>> {
         self.prune();
 
-        for (env_name, changes_for_env) in self.changes {
-            // If there are no changes for the environment, skip it
-            if changes_for_env.is_empty() {
-                continue;
+        let env_names = self
+            .changes
+            .keys()
+            .cloned()
+            .sorted_by(|left, right| left.as_str().cmp(right.as_str()))
+            .collect_vec();
+
+        let mut reports = Vec::with_capacity(env_names.len());
+        for env_name in env_names {
+            let changes = &self.changes[&env_name];
+            reports.push(build_report(project, &env_name, changes).await?);
+        }
+        Ok(reports)
+    }
+
+    /// The reports for these changes, or nothing if they can't be built.
+    /// Describing an operation is not part of performing it, so a failure here
+    /// is a warning rather than something that affects the exit code.
+    pub async fn reports_or_warn(self, project: &super::Project) -> Vec<EnvReport> {
+        match self.into_reports(project).await {
+            Ok(reports) => reports,
+            Err(err) => {
+                tracing::warn!("Couldn't describe what changed\n{err:?}");
+                Vec::new()
             }
+        }
+    }
 
-            let mut iter = changes_for_env.iter().peekable();
+    /// Print a block for every environment these changes touched.
+    pub async fn report(self, project: &super::Project) {
+        for env_report in self.reports_or_warn(project).await {
+            report::print(&env_report);
+        }
+    }
+}
 
-            while let Some(change) = iter.next() {
-                match change {
-                    StateChange::AddedExposed(first_name) => {
-                        let mut exposed_names = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::AddedExposed(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(first_name.clone()),
-                        );
+/// How many packages an environment gained, changed and lost besides the ones
+/// named in its manifest.
+#[derive(Debug, Default)]
+struct TransitiveCounts {
+    added: usize,
+    changed: usize,
+    removed: usize,
+}
 
-                        exposed_names.sort();
+impl TransitiveCounts {
+    fn add(&mut self, change: &InstallChange) {
+        match change {
+            InstallChange::Installed(_) => self.added += 1,
+            InstallChange::Removed => self.removed += 1,
+            InstallChange::Upgraded(_, _)
+            | InstallChange::TransitiveUpgraded(_, _)
+            | InstallChange::Reinstalled(_, _) => self.changed += 1,
+        }
+    }
+}
 
-                        if exposed_names.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Exposed executable {} from environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                exposed_names[0].fancy_display(),
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Exposed executables from environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for exposed_name in exposed_names {
-                                pixi_progress::println!("   - {}", exposed_name.fancy_display());
-                            }
-                        }
-                    }
-                    StateChange::RemovedExposed(removed) => {
-                        let mut exposed_names = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::RemovedExposed(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(removed.clone()),
-                        );
-                        exposed_names.sort();
-                        if exposed_names.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Removed exposed executable {} from environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                exposed_names[0].fancy_display(),
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Removed exposed executables from environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for exposed_name in exposed_names {
-                                pixi_progress::println!("   - {}", exposed_name.fancy_display());
-                            }
-                        }
-                    }
-                    StateChange::UpdatedExposed(exposed) => {
-                        let mut exposed_names = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::UpdatedExposed(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(exposed.clone()),
-                        );
-                        exposed_names.sort();
-                        if exposed_names.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Updated executable {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                exposed_names[0].fancy_display(),
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Updated executables of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for exposed_name in exposed_names {
-                                pixi_progress::println!("   - {}", exposed_name.fancy_display());
-                            }
-                        }
-                    }
-                    StateChange::AddedPackage(pkg) => {
-                        let mut added_pkgs = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::AddedPackage(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(pkg.clone()),
-                        );
+impl std::fmt::Display for TransitiveCounts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let parts = [
+            (self.added, "added"),
+            (self.changed, "changed"),
+            (self.removed, "removed"),
+        ]
+        .into_iter()
+        .filter(|(count, _)| *count > 0)
+        .map(|(count, what)| format!("{count} {what}"))
+        .join(", ");
+        write!(f, "{parts}")
+    }
+}
 
-                        added_pkgs.sort_by(|pkg1, pkg2| pkg1.name.cmp(&pkg2.name));
+/// The executable an exposed name points at, spelled out only when it differs
+/// from the name itself.
+fn exposed_target(name: &ExposedName, executable: Option<&str>) -> Option<String> {
+    executable
+        .filter(|executable| *executable != name.to_string())
+        .map(|executable| format!("-> {executable}"))
+}
 
-                        if added_pkgs.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Added package {}={} to environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                console::style(pkg.name.as_normalized()).green(),
-                                console::style(&pkg.version).blue(),
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Added packages of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for pkg in added_pkgs {
-                                pixi_progress::println!(
-                                    "   - {}={}",
-                                    console::style(pkg.name.as_normalized()).green(),
-                                    console::style(&pkg.version).blue(),
-                                );
-                            }
-                        }
-                    }
-                    StateChange::AddedEnvironment => {
-                        pixi_progress::println!(
-                            "{}Added environment {}.",
-                            console::style(console::Emoji("✔ ", "")).green(),
-                            env_name.fancy_display()
-                        );
-                    }
-                    StateChange::RemovedEnvironment => {
-                        pixi_progress::println!(
-                            "{}Removed environment {}.",
-                            console::style(console::Emoji("✔ ", "")).green(),
-                            env_name.fancy_display()
-                        );
-                    }
-                    StateChange::UpdatedEnvironment(update_change) => {
-                        StateChanges::report_update_changes(&env_name, update_change);
-                    }
-                    StateChange::InstalledShortcut(name) => {
-                        let mut installed_items = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::InstalledShortcut(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(name.clone()),
-                        );
+/// The item describing a single package change.
+fn install_change_item(name: &str, change: &InstallChange) -> Item {
+    let (marker, detail) = match change {
+        InstallChange::Installed(version) => (Marker::Added, Some(version.to_string())),
+        // A package can be rebuilt without its version moving, and `1.0 -> 1.0`
+        // says less than the version on its own.
+        InstallChange::Upgraded(old, new)
+        | InstallChange::TransitiveUpgraded(old, new)
+        | InstallChange::Reinstalled(old, new)
+            if old == new =>
+        {
+            (Marker::Changed, Some(new.to_string()))
+        }
+        InstallChange::Upgraded(old, new)
+        | InstallChange::TransitiveUpgraded(old, new)
+        | InstallChange::Reinstalled(old, new) => {
+            (Marker::Changed, Some(format!("{old} -> {new}")))
+        }
+        InstallChange::Removed => (Marker::Removed, None),
+    };
+    Item::package(marker, name, detail)
+}
 
-                        installed_items.sort();
+/// Whether the environment holds a single dependency named after the
+/// environment itself, the case where its version goes into the header instead
+/// of a `dependencies` row.
+pub(crate) fn is_single_package_environment(
+    project: &super::Project,
+    env_name: &EnvironmentName,
+) -> bool {
+    project.environment(env_name).is_some_and(|environment| {
+        environment.dependencies.specs.len() == 1
+            && environment
+                .dependencies
+                .specs
+                .keys()
+                .next()
+                .is_some_and(|name| name.as_normalized() == env_name.as_str())
+    })
+}
 
-                        if installed_items.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Installed shortcut {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                installed_items[0],
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Installed shortcuts of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for installed_item in installed_items {
-                                pixi_progress::println!("   - {}", installed_item);
-                            }
-                        }
-                    }
-                    StateChange::UninstalledShortcut(name) => {
-                        let mut uninstalled_items = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::UninstalledShortcut(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(name.clone()),
-                        );
+/// The installed version of the package an environment is named after.
+///
+/// Records are named `<package>-<version>-<build>.json`, so only the files that
+/// could belong to this package are parsed rather than the whole prefix.
+pub(crate) async fn installed_version(
+    project: &super::Project,
+    env_name: &EnvironmentName,
+) -> miette::Result<Option<String>> {
+    let conda_meta = project
+        .env_root_path()
+        .join(env_name.as_str())
+        .join(consts::CONDA_META_DIR);
 
-                        uninstalled_items.sort();
+    let mut read_dir = match tokio_fs::read_dir(&conda_meta).await {
+        Ok(read_dir) => read_dir,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => miette::bail!(
+            "Failed to read conda-meta directory {}: {}",
+            conda_meta.display(),
+            err
+        ),
+    };
 
-                        if uninstalled_items.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Uninstalled shortcut {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                uninstalled_items[0],
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Uninstalled shortcuts of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for uninstalled_item in uninstalled_items {
-                                pixi_progress::println!("   - {}", uninstalled_item);
-                            }
-                        }
-                    }
-                    StateChange::AddedCompletion(name) => {
-                        let mut installed_items = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::AddedCompletion(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(name.clone()),
-                        );
+    // Records written by conda or mamba keep the original case of the package
+    // name in the file name, so the candidate test is case insensitive; the
+    // parsed record still has to match by normalized name.
+    let prefix = format!("{}-", env_name.as_str().to_lowercase());
+    while let Some(entry) = read_dir.next_entry().await.into_diagnostic()? {
+        let path = entry.path();
+        if path.extension().and_then(OsStr::to_str) != Some("json") {
+            continue;
+        }
+        let is_candidate = path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .is_some_and(|name| name.to_lowercase().starts_with(&prefix));
+        if !is_candidate {
+            continue;
+        }
 
-                        installed_items.sort();
+        let record = PrefixRecord::from_path(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("Couldn't parse json from {}", path.display()))?;
+        if record.repodata_record.package_record.name.as_normalized() == env_name.as_str() {
+            return Ok(Some(
+                record
+                    .repodata_record
+                    .package_record
+                    .version
+                    .version()
+                    .to_string(),
+            ));
+        }
+    }
 
-                        if installed_items.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Exposed completion {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                installed_items[0],
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Exposed completions of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for installed_item in installed_items {
-                                pixi_progress::println!("   - {}", installed_item);
-                            }
-                        }
-                    }
-                    StateChange::RemovedCompletion(name) => {
-                        let mut uninstalled_items = StateChanges::accumulate_changes(
-                            &mut iter,
-                            |next| match next {
-                                Some(StateChange::RemovedCompletion(name)) => Some(name.clone()),
-                                _ => None,
-                            },
-                            Some(name.clone()),
-                        );
+    Ok(None)
+}
 
-                        uninstalled_items.sort();
+fn push_row(rows: &mut Vec<Row>, label: Label, items: BTreeMap<String, Item>) {
+    if !items.is_empty() {
+        rows.push(Row::new(label, items.into_values().collect()));
+    }
+}
 
-                        if uninstalled_items.len() == 1 {
-                            pixi_progress::println!(
-                                "{}Removed completion {} of environment {}.",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                uninstalled_items[0],
-                                env_name.fancy_display()
-                            );
-                        } else {
-                            pixi_progress::println!(
-                                "{}Removed completions of environment {}:",
-                                console::style(console::Emoji("✔ ", "")).green(),
-                                env_name.fancy_display()
-                            );
-                            for uninstalled_item in uninstalled_items {
-                                pixi_progress::println!("   - {}", uninstalled_item);
-                            }
-                        }
+/// Build the report of a single environment out of the changes recorded for it.
+async fn build_report(
+    project: &super::Project,
+    env_name: &EnvironmentName,
+    changes: &[StateChange],
+) -> miette::Result<EnvReport> {
+    // Keyed by name so that an item is reported once with its net effect: a
+    // `--force-reinstall` unexposes and re-exposes the same executable, and all
+    // that matters is that it ended up exposed. Changes are walked in the order
+    // they were recorded, so the last one wins.
+    let mut dependencies: BTreeMap<String, Item> = BTreeMap::new();
+    let mut transitive: BTreeMap<String, Item> = BTreeMap::new();
+    let mut transitive_counts = TransitiveCounts::default();
+    let mut exposed: BTreeMap<String, Item> = BTreeMap::new();
+    let mut shortcuts: BTreeMap<String, Item> = BTreeMap::new();
+    let mut completions: BTreeMap<String, Item> = BTreeMap::new();
+    // The last environment-level change wins: `--force-reinstall` removes the
+    // environment and creates it again, and that reads as an install.
+    let mut environment_change = None;
+
+    for change in changes {
+        match change {
+            StateChange::AddedExposed(name, executable) => {
+                exposed.insert(
+                    name.to_string(),
+                    Item::exposed(
+                        Marker::Added,
+                        name.to_string(),
+                        exposed_target(name, executable.as_deref()),
+                    ),
+                );
+            }
+            StateChange::RemovedExposed(name) => {
+                exposed.insert(
+                    name.to_string(),
+                    Item::exposed(Marker::Removed, name.to_string(), None),
+                );
+            }
+            // Not reported: a rewritten trampoline doesn't change what the
+            // `exposed` row says, and it happens as a side effect of almost any
+            // change to the environment.
+            StateChange::UpdatedExposed(_, _) => {}
+            StateChange::AddedEnvironment => environment_change = Some(EnvStatus::Installed),
+            StateChange::RemovedEnvironment => environment_change = Some(EnvStatus::Removed),
+            StateChange::UpdatedEnvironment(update) => {
+                for (package_name, install_change) in
+                    update.changes().iter().sorted_by(|(left, _), (right, _)| {
+                        left.as_normalized().cmp(right.as_normalized())
+                    })
+                {
+                    let name = package_name.as_normalized().to_string();
+                    let item = install_change_item(&name, install_change);
+                    // A package the manifest names is a dependency; everything
+                    // else came along with it.
+                    if update.current_packages().contains(package_name) {
+                        dependencies.insert(name, item);
+                    } else {
+                        transitive_counts.add(install_change);
+                        transitive.insert(name, item);
                     }
                 }
             }
-        }
-    }
-
-    pub(crate) fn report_update_changes(
-        env_name: &EnvironmentName,
-        environment_update: &EnvironmentUpdate,
-    ) {
-        // Check if there are any changes
-        if environment_update.is_empty() {
-            pixi_progress::println!(
-                "{}Environment {} was already up-to-date.",
-                console::style(console::Emoji("✔ ", "")).green(),
-                env_name.fancy_display(),
-            );
-            return;
-        }
-
-        // Separate top-level and transitive changes
-        let mut top_level_changes: Vec<(&PackageName, &InstallChange)> = Vec::new();
-        let mut transitive_changes = Vec::new();
-
-        let env_dependencies = environment_update.current_packages();
-
-        for (package_name, change) in environment_update.changes() {
-            if env_dependencies.contains(package_name) && !change.is_transitive() {
-                top_level_changes.push((package_name, change));
-            } else if change.is_transitive() {
-                transitive_changes.push((package_name, change));
+            StateChange::InstalledShortcut(name) => {
+                shortcuts.insert(name.clone(), Item::plain(Marker::Added, name.clone()));
             }
-        }
-
-        #[allow(clippy::unnecessary_sort_by)]
-        {
-            top_level_changes.sort_by(|(name1, _), (name2, _)| name1.cmp(name2));
-        }
-
-        let was_removed = top_level_changes
-            .iter()
-            .find_map(|(_, change)| change.is_removed().then_some(|| true))
-            .is_some();
-
-        let message = if was_removed { "Removed" } else { "Updated" };
-        let check_mark = console::style(console::Emoji("✔ ", "")).green();
-        let env_fancy = env_name.fancy_display();
-
-        // Output messages based on the type of changes
-        if top_level_changes.is_empty() && !transitive_changes.is_empty() {
-            pixi_progress::println!("{check_mark}Updated environment {env_fancy}.",);
-        } else if top_level_changes.is_empty() && transitive_changes.is_empty() {
-            pixi_progress::println!("{check_mark}Environment {env_fancy} was already up-to-date.");
-        } else if top_level_changes.len() == 1 {
-            let changes = console::style(top_level_changes[0].0.as_normalized()).green();
-            let version_string = top_level_changes[0]
-                .1
-                .version_fancy_display()
-                .map(|version| format!("={version}"))
-                .unwrap_or_default();
-
-            pixi_progress::println!(
-                "{check_mark}{message} package {changes}{version_string} in environment {env_fancy}."
-            );
-        } else if top_level_changes.len() > 1 {
-            pixi_progress::println!(
-                "{}{} packages in environment {}.",
-                console::style(console::Emoji("✔ ", "")).green(),
-                message,
-                env_name.fancy_display()
-            );
-            for (package, install_change) in top_level_changes {
-                let package_fancy = console::style(package.as_normalized()).green();
-                let change_fancy = install_change
-                    .version_fancy_display()
-                    .map(|version| format!(" {version}"))
-                    .unwrap_or_default();
-                pixi_progress::println!("    - {package_fancy}{change_fancy}");
+            StateChange::UninstalledShortcut(name) => {
+                shortcuts.insert(name.clone(), Item::plain(Marker::Removed, name.clone()));
+            }
+            StateChange::AddedCompletion(name) => {
+                completions.insert(name.clone(), Item::plain(Marker::Added, name.clone()));
+            }
+            StateChange::RemovedCompletion(name) => {
+                completions.insert(name.clone(), Item::plain(Marker::Removed, name.clone()));
             }
         }
     }
+
+    // An environment that holds a single dependency named after itself says
+    // everything about it in the header, so a row would repeat the name
+    // standing right above it.
+    let single_package = is_single_package_environment(project, env_name);
+    let own_dependency = single_package
+        .then(|| dependencies.remove(env_name.as_str()))
+        .flatten();
+
+    let mut rows = Vec::new();
+    push_row(&mut rows, Label::Dependencies, dependencies);
+    if !transitive.is_empty() {
+        let items = if report::verbosity() == report::Verbosity::Detailed {
+            transitive.into_values().collect()
+        } else {
+            vec![Item::summary(transitive_counts.to_string())]
+        };
+        rows.push(Row::new(Label::Transitive, items));
+    }
+    push_row(&mut rows, Label::Exposed, exposed);
+    push_row(&mut rows, Label::Shortcuts, shortcuts);
+    push_row(&mut rows, Label::Completions, completions);
+
+    let status = match environment_change {
+        Some(status) => status,
+        // The dependency that was lifted into the header still counts as a
+        // change, even though it left no row behind.
+        None if rows.is_empty() && own_dependency.is_none() => EnvStatus::Unchanged,
+        None => EnvStatus::Updated,
+    };
+
+    let version = if status == EnvStatus::Removed || !single_package {
+        None
+    } else if let Some(dependency) = &own_dependency {
+        // The change rather than the resulting version alone, so an upgrade
+        // reads `0.26.1 -> 0.27.0` in the header.
+        dependency.detail.clone()
+    } else {
+        installed_version(project, env_name).await?
+    };
+
+    Ok(EnvReport::new(env_name.as_str(), version, Some(status)).with_rows(rows))
 }
 
 impl std::ops::BitOrAssign for StateChanges {

--- a/crates/pixi_global/src/install.rs
+++ b/crates/pixi_global/src/install.rs
@@ -134,7 +134,7 @@ pub(crate) async fn create_executable_trampolines(
 
         let mut env_for_trampoline = activation_variables.clone();
         if pixi_config_dir
-            .join(executable_name)
+            .join(&executable_name)
             .join(IGNORE_CONDA_PREFIX_MARKER)
             .is_file()
         {
@@ -188,10 +188,16 @@ pub(crate) async fn create_executable_trampolines(
         match changed {
             AddedOrChanged::Unchanged => {}
             AddedOrChanged::Added => {
-                state_changes.insert_change(env_name, StateChange::AddedExposed(exposed_name));
+                state_changes.insert_change(
+                    env_name,
+                    StateChange::AddedExposed(exposed_name, Some(executable_name.clone())),
+                );
             }
             AddedOrChanged::Changed | AddedOrChanged::Migrated => {
-                state_changes.insert_change(env_name, StateChange::UpdatedExposed(exposed_name));
+                state_changes.insert_change(
+                    env_name,
+                    StateChange::UpdatedExposed(exposed_name, Some(executable_name)),
+                );
             }
         }
     }

--- a/crates/pixi_global/src/lib.rs
+++ b/crates/pixi_global/src/lib.rs
@@ -4,9 +4,10 @@ pub mod completions;
 pub mod install;
 pub mod list;
 pub mod project;
+pub mod report;
 pub mod trampoline;
 
-pub use common::{BinDir, EnvChanges, EnvDir, EnvRoot, EnvState, StateChange, StateChanges};
+pub use common::{BinDir, EnvDir, EnvRoot, StateChange, StateChanges};
 use pixi_utils::executable_from_path;
 pub use project::{EnvironmentName, ExposedName, Mapping, Project};
 

--- a/crates/pixi_global/src/list.rs
+++ b/crates/pixi_global/src/list.rs
@@ -1,17 +1,22 @@
 use std::io::Write;
 
 use fancy_display::FancyDisplay;
+use human_bytes::human_bytes;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use miette::{IntoDiagnostic, miette};
 use pixi_consts::consts;
 use pixi_core::environment::list::{PackageToOutput, print_package_table};
 use pixi_spec::PixiSpec;
-use rattler_conda_types::{PackageName, PrefixRecord, Version};
+use rattler_conda_types::{PackageName, PrefixRecord};
 use serde::Serialize;
 
-use super::{EnvChanges, EnvState, EnvironmentName, Mapping, Project, project::ParsedEnvironment};
-use crate::common::find_package_records;
+use super::{
+    EnvironmentName, Mapping, Project,
+    project::ParsedEnvironment,
+    report::{self, EnvReport, Item, Label, Marker, Row},
+};
+use crate::common::{self, find_package_records};
 
 /// JSON-serializable representation of an exposed mapping.
 #[derive(Serialize)]
@@ -124,98 +129,116 @@ pub async fn list_global_environments_json(
     Ok(())
 }
 
-/// Creating the ASCII art representation of a section.
-pub fn format_asciiart_section(label: &str, content: String, last: bool, more: bool) -> String {
-    let prefix = if last { " " } else { "│" };
-    let symbol = if more { "├" } else { "└" };
-    format!("\n{prefix}   {symbol}─ {label}: {content}")
+/// Write a line to stdout, treating a closed pipe as a normal end of output.
+fn write_stdout(line: &str) -> miette::Result<()> {
+    writeln!(std::io::stdout(), "{line}")
+        .inspect_err(|e| {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                std::process::exit(0);
+            }
+        })
+        .into_diagnostic()
 }
 
-pub fn format_exposed(exposed: &IndexSet<Mapping>, last: bool, more: bool) -> Option<String> {
+fn format_mapping(mapping: &Mapping) -> Item {
+    let exposed = mapping.exposed_name().to_string();
+    let detail = (exposed != mapping.executable_relname())
+        .then(|| format!("-> {}", mapping.executable_relname()));
+    Item::exposed(Marker::None, exposed, detail)
+}
+
+/// The row listing what an environment exposes, or that it exposes nothing.
+fn exposed_row(exposed: &IndexSet<Mapping>) -> Row {
     if exposed.is_empty() {
-        Some(format_asciiart_section(
-            "exposes",
-            console::style("Nothing").dim().red().to_string(),
-            last,
-            more,
-        ))
+        Row::new(Label::Exposed, vec![Item::summary("nothing")])
     } else {
-        let formatted_exposed = exposed.iter().map(format_mapping).join(", ");
-        Some(format_asciiart_section(
-            "exposes",
-            formatted_exposed,
-            last,
-            more,
-        ))
+        Row::new(Label::Exposed, exposed.iter().map(format_mapping).collect())
     }
 }
 
-fn format_mapping(mapping: &Mapping) -> String {
-    let exp = mapping.exposed_name().to_string();
-    if exp == mapping.executable_relname() {
-        console::style(exp).yellow().to_string()
-    } else {
-        format!(
-            "{} -> {}",
-            console::style(exp).yellow(),
-            console::style(mapping.executable_relname()).yellow()
+/// The row naming the dependencies of an environment with their installed
+/// versions. An environment holding a single dependency named after itself
+/// carries it in the header instead.
+fn dependencies_row(
+    env_name: &EnvironmentName,
+    dependencies: &IndexMap<PackageName, PixiSpec>,
+    records: &[PrefixRecord],
+) -> Option<Row> {
+    if !dependencies
+        .keys()
+        .any(|name| name.as_normalized() != env_name.as_str())
+    {
+        return None;
+    }
+
+    let items = dependencies
+        .keys()
+        .sorted_by_key(|name| name.as_normalized())
+        .map(|name| {
+            let version = records
+                .iter()
+                .find(|record| {
+                    record.repodata_record.package_record.name.as_normalized()
+                        == name.as_normalized()
+                })
+                .map(|record| {
+                    record
+                        .repodata_record
+                        .package_record
+                        .version
+                        .version()
+                        .to_string()
+                });
+            Item::package(Marker::None, name.as_normalized(), version)
+        })
+        .collect();
+
+    Some(Row::new(Label::Dependencies, items))
+}
+
+fn shortcuts_row(shortcuts: &IndexSet<PackageName>) -> Option<Row> {
+    (!shortcuts.is_empty()).then(|| {
+        Row::new(
+            Label::Shortcuts,
+            shortcuts
+                .iter()
+                .map(|name| Item::plain(Marker::None, name.as_normalized()))
+                .collect(),
         )
-    }
-}
-
-fn print_meta_info(environment: &ParsedEnvironment) -> miette::Result<()> {
-    // Print exposed binaries, if binary similar to path only print once.
-    let formatted_exposed = environment.exposed.iter().map(format_mapping).join(", ");
-    writeln!(
-        std::io::stdout(),
-        "{}\n{}",
-        console::style("Exposes:").bold().cyan(),
-        if !formatted_exposed.is_empty() {
-            formatted_exposed
-        } else {
-            "Nothing".to_string()
-        }
-    )
-    .inspect_err(|e| {
-        if e.kind() == std::io::ErrorKind::BrokenPipe {
-            std::process::exit(0);
-        }
     })
-    .into_diagnostic()?;
+}
 
-    // Print channels
-    if !environment.channels().is_empty() {
-        writeln!(
-            std::io::stdout(),
-            "{}\n{}",
-            console::style("Channels:").bold().cyan(),
-            environment.channels().iter().join(", ")
-        )
-        .inspect_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-        })
-        .into_diagnostic()?;
-    }
+/// The report describing the current state of one environment.
+async fn state_report(
+    project: &Project,
+    env_name: &EnvironmentName,
+    environment: &ParsedEnvironment,
+) -> miette::Result<EnvReport> {
+    let conda_meta = project
+        .env_root
+        .path()
+        .join(env_name.as_str())
+        .join(consts::CONDA_META_DIR);
+    let records = find_package_records(&conda_meta).await?;
 
-    // Print platform
-    if let Some(platform) = environment.platform {
-        writeln!(
-            std::io::stdout(),
-            "{} {}",
-            console::style("Platform:").bold().cyan(),
-            platform
-        )
-        .inspect_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-        })
-        .into_diagnostic()?;
-    }
+    let version = if common::is_single_package_environment(project, env_name) {
+        common::installed_version(project, env_name).await?
+    } else {
+        None
+    };
 
-    Ok(())
+    let mut rows = Vec::new();
+    rows.extend(dependencies_row(
+        env_name,
+        &environment.dependencies.specs,
+        &records,
+    ));
+    rows.push(exposed_row(&environment.exposed));
+    rows.extend(shortcuts_row(
+        environment.shortcuts.as_ref().unwrap_or(&IndexSet::new()),
+    ));
+
+    Ok(EnvReport::new(env_name.as_str(), version, None).with_rows(rows))
 }
 
 /// List package and binaries in global environment
@@ -239,6 +262,75 @@ pub async fn list_specific_global_environment(
     )
     .await?;
 
+    let mut report = state_report(project, environment_name, env).await?;
+
+    // Everything the environment pulled in besides the packages its manifest
+    // names, counted rather than listed: the table below has the detail, and
+    // the `size` row the total.
+    let transitive = records
+        .iter()
+        .filter(|record| {
+            !env.dependencies
+                .specs
+                .contains_key(&record.repodata_record.package_record.name)
+        })
+        .count();
+    if transitive > 0 {
+        // Right after the dependencies, so the rows stay in the same order as
+        // in a change report.
+        let position = report
+            .rows
+            .iter()
+            .position(|row| row.label == Label::Dependencies)
+            .map_or(0, |index| index + 1);
+        report.rows.insert(
+            position,
+            Row::new(
+                Label::Transitive,
+                vec![Item::summary(format!(
+                    "{transitive} package{}",
+                    if transitive == 1 { "" } else { "s" }
+                ))],
+            ),
+        );
+    }
+
+    if !env.channels().is_empty() {
+        report.rows.push(Row::new(
+            Label::Channels,
+            env.channels()
+                .iter()
+                .map(|channel| Item::plain(Marker::None, channel.to_string()))
+                .collect(),
+        ));
+    }
+
+    if let Some(platform) = env.platform {
+        report.rows.push(Row::new(
+            Label::Platform,
+            vec![Item::plain(Marker::None, platform.to_string())],
+        ));
+    }
+
+    // Last, so it sits against the table it adds up: every package of the
+    // environment, the ones its manifest names included.
+    let size: u64 = records
+        .iter()
+        .filter_map(|record| record.repodata_record.package_record.size)
+        .sum();
+    if size > 0 {
+        report.rows.push(Row::new(
+            Label::Size,
+            vec![Item::summary(human_bytes(size as f64))],
+        ));
+    }
+
+    write_stdout(&report::render(
+        &report,
+        &report::RenderOptions::for_stdout(),
+    ))?;
+    write_stdout("")?;
+
     let mut packages_to_output = records
         .iter()
         .map(|record| {
@@ -257,36 +349,14 @@ pub async fn list_specific_global_environment(
         packages_to_output.retain(|package| regex.is_match(package.name.as_normalized()));
     }
 
-    let output_message = if let Some(ref regex) = regex {
-        format!(
-            "The {} environment has {} packages filtered by regex `{}`:",
-            environment_name.fancy_display(),
-            console::style(packages_to_output.len()).bold(),
-            regex
-        )
-    } else {
-        format!(
-            "The {} environment has {} packages:",
-            environment_name.fancy_display(),
-            console::style(packages_to_output.len()).bold()
-        )
-    };
-
     // Sort according to the sorting strategy
     if sort_by_size {
         packages_to_output.sort_by_key(|a| a.size_bytes.unwrap_or(0));
     } else {
         packages_to_output.sort_by(|a, b| a.name.cmp(&b.name));
     }
-    writeln!(std::io::stdout(), "{output_message}")
-        .inspect_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-        })
-        .into_diagnostic()?;
+
     print_package_table(packages_to_output).into_diagnostic()?;
-    print_meta_info(env)?;
 
     Ok(())
 }
@@ -294,10 +364,7 @@ pub async fn list_specific_global_environment(
 /// List all environments in the global environment
 pub async fn list_all_global_environments(
     project: &Project,
-    envs: Option<Vec<EnvironmentName>>,
-    envs_changes: Option<&EnvChanges>,
     regex: Option<String>,
-    show_header: bool,
 ) -> miette::Result<()> {
     let mut project_envs = project.environments().clone();
     project_envs.sort_by(|a, _, b, _| a.to_string().cmp(&b.to_string()));
@@ -319,170 +386,17 @@ pub async fn list_all_global_environments(
         project_envs.retain(|env_name, _| regex.is_match(env_name.as_str()));
     }
 
-    if let Some(envs) = envs {
-        project_envs.retain(|env_name, _| envs.contains(env_name));
+    if project_envs.is_empty() {
+        return write_stdout("No global environments found.");
     }
 
-    let mut message = String::new();
-
-    let len = project_envs.len();
-    for (idx, (env_name, env)) in project_envs.iter().enumerate() {
-        let env_dir = project.env_root.path().join(env_name.as_str());
-        let conda_meta = env_dir.join(consts::CONDA_META_DIR);
-        let records = find_package_records(&conda_meta).await?;
-
-        let last = (idx + 1) == len;
-
-        if last {
-            message.push_str("└──");
-        } else {
-            message.push_str("├──");
-        }
-
-        // get the state of the environment if available
-        // and also it's state if present
-        let state = envs_changes
-            .and_then(|env_changes| env_changes.changes.get(env_name))
-            .map(|state| match state {
-                EnvState::Installed => {
-                    format!("({})", console::style("installed".to_string()).green())
-                }
-                EnvState::NotChanged(reason) => {
-                    format!("({})", reason.fancy_display())
-                }
-            })
-            .unwrap_or_default();
-
-        if !env
-            .dependencies
-            .specs
-            .iter()
-            .any(|(pkg_name, _spec)| pkg_name.as_normalized() != env_name.as_str())
-        {
-            if let Some(env_package) = records.iter().find(|rec| {
-                rec.repodata_record.package_record.name.as_normalized() == env_name.as_str()
-            }) {
-                // output the environment name and version
-                message.push_str(&format!(
-                    " {}: {} {}",
-                    env_name.fancy_display(),
-                    console::style(env_package.repodata_record.package_record.version.clone())
-                        .blue(),
-                    state
-                ));
-            } else {
-                message.push_str(&format!(" {} {}", env_name.fancy_display(), state));
-            }
-        } else {
-            message.push_str(&format!(" {} {}", env_name.fancy_display(), state));
-        }
-
-        // Write dependencies
-        if let Some(dep_message) = format_dependencies(
-            env_name.as_str(),
-            &env.dependencies.specs,
-            &records,
-            last,
-            !env.exposed.is_empty(),
-        ) {
-            message.push_str(&dep_message);
-        }
-
-        // Check for shortcuts
-        let shortcuts = env.shortcuts.clone().unwrap_or_else(IndexSet::new);
-
-        // Write exposed binaries
-        if let Some(exp_message) = format_exposed(&env.exposed, last, !shortcuts.is_empty()) {
-            message.push_str(&exp_message);
-        }
-
-        // Write shortcuts
-        if !shortcuts.is_empty() {
-            message.push_str(&format_asciiart_section(
-                "shortcuts",
-                shortcuts.iter().map(PackageName::as_normalized).join(", "),
-                last,
-                false,
-            ));
-        }
-
-        if !last {
-            message.push('\n');
-        }
-    }
-    if message.is_empty() {
-        writeln!(std::io::stdout(), "No global environments found.")
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
-            .into_diagnostic()?;
-    } else {
-        let header = format!(
-            "Global environments as specified in '{}'",
-            project.manifest.path.display()
-        );
-        if show_header {
-            writeln!(std::io::stdout(), "{header}")
-                .inspect_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                })
-                .into_diagnostic()?;
-        }
-        writeln!(std::io::stdout(), "{message}")
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
-            .into_diagnostic()?;
+    let mut reports = Vec::with_capacity(project_envs.len());
+    for (env_name, environment) in project_envs.iter() {
+        reports.push(state_report(project, env_name, environment).await?);
     }
 
-    Ok(())
-}
-
-/// Display a dependency in a human-readable format.
-fn display_dependency(name: &PackageName, version: Option<Version>) -> String {
-    if let Some(version) = version {
-        format!(
-            "{} {}",
-            console::style(name.as_normalized()).green(),
-            console::style(version).blue()
-        )
-    } else {
-        console::style(name.as_normalized()).green().to_string()
-    }
-}
-
-fn format_dependencies(
-    env_name: &str,
-    dependencies: &IndexMap<PackageName, PixiSpec>,
-    records: &[PrefixRecord],
-    last: bool,
-    more: bool,
-) -> Option<String> {
-    if dependencies
-        .iter()
-        .any(|(pkg_name, _spec)| pkg_name.as_normalized() != env_name)
-    {
-        let content = dependencies
-            .iter()
-            .map(|(name, _spec)| {
-                let version = records
-                    .iter()
-                    .find(|rec| {
-                        rec.repodata_record.package_record.name.as_normalized()
-                            == name.as_normalized()
-                    })
-                    .map(|rec| rec.repodata_record.package_record.version.version().clone());
-                display_dependency(name, version)
-            })
-            .join(", ");
-        Some(format_asciiart_section("dependencies", content, last, more))
-    } else {
-        None
-    }
+    write_stdout(&report::render_all(
+        &reports,
+        &report::RenderOptions::for_stdout(),
+    ))
 }

--- a/crates/pixi_global/src/list.rs
+++ b/crates/pixi_global/src/list.rs
@@ -264,37 +264,6 @@ pub async fn list_specific_global_environment(
 
     let mut report = state_report(project, environment_name, env).await?;
 
-    // Everything the environment pulled in besides the packages its manifest
-    // names, counted rather than listed: the table below has the detail, and
-    // the `size` row the total.
-    let transitive = records
-        .iter()
-        .filter(|record| {
-            !env.dependencies
-                .specs
-                .contains_key(&record.repodata_record.package_record.name)
-        })
-        .count();
-    if transitive > 0 {
-        // Right after the dependencies, so the rows stay in the same order as
-        // in a change report.
-        let position = report
-            .rows
-            .iter()
-            .position(|row| row.label == Label::Dependencies)
-            .map_or(0, |index| index + 1);
-        report.rows.insert(
-            position,
-            Row::new(
-                Label::Transitive,
-                vec![Item::summary(format!(
-                    "{transitive} package{}",
-                    if transitive == 1 { "" } else { "s" }
-                ))],
-            ),
-        );
-    }
-
     if !env.channels().is_empty() {
         report.rows.push(Row::new(
             Label::Channels,

--- a/crates/pixi_global/src/project/mod.rs
+++ b/crates/pixi_global/src/project/mod.rs
@@ -1359,6 +1359,18 @@ impl Project {
                 env_name.fancy_display()
             );
         } else {
+            // Creating an environment reads as an install rather than an
+            // update, whether it was `install` or a `sync` acting on a manifest
+            // entry whose prefix is missing.
+            if !self
+                .env_root
+                .path()
+                .join(env_name.as_str())
+                .join(consts::CONDA_META_DIR)
+                .exists()
+            {
+                state_changes.insert_change(env_name, StateChange::AddedEnvironment);
+            }
             tracing::debug!(
                 "Environment {} specs not up to date with global manifest",
                 env_name.fancy_display()

--- a/crates/pixi_global/src/report.rs
+++ b/crates/pixi_global/src/report.rs
@@ -9,15 +9,14 @@
 //!
 //! ```text
 //! (installed) ripgrep 15.2.0
-//! ├── transitive    3 added
 //! ├── exposed       + rg
 //! └── completions   + rg
 //! ```
 //!
 //! Rows are children of their own header, so a block is self-contained and can
 //! be printed as soon as its environment is done. The labels are the keys of
-//! `pixi-global.toml`, except for `transitive`, `completions` and `size`, which
-//! describe the result rather than the manifest.
+//! `pixi-global.toml`, except for `completions` and `size`, which describe the
+//! result rather than the manifest.
 
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
@@ -48,10 +47,8 @@ const ITEMS_PER_LINE: usize = 4;
 pub enum Verbosity {
     /// Print nothing but failures.
     Quiet,
-    /// Print the report, with transitive changes aggregated into a count.
+    /// Print the whole report.
     Normal,
-    /// Print the report, with every transitive change listed individually.
-    Detailed,
 }
 
 static VERBOSITY: AtomicU8 = AtomicU8::new(Verbosity::Normal as u8);
@@ -69,7 +66,6 @@ pub fn set_verbosity(verbosity: Verbosity) {
 pub fn verbosity() -> Verbosity {
     match VERBOSITY.load(Ordering::Relaxed) {
         value if value == Verbosity::Quiet as u8 => Verbosity::Quiet,
-        value if value == Verbosity::Detailed as u8 => Verbosity::Detailed,
         _ => Verbosity::Normal,
     }
 }
@@ -151,7 +147,6 @@ impl Marker {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Label {
     Dependencies,
-    Transitive,
     Exposed,
     Shortcuts,
     Completions,
@@ -164,7 +159,6 @@ impl Label {
     pub fn as_str(self) -> &'static str {
         match self {
             Label::Dependencies => "dependencies",
-            Label::Transitive => "transitive",
             Label::Exposed => "exposed",
             Label::Shortcuts => "shortcuts",
             Label::Completions => "completions",
@@ -689,20 +683,16 @@ mod tests {
             Some("15.2.0".to_string()),
             Some(EnvStatus::Installed),
         )
-        .with_rows(vec![
-            Row::new(Label::Transitive, vec![Item::summary("3 added")]),
-            Row::new(
-                Label::Exposed,
-                vec![Item::exposed(Marker::Added, "rg", None)],
-            ),
-        ])
+        .with_rows(vec![Row::new(
+            Label::Exposed,
+            vec![Item::exposed(Marker::Added, "rg", None)],
+        )])
     }
 
     #[test]
     fn renders_install() {
         insta::assert_snapshot!(render(&installed(), &options()), @r"
         (installed) ripgrep 15.2.0
-        ├── transitive    3 added
         └── exposed       + rg
         ");
     }
@@ -715,20 +705,22 @@ mod tests {
             "ripgrep",
             Some("15.2.0 -> 15.3.0".to_string()),
             Some(EnvStatus::Updated),
-        )
-        .with_rows(vec![Row::new(
-            Label::Transitive,
-            vec![Item::summary("2 changed")],
-        )]);
+        );
 
-        insta::assert_snapshot!(render(&report, &options()), @r"
-        (updated)   ripgrep 15.2.0 -> 15.3.0
-        └── transitive    2 changed
-        ");
+        insta::assert_snapshot!(render(&report, &options()), @"(updated)   ripgrep 15.2.0 -> 15.3.0");
+    }
+
+    /// An environment where only packages the manifest doesn't name moved still
+    /// says that it changed, even though nothing is listed below it.
+    #[test]
+    fn renders_an_update_without_rows() {
+        let report = EnvReport::new("dev", None, Some(EnvStatus::Updated));
+
+        insta::assert_snapshot!(render(&report, &options()), @"(updated)   dev");
     }
 
     #[test]
-    fn renders_update_with_transitive_summary() {
+    fn renders_update_with_dependency_changes() {
         let report = EnvReport::new("dev", None, Some(EnvStatus::Updated)).with_rows(vec![
             Row::new(
                 Label::Dependencies,
@@ -742,10 +734,6 @@ mod tests {
                 ],
             ),
             Row::new(
-                Label::Transitive,
-                vec![Item::summary("12 added, 3 changed, 1 removed")],
-            ),
-            Row::new(
                 Label::Exposed,
                 vec![Item::exposed(Marker::Removed, "bat", None)],
             ),
@@ -754,7 +742,6 @@ mod tests {
         insta::assert_snapshot!(render(&report, &options()), @r"
         (updated)   dev
         ├── dependencies  ~ ripgrep 15.2.0 -> 15.3.0, - bat 0.26.1
-        ├── transitive    12 added, 3 changed, 1 removed
         └── exposed       - bat
         ");
     }
@@ -1025,7 +1012,6 @@ mod tests {
 
         insta::assert_snapshot!(render_all(&[installed(), second], &options()), @r"
         (installed) ripgrep 15.2.0
-        ├── transitive    3 added
         └── exposed       + rg
 
         (installed) bat 0.27.0

--- a/crates/pixi_global/src/report.rs
+++ b/crates/pixi_global/src/report.rs
@@ -1,0 +1,1068 @@
+//! Rendering of the terminal output of `pixi global`.
+//!
+//! Every subcommand describes what it did as a list of [`EnvReport`]s, one per
+//! environment, and hands them to [`print()`]. Rendering is a pure function of
+//! the report and the [`RenderOptions`], so it can be tested without a
+//! terminal.
+//!
+//! A block looks like this:
+//!
+//! ```text
+//! (installed) ripgrep 15.2.0
+//! ├── transitive    3 added
+//! ├── exposed       + rg
+//! └── completions   + rg
+//! ```
+//!
+//! Rows are children of their own header, so a block is self-contained and can
+//! be printed as soon as its environment is done. The labels are the keys of
+//! `pixi-global.toml`, except for `transitive`, `completions` and `size`, which
+//! describe the result rather than the manifest.
+
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+use console::Style;
+use pixi_consts::consts;
+
+/// Width of the label column, sized to the longest label.
+const LABEL_WIDTH: usize = "dependencies".len();
+/// Indentation of the body of a failure, which is prose rather than rows.
+const INDENT: usize = 2;
+/// Width of the status column, sized to the longest status. Names are padded
+/// out past it so that headers line up down a run without knowing how wide the
+/// widest one will be.
+const STATUS_WIDTH: usize = "(installed)".len();
+/// Drawn in front of a row, and in front of the lines that continue it.
+const BRANCH: &str = "├── ";
+const LAST_BRANCH: &str = "└── ";
+const TRUNK: &str = "│   ";
+const NO_TRUNK: &str = "    ";
+/// Gap between the label column and the value column.
+const GAP: usize = 2;
+/// Item lists longer than this get one item per line instead of being joined
+/// into a wrapped line.
+const ITEMS_PER_LINE: usize = 4;
+
+/// How much of the report to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verbosity {
+    /// Print nothing but failures.
+    Quiet,
+    /// Print the report, with transitive changes aggregated into a count.
+    Normal,
+    /// Print the report, with every transitive change listed individually.
+    Detailed,
+}
+
+static VERBOSITY: AtomicU8 = AtomicU8::new(Verbosity::Normal as u8);
+
+/// Whether anything has been printed yet, so blocks after the first can be
+/// separated by a blank line without the callers having to keep track.
+static PRINTED: AtomicBool = AtomicBool::new(false);
+
+/// Set the verbosity of the reports of this process.
+pub fn set_verbosity(verbosity: Verbosity) {
+    VERBOSITY.store(verbosity as u8, Ordering::Relaxed);
+}
+
+/// The verbosity of the reports of this process.
+pub fn verbosity() -> Verbosity {
+    match VERBOSITY.load(Ordering::Relaxed) {
+        value if value == Verbosity::Quiet as u8 => Verbosity::Quiet,
+        value if value == Verbosity::Detailed as u8 => Verbosity::Detailed,
+        _ => Verbosity::Normal,
+    }
+}
+
+/// What happened to an environment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvStatus {
+    /// The environment didn't exist before.
+    Installed,
+    /// An existing environment changed in any way.
+    Updated,
+    /// The environment was removed.
+    Removed,
+    /// The environment was considered but nothing changed.
+    Unchanged,
+    /// The environment couldn't be processed.
+    Failed,
+}
+
+impl EnvStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EnvStatus::Installed => "installed",
+            EnvStatus::Updated => "updated",
+            EnvStatus::Removed => "removed",
+            EnvStatus::Unchanged => "unchanged",
+            EnvStatus::Failed => "failed",
+        }
+    }
+
+    /// The color of the status word, matching the [`Marker`] of the change it
+    /// describes: green adds, yellow changes, red takes away.
+    fn style(self) -> Style {
+        match self {
+            EnvStatus::Installed => Style::new().green(),
+            EnvStatus::Updated => Style::new().yellow(),
+            EnvStatus::Removed => Style::new().red(),
+            EnvStatus::Failed => Style::new().red().bold(),
+            EnvStatus::Unchanged => Style::new().dim(),
+        }
+    }
+}
+
+/// What happened to a single item of a row.
+///
+/// The markers are ASCII: they are the only signal left when colors are
+/// disabled, so they can't depend on the terminal rendering a glyph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Marker {
+    Added,
+    Removed,
+    Changed,
+    /// The item describes state rather than a change, as in `pixi global list`.
+    None,
+}
+
+impl Marker {
+    fn as_str(self) -> &'static str {
+        match self {
+            Marker::Added => "+",
+            Marker::Removed => "-",
+            Marker::Changed => "~",
+            Marker::None => "",
+        }
+    }
+
+    fn style(self) -> Style {
+        match self {
+            Marker::Added => Style::new().green(),
+            Marker::Removed => Style::new().red(),
+            Marker::Changed => Style::new().yellow(),
+            Marker::None => Style::new(),
+        }
+    }
+}
+
+/// The label of a row, matching the key of `pixi-global.toml` where there is
+/// one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Label {
+    Dependencies,
+    Transitive,
+    Exposed,
+    Shortcuts,
+    Completions,
+    Channels,
+    Platform,
+    Size,
+}
+
+impl Label {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Label::Dependencies => "dependencies",
+            Label::Transitive => "transitive",
+            Label::Exposed => "exposed",
+            Label::Shortcuts => "shortcuts",
+            Label::Completions => "completions",
+            Label::Channels => "channels",
+            Label::Platform => "platform",
+            Label::Size => "size",
+        }
+    }
+}
+
+/// What an item refers to, which decides how it is colored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ItemKind {
+    Package,
+    Exposed,
+    Plain,
+    /// An aggregate such as `12 added, 3 changed, 1 removed`.
+    Summary,
+}
+
+/// A single entry of a row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Item {
+    pub marker: Marker,
+    pub kind: ItemKind,
+    pub name: String,
+    /// Trails the name, dimmed: a version, a version transition or the target
+    /// of an exposed mapping.
+    pub detail: Option<String>,
+}
+
+impl Item {
+    pub fn package(marker: Marker, name: impl Into<String>, detail: Option<String>) -> Self {
+        Self {
+            marker,
+            kind: ItemKind::Package,
+            name: name.into(),
+            detail,
+        }
+    }
+
+    pub fn exposed(marker: Marker, name: impl Into<String>, detail: Option<String>) -> Self {
+        Self {
+            marker,
+            kind: ItemKind::Exposed,
+            name: name.into(),
+            detail,
+        }
+    }
+
+    pub fn plain(marker: Marker, name: impl Into<String>) -> Self {
+        Self {
+            marker,
+            kind: ItemKind::Plain,
+            name: name.into(),
+            detail: None,
+        }
+    }
+
+    pub fn summary(name: impl Into<String>) -> Self {
+        Self {
+            marker: Marker::None,
+            kind: ItemKind::Summary,
+            name: name.into(),
+            detail: None,
+        }
+    }
+}
+
+/// A labelled line of a block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Row {
+    pub label: Label,
+    pub items: Vec<Item>,
+}
+
+impl Row {
+    pub fn new(label: Label, items: Vec<Item>) -> Self {
+        Self { label, items }
+    }
+}
+
+/// Everything that is reported about one environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvReport {
+    pub name: String,
+    /// Only set for environments that hold a single dependency named after the
+    /// environment, where a `dependencies` row would just repeat the name.
+    pub version: Option<String>,
+    /// Absent in `pixi global list`, which describes state rather than change.
+    pub status: Option<EnvStatus>,
+    pub rows: Vec<Row>,
+    /// Why an environment failed, rendered by miette. Only set on the entries
+    /// of the closing section, never on the marker printed in place.
+    pub diagnostic: Option<String>,
+}
+
+impl EnvReport {
+    pub fn new(
+        name: impl Into<String>,
+        version: Option<String>,
+        status: Option<EnvStatus>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            version,
+            status,
+            rows: Vec::new(),
+            diagnostic: None,
+        }
+    }
+
+    pub fn with_rows(mut self, rows: Vec<Row>) -> Self {
+        self.rows = rows;
+        self
+    }
+
+    /// A report for an environment that couldn't be processed. The reason is
+    /// reported at the end of the run, not here.
+    pub fn failed(name: impl Into<String>) -> Self {
+        Self::new(name, None, Some(EnvStatus::Failed))
+    }
+
+    /// An entry of the closing section: the environment name and why it
+    /// failed. No status word, since the marker above already said `failed`.
+    pub fn reason(name: impl Into<String>, diagnostic: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: None,
+            status: None,
+            rows: Vec::new(),
+            diagnostic: Some(diagnostic.into()),
+        }
+    }
+
+    /// Whether this report is about a failed environment, either as the marker
+    /// printed in place or as its reason in the closing section.
+    fn is_failure(&self) -> bool {
+        self.status == Some(EnvStatus::Failed) || self.diagnostic.is_some()
+    }
+}
+
+/// How to turn a report into text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RenderOptions {
+    /// Where to wrap joined item lists. `None` doesn't wrap at all, which is
+    /// what piped output wants.
+    pub width: Option<usize>,
+    pub color: bool,
+}
+
+impl RenderOptions {
+    /// The options matching stderr, where the reports go.
+    pub fn from_terminal() -> Self {
+        let term = console::Term::stderr();
+        Self {
+            width: term.is_term().then(|| term.size().1 as usize),
+            color: console::colors_enabled_stderr(),
+        }
+    }
+
+    /// The options matching the terminal the queryable output goes to.
+    pub fn for_stdout() -> Self {
+        let term = console::Term::stdout();
+        Self {
+            width: term.is_term().then(|| term.size().1 as usize),
+            color: console::colors_enabled(),
+        }
+    }
+}
+
+fn styled(style: &Style, color: bool, text: &str) -> String {
+    style
+        .clone()
+        .force_styling(color)
+        .apply_to(text)
+        .to_string()
+}
+
+/// Render a single block, without a trailing newline.
+pub fn render(report: &EnvReport, options: &RenderOptions) -> String {
+    let mut lines = vec![render_header(report, options)];
+
+    let last = report.rows.len().saturating_sub(1);
+    for (index, row) in report.rows.iter().enumerate() {
+        lines.extend(render_row(row, index == last, options));
+    }
+
+    if let Some(diagnostic) = &report.diagnostic {
+        lines.extend(indent_diagnostic(diagnostic));
+    }
+
+    lines.join("\n")
+}
+
+/// Render several blocks, separated by a blank line.
+pub fn render_all(reports: &[EnvReport], options: &RenderOptions) -> String {
+    reports
+        .iter()
+        .map(|report| render(report, options))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Render the line counting the environments left out of the report because
+/// nothing changed. `secondary` dims it, which suits a line trailing the blocks
+/// it belongs to but not one that is the whole answer.
+pub fn render_unchanged_summary(count: usize, options: &RenderOptions, secondary: bool) -> String {
+    let text = if count == 1 {
+        "1 environment unchanged".to_string()
+    } else {
+        format!("{count} environments unchanged")
+    };
+    let style = if secondary {
+        Style::new().dim()
+    } else {
+        Style::new()
+    };
+    styled(&style, options.color, &text)
+}
+
+/// Render the heading that opens the closing section, marking where the reasons
+/// of the failed environments start. Over a long run they sit a screen of
+/// scrollback away from the markers they belong to.
+pub fn render_failure_heading(action: &str, count: usize, options: &RenderOptions) -> String {
+    let text = if count == 1 {
+        format!("1 environment failed to {action}:")
+    } else {
+        format!("{count} environments failed to {action}:")
+    };
+    styled(&EnvStatus::Failed.style(), options.color, &text)
+}
+
+/// Split off the escape sequences a line starts with.
+///
+/// Miette puts the color before the indentation, so the spaces can only be
+/// found after stepping over it.
+fn split_leading_ansi(line: &str) -> (&str, &str) {
+    let mut index = 0;
+    while line[index..].starts_with('\u{1b}') {
+        let Some(end) = line[index..].find(|character: char| character.is_ascii_alphabetic())
+        else {
+            break;
+        };
+        index += end + 1;
+    }
+    line.split_at(index)
+}
+
+/// Whether a line carries nothing but color and whitespace.
+///
+/// Miette paints the indentation of its wrapped lines, so a "blank" line can
+/// arrive as an escape sequence, four spaces and a reset.
+fn is_blank(line: &str) -> bool {
+    console::strip_ansi_codes(line).trim().is_empty()
+}
+
+/// Re-indent a rendered diagnostic to sit at the same column as the rows.
+///
+/// Miette indents its own output, so the indentation it brought along is
+/// stripped rather than added to, and blank lines around it are dropped.
+fn indent_diagnostic(diagnostic: &str) -> Vec<String> {
+    let lines: Vec<&str> = diagnostic
+        .lines()
+        .skip_while(|line| is_blank(line))
+        .collect();
+    let lines = match lines.iter().rposition(|line| !is_blank(line)) {
+        Some(last) => &lines[..=last],
+        None => return Vec::new(),
+    };
+
+    // Only ASCII spaces count as indentation: measuring bytes of arbitrary
+    // whitespace would slice a multi-byte character in half.
+    let leading_spaces = |line: &str| {
+        let (_, rest) = split_leading_ansi(line);
+        rest.len() - rest.trim_start_matches(' ').len()
+    };
+
+    let existing = lines
+        .iter()
+        .filter(|line| !is_blank(line))
+        .map(|line| leading_spaces(line))
+        .min()
+        .unwrap_or(0);
+
+    let indent = " ".repeat(INDENT);
+    lines
+        .iter()
+        .map(|line| {
+            if is_blank(line) {
+                return String::new();
+            }
+            let (prefix, rest) = split_leading_ansi(line);
+            let strip = existing.min(leading_spaces(line));
+            format!("{indent}{prefix}{}", &rest[strip..])
+                .trim_end()
+                .to_string()
+        })
+        .collect()
+}
+
+fn render_header(report: &EnvReport, options: &RenderOptions) -> String {
+    let mut header = String::new();
+
+    if let Some(status) = report.status {
+        // Padded before styling: escape sequences carry no width, so
+        // formatting the styled string to a field would misalign it.
+        let word = format!("({})", status.as_str());
+        header.push_str(&styled(&status.style(), options.color, &word));
+        header.push_str(&" ".repeat(STATUS_WIDTH.saturating_sub(word.len()) + 1));
+    }
+
+    header.push_str(&styled(
+        &consts::ENVIRONMENT_STYLE,
+        options.color,
+        &report.name,
+    ));
+
+    if let Some(version) = &report.version {
+        header.push(' ');
+        header.push_str(&styled(&Style::new().dim(), options.color, version));
+    }
+
+    header
+}
+
+fn render_row(row: &Row, last: bool, options: &RenderOptions) -> Vec<String> {
+    if row.items.is_empty() {
+        return Vec::new();
+    }
+
+    let branch = if last { LAST_BRANCH } else { BRANCH };
+    let label = format!(
+        "{branch}{label:<LABEL_WIDTH$}{gap}",
+        label = row.label.as_str(),
+        gap = " ".repeat(GAP),
+    );
+    // Continuation lines keep the trunk running past them, unless this is the
+    // last row and there is nothing left to connect to.
+    let continuation = format!(
+        "{}{}",
+        if last { NO_TRUNK } else { TRUNK },
+        " ".repeat(LABEL_WIDTH + GAP)
+    );
+
+    let rendered: Vec<String> = row
+        .items
+        .iter()
+        .map(|item| render_item(item, options))
+        .collect();
+
+    // Past the threshold a joined line is more work to read than it saves, so
+    // every item gets its own line.
+    let values = if rendered.len() > ITEMS_PER_LINE {
+        rendered
+    } else {
+        wrap(
+            &rendered,
+            options.width,
+            console::measure_text_width(&continuation),
+        )
+    };
+
+    values
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let prefix = if index == 0 { &label } else { &continuation };
+            format!("{prefix}{value}")
+        })
+        .collect()
+}
+
+fn render_item(item: &Item, options: &RenderOptions) -> String {
+    let mut rendered = String::new();
+
+    if item.marker != Marker::None {
+        rendered.push_str(&styled(
+            &item.marker.style(),
+            options.color,
+            item.marker.as_str(),
+        ));
+        rendered.push(' ');
+    }
+
+    // A change report colors by what happened to the item, a state listing by
+    // what the item is. Coloring a removed package green would collide with the
+    // green that means "added" everywhere else.
+    let name_style = match item.marker {
+        Marker::None => match item.kind {
+            ItemKind::Package => consts::CONDA_PACKAGE_STYLE.clone(),
+            ItemKind::Exposed => consts::EXPOSED_NAME_STYLE.clone(),
+            ItemKind::Plain => Style::new(),
+            ItemKind::Summary => Style::new().dim(),
+        },
+        marker => marker.style(),
+    };
+    rendered.push_str(&styled(&name_style, options.color, &item.name));
+
+    if let Some(detail) = &item.detail {
+        // The target of an exposed mapping is a second name rather than an
+        // annotation on the first, so it is not dimmed away.
+        let detail_style = match (item.marker, item.kind) {
+            (Marker::None, ItemKind::Exposed) => consts::EXPOSED_NAME_STYLE.clone(),
+            (marker, ItemKind::Exposed) => marker.style(),
+            _ => Style::new().dim(),
+        };
+        rendered.push(' ');
+        rendered.push_str(&styled(&detail_style, options.color, detail));
+    }
+
+    rendered
+}
+
+/// Join items with `, `, breaking into further lines so that no line exceeds
+/// `width` once `indent` columns are taken into account.
+fn wrap(items: &[String], width: Option<usize>, indent: usize) -> Vec<String> {
+    let joined = items.join(", ");
+    let Some(width) = width else {
+        return vec![joined];
+    };
+    if indent + console::measure_text_width(&joined) <= width {
+        return vec![joined];
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for (index, item) in items.iter().enumerate() {
+        let piece = if index + 1 == items.len() {
+            item.clone()
+        } else {
+            format!("{item},")
+        };
+
+        if current.is_empty() {
+            current = piece;
+        } else if indent
+            + console::measure_text_width(&current)
+            + 1
+            + console::measure_text_width(&piece)
+            <= width
+        {
+            current.push(' ');
+            current.push_str(&piece);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current = piece;
+        }
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    lines
+}
+
+/// Print a block to stderr, above any progress bars.
+///
+/// Failures are printed even when quiet, marker and reason alike: they are the
+/// reason the command exits non-zero.
+pub fn print(report: &EnvReport) {
+    if verbosity() == Verbosity::Quiet && !report.is_failure() {
+        return;
+    }
+    print_block(&render(report, &RenderOptions::from_terminal()));
+}
+
+/// Print the heading of the closing section. Never silenced: it introduces the
+/// reasons, which are printed even when quiet.
+pub fn print_failure_heading(action: &str, count: usize) {
+    let options = RenderOptions::from_terminal();
+    print_block(&render_failure_heading(action, count, &options));
+}
+
+/// Say that a command found nothing to do, for when there was not even an
+/// unchanged environment to count. Stays quiet if anything has been printed.
+pub fn print_nothing_to_do() {
+    if verbosity() == Verbosity::Quiet || PRINTED.load(Ordering::Relaxed) {
+        return;
+    }
+    let options = RenderOptions::from_terminal();
+    print_block(&styled(&Style::new(), options.color, "Nothing to do."));
+}
+
+/// Print the line accounting for environments left out of the report.
+pub fn print_unchanged_summary(count: usize) {
+    if verbosity() == Verbosity::Quiet || count == 0 {
+        return;
+    }
+    let options = RenderOptions::from_terminal();
+    let secondary = PRINTED.load(Ordering::Relaxed);
+    print_block(&render_unchanged_summary(count, &options, secondary));
+}
+
+fn print_block(block: &str) {
+    // Blocks stream as environments finish, so the blank line that separates
+    // them has to be emitted before the block rather than after it. Otherwise
+    // the report always ends on an empty line.
+    if PRINTED.swap(true, Ordering::Relaxed) {
+        pixi_progress::println!("\n{block}");
+    } else {
+        pixi_progress::println!("{block}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> RenderOptions {
+        RenderOptions {
+            width: Some(80),
+            color: false,
+        }
+    }
+
+    fn installed() -> EnvReport {
+        EnvReport::new(
+            "ripgrep",
+            Some("15.2.0".to_string()),
+            Some(EnvStatus::Installed),
+        )
+        .with_rows(vec![
+            Row::new(Label::Transitive, vec![Item::summary("3 added")]),
+            Row::new(
+                Label::Exposed,
+                vec![Item::exposed(Marker::Added, "rg", None)],
+            ),
+        ])
+    }
+
+    #[test]
+    fn renders_install() {
+        insta::assert_snapshot!(render(&installed(), &options()), @r"
+        (installed) ripgrep 15.2.0
+        ├── transitive    3 added
+        └── exposed       + rg
+        ");
+    }
+
+    /// An environment named after its only dependency carries the whole change
+    /// in its header, transition included, so no row repeats the name.
+    #[test]
+    fn renders_an_upgrade_of_the_environments_own_package() {
+        let report = EnvReport::new(
+            "ripgrep",
+            Some("15.2.0 -> 15.3.0".to_string()),
+            Some(EnvStatus::Updated),
+        )
+        .with_rows(vec![Row::new(
+            Label::Transitive,
+            vec![Item::summary("2 changed")],
+        )]);
+
+        insta::assert_snapshot!(render(&report, &options()), @r"
+        (updated)   ripgrep 15.2.0 -> 15.3.0
+        └── transitive    2 changed
+        ");
+    }
+
+    #[test]
+    fn renders_update_with_transitive_summary() {
+        let report = EnvReport::new("dev", None, Some(EnvStatus::Updated)).with_rows(vec![
+            Row::new(
+                Label::Dependencies,
+                vec![
+                    Item::package(
+                        Marker::Changed,
+                        "ripgrep",
+                        Some("15.2.0 -> 15.3.0".to_string()),
+                    ),
+                    Item::package(Marker::Removed, "bat", Some("0.26.1".to_string())),
+                ],
+            ),
+            Row::new(
+                Label::Transitive,
+                vec![Item::summary("12 added, 3 changed, 1 removed")],
+            ),
+            Row::new(
+                Label::Exposed,
+                vec![Item::exposed(Marker::Removed, "bat", None)],
+            ),
+        ]);
+
+        insta::assert_snapshot!(render(&report, &options()), @r"
+        (updated)   dev
+        ├── dependencies  ~ ripgrep 15.2.0 -> 15.3.0, - bat 0.26.1
+        ├── transitive    12 added, 3 changed, 1 removed
+        └── exposed       - bat
+        ");
+    }
+
+    #[test]
+    fn renders_failure_as_a_header_only() {
+        insta::assert_snapshot!(
+            render(&EnvReport::failed("nope"), &options()),
+            @"(failed)    nope"
+        );
+    }
+
+    #[test]
+    fn renders_removal() {
+        let report = EnvReport::new("ripgrep", None, Some(EnvStatus::Removed));
+        insta::assert_snapshot!(render(&report, &options()), @"(removed)   ripgrep");
+    }
+
+    #[test]
+    fn renders_unchanged() {
+        let report = EnvReport::new(
+            "ripgrep",
+            Some("15.2.0".to_string()),
+            Some(EnvStatus::Unchanged),
+        );
+        insta::assert_snapshot!(render(&report, &options()), @"(unchanged) ripgrep 15.2.0");
+    }
+
+    #[test]
+    fn renders_list_without_markers() {
+        let report = EnvReport::new("dev", None, None).with_rows(vec![
+            Row::new(
+                Label::Dependencies,
+                vec![
+                    Item::package(Marker::None, "bat", Some("0.26.1".to_string())),
+                    Item::package(Marker::None, "ripgrep", Some("15.3.0".to_string())),
+                ],
+            ),
+            Row::new(
+                Label::Exposed,
+                vec![
+                    Item::exposed(Marker::None, "bat", None),
+                    Item::exposed(Marker::None, "rg", None),
+                ],
+            ),
+            Row::new(
+                Label::Channels,
+                vec![Item::plain(Marker::None, "conda-forge")],
+            ),
+        ]);
+
+        insta::assert_snapshot!(render(&report, &options()), @r"
+        dev
+        ├── dependencies  bat 0.26.1, ripgrep 15.3.0
+        ├── exposed       bat, rg
+        └── channels      conda-forge
+        ");
+    }
+
+    #[test]
+    fn renders_exposed_mapping() {
+        let report =
+            EnvReport::new("ripgrep", None, Some(EnvStatus::Updated)).with_rows(vec![Row::new(
+                Label::Exposed,
+                vec![Item::exposed(
+                    Marker::Added,
+                    "rgx",
+                    Some("-> rg".to_string()),
+                )],
+            )]);
+
+        insta::assert_snapshot!(render(&report, &options()), @r"
+        (updated)   ripgrep
+        └── exposed       + rgx -> rg
+        ");
+    }
+
+    #[test]
+    fn puts_every_item_on_its_own_line_past_the_threshold() {
+        let names = ["FFLMoni", "FdIOServer", "FdMoni", "FdSend", "fd"];
+        let report = EnvReport::new("fd", Some("10.4.0".to_string()), Some(EnvStatus::Installed))
+            .with_rows(vec![Row::new(
+                Label::Exposed,
+                names
+                    .iter()
+                    .map(|name| Item::exposed(Marker::Added, *name, None))
+                    .collect(),
+            )]);
+
+        insta::assert_snapshot!(render(&report, &options()), @r"
+        (installed) fd 10.4.0
+        └── exposed       + FFLMoni
+                          + FdIOServer
+                          + FdMoni
+                          + FdSend
+                          + fd
+        ");
+    }
+
+    #[test]
+    fn wraps_a_short_list_that_does_not_fit() {
+        let report = EnvReport::new("jupyterlab", None, None).with_rows(vec![Row::new(
+            Label::Exposed,
+            vec![
+                Item::exposed(Marker::None, "jupyter-lab", None),
+                Item::exposed(Marker::None, "jupyter-labextension", None),
+                Item::exposed(Marker::None, "jupyter-labhub", None),
+            ],
+        )]);
+
+        let narrow = RenderOptions {
+            width: Some(60),
+            color: false,
+        };
+        insta::assert_snapshot!(render(&report, &narrow), @r"
+        jupyterlab
+        └── exposed       jupyter-lab, jupyter-labextension,
+                          jupyter-labhub
+        ");
+    }
+
+    #[test]
+    fn does_not_wrap_without_a_width() {
+        let report = EnvReport::new("jupyterlab", None, None).with_rows(vec![Row::new(
+            Label::Exposed,
+            vec![
+                Item::exposed(Marker::None, "jupyter-lab", None),
+                Item::exposed(Marker::None, "jupyter-labextension", None),
+                Item::exposed(Marker::None, "jupyter-labhub", None),
+            ],
+        )]);
+
+        insta::assert_snapshot!(
+            render(&report, &RenderOptions::default()),
+            @r"
+        jupyterlab
+        └── exposed       jupyter-lab, jupyter-labextension, jupyter-labhub
+        "
+        );
+    }
+
+    #[test]
+    fn markers_survive_without_color() {
+        let report =
+            EnvReport::new("dev", None, Some(EnvStatus::Updated)).with_rows(vec![Row::new(
+                Label::Dependencies,
+                vec![
+                    Item::package(Marker::Added, "bat", Some("0.27.0".to_string())),
+                    Item::package(Marker::Removed, "fd", Some("10.4.0".to_string())),
+                    Item::package(Marker::Changed, "rg", Some("15.2.0 -> 15.3.0".to_string())),
+                ],
+            )]);
+
+        let rendered = render(&report, &options());
+        assert!(!rendered.contains('\u{1b}'), "{rendered}");
+        insta::assert_snapshot!(rendered, @r"
+        (updated)   dev
+        └── dependencies  + bat 0.27.0, - fd 10.4.0, ~ rg 15.2.0 -> 15.3.0
+        ");
+    }
+
+    #[test]
+    fn colors_the_marker_and_the_status() {
+        let report = EnvReport::new(
+            "ripgrep",
+            Some("15.2.0".to_string()),
+            Some(EnvStatus::Installed),
+        )
+        .with_rows(vec![Row::new(
+            Label::Exposed,
+            vec![Item::exposed(Marker::Added, "rg", None)],
+        )]);
+
+        let rendered = render(
+            &report,
+            &RenderOptions {
+                width: Some(80),
+                color: true,
+            },
+        );
+
+        // Magenta environment, dim version, green status, and a green marker
+        // carrying its name along with it.
+        insta::assert_snapshot!(rendered.replace('\u{1b}', "\\e"), @r"
+        \e[32m(installed)\e[0m \e[35mripgrep\e[0m \e[2m15.2.0\e[0m
+        └── exposed       \e[32m+\e[0m \e[32mrg\e[0m
+        ");
+    }
+
+    /// A removal is drawn in red throughout, since green means an addition.
+    #[test]
+    fn colors_a_removal_without_using_the_color_of_an_addition() {
+        let report = EnvReport::new("dev", None, Some(EnvStatus::Removed)).with_rows(vec![
+            Row::new(
+                Label::Dependencies,
+                vec![Item::package(
+                    Marker::Removed,
+                    "bat",
+                    Some("0.26.1".to_string()),
+                )],
+            ),
+            Row::new(
+                Label::Exposed,
+                vec![Item::exposed(Marker::Removed, "bat", None)],
+            ),
+        ]);
+
+        let rendered = render(
+            &report,
+            &RenderOptions {
+                width: Some(80),
+                color: true,
+            },
+        );
+
+        insta::assert_snapshot!(rendered.replace('\u{1b}', "\\e"), @r"
+        \e[31m(removed)\e[0m   \e[35mdev\e[0m
+        ├── dependencies  \e[31m-\e[0m \e[31mbat\e[0m \e[2m0.26.1\e[0m
+        └── exposed       \e[31m-\e[0m \e[31mbat\e[0m
+        ");
+    }
+
+    /// Without a marker there is no change to color by, so the item falls back
+    /// to the color of what it is. That is what `pixi global list` renders.
+    #[test]
+    fn colors_a_state_listing_by_what_the_items_are() {
+        let report = EnvReport::new("dev", None, None).with_rows(vec![
+            Row::new(
+                Label::Dependencies,
+                vec![Item::package(
+                    Marker::None,
+                    "bat",
+                    Some("0.26.1".to_string()),
+                )],
+            ),
+            Row::new(
+                Label::Exposed,
+                vec![Item::exposed(Marker::None, "bat", None)],
+            ),
+        ]);
+
+        let rendered = render(
+            &report,
+            &RenderOptions {
+                width: Some(80),
+                color: true,
+            },
+        );
+
+        insta::assert_snapshot!(rendered.replace('\u{1b}', "\\e"), @r"
+        \e[35mdev\e[0m
+        ├── dependencies  \e[32mbat\e[0m \e[2m0.26.1\e[0m
+        └── exposed       \e[33mbat\e[0m
+        ");
+    }
+
+    #[test]
+    fn renders_several_blocks_with_a_blank_line_between_them() {
+        let second = EnvReport::new(
+            "bat",
+            Some("0.27.0".to_string()),
+            Some(EnvStatus::Installed),
+        )
+        .with_rows(vec![Row::new(
+            Label::Exposed,
+            vec![Item::exposed(Marker::Added, "bat", None)],
+        )]);
+
+        insta::assert_snapshot!(render_all(&[installed(), second], &options()), @r"
+        (installed) ripgrep 15.2.0
+        ├── transitive    3 added
+        └── exposed       + rg
+
+        (installed) bat 0.27.0
+        └── exposed       + bat
+        ");
+    }
+
+    #[test]
+    fn renders_the_unchanged_summary() {
+        assert_eq!(
+            render_unchanged_summary(1, &options(), false),
+            "1 environment unchanged"
+        );
+        assert_eq!(
+            render_unchanged_summary(20, &options(), true),
+            "20 environments unchanged"
+        );
+    }
+
+    #[test]
+    fn renders_the_failure_heading() {
+        assert_eq!(
+            render_failure_heading("install", 1, &options()),
+            "1 environment failed to install:"
+        );
+        assert_eq!(
+            render_failure_heading("sync", 3, &options()),
+            "3 environments failed to sync:"
+        );
+    }
+
+    /// A quiet run still gets the reason, otherwise a failing name would be
+    /// left without a diagnosis.
+    #[test]
+    fn a_reason_counts_as_a_failure() {
+        assert!(EnvReport::failed("broken").is_failure());
+        assert!(EnvReport::reason("broken", "× no such package").is_failure());
+        assert!(!installed().is_failure());
+    }
+}

--- a/docs/reference/cli/pixi/global/list.md
+++ b/docs/reference/cli/pixi/global/list.md
@@ -68,10 +68,10 @@ Lists global environments with their dependencies and exposed commands. Can also
 
 All environments:
 
-- Yellow: the binaries that are exposed.
+- Magenta: the name of the environment.
 - Green: the packages that are explicit dependencies of the environment.
-- Blue: the version of the installed package.
-- Cyan: the name of the environment.
+- Yellow: the binaries that are exposed.
+- Dim: the version of the installed package.
 
 Per environment:
 

--- a/docs/reference/cli/pixi/global/list_extender
+++ b/docs/reference/cli/pixi/global/list_extender
@@ -33,8 +33,8 @@ python 3.14.6
                   python3.14-config
 ```
 
-Here is an example of list of a single environment, which adds the packages that
-came along with the dependencies, the channels, and the full package table:
+Here is an example of list of a single environment, which adds the channels, the
+size the environment takes up on disk, and the full package table:
 ```
 pixi global list --environment demo
 ```
@@ -42,9 +42,9 @@ Results in:
 ```
 demo
 ├── dependencies  bat 0.26.1, ripgrep 15.2.0
-├── transitive    3 packages, 1.6 MiB total
 ├── exposed       demo-cli -> bat
-└── channels      conda-forge
+├── channels      conda-forge
+└── size          6.2 MiB
 
 Package        Version  Build       Size
 _openmp_mutex  4.5      20_gnu      28.3 KiB

--- a/docs/reference/cli/pixi/global/list_extender
+++ b/docs/reference/cli/pixi/global/list_extender
@@ -2,50 +2,56 @@
 
 ## Examples
 
-We'll only show the dependencies and exposed binaries of the environment if they differ from the environment name.
-Here is an example of a few installed packages:
+Every environment gets a block: its name, the version of the package it is named
+after, and a row per part of the manifest that has something to show.
+Environments holding more than one package list them under `dependencies`
+instead of in the header.
 
 ```
 pixi global list
 ```
 Results in:
 ```
-Global environments at /home/user/.pixi:
-├── gh: 2.57.0
-├── pixi-pack: 0.1.8
-├── python: 3.11.0
-│   └─ exposes: 2to3, 2to3-3.11, idle3, idle3.11, pydoc, pydoc3, pydoc3.11, python, python3, python3-config, python3.1, python3.11, python3.11-config
-├── rattler-build: 0.22.0
-├── ripgrep: 14.1.0
-│   └─ exposes: rg
-├── vim: 9.1.0611
-│   └─ exposes: ex, rview, rvim, view, vim, vimdiff, vimtutor, xxd
-└── zoxide: 0.9.6
+bat 0.26.1
+└── exposed       bat
+
+demo
+├── dependencies  bat 0.26.1, ripgrep 15.2.0
+└── exposed       demo-cli -> bat
+
+python 3.14.6
+└── exposed       idle3
+                  idle3.14
+                  pydoc
+                  pydoc3
+                  pydoc3.14
+                  python
+                  python3
+                  python3-config
+                  python3.1
+                  python3.14
+                  python3.14-config
 ```
 
-Here is an example of list of a single environment:
+Here is an example of list of a single environment, which adds the packages that
+came along with the dependencies, the channels, and the full package table:
 ```
-pixi g list -e pixi-pack
+pixi global list --environment demo
 ```
 Results in:
 ```
-The 'pixi-pack' environment has 8 packages:
-Package          Version    Build        Size
-_libgcc_mutex    0.1        conda_forge  2.5 KiB
-_openmp_mutex    4.5        2_gnu        23.1 KiB
-ca-certificates  2024.8.30  hbcca054_0   155.3 KiB
-libgcc           14.1.0     h77fa898_1   826.5 KiB
-libgcc-ng        14.1.0     h69a702a_1   50.9 KiB
-libgomp          14.1.0     h77fa898_1   449.4 KiB
-openssl          3.3.2      hb9d3cd8_0   2.8 MiB
-pixi-pack        0.1.8      hc762bcd_0   4.3 MiB
-Package          Version    Build        Size
+demo
+├── dependencies  bat 0.26.1, ripgrep 15.2.0
+├── transitive    3 packages, 1.6 MiB total
+├── exposed       demo-cli -> bat
+└── channels      conda-forge
 
-Exposes:
-pixi-pack
-Channels:
-conda-forge
-Platform: linux-64
+Package        Version  Build       Size
+_openmp_mutex  4.5      20_gnu      28.3 KiB
+bat            0.26.1   hdab8a38_0  2.8 MiB
+libgcc         16.1.0   ha9f2e26_1  1 MiB
+libgomp        16.1.0   he0feb66_1  625.4 KiB
+ripgrep        15.2.0   hf19af3b_1  1.8 MiB
 ```
 
 

--- a/tests/integration_python/pixi_global/test_global.py
+++ b/tests/integration_python/pixi_global/test_global.py
@@ -167,7 +167,10 @@ def test_sync_prune(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     del parsed_toml["envs"]["test"]
     manifest.write_text(tomli_w.dumps(parsed_toml))
     verify_cli_command(
-        [pixi, "global", "sync"], env=env, stderr_contains="Removed environment test"
+        [pixi, "global", "sync"],
+        env=env,
+        stderr_contains="(removed)   test",
+        strip_ansi=True,
     )
     assert not dummy_a.is_file()
 
@@ -741,7 +744,8 @@ def test_install_twice(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None
             "dummy-b",
         ],
         env=env,
-        stdout_contains="dummy-b: 0.1.0 (installed)",
+        stderr_contains="(installed) dummy-b 0.1.0",
+        strip_ansi=True,
     )
     assert dummy_b.is_file()
 
@@ -756,7 +760,8 @@ def test_install_twice(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None
             "dummy-b",
         ],
         env=env,
-        stdout_contains="dummy-b: 0.1.0 (already installed)",
+        stderr_contains="(unchanged) dummy-b 0.1.0",
+        strip_ansi=True,
     )
     assert dummy_b.is_file()
 
@@ -786,7 +791,8 @@ def test_install_twice_with_same_env_name_as_expose(
             "customdummyb=dummy-b",
         ],
         env=env,
-        stdout_contains=["customdummyb (installed)", "exposes: customdummyb -> dummy-b"],
+        stderr_contains=["(installed) customdummyb", "+ customdummyb -> dummy-b"],
+        strip_ansi=True,
     )
     assert dummy_b.is_file()
 
@@ -805,7 +811,8 @@ def test_install_twice_with_same_env_name_as_expose(
             "customdummyb=dummy-b",
         ],
         env=env,
-        stdout_contains=["customdummyb (already installed)", "exposes: customdummyb -> dummy-b"],
+        stderr_contains="(unchanged) customdummyb",
+        strip_ansi=True,
     )
     assert dummy_b.is_file()
 
@@ -892,7 +899,8 @@ def test_install_with_different_channel_and_force_reinstall(
             "dummy-b",
         ],
         env=env,
-        stdout_contains="dummy-b: 0.1.0 (installed)",
+        stderr_contains="(installed) dummy-b 0.1.0",
+        strip_ansi=True,
     )
     assert dummy_b.is_file()
 
@@ -916,7 +924,8 @@ def test_install_with_different_channel_and_force_reinstall(
             "dummy-b",
         ],
         env=env,
-        stdout_contains="dummy-b: 0.1.0 (already installed)",
+        stderr_contains="(unchanged) dummy-b 0.1.0",
+        strip_ansi=True,
     )
 
     # Install dummy-b again, but with force-reinstall
@@ -932,7 +941,8 @@ def test_install_with_different_channel_and_force_reinstall(
             "dummy-b",
         ],
         env=env,
-        stdout_contains="dummy-b: 0.1.0 (installed)",
+        stderr_contains="(installed) dummy-b 0.1.0",
+        strip_ansi=True,
     )
 
 
@@ -1161,6 +1171,117 @@ def test_install_continues_past_failing_env(
     assert dummy_b.is_file()
 
 
+def test_quiet_keeps_the_reason_of_a_failure(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """`--quiet` drops the report, but a failure has to stay readable.
+
+    The reason used to be a `tracing::warn!` that `--quiet` swallowed, so a
+    quiet run has to end up with more than a name and an exit code.
+    """
+    env = {"PIXI_HOME": str(tmp_path)}
+
+    verify_cli_command(
+        [pixi, "global", "install", "--quiet", "--channel", dummy_channel_1, "dummy-x"],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains=["dummy-x", "No candidates were found for dummy-x"],
+    )
+
+    # The report of a run that worked is still silenced.
+    verify_cli_command(
+        [pixi, "global", "install", "--quiet", "--channel", dummy_channel_1, "dummy-a"],
+        env=env,
+        stderr_excludes=["installed", "exposed"],
+    )
+    assert tmp_path.joinpath("bin", exec_extension("dummy-a")).is_file()
+
+
+def test_expose_remove_reports_what_it_already_removed(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """A name removed before a later one fails is still gone from disk.
+
+    The removals are collected and reported once at the end, so the error path
+    has to report them too rather than returning straight past them.
+    """
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+    manifest = manifests.joinpath("pixi-global.toml")
+    manifest.write_text(f"""
+version = {MANIFEST_VERSION}
+
+[envs.one]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-a = "*" }}
+exposed = {{ dummy-a = "dummy-a" }}
+
+[envs.broken]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-x = "*" }}
+exposed = {{ dummy-x = "dummy-x" }}
+""")
+    dummy_a = tmp_path / "bin" / exec_extension("dummy-a")
+
+    verify_cli_command([pixi, "global", "sync"], ExitCode.FAILURE, env=env)
+    assert dummy_a.is_file()
+
+    # `dummy-a` is removed and saved before `dummy-x` fails to solve.
+    verify_cli_command(
+        [pixi, "global", "expose", "remove", "dummy-a", "dummy-x"],
+        ExitCode.FAILURE,
+        env=env,
+        stderr_contains=["one", "dummy-a", "broken"],
+    )
+    assert not dummy_a.is_file()
+
+
+def test_install_of_an_environment_missing_from_the_manifest(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """An environment the manifest has lost reads as installed, and is saved.
+
+    The prefix satisfying the manifest is a shortcut past the solve, not a
+    reason to drop the environment the manifest just gained.
+    """
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+    manifest = manifests.joinpath("pixi-global.toml")
+    manifest.write_text(f"""
+version = {MANIFEST_VERSION}
+
+[envs.dummy-a]
+channels = ["{dummy_channel_1}"]
+dependencies = {{ dummy-a = "*" }}
+exposed = {{ dummy-a = "dummy-a" }}
+""")
+    verify_cli_command([pixi, "global", "sync"], env=env)
+    assert tmp_path.joinpath("bin", exec_extension("dummy-a")).is_file()
+
+    # The prefix and its trampolines stay, the manifest forgets the environment.
+    manifest.write_text(f"version = {MANIFEST_VERSION}\n")
+    verify_cli_command(
+        [
+            pixi,
+            "global",
+            "install",
+            "--channel",
+            dummy_channel_1,
+            "--expose",
+            "dummy-a=dummy-a",
+            "dummy-a",
+        ],
+        env=env,
+        stderr_contains="installed",
+        stderr_excludes="unchanged",
+    )
+
+    assert "[envs.dummy-a]" in manifest.read_text()
+    verify_cli_command([pixi, "global", "list"], env=env, stdout_contains="dummy-a")
+
+
 @pytest.mark.slow
 def test_install_platform(pixi: Path, tmp_path: Path) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
@@ -1336,6 +1457,112 @@ def test_pixi_install_cleanup(pixi: Path, tmp_path: Path, multiple_versions_chan
     assert package0_2_0.is_file()
 
 
+def test_sync_and_update_speak_up_when_there_is_nothing_to_do(pixi: Path, tmp_path: Path) -> None:
+    """A command that takes a moment and then says nothing reads as a hang."""
+    env = {"PIXI_HOME": str(tmp_path)}
+    manifests = tmp_path.joinpath("manifests")
+    manifests.mkdir()
+
+    verify_cli_command(
+        [pixi, "global", "sync"],
+        env=env,
+        stderr_contains="Nothing to do",
+        strip_ansi=True,
+    )
+    verify_cli_command(
+        [pixi, "global", "update"],
+        env=env,
+        stderr_contains="Nothing to do",
+        strip_ansi=True,
+    )
+
+
+def test_sync_creating_an_environment_says_installed(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """The same event gets the same word whichever command triggers it."""
+    env = {"PIXI_HOME": str(tmp_path)}
+    verify_cli_command(
+        [pixi, "global", "install", "--channel", dummy_channel_1, "dummy-a"], env=env
+    )
+    shutil.rmtree(tmp_path / "envs")
+
+    verify_cli_command(
+        [pixi, "global", "sync"],
+        env=env,
+        stderr_contains="(installed) dummy-a 0.1.0",
+        stderr_excludes="updated",
+        strip_ansi=True,
+    )
+
+
+def test_a_single_package_environment_is_described_by_its_header(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """The header already names the package, so no `dependencies` row repeats it."""
+    env = {"PIXI_HOME": str(tmp_path)}
+    verify_cli_command(
+        [pixi, "global", "install", "--channel", dummy_channel_1, "dummy-a"],
+        env=env,
+        stderr_contains=["(installed) dummy-a 0.1.0", "exposed       + dummy-a"],
+        stderr_excludes="dependencies",
+        strip_ansi=True,
+    )
+
+    # An environment holding more than the package it is named after keeps the
+    # row, since it has something to say that the header doesn't.
+    verify_cli_command(
+        [pixi, "global", "add", "--environment", "dummy-a", "dummy-b"],
+        env=env,
+        stderr_contains=["(updated)   dummy-a", "dependencies  + dummy-b 0.1.0"],
+        strip_ansi=True,
+    )
+
+
+def test_update_reports_a_failure_and_carries_on(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """A failed environment must not swallow the ones after it."""
+    env = {"PIXI_HOME": str(tmp_path)}
+    verify_cli_command(
+        [pixi, "global", "install", "--channel", dummy_channel_1, "dummy-a"], env=env
+    )
+
+    verify_cli_command(
+        [pixi, "global", "update", "does-not-exist", "dummy-a"],
+        env=env,
+        expected_exit_code=ExitCode.FAILURE,
+        stderr_contains=[
+            "(failed)    does-not-exist",
+            "not found in manifest",
+            "(unchanged) dummy-a 0.1.0",
+        ],
+        strip_ansi=True,
+    )
+
+
+def test_expose_remove_reports_one_block_per_environment(
+    pixi: Path, tmp_path: Path, dummy_channel_1: str
+) -> None:
+    """Several names leaving one environment is one change to that environment."""
+    env = {"PIXI_HOME": str(tmp_path)}
+    verify_cli_command(
+        [pixi, "global", "install", "--channel", dummy_channel_1, "dummy-a"], env=env
+    )
+    verify_cli_command(
+        [pixi, "global", "expose", "add", "--environment", "dummy-a", "one=dummy-a", "two=dummy-a"],
+        env=env,
+    )
+
+    result = verify_cli_command(
+        [pixi, "global", "expose", "remove", "one", "two"],
+        env=env,
+        stderr_contains="- one, - two",
+        strip_ansi=True,
+    )
+    assert result.stderr.count("(updated)   dummy-a 0.1.0") == 1
+
+
 def test_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     env = {"PIXI_HOME": str(tmp_path)}
     manifests = tmp_path.joinpath("manifests")
@@ -1366,7 +1593,7 @@ def test_list(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     verify_cli_command(
         [pixi, "global", "list"],
         env=env,
-        stdout_contains=["dummy-b: 0.1.0", "dummy-a: 0.1.0", "dummy-a", "dummy-aa"],
+        stdout_contains=["dummy-b 0.1.0", "dummy-a 0.1.0", "dummy-a", "dummy-aa"],
     )
 
 
@@ -1413,7 +1640,7 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
     verify_cli_command(
         [pixi, "global", "list", "dummy-a"],
         env=env,
-        stdout_contains=["dummy-a: 0.1.0", "dummy-a", "dummy-aa"],
+        stdout_contains=["dummy-a 0.1.0", "dummy-a", "dummy-aa"],
         stdout_excludes=["dummy-b"],
     )
 
@@ -1422,7 +1649,7 @@ def test_list_with_filter(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> N
     verify_cli_command(
         [pixi, "global", "list", "--environment", "dummy-a", "dummy"],
         env=env,
-        stdout_contains=["The dummy-a environment", "dummy-a", "0.1.0"],
+        stdout_contains=["dummy-a", "0.1.0"],
         stdout_excludes=["dummy-b"],
     )
 
@@ -1559,7 +1786,8 @@ exposed = {{ dummy-c = "dummy-c" }}
     verify_cli_command(
         [pixi, "global", "uninstall", "dummy-a"],
         env=env,
-        stderr_contains="Removed environment dummy-a",
+        stderr_contains="(removed)   dummy-a",
+        strip_ansi=True,
     )
     assert not dummy_a.is_file()
     assert not dummy_aa.is_file()
@@ -1604,7 +1832,8 @@ exposed = {{ dummy-c = "dummy-c" }}
         [pixi, "global", "uninstall", "dummy-a"],
         ExitCode.FAILURE,
         env=env,
-        stderr_contains="Couldn't remove environment dummy-a",
+        stderr_contains=["(failed)    dummy-a", "Environment dummy-a doesn't exist"],
+        strip_ansi=True,
     )
 
     # Uninstall multiple packages
@@ -1712,7 +1941,8 @@ def test_global_update_single_package(
     verify_cli_command(
         [pixi, "global", "update", "package"],
         env=env,
-        stderr_contains=["Updated", "package", "0.1.0", "0.2.0"],
+        stderr_contains=["updated", "package", "0.1.0 -> 0.2.0"],
+        strip_ansi=True,
     )
     package = tmp_path / "bin" / exec_extension("package")
     package0_1_0 = tmp_path / "bin" / exec_extension("package0.1.0")
@@ -1748,7 +1978,10 @@ def test_global_update_single_package_with_transient_dependency(
     verify_cli_command(
         [pixi, "global", "update", "jupyter"],
         env=env,
-        stderr_contains="Updated environment jupyter.",
+        stderr_contains=["(updated)   jupyter 0.1.0"],
+        # The environment's own package is named by the header, never by a row.
+        stderr_excludes="~ jupyter",
+        strip_ansi=True,
     )
 
 
@@ -1785,7 +2018,8 @@ def test_global_update_doesnt_remove_exposed_key_of_transient_dependencies(
     verify_cli_command(
         [pixi, "global", "update", "package4"],
         env=env,
-        stderr_contains=["Updated", "package4", "0.1.0", "0.2.0"],
+        stderr_contains=["updated", "package4", "0.1.0 -> 0.2.0"],
+        strip_ansi=True,
     )
 
     # package3 should still be exposed
@@ -1882,7 +2116,8 @@ def test_global_update_multiple_packages_in_one_env(
     verify_cli_command(
         [pixi, "global", "update", "my-packages"],
         env=env,
-        stderr_contains=["- package 0.1.0 -> 0.2.0", "- package2 0.1.0 -> 0.2.0"],
+        stderr_contains=["~ package 0.1.0 -> 0.2.0", "~ package2 0.1.0 -> 0.2.0"],
+        strip_ansi=True,
     )
 
     assert package2.is_file()
@@ -2015,7 +2250,8 @@ def test_add(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
     verify_cli_command(
         [pixi, "global", "add", "--environment", "dummy-a", "dummy-b"],
         env=env,
-        stderr_contains="Added package dummy-b",
+        stderr_contains="+ dummy-b 0.1.0",
+        strip_ansi=True,
     )
     # Make sure it doesn't expose a binary from this package
     dummy_b = tmp_path / "bin" / exec_extension("dummy-b")
@@ -2033,7 +2269,8 @@ def test_add(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> None:
             "dummy-b",
         ],
         env=env,
-        stderr_contains=["Exposed executable dummy-b from environment dummy-a"],
+        stderr_contains=["(updated)   dummy-a", "+ dummy-b"],
+        strip_ansi=True,
     )
     # Make sure it now exposes the binary
     dummy_b = tmp_path / "bin" / exec_extension("dummy-b")
@@ -2056,10 +2293,14 @@ def test_remove_dependency(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> 
             "dummy-b",
         ],
         env=env,
-        stdout_contains=[
-            "dependencies: dummy-a 0.1.0, dummy-b 0.1.0",
-            "exposes: dummy-a, dummy-aa, dummy-b",
+        stderr_contains=[
+            "+ dummy-a 0.1.0",
+            "+ dummy-b 0.1.0",
+            "+ dummy-a",
+            "+ dummy-aa",
+            "+ dummy-b",
         ],
+        strip_ansi=True,
     )
     dummy_a = tmp_path / "bin" / exec_extension("dummy-a")
     dummy_b = tmp_path / "bin" / exec_extension("dummy-b")
@@ -2071,9 +2312,11 @@ def test_remove_dependency(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> 
         [pixi, "global", "remove", "--environment", "my-env", "dummy-a"],
         env=env,
         stderr_contains=[
-            "Removed package dummy-a in environment my-env.",
-            "Removed exposed executables from environment my-env:\n   - dummy-a\n   - dummy-aa\n",
+            "(updated)   my-env",
+            "- dummy-a",
+            "exposed       - dummy-a, - dummy-aa",
         ],
+        strip_ansi=True,
     )
     assert not dummy_a.is_file()
 
@@ -2096,9 +2339,11 @@ def test_remove_dependency(pixi: Path, tmp_path: Path, dummy_channel_1: str) -> 
         [pixi, "global", "remove", "--environment", "my-env", "dummy-a", "dummy-b"],
         env=env,
         stderr_contains=[
-            "Removed packages in environment my-env.\n    - dummy-a\n    - dummy-b",
-            "Removed exposed executables from environment my-env:\n   - dummy-a\n   - dummy-aa\n   - dummy-b",
+            "(updated)   my-env",
+            "dependencies  - dummy-a, - dummy-b",
+            "exposed       - dummy-a, - dummy-aa, - dummy-b",
         ],
+        strip_ansi=True,
     )
 
     # Remove non-existing package
@@ -2431,7 +2676,8 @@ class TestCondaFile:
             ],
             env=env,
             cwd=cwd,
-            stderr_contains="Environment pixi-editor was already up-to-date.",
+            stderr_contains="(unchanged) pixi-editor 1.0.0",
+            strip_ansi=True,
         )
 
         # sync with file still there
@@ -2443,7 +2689,8 @@ class TestCondaFile:
             ],
             env=env,
             cwd=cwd,
-            stderr_contains="Nothing to do",
+            stderr_contains="1 environment unchanged",
+            strip_ansi=True,
         )
 
         os.remove(conda_file)
@@ -2458,7 +2705,8 @@ class TestCondaFile:
             ],
             env=env,
             cwd=cwd,
-            stderr_contains="Environment pixi-editor was already up-to-date.",
+            stderr_contains="(unchanged) pixi-editor 1.0.0",
+            strip_ansi=True,
         )
 
         # sync with file gone
@@ -2470,7 +2718,8 @@ class TestCondaFile:
             ],
             env=env,
             cwd=cwd,
-            stderr_contains="Nothing to do",
+            stderr_contains="1 environment unchanged",
+            strip_ansi=True,
         )
 
         # remove the environment

--- a/tests/integration_python/pixi_global/test_trampoline.py
+++ b/tests/integration_python/pixi_global/test_trampoline.py
@@ -205,8 +205,9 @@ def test_trampoline_migrate_with_newer_trampoline(
             "update",
         ],
         env=env,
-        stderr_contains="Environment dummy-trampoline was already up-to-date",
-        stderr_excludes="Updated executable dummy-trampoline of environment dummy-trampoline",
+        stderr_contains="1 environment unchanged",
+        stderr_excludes="~ dummy-trampoline",
+        strip_ansi=True,
     )
 
     # now change the trampoline binary , and verify that it will install the new one
@@ -220,8 +221,11 @@ def test_trampoline_migrate_with_newer_trampoline(
             "update",
         ],
         env=env,
-        stderr_contains="Updated executable dummy-trampoline of environment dummy-trampoline",
+        stderr_contains="1 environment unchanged",
+        strip_ansi=True,
     )
+    # Rewriting a trampoline is not reported, so the file itself is the proof.
+    assert is_binary(dummy_trampoline)
 
     # run an update again
     verify_cli_command(
@@ -231,8 +235,9 @@ def test_trampoline_migrate_with_newer_trampoline(
             "update",
         ],
         env=env,
-        stderr_contains="Environment dummy-trampoline was already up-to-date",
-        stderr_excludes="Updated executable dummy-trampoline of environment dummy-trampoline",
+        stderr_contains="1 environment unchanged",
+        stderr_excludes="~ dummy-trampoline",
+        strip_ansi=True,
     )
 
 
@@ -357,8 +362,9 @@ def test_trampoline_migrate_with_newer_configuration(
             "update",
         ],
         env=env,
-        stderr_contains="Environment dummy-trampoline was already up-to-date",
-        stderr_excludes="Updated executable dummy-trampoline of environment dummy-trampoline",
+        stderr_contains="1 environment unchanged",
+        stderr_excludes="~ dummy-trampoline",
+        strip_ansi=True,
     )
 
     original_configuration = break_configuration(dummy_trampoline_json)
@@ -384,8 +390,12 @@ def test_trampoline_migrate_with_newer_configuration(
             "update",
         ],
         env=env,
-        stderr_contains="Updated executable dummy-trampoline of environment dummy-trampoline",
+        stderr_contains="1 environment unchanged",
+        strip_ansi=True,
     )
+    # Rewriting a trampoline is not reported, so the files themselves are the proof.
+    assert is_binary(dummy_trampoline)
+    assert json.loads(dummy_trampoline_json.read_text()) == original_configuration
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Every `pixi global` subcommand now reports what it did the same way, on the same
stream. `install` used to print a tree to stdout and throw away the changes it
had computed, while everything else printed a `✔` sentence per change to stderr.

### Syncing several environments

**before**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/04-sync-before.png" width="720">

**after**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/04-sync-after.png" width="720">

### Installing a tool

**before**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/01-install-before.png" width="720">

**after**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/01-install-after.png" width="720">

### Installing several, one of them misspelled

**before**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/02-batch-before.png" width="720">

**after**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/02-batch-after.png" width="720">

### Listing what is installed

**before**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/03-list-before.png" width="720">

**after**

<img src="https://raw.githubusercontent.com/Hofer-Julian/pixi/5d30e09096b6f7468dad6988c68f7e55ad4ec5db/03-list-after.png" width="720">

### How Has This Been Tested?

Rendering is a pure function in the new `pixi_global::report`, covered by inline
`insta` snapshots, and the integration tests are updated to the new output.

[global-output-demo.zip](https://raw.githubusercontent.com/Hofer-Julian/pixi/pr-6869-assets/global-output-demo.zip) runs the same command twice,
once with the released pixi and once with this branch, one keystroke apart.
Throwaway `PIXI_HOME` and package cache per demo, so it never touches your own
installation.



