### PR TITLE
chore: revert "feat: add `magic_enum` to `pixi-build-ros`"

### DIFF
--- a/crates/pixi_build_ros/robostack.yaml
+++ b/crates/pixi_build_ros/robostack.yaml
@@ -571,8 +571,6 @@ lz4:
   robostack: [lz4]
 maven:
   robostack: [maven]
-magic_enum:
-  robostack: [magic_enum]
 mongodb:
   robostack: [mongodb]
 mosquitto:


### PR DESCRIPTION
Reverts prefix-dev/pixi#6830

Following the discussion in https://github.com/RoboStack/ros-kilted/pull/96