### PR TITLE
refactor(pixi-build-ros): replace the distro index fetch with a static mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,11 +6165,8 @@ dependencies = [
 name = "pixi-build-ros"
 version = "0.7.4"
 dependencies = [
- "astral-reqwest-middleware",
- "astral-reqwest-retry",
  "async-trait",
  "fs-err",
- "http-cache-reqwest",
  "indexmap 2.14.0",
  "insta",
  "miette 7.6.0",
@@ -6183,8 +6180,6 @@ dependencies = [
  "rattler_build_types",
  "rattler_conda_types",
  "regex",
- "reqwest",
- "retry-policies",
  "roxmltree",
  "serde",
  "serde_json",

--- a/crates/pixi_build_ros/Cargo.toml
+++ b/crates/pixi_build_ros/Cargo.toml
@@ -12,7 +12,6 @@ dist = false
 [dependencies]
 async-trait = { workspace = true }
 fs-err = { workspace = true }
-http-cache-reqwest = { workspace = true }
 indexmap = { workspace = true }
 miette = { workspace = true }
 pathdiff = { workspace = true }
@@ -25,10 +24,6 @@ rattler_build_recipe = { workspace = true }
 rattler_build_types = { workspace = true }
 rattler_conda_types = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true }
-reqwest-middleware = { workspace = true }
-reqwest-retry = { workspace = true }
-retry-policies = { workspace = true }
 roxmltree = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -47,4 +42,3 @@ tempfile = { workspace = true }
 default = ["rustls"]
 native-tls = ["pixi_build_backend/native-tls"]
 rustls = ["pixi_build_backend/rustls"]
-slow_integration_tests = []

--- a/crates/pixi_build_ros/src/distro.rs
+++ b/crates/pixi_build_ros/src/distro.rs
@@ -1,191 +1,83 @@
-//! ROS distribution index client.
+//! ROS distribution metadata.
 //!
-//! Fetches the ROS distribution index from GitHub and extracts distribution
-//! metadata (ROS1 vs ROS2, Python version, package list).
+//! Maps a ROS distribution name to the ROS version it belongs to. That version
+//! selects the distro mutex package, the `ROS_VERSION` build environment
+//! variable, and whether `ros_workspace` is added as a build dependency.
 
-use std::{collections::HashMap, path::Path};
+/// The ROS 1 distributions.
+///
+/// ROS 1 reached end-of-life with noetic (EOSL May 2025), so this list is
+/// closed and any distribution outside it is ROS 2.
+///
+/// Upstream `index-v4.yaml` only lists `groovy` onward; the earlier names are
+/// included so the list covers every ROS 1 release.
+const ROS1_DISTROS: &[&str] = &[
+    "boxturtle",
+    "cturtle",
+    "diamondback",
+    "electric",
+    "fuerte",
+    "groovy",
+    "hydro",
+    "indigo",
+    "jade",
+    "kinetic",
+    "lunar",
+    "melodic",
+    "noetic",
+];
 
-use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
-use miette::Diagnostic;
-use reqwest_middleware::ClientBuilder;
-use reqwest_retry::RetryTransientMiddleware;
-use retry_policies::policies::ExponentialBackoff;
-use serde::Deserialize;
-use thiserror::Error;
-
-const INDEX_URL: &str = "https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml";
-
-/// Number of times a transient failure (e.g. HTTP 429) is retried before giving
-/// up on the ROS distribution index request.
-const MAX_RETRIES: u32 = 3;
-
-/// Errors that can occur when fetching ROS distribution info.
-#[derive(Debug, Error, Diagnostic)]
-pub enum DistroError {
-    #[error("failed to fetch ROS distribution index")]
-    Fetch(#[from] reqwest_middleware::Error),
-
-    #[error(
-        "the ROS distribution index at {url} is being rate limited (HTTP 429 Too Many Requests)"
-    )]
-    #[diagnostic(help(
-        "GitHub throttled the request. The response is cached on disk once it \
-         succeeds, so retrying shortly usually resolves this. If it persists, \
-         wait a few minutes before building again."
-    ))]
-    RateLimited { url: String },
-
-    #[error("the ROS distribution index request to {url} failed with HTTP {status}")]
-    Status { url: String, status: u16 },
-
-    #[error("failed to read ROS distribution index response body")]
-    Body(#[from] reqwest::Error),
-
-    #[error("failed to parse ROS distribution index YAML")]
-    ParseIndex(#[source] serde_yaml::Error),
-
-    #[error("distribution '{name}' not found in ROS distribution index")]
-    #[diagnostic(help("Available distributions can be found at https://github.com/ros/rosdistro"))]
-    NotFound { name: String },
+/// The major ROS version a distribution belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RosVersion {
+    Ros1,
+    Ros2,
 }
 
-/// Information about a ROS distribution.
+impl RosVersion {
+    /// The version the given distribution belongs to.
+    fn for_distro(name: &str) -> Self {
+        if ROS1_DISTROS.contains(&name) {
+            Self::Ros1
+        } else {
+            Self::Ros2
+        }
+    }
+
+    /// The mutex package that pins a build to a single ROS distribution.
+    pub fn mutex_package_name(self) -> &'static str {
+        match self {
+            Self::Ros1 => "ros-distro-mutex",
+            Self::Ros2 => "ros2-distro-mutex",
+        }
+    }
+
+    /// The value of the `ROS_VERSION` environment variable.
+    pub fn as_env_value(self) -> &'static str {
+        match self {
+            Self::Ros1 => "1",
+            Self::Ros2 => "2",
+        }
+    }
+}
+
+/// A ROS distribution and the ROS version it belongs to.
 #[derive(Debug, Clone)]
 pub struct Distro {
     pub name: String,
-    pub is_ros1: bool,
-    pub python_version: Option<String>,
+    pub version: RosVersion,
 }
 
 impl Distro {
-    /// Fetch distribution info from the ROS distribution index.
+    /// The distribution with the given name.
     ///
-    /// When `http_cache_dir` is provided, the index response is cached on disk so
-    /// repeated backend invocations within the same workspace avoid hitting the
-    /// network. GitHub rate limits the unauthenticated `raw.githubusercontent.com`
-    /// request (HTTP 429), so it is also retried with exponential backoff.
-    pub async fn fetch(name: &str, http_cache_dir: Option<&Path>) -> Result<Self, DistroError> {
-        let client = reqwest::Client::new();
-        let mut builder = ClientBuilder::from_client(client.into());
-
-        // Cache outermost: a fresh cached index skips the network entirely.
-        if let Some(cache_dir) = http_cache_dir {
-            builder = builder.with(Cache(HttpCache {
-                mode: CacheMode::Default,
-                manager: CACacheManager {
-                    path: cache_dir.to_path_buf(),
-                    remove_opts: Default::default(),
-                },
-                options: HttpCacheOptions::default(),
-            }));
-        }
-
-        // Retry innermost: retries transient 429/5xx, honoring `Retry-After`.
-        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(MAX_RETRIES);
-        builder = builder.with(RetryTransientMiddleware::new_with_policy(retry_policy));
-
-        let client = builder.build();
-
-        let response = client.get(INDEX_URL).send().await?;
-
-        // Retries exhausted still return the last (error) response; check the
-        // status so a 429 body isn't misreported as a YAML parse failure.
-        let status = response.status();
-        if !status.is_success() {
-            return Err(if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                DistroError::RateLimited {
-                    url: INDEX_URL.to_string(),
-                }
-            } else {
-                DistroError::Status {
-                    url: INDEX_URL.to_string(),
-                    status: status.as_u16(),
-                }
-            });
-        }
-
-        let index_yaml = response.text().await?;
-
-        let index: DistroIndex =
-            serde_yaml::from_str(&index_yaml).map_err(DistroError::ParseIndex)?;
-
-        let entry = index.distributions.get(name).ok_or(DistroError::NotFound {
-            name: name.to_string(),
-        })?;
-
-        let is_ros1 = entry
-            .distribution_type
-            .as_deref()
-            .map(|t| t == "ros1")
-            .unwrap_or(false);
-
-        Ok(Distro {
-            name: name.to_string(),
-            is_ros1,
-            python_version: entry.python_version.clone(),
-        })
+    /// The name is lowercased and stripped of surrounding whitespace, matching
+    /// the normalization conda applies to the package names derived from it.
+    pub fn new(name: impl Into<String>) -> Self {
+        let name = name.into().trim().to_lowercase();
+        let version = RosVersion::for_distro(&name);
+        Self { name, version }
     }
-
-    /// Create a builder for constructing a Distro without fetching from the network.
-    #[cfg(test)]
-    pub fn builder(name: &str) -> DistroBuilder {
-        DistroBuilder {
-            name: name.to_string(),
-            is_ros1: false,
-            python_version: None,
-        }
-    }
-
-    /// Returns the mutex package name for this distro.
-    pub fn ros_distro_mutex_name(&self) -> String {
-        if self.is_ros1 {
-            "ros-distro-mutex".to_string()
-        } else {
-            "ros2-distro-mutex".to_string()
-        }
-    }
-}
-
-/// Builder for constructing a [`Distro`] in tests.
-#[cfg(test)]
-pub struct DistroBuilder {
-    name: String,
-    is_ros1: bool,
-    python_version: Option<String>,
-}
-
-#[cfg(test)]
-impl DistroBuilder {
-    pub fn ros1(mut self, is_ros1: bool) -> Self {
-        self.is_ros1 = is_ros1;
-        self
-    }
-
-    pub fn python_version(mut self, version: impl Into<String>) -> Self {
-        self.python_version = Some(version.into());
-        self
-    }
-
-    pub fn build(self) -> Distro {
-        Distro {
-            name: self.name,
-            is_ros1: self.is_ros1,
-            python_version: self.python_version,
-        }
-    }
-}
-
-/// The top-level ROS distribution index (index-v4.yaml).
-#[derive(Debug, Deserialize)]
-struct DistroIndex {
-    distributions: HashMap<String, DistroEntry>,
-}
-
-/// An entry in the distribution index.
-#[derive(Debug, Deserialize)]
-struct DistroEntry {
-    distribution_type: Option<String>,
-    python_version: Option<String>,
 }
 
 #[cfg(test)]
