### PR TITLE
chore: update rattler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,7 +3150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
  "gloo-timers 0.2.6",
- "send_wrapper",
+ "send_wrapper 0.4.0",
 ]
 
 [[package]]
@@ -5797,9 +5797,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "path_resolver"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b79fa64c9aac78dc850c3ac23f27de50be06cb7d2a051aa4324c3d4d7bcaeb"
+checksum = "9994183d6ed25258205ec5612143b3da8cf2a2027d5e532b0af961ebf32ea5a1"
 dependencies = [
  "ahash",
  "fs-err",
@@ -8064,9 +8064,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.48.3"
+version = "0.48.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accfedd36855dd35f96ce944c9ec186a3193fe00f27f2ac8f7cc09e2b669bb93"
+checksum = "6595b5f9878f0e2787da607235c158c7c125d4c4f145cfcc3febade9c66c3a4f"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -8117,9 +8117,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_core"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e93a9fe0685ba3ba6ab3e9ba34ef4eec5739306645bcee66d419f49861e7a5"
+checksum = "031287c2559ca34400d99afeccec76fc74942dfcaf85a932985b6d24247e32f7"
 dependencies = [
  "anyhow",
  "arwen-codesign",
@@ -8202,9 +8202,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_jinja"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7a4b55fc8cbb1ecf067ff0c96fbfb0e580ee6f5c3c4b0d14431c5713adfe7f"
+checksum = "e0626b6d9b6b4e134d7f491f23909a6a4f6112a1cd5723cb8a1d99dcf7881c12"
 dependencies = [
  "fs-err",
  "indexmap 2.14.0",
@@ -8237,9 +8237,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_recipe"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38a0596a5834d981d696176a727c32af9c7c2b88cf829175f4d610e1420ac77"
+checksum = "5ec48c96cdb2a4f122b7c02493ca3195d3a941dd198bc47b9601840e61f8fd38"
 dependencies = [
  "fs-err",
  "globset",
@@ -8272,9 +8272,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_script"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94a0c75a45ca6b31eebb477f928cd5ce07ea0e97a327069344707e903251bc"
+checksum = "f667979479b89d51d885816624bd49c960261ab59cd4942515fbc518d3042469"
 dependencies = [
  "async-trait",
  "clap",
@@ -8337,9 +8337,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_types"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb3b6dab3a713aa75053e613c60a9c153e518ca20312d8f5f18fc6198e777f1"
+checksum = "f5e05f0861f45a43a144d4405de22dddb69ba9af1c4f9b0df4e68725b6d46803"
 dependencies = [
  "globset",
  "itertools 0.15.0",
@@ -8353,9 +8353,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_variant_config"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcff1a82628af69a48a026de41be6ddc761f2e7e65e6453e09dc29828e2db6a"
+checksum = "a00d5153de65876afe46d3521a8ba2bedaf881062e4f4a910cb1ce8b3c80e419"
 dependencies = [
  "fs-err",
  "marked-yaml",
@@ -8374,9 +8374,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_build_yaml_parser"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df121233fc0db47e4fb3b50053fbeb5a6198287ae8ff92a925418c840b0e7657"
+checksum = "8ba8befa447fc0541f87281bc14f0829f2a7f8a4e24dc9bab68eefb906a0fc6f"
 dependencies = [
  "marked-yaml",
  "miette 7.6.0",
@@ -8387,9 +8387,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b8ea7ad44f970b12b7698225e7890b19e3f4dcbae7a7b8fe4d7a0326539677"
+checksum = "10e0c05d770d92af1f4230f6f549ab6c4cb47d5e5f7a65339f91fca7fc6b3545"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8422,9 +8422,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2becf7d5e10e770b597acc91de1c0b79d2a5ff83a5acabe3480f2eb71bdd865c"
+checksum = "654ccb4b723cd1e288bbbb8e798721b8316e19f0de3610ed90ebfbedabf45d45"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -8465,9 +8465,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8cb547526f1bd3e84173b22f152628c9a5af451019b8969bf9932befcd1d3d"
+checksum = "e7cb7a3302ec74284640c5c7aa911269e1cfd65bd5e8da4299923453e50a0c78"
 dependencies = [
  "dirs",
  "fs-err",
@@ -8504,9 +8504,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_git"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b3e31df047a1415310d19427de0544ddc5ef88102df9bc43223e95ece378c1"
+checksum = "a9b7152dc6e591f5b1512ebcbb5b738cc0adddb61a519e98b62495c211065523"
 dependencies = [
  "astral-reqwest-middleware",
  "dashmap",
@@ -8526,9 +8526,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5beff6ddf8ad1b58ecba95b5b39f7905ccf00f9db046e92af76c585b487a66f5"
+checksum = "308fb45f4a01891e77e9a6ca585f493169586afee85b374e08f889b460951144"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8566,9 +8566,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4967b418e40b5d7cbfc355093ae01801459992e447f8ccc3eee0393f3d19d9f8"
+checksum = "383f34cb66299b71ded79b35a0baa2f5865f1e59a0ecca844016ef9bd40f45ff"
 dependencies = [
  "ahash",
  "file_url",
@@ -8605,9 +8605,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7514de242935a48908dd7243c25191497fe0483b47ed1d6da01466d265ee57"
+checksum = "1a39794d7486efd34a701c4e33abd094cff04d78d1f3a9bf9f539a3193b3406c"
 dependencies = [
  "configparser",
  "dirs",
@@ -8636,9 +8636,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.30.5"
+version = "0.30.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769ff012fafdef054b2d697f3807d1a14a551f1b203fe365da6e81ea544b2268"
+checksum = "bad2167f271e0b3ad411a9623de1e948c12dadb05040cd7508015fed78f4e852"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -8677,9 +8677,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ee9c39cab94ce1c8308c25b170eb8757d9837416c708be37a3cb60c66abc98"
+checksum = "364ad3b4bac0c95ae1f7c7bdfa33b679c8d64fde14fd47f6fb965836dbc94628"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -8745,9 +8745,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b9b88444342b01133c4eb1af90f44e3bc04463d738ac3fa3813df0096c177"
+checksum = "308e86344e78b42b96570e765f287d7cf87fab7f21ba2eb12508363c11b55f72"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -8756,9 +8756,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769106c5625e788197cfa2c5cb98c585fecf7fea92e8fff90d8d6e8014bb6e76"
+checksum = "50b705828891a4184451f8c5300b9b123bd946c76fa9f55c0057d81fab3f8d28"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8785,6 +8785,7 @@ dependencies = [
  "humantime",
  "itertools 0.15.0",
  "jiff",
+ "js-sys",
  "json-patch",
  "libc",
  "memmap2 0.9.11",
@@ -8800,6 +8801,7 @@ dependencies = [
  "retry-policies",
  "rmp-serde",
  "self_cell",
+ "send_wrapper 0.6.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -8812,16 +8814,19 @@ dependencies = [
  "tokio-util 0.7.19",
  "tracing",
  "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasmtimer",
+ "web-sys",
  "windows-sys 0.61.2",
  "zstd",
 ]
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb450835967a6620a1b73d10db9d697838105d4570d9320c94d7101b2dc15cb3"
+checksum = "3b9701fa2e3a6666991f32fe3b8157afc73caee15c1248bfc08343fb103d9dba"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -8836,9 +8841,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.14"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b47240a8bd326257e1804e2b521ad00f505db9c229c3b49b69939113f1f1a"
+checksum = "1d87277b0a7b7ccba831890810e903c35b56b3c1003952ad07374da9ebb0b46b"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -8858,9 +8863,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "9.0.2"
+version = "9.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc14e2b00952ae96b6356625cfd4083fb3f1de92a32aa3f2bd78e823bf16c95"
+checksum = "9c287fe2c2a57e66162cadc4430b7aa300251edd73034b1b7bf222a660a9a45e"
 dependencies = [
  "futures",
  "hex",
@@ -8878,9 +8883,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ae9c5d57e5701bcc705a152f9703ecb64be96d83d258bf522a0ff3e253e437"
+checksum = "09043dd6c41243fbb8cb118e7809f0238a8f7eea198c728ca551167d67874841"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
@@ -8917,9 +8922,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85109cb080a3232e181a360e1db1d140bbe3fabbea6f9cecafeb3b94e63f2608"
+checksum = "4c249324b90e9dcf985991ca4a066b6df72c4c9b300a70746c596e90abe8df2f"
 dependencies = [
  "archspec",
  "libloading",
@@ -9877,6 +9882,12 @@ name = "send_wrapper"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,7 @@ zstd = { version = "0.13.3", default-features = false }
 file_url = "0.3.0"
 rattler = { version = "0.48", default-features = false }
 rattler_cache = { version = "0.10", default-features = false }
-rattler_conda_types = { version = "0.50", default-features = false, features = [
+rattler_conda_types = { version = "0.51", default-features = false, features = [
   "rayon",
 ] }
 rattler_config = { version = "0.7", default-features = false }
@@ -251,7 +251,7 @@ rattler_networking = { version = "0.30", default-features = false, features = [
 ] }
 rattler_package_streaming = { version = "0.27", default-features = false }
 rattler_redaction = { version = "0.2.2", default-features = false }
-rattler_repodata_gateway = { version = "0.32", default-features = false }
+rattler_repodata_gateway = { version = "0.33", default-features = false }
 rattler_s3 = { version = "0.2", default-features = false }
 rattler_shell = { version = "0.27", default-features = false }
 rattler_solve = { version = "9.0", default-features = false }
@@ -259,17 +259,17 @@ rattler_upload = { version = "0.10", default-features = false, features = [
   "s3",
   "sigstore-sign",
 ] }
-rattler_virtual_packages = { version = "5.0", default-features = false }
+rattler_virtual_packages = { version = "5.1", default-features = false }
 simple_spawn_blocking = { version = "1.1.0", default-features = false }
 
 # Rattler build crates
-rattler_build_core = { version = "0.2.11", default-features = false, features = [
+rattler_build_core = { version = "0.2.12", default-features = false, features = [
   "s3",
 ] }
-rattler_build_jinja = { version = "0.1.12" }
-rattler_build_recipe = { version = "0.1.12" }
-rattler_build_types = { version = "0.1.11" }
-rattler_build_variant_config = { version = "0.1.12" }
+rattler_build_jinja = { version = "0.1.13" }
+rattler_build_recipe = { version = "0.1.13" }
+rattler_build_types = { version = "0.1.12" }
+rattler_build_variant_config = { version = "0.1.13" }
 
 [patch.crates-io]
 version-ranges = { git = "https://github.com/astral-sh/pubgrub", rev = "d8efd77673c9a90792da9da31b6c0da7ea8a324b" }

--- a/crates/pixi_core/src/lock_file/virtual_packages.rs
+++ b/crates/pixi_core/src/lock_file/virtual_packages.rs
@@ -465,7 +465,7 @@ packages:
         assert_eq!(
             specs.iter().map(ToString::to_string).collect_vec(),
             vec![
-                "__archspec 1.* ^(x86_64_v3|skylake)$",
+                "__archspec 1.*[build=\"^(x86_64_v3|skylake)$\"]",
                 "__glibc >=2.17",
                 "__glibc >=2.28",
             ]

--- a/crates/pixi_spec/src/toml.rs
+++ b/crates/pixi_spec/src/toml.rs
@@ -1837,7 +1837,7 @@ mod test {
                 .as_ref()
                 .unwrap()
                 .to_string(),
-            "(__linux or __osx)"
+            "__linux or __osx"
         );
 
         let spec: PixiSpec = serde_json::from_value(json!({
@@ -1852,7 +1852,7 @@ mod test {
                 .as_ref()
                 .unwrap()
                 .to_string(),
-            "(__unix and (__linux or __osx))"
+            "__unix and (__linux or __osx)"
         );
 
         let mut value = toml_span::parse(
@@ -1870,7 +1870,7 @@ mod test {
                 .as_ref()
                 .unwrap()
                 .to_string(),
-            "(__unix and python[version=\">=3.10\", build=\"*cuda\"])"
+            "__unix and python[version=\">=3.10\", build=\"*cuda\"]"
         );
     }
 
@@ -1883,13 +1883,13 @@ mod test {
     #[test]
     fn test_when_condition_all() {
         let input = json!({ "version": "*", "when": { "all": ["__unix", "python >=3.10"] } });
-        assert_snapshot!(parse_json_condition(input), @"(__unix and python>=3.10)");
+        assert_snapshot!(parse_json_condition(input), @"__unix and python>=3.10");
     }
 
     #[test]
     fn test_when_condition_any() {
         let input = json!({ "version": "*", "when": { "any": ["__linux", "__osx"] } });
-        assert_snapshot!(parse_json_condition(input), @"(__linux or __osx)");
+        assert_snapshot!(parse_json_condition(input), @"__linux or __osx");
     }
 
     #[test]
@@ -1898,7 +1898,7 @@ mod test {
             "version": "*",
             "when": { "all": ["__unix", { "any": ["__linux", "__osx"] }] },
         });
-        assert_snapshot!(parse_json_condition(input), @"(__unix and (__linux or __osx))");
+        assert_snapshot!(parse_json_condition(input), @"__unix and (__linux or __osx)");
     }
 
     #[test]
@@ -1977,14 +1977,14 @@ mod test {
     fn test_when_condition_toml_all_with_expanded_build_match() {
         let input = r#"version = "*"
 when = { all = ["__unix", { package = "python", version = ">=3.10", build = "*cuda" }] }"#;
-        assert_snapshot!(parse_toml_condition(input), @r###"(__unix and python[version=">=3.10", build="*cuda"])"###);
+        assert_snapshot!(parse_toml_condition(input), @r###"__unix and python[version=">=3.10", build="*cuda"]"###);
     }
 
     #[test]
     fn test_when_condition_toml_any() {
         let input = r#"version = "*"
 when = { any = ["__linux", "__osx"] }"#;
-        assert_snapshot!(parse_toml_condition(input), @"(__linux or __osx)");
+        assert_snapshot!(parse_toml_condition(input), @"__linux or __osx");
     }
 
     #[test]


### PR DESCRIPTION
### Description

Updates the rattler crates:

| crate | from | to |
| --- | --- | --- |
| `rattler_conda_types` | 0.50 | 0.51 |
| `rattler_repodata_gateway` | 0.32 | 0.33 |
| `rattler_virtual_packages` | 5.0 | 5.1 |
| `rattler_build_core` | 0.2.11 | 0.2.12 |
| `rattler_build_jinja` | 0.1.12 | 0.1.13 |
| `rattler_build_recipe` | 0.1.12 | 0.1.13 |
| `rattler_build_types` | 0.1.11 | 0.1.12 |
| `rattler_build_variant_config` | 0.1.12 | 0.1.13 |

Two renderings changed upstream, so the expectations move with them:

- A condition no longer carries redundant outer parentheses, so `(__linux or __osx)` reads `__linux or __osx`.
- A `MatchSpec` build string renders as a selector, so `__archspec 1.* ^(x86_64_v3|skylake)$` reads `__archspec 1.*[build="^(x86_64_v3|skylake)$"]`.

Both are user visible: they show up wherever pixi prints a spec or a condition.

### How Has This Been Tested?

- `cargo nextest run --workspace`: 2987 pass.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets` clean.