@@ -193,47 +85,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_distro_ros1() {
-        let distro = Distro::builder("noetic").ros1(true).build();
+    fn test_ros1_distro() {
+        let distro = Distro::new("noetic");
         assert_eq!(distro.name, "noetic");
-        assert!(distro.is_ros1);
-        assert_eq!(distro.ros_distro_mutex_name(), "ros-distro-mutex");
+        assert_eq!(distro.version, RosVersion::Ros1);
     }
 
     #[test]
-    fn test_distro_ros_2() {
-        let distro = Distro::builder("jazzy").build();
-        assert_eq!(distro.name, "jazzy");
-        assert!(!distro.is_ros1);
-        assert_eq!(distro.ros_distro_mutex_name(), "ros2-distro-mutex");
+    fn test_ros2_distro() {
+        assert_eq!(Distro::new("jazzy").version, RosVersion::Ros2);
+        assert_eq!(Distro::new("rolling").version, RosVersion::Ros2);
     }
 
     #[test]
-    fn test_parse_index_yaml() {
-        let yaml = r#"
-distributions:
-  noetic:
-    distribution:
-      - https://example.com/noetic/distribution.yaml
-    distribution_type: ros1
-    python_version: "3"
-  jazzy:
-    distribution:
-      - https://example.com/jazzy/distribution.yaml
-    distribution_type: ros2
-    python_version: "3"
-"#;
+    fn test_every_ros1_distro_is_recognized() {
+        for name in ROS1_DISTROS {
+            assert_eq!(Distro::new(*name).version, RosVersion::Ros1, "{name}");
+        }
+    }
 
-        let index: DistroIndex = serde_yaml::from_str(yaml).unwrap();
-        assert!(index.distributions.contains_key("noetic"));
-        assert!(index.distributions.contains_key("jazzy"));
-        assert_eq!(
-            index.distributions["noetic"].distribution_type.as_deref(),
-            Some("ros1")
-        );
-        assert_eq!(
-            index.distributions["jazzy"].distribution_type.as_deref(),
-            Some("ros2")
-        );
+    /// Distributions released after this code was written are ROS 2, so they
+    /// need no changes here.
+    #[test]
+    fn test_distro_postdating_this_code_is_ros2() {
+        assert_eq!(Distro::new("lyrical").version, RosVersion::Ros2);
+    }
+
+    /// Conda lowercases the package names derived from the distro, so the
+    /// classification has to agree with that rather than with what was typed.
+    #[test]
+    fn test_name_is_normalized() {
+        let distro = Distro::new("  Noetic  ");
+        assert_eq!(distro.name, "noetic");
+        assert_eq!(distro.version, RosVersion::Ros1);
+
+        assert_eq!(Distro::new("JAZZY").name, "jazzy");
+    }
+
+    #[test]
+    fn test_unknown_distro_is_ros2() {
+        assert_eq!(Distro::new("not-a-distro").version, RosVersion::Ros2);
+    }
+
+    #[test]
+    fn test_mutex_package_name() {
+        assert_eq!(RosVersion::Ros1.mutex_package_name(), "ros-distro-mutex");
+        assert_eq!(RosVersion::Ros2.mutex_package_name(), "ros2-distro-mutex");
+    }
+
+    #[test]
+    fn test_env_value() {
+        assert_eq!(RosVersion::Ros1.as_env_value(), "1");
+        assert_eq!(RosVersion::Ros2.as_env_value(), "2");
     }
 }

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -56,7 +56,7 @@ impl GenerateRecipe for RosGenerator {
         _variants: &HashSet<NormalizedKey>,
         channels: Vec<ChannelUrl>,
         _cache_dir: Option<PathBuf>,
-        workspace_scratch_directory: Option<PathBuf>,
+        _workspace_scratch_directory: Option<PathBuf>,
         workspace_directory: Option<PathBuf>,
         checkout_root: Option<PathBuf>,
     ) -> miette::Result<GeneratedRecipe> {
@@ -89,24 +89,19 @@ impl GenerateRecipe for RosGenerator {
                 )
             })?;
 
-        // Subdirectory inside the workspace scratch dir owned exclusively by this
-        // backend. `pixi-build-ros-v0` lets us bump the cache layout without
-        // colliding with concurrent backends or older cached entries.
-        let http_cache_dir = workspace_scratch_directory
-            .as_deref()
-            .map(|root| root.join("pixi-build-ros-v0").join("http-cache"));
-
-        let distro = Distro::fetch(&distro_name, http_cache_dir.as_deref()).await?;
+        let distro = Distro::new(distro_name);
 
         // Parse package.xml
         let package_xml_path = manifest_root.join("package.xml");
         let package_xml_content = fs::read_to_string(&package_xml_path).into_diagnostic()?;
 
         // Set up ROS environment for condition evaluation
-        let ros_version_str = if distro.is_ros1 { "1" } else { "2" };
         let mut env_vars: HashMap<String, String> = HashMap::new();
-        env_vars.insert("ROS_DISTRO".to_string(), distro_name.clone());
-        env_vars.insert("ROS_VERSION".to_string(), ros_version_str.to_string());
+        env_vars.insert("ROS_DISTRO".to_string(), distro.name.clone());
+        env_vars.insert(
+            "ROS_VERSION".to_string(),
+            distro.version.as_env_value().to_string(),
+        );
         if let Some(user_env) = &config.env {
             for (k, v) in user_env {
                 env_vars.insert(k.clone(), v.clone());
@@ -126,7 +121,7 @@ impl GenerateRecipe for RosGenerator {
 
         let mut generated_recipe = parse_and_render(
             package_xml.clone(),
-            &distro_name,
+            &distro.name,
             model.clone(),
             extra_input_globs.clone(),
             package_mapping_files,
@@ -188,7 +183,7 @@ impl GenerateRecipe for RosGenerator {
                 &discovery.packages,
                 &package_xml.name,
                 &manifest_root,
-                &distro_name,
+                &distro.name,
             );
 
             // Apply per-class: a manual entry in the model for the same conda
@@ -284,13 +279,13 @@ impl GenerateRecipe for RosGenerator {
         }
 
         // Add distro mutex to host and run
-        let mutex_name = distro.ros_distro_mutex_name();
+        let mutex_name = distro.version.mutex_package_name();
         host_items.push(Item::Value(Value::new_concrete(
-            SerializableMatchSpec::from(mutex_name.as_str()),
+            SerializableMatchSpec::from(mutex_name),
             None,
         )));
         run_items.push(Item::Value(Value::new_concrete(
-            SerializableMatchSpec::from(mutex_name.as_str()),
+            SerializableMatchSpec::from(mutex_name),
             None,
         )));
 
@@ -302,16 +297,16 @@ impl GenerateRecipe for RosGenerator {
 
         // Generate build script
         let build_type = package_xml.build_type();
-        let build_script_content = render_build_script(&build_type, &distro_name, &manifest_root)?;
+        let build_script_content = render_build_script(&build_type, &distro.name, &manifest_root)?;
 
         let mut script_env: indexmap::IndexMap<String, Value<String>> = indexmap::IndexMap::new();
         script_env.insert(
             "ROS_DISTRO".to_string(),
-            Value::new_concrete(distro_name.clone(), None),
+            Value::new_concrete(distro.name.clone(), None),
         );
         script_env.insert(
             "ROS_VERSION".to_string(),
-            Value::new_concrete(ros_version_str.to_string(), None),
+            Value::new_concrete(distro.version.as_env_value().to_string(), None),
         );
         if let Some(user_env) = &config.env {
             for (k, v) in user_env {
@@ -425,7 +420,7 @@ mod tests {
     }
 
     fn jazzy_distro() -> Distro {
-        Distro::builder("jazzy").build()
+        Distro::new("jazzy")
     }
 
     #[test]
@@ -647,7 +642,6 @@ mod tests {
     }
 
     /// Helper to generate a recipe from a package.xml fixture.
-    /// Uses Distro::fetch which requires network access.
     async fn generate_recipe_for_fixture(
         package_xml_name: &str,
         distro_name: &str,
@@ -686,7 +680,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_recipe_includes_project_run_dependency() {
         let model = project_fixture!({
             "name": "custom_ros",
@@ -811,7 +804,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_condition_evaluation_ros2_default() {
         let generated = generate_conditional_recipe("jazzy", None).await;
         insta::assert_yaml_snapshot!(filter_conditional_deps(&generated, "jazzy"), @r###"
@@ -824,7 +816,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_condition_evaluation_ros1_default() {
         let generated = generate_conditional_recipe("noetic", None).await;
         insta::assert_yaml_snapshot!(filter_conditional_deps(&generated, "noetic"), @r###"
@@ -837,7 +828,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_condition_evaluation_ros2_override_to_ros1() {
         let env = indexmap::IndexMap::from([
             ("ROS_VERSION".to_string(), "1".to_string()),
@@ -854,7 +844,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_generate_recipe_with_versions() {
         let model = project_fixture!({
             "targets": { "defaultTarget": {} }
@@ -878,7 +867,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_generate_recipe_with_mutex_version() {
         let model = project_fixture!({
             "name": "custom_ros",
@@ -924,7 +912,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_generate_recipe_with_versions_in_model_and_package() {
         let model = project_fixture!({
             "name": "custom_ros",
@@ -964,7 +951,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_generate_recipe_with_explicit_package_xml_path() {
         let model = project_fixture!({
             "targets": { "defaultTarget": {} }
@@ -1011,7 +997,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_config_auto_detects_distro_from_channel() {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_path = temp_dir.path();
@@ -1057,7 +1042,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_config_explicit_distro_overrides_channel() {
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_path = temp_dir.path();
@@ -1180,7 +1164,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_generate_recipe_with_custom_ros() {
         let model = project_fixture!({
             "targets": { "defaultTarget": {} }
@@ -1241,7 +1224,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(not(feature = "slow_integration_tests"), ignore)]
     async fn test_generate_recipe_with_inline_package_mappings() {
         let model = project_fixture!({
             "targets": { "defaultTarget": {} }

--- a/crates/pixi_build_ros/src/package_map.rs
+++ b/crates/pixi_build_ros/src/package_map.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::config::PackageMappingSource;
-use crate::distro::Distro;
+use crate::distro::{Distro, RosVersion};
 use crate::package_xml::{Dependency, PackageXml};
 
 /// Errors that can occur during package mapping resolution.
@@ -386,7 +386,7 @@ pub fn package_xml_to_conda_requirements(
 
     // Add ros_workspace for ROS2
     let ros_workspace_dep;
-    if !distro.is_ros1 {
+    if distro.version == RosVersion::Ros2 {
         ros_workspace_dep = Dependency::from("ros_workspace");
         build_deps.push(&ros_workspace_dep);
     }
@@ -628,7 +628,7 @@ mod tests {
     }
 
     fn jazzy_distro() -> Distro {
-        Distro::builder("jazzy").build()
+        Distro::new("jazzy")
     }
 
     #[test]

--- a/crates/pixi_build_types/src/procedures/initialize.rs
+++ b/crates/pixi_build_types/src/procedures/initialize.rs
@@ -75,6 +75,9 @@ pub struct InitializeParams {
     /// here. Concurrent backend instances may run simultaneously
     /// against the same path, so writes should be atomic
     /// (write-tempfile-then-rename style).
+    // TODO: No backend in this repository consumes this, though out-of-tree
+    // backends may. Remove it along with the next breaking change to the build
+    // API, so the removal rides a version bump that is already being paid for.
     pub workspace_scratch_directory: Option<PathBuf>,
 
     /// Project model that the backend should use even though it is an option


### PR DESCRIPTION
### Description

`pixi-build-ros` downloaded `index-v4.yaml` from `raw.githubusercontent.com` on every build to work out a single bit: whether a distro is ROS 1 or ROS 2. ROS 1 ended with noetic, so that is just a list now. Everything outside it is ROS 2, so new distros keep working without a pixi release.

- Replace `Distro::fetch` with `Distro::new`, which is infallible and does no I/O
- Add a `RosVersion` enum that owns the mutex package name and the `ROS_VERSION` value, replacing the `is_ros1` boolean
- Drop `reqwest`, `reqwest-middleware`, `reqwest-retry`, `retry-policies` and `http-cache-reqwest`, along with the unused `python_version` field
- Ungate the 13 tests that only needed the network for this fetch

### How Has This Been Tested?

Compared every distribution in upstream `index-v4.yaml` against `Distro::new`, all 21 agree. The suite passes inside `unshare -rn`, and the snapshots from the fetch era needed no updating.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

```plaintext
Please get rid of the distro fetch and replace it with a global mapping that
maps ros distro to ros version. Don't optimize for small diff, but for cleanes
code & architecture. Grill me
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
