### PR TITLE
feat: Cache unlocked script resolutions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6723,6 +6723,7 @@ dependencies = [
 name = "pixi_core"
 version = "0.1.0"
 dependencies = [
+ "async-fd-lock",
  "async-once-cell",
  "barrier_cell",
  "console",

--- a/crates/pixi_api/src/workspace/list/mod.rs
+++ b/crates/pixi_api/src/workspace/list/mod.rs
@@ -34,7 +34,7 @@ pub async fn list(
     let environment = workspace.environment_from_name_or_env_var(environment)?;
 
     let lock_file = workspace
-        .update_lock_file(
+        .resolve_lock_file(
             None,
             UpdateLockFileOptions {
                 lock_file_usage,

--- a/crates/pixi_api/src/workspace/remove/mod.rs
+++ b/crates/pixi_api/src/workspace/remove/mod.rs
@@ -59,6 +59,12 @@ pub async fn remove_conda_deps(
     spec_type: SpecType,
     options: DependencyOptions,
 ) -> Result<(), RemoveError> {
+    let update_environment = options.lock_file_usage == LockFileUsage::Update
+        && (!workspace.workspace().is_script()
+            || workspace
+                .workspace()
+                .persistent_lock_file_path()
+                .is_some_and(|path| path.is_file()));
     // Prevent removing Python if PyPI dependencies exist
     for name in specs.keys() {
         if name.as_source() == "python" {
@@ -89,7 +95,7 @@ pub async fn remove_conda_deps(
 
     // TODO: update all environments touched by this feature defined.
     // updating prefix after removing from toml
-    if options.lock_file_usage == LockFileUsage::Update {
+    if update_environment {
         get_update_lock_file_and_prefix(
             &workspace.default_environment(),
             None,
@@ -115,6 +121,12 @@ pub async fn remove_pypi_deps(
     pypi_deps: PypiDeps,
     options: DependencyOptions,
 ) -> Result<(), RemoveError> {
+    let update_environment = options.lock_file_usage == LockFileUsage::Update
+        && (!workspace.workspace().is_script()
+            || workspace
+                .workspace()
+                .persistent_lock_file_path()
+                .is_some_and(|path| path.is_file()));
     for name in pypi_deps.keys() {
         workspace
             .manifest()
@@ -125,7 +137,7 @@ pub async fn remove_pypi_deps(
 
     // TODO: update all environments touched by this feature defined.
     // updating prefix after removing from toml
-    if options.lock_file_usage == LockFileUsage::Update {
+    if update_environment {
         get_update_lock_file_and_prefix(
             &workspace.default_environment(),
             None,

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -9,8 +9,7 @@ use pixi_api::{
 use pixi_config::ConfigCli;
 use pixi_consts::consts;
 use pixi_core::{
-    DependencyType, Workspace, WorkspaceLocator,
-    environment::LockFileUsage,
+    DependencyType, WorkspaceLocator,
     workspace::{PypiDeps, SkippedPackage},
 };
 use pixi_manifest::HasFeaturesIter;
@@ -145,16 +144,12 @@ impl Args {
         }
     }
 
-    fn dependency_options(&self, workspace: &Workspace) -> miette::Result<DependencyOptions> {
+    fn dependency_options(&self) -> miette::Result<DependencyOptions> {
         Ok(DependencyOptions {
             feature: self.dependency_config.feature_name(),
             platforms: self.dependency_config.platforms.clone(),
             no_install: self.no_install_config.no_install,
-            lock_file_usage: add_lock_file_usage(
-                self.lock_file_update_config.lock_file_usage()?,
-                self.workspace_config.script.is_some(),
-                workspace.lock_file_path().is_file(),
-            ),
+            lock_file_usage: self.lock_file_update_config.lock_file_usage()?,
         })
     }
 }
@@ -244,12 +239,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .map(|n| n.as_normalized().to_string())
                     .collect();
                 let result = workspace_ctx
-                    .add_conda_deps(
-                        specs,
-                        spec_type,
-                        args.dependency_options(&workspace)?,
-                        git_options,
-                    )
+                    .add_conda_deps(specs, spec_type, args.dependency_options()?, git_options)
                     .await?;
                 (result.0, result.1, names)
             }
@@ -271,11 +261,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                     .map(|n| n.as_normalized().to_string())
                     .collect();
                 let result = workspace_ctx
-                    .add_pypi_deps(
-                        pypi_deps,
-                        args.editable,
-                        args.dependency_options(&workspace)?,
-                    )
+                    .add_pypi_deps(pypi_deps, args.editable, args.dependency_options()?)
                     .await?;
                 (result.0, result.1, names)
             }
@@ -373,16 +359,4 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     }
 
     Ok(())
-}
-
-fn add_lock_file_usage(
-    requested: LockFileUsage,
-    is_script: bool,
-    lock_file_exists: bool,
-) -> LockFileUsage {
-    if is_script && !lock_file_exists && requested == LockFileUsage::Update {
-        LockFileUsage::DryRun
-    } else {
-        requested
-    }
 }

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -78,37 +78,13 @@ impl ScriptWorkspaceConfig {
     }
 }
 
-/// Select the lock-file policy for commands that can consume a script
-/// without persisting an adjacent lock file.
-pub(crate) fn script_lock_file_usage(
+/// Reject lock-file modes that require authority a transient script cannot
+/// provide.
+pub(crate) fn validate_transient_script_lock_file_usage(
     requested: LockFileUsage,
-    is_script: bool,
-    lock_file_exists: bool,
-) -> miette::Result<LockFileUsage> {
-    if !is_script || lock_file_exists {
-        return Ok(requested);
-    }
-
+) -> miette::Result<()> {
     match requested {
-        LockFileUsage::Update | LockFileUsage::DryRun => Ok(LockFileUsage::DryRun),
-        LockFileUsage::Locked => Err(miette::miette!(
-            help = "Create one with `pixi lock --script <PATH>`.",
-            "no lock file exists for the script, but `--locked` was requested"
-        )),
-        LockFileUsage::Frozen => Err(miette::miette!(
-            help = "Create one with `pixi lock --script <PATH>`.",
-            "no lock file exists for the script, but `--frozen` was requested"
-        )),
-    }
-}
-
-/// Select the lock-file policy for a transient script, which can never have an
-/// adjacent lock file.
-pub(crate) fn transient_script_lock_file_usage(
-    requested: LockFileUsage,
-) -> miette::Result<LockFileUsage> {
-    match requested {
-        LockFileUsage::Update | LockFileUsage::DryRun => Ok(LockFileUsage::DryRun),
+        LockFileUsage::Update | LockFileUsage::DryRun => Ok(()),
         LockFileUsage::Locked => Err(miette::miette!(
             "transient scripts cannot be run with `--locked` because they do not have an adjacent lock file"
         )),
@@ -589,8 +565,7 @@ mod tests {
 
     use crate::cli_config::{
         DependencyConfig, GitRev, LockAndInstallConfig, LockFileUpdateConfig, NoInstallConfig,
-        ScriptWorkspaceConfig, build_vcs_requirement, script_lock_file_usage,
-        transient_script_lock_file_usage,
+        ScriptWorkspaceConfig, build_vcs_requirement, validate_transient_script_lock_file_usage,
     };
     use pixi_core::environment::LockFileUsage;
     use pixi_core::workspace::DiscoveryStart;
@@ -637,27 +612,10 @@ mod tests {
     }
 
     #[test]
-    fn an_absent_script_lock_is_solved_without_being_written() {
-        assert_eq!(
-            script_lock_file_usage(LockFileUsage::Update, true, false).unwrap(),
-            LockFileUsage::DryRun
-        );
-        assert_eq!(
-            script_lock_file_usage(LockFileUsage::Update, true, true).unwrap(),
-            LockFileUsage::Update
-        );
-        assert!(script_lock_file_usage(LockFileUsage::Locked, true, false).is_err());
-        assert!(script_lock_file_usage(LockFileUsage::Frozen, true, false).is_err());
-        assert_eq!(
-            script_lock_file_usage(LockFileUsage::Update, false, false).unwrap(),
-            LockFileUsage::Update
-        );
-        assert_eq!(
-            transient_script_lock_file_usage(LockFileUsage::Update).unwrap(),
-            LockFileUsage::DryRun
-        );
-        assert!(transient_script_lock_file_usage(LockFileUsage::Locked).is_err());
-        assert!(transient_script_lock_file_usage(LockFileUsage::Frozen).is_err());
+    fn transient_scripts_reject_authoritative_lock_modes() {
+        assert!(validate_transient_script_lock_file_usage(LockFileUsage::Update).is_ok());
+        assert!(validate_transient_script_lock_file_usage(LockFileUsage::Locked).is_err());
+        assert!(validate_transient_script_lock_file_usage(LockFileUsage::Frozen).is_err());
     }
 
     #[test]

--- a/crates/pixi_cli/src/list.rs
+++ b/crates/pixi_cli/src/list.rs
@@ -16,9 +16,7 @@ use rattler_conda_types::Platform;
 use serde::Serialize;
 
 use crate::{
-    cli_config::{
-        LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage,
-    },
+    cli_config::{LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig},
     cli_interface::CliInterface,
 };
 
@@ -216,11 +214,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let lock_file_usage = script_lock_file_usage(
-        args.lock_file_update_config.lock_file_usage()?,
-        args.workspace_config.script.is_some(),
-        workspace.lock_file_path().is_file(),
-    )?;
+    let lock_file_usage = args.lock_file_update_config.lock_file_usage()?;
     let environment = workspace.environment_from_name_or_env_var(args.environment.clone())?;
     let platform_display: String = match &args.platform {
         Some(p) => p.to_string(),

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -7,7 +7,7 @@ use pixi_api::{
     workspace::{DependencyOptions, RemoveError},
 };
 use pixi_config::ConfigCli;
-use pixi_core::{DependencyType, WorkspaceLocator, environment::LockFileUsage};
+use pixi_core::{DependencyType, WorkspaceLocator};
 use pixi_manifest::HasWorkspaceManifest;
 
 use crate::{cli_config::LockFileUpdateConfig, has_specs::HasSpecs};
@@ -95,11 +95,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         feature: args.dependency_config.feature_name(),
         platforms: args.dependency_config.platforms.clone(),
         no_install: args.no_install_config.no_install,
-        lock_file_usage: remove_lock_file_usage(
-            args.lock_file_update_config.lock_file_usage()?,
-            args.workspace_config.script.is_some(),
-            workspace.lock_file_path().is_file(),
-        ),
+        lock_file_usage: args.lock_file_update_config.lock_file_usage()?,
     };
 
     let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
@@ -163,17 +159,5 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             )))
         }
         (Err(other), _) => Err(miette::Report::new(other)),
-    }
-}
-
-fn remove_lock_file_usage(
-    requested: LockFileUsage,
-    is_script: bool,
-    lock_file_exists: bool,
-) -> LockFileUsage {
-    if is_script && !lock_file_exists && requested == LockFileUsage::Update {
-        LockFileUsage::DryRun
-    } else {
-        requested
     }
 }

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -42,13 +42,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::Level;
 
 use crate::cli_config::{
-    LockAndInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage,
-    transient_script_lock_file_usage,
+    LockAndInstallConfig, ScriptWorkspaceConfig, validate_transient_script_lock_file_usage,
 };
 use crate::process_exit;
 use crate::run_script::{
     RunScriptInput, STDIN_SCRIPT_COMMAND, StdinScriptCommand, prepare_remote_script,
-    prepare_stdin_script,
+    prepare_stdin_script, transient_script_cache_key,
 };
 use crate::shared::install_platform::resolve_install_platform;
 
@@ -177,21 +176,22 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
         .script
         .as_deref()
         .map(RunScriptInput::classify);
+    let requested_lock_file_usage = args.lock_and_install_config.lock_file_usage()?;
     let global_config_source = args.config_source.source();
-    let mut transient_lock_file_usage = None;
     let mut _remote_script_file = None;
     let mut stdin_script_command = None;
     let workspace = match script_input {
         Some(RunScriptInput::Remote(url)) => {
-            transient_lock_file_usage = Some(transient_script_lock_file_usage(
-                args.lock_and_install_config.lock_file_usage()?,
-            )?);
+            validate_transient_script_lock_file_usage(requested_lock_file_usage)?;
             let root = std::env::current_dir().into_diagnostic()?;
             let config = pixi_config::Config::load_with(&root, &global_config_source)
                 .merge_config(cli_config);
             let prepared = prepare_remote_script(url, &config, &root).await?;
-            let mut cache_key = b"remote\0".to_vec();
-            cache_key.extend_from_slice(prepared.original_url.as_str().as_bytes());
+            let cache_key = transient_script_cache_key(
+                b"remote",
+                prepared.original_url.as_str().as_bytes(),
+                &root,
+            );
             let WithWarnings {
                 value: workspace,
                 warnings,
@@ -210,9 +210,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             workspace
         }
         Some(RunScriptInput::Stdin) => {
-            transient_lock_file_usage = Some(transient_script_lock_file_usage(
-                args.lock_and_install_config.lock_file_usage()?,
-            )?);
+            validate_transient_script_lock_file_usage(requested_lock_file_usage)?;
             let root = std::env::current_dir().into_diagnostic()?;
             let config = pixi_config::Config::load_with(&root, &global_config_source)
                 .merge_config(cli_config);
@@ -221,8 +219,11 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                 .read_to_end(&mut contents)
                 .into_diagnostic()?;
             let prepared = prepare_stdin_script(contents, &root)?;
-            let mut cache_key = b"stdin\0".to_vec();
-            cache_key.extend_from_slice(prepared.manifest.metadata().as_bytes());
+            let cache_key = transient_script_cache_key(
+                b"stdin",
+                prepared.manifest.metadata().as_bytes(),
+                &root,
+            );
             let WithWarnings {
                 value: workspace,
                 warnings,
@@ -332,21 +333,11 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
     let progress = pixi_reporters::TopLevelProgress::from_global();
 
     // Ensure that the lock file is up-to-date.
-    let lock_file_usage = match transient_lock_file_usage {
-        Some(lock_file_usage) => lock_file_usage,
-        None => script_lock_file_usage(
-            args.lock_and_install_config.lock_file_usage()?,
-            is_script,
-            workspace
-                .persistent_lock_file_path()
-                .is_some_and(|path| path.is_file()),
-        )?,
-    };
     let mut lock_file = workspace
-        .update_lock_file(
+        .resolve_lock_file(
             Some(progress.clone()),
             UpdateLockFileOptions {
-                lock_file_usage,
+                lock_file_usage: requested_lock_file_usage,
                 no_install: args.lock_and_install_config.no_install(),
                 max_concurrent_solves: workspace.config().max_concurrent_solves(),
                 ..Default::default()

--- a/crates/pixi_cli/src/run_script.rs
+++ b/crates/pixi_cli/src/run_script.rs
@@ -41,6 +41,16 @@ impl RunScriptInput {
 
 pub(crate) const STDIN_SCRIPT_COMMAND: &str = "__pixi_stdin_script__";
 
+pub(crate) fn transient_script_cache_key(kind: &[u8], identity: &[u8], root: &Path) -> Vec<u8> {
+    let mut key = Vec::with_capacity(kind.len() + identity.len() + root.as_os_str().len() + 2);
+    key.extend_from_slice(kind);
+    key.push(0);
+    key.extend_from_slice(root.as_os_str().as_encoded_bytes());
+    key.push(0);
+    key.extend_from_slice(identity);
+    key
+}
+
 #[derive(Clone)]
 pub(crate) struct StdinScriptCommand {
     contents: Arc<str>,
@@ -285,6 +295,7 @@ fn friendly_name(url: &Url) -> String {
 mod tests {
     use super::{
         Gist, RunScriptInput, friendly_name, gist_id, resolve_gist_at, safe_url, select_gist_file,
+        transient_script_cache_key,
     };
     use std::{
         io::{Read, Write},
@@ -352,6 +363,17 @@ mod tests {
             RunScriptInput::classify(Path::new("-")),
             RunScriptInput::Stdin
         ));
+    }
+
+    #[test]
+    fn transient_cache_keys_include_kind_and_working_directory() {
+        let identity = b"same metadata";
+        let first = transient_script_cache_key(b"stdin", identity, Path::new("/first"));
+        let second = transient_script_cache_key(b"stdin", identity, Path::new("/second"));
+        let remote = transient_script_cache_key(b"remote", identity, Path::new("/first"));
+
+        assert_ne!(first, second);
+        assert_ne!(first, remote);
     }
 
     #[test]

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -1,6 +1,4 @@
-use crate::cli_config::{
-    LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage,
-};
+use crate::cli_config::{LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig};
 use crate::shared::tree::{
     Dependency, Package, PackageSource, build_reverse_dependency_map, print_dependency_tree,
     print_inverted_dependency_tree,
@@ -87,13 +85,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .environment_from_name_or_env_var(args.environment)
         .wrap_err("Environment not found")?;
 
-    let lock_file_usage = script_lock_file_usage(
-        args.lock_file_update_config.lock_file_usage()?,
-        args.workspace_config.script.is_some(),
-        workspace.lock_file_path().is_file(),
-    )?;
+    let lock_file_usage = args.lock_file_update_config.lock_file_usage()?;
     let lock_file = workspace
-        .update_lock_file(
+        .resolve_lock_file(
             Some(pixi_reporters::TopLevelProgress::from_global()),
             UpdateLockFileOptions {
                 lock_file_usage,

--- a/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
@@ -15,9 +15,7 @@ use rattler_lock::{
     CondaPackageData, Environment, LockedPackage, Platform as LockedPlatform, PlatformName,
 };
 
-use crate::cli_config::{
-    LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage,
-};
+use crate::cli_config::{LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig};
 
 #[derive(Debug, Parser)]
 #[clap(arg_required_else_help = false)]
@@ -204,13 +202,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .locate()?
         .with_cli_config(args.config.clone());
 
-    let lock_file_usage = script_lock_file_usage(
-        args.lock_file_update_config.lock_file_usage()?,
-        args.workspace_config.script.is_some(),
-        workspace.lock_file_path().is_file(),
-    )?;
+    let lock_file_usage = args.lock_file_update_config.lock_file_usage()?;
     let lock_file = workspace
-        .update_lock_file(
+        .resolve_lock_file(
             Some(pixi_reporters::TopLevelProgress::from_global()),
             UpdateLockFileOptions {
                 lock_file_usage,

--- a/crates/pixi_core/Cargo.toml
+++ b/crates/pixi_core/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+async-fd-lock = { workspace = true }
 async-once-cell = { workspace = true }
 barrier_cell = { workspace = true }
 console = { workspace = true }

--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -17,6 +17,7 @@ pub use package_identifier::PypiPackageIdentifier;
 use pixi_install_pypi::LockedPypiRecord;
 use pixi_record::PixiRecord;
 pub use pixi_uv_context::UvResolutionContext;
+pub(crate) use platform_rename::align_platform_names;
 pub use rattler_lock::Verbatim;
 pub use records_by_name::{
     HasNameVersion, PixiRecordsByName, PypiRecordsByName, UnresolvedPixiRecordsByName,

--- a/crates/pixi_core/src/lock_file/mod.rs
+++ b/crates/pixi_core/src/lock_file/mod.rs
@@ -17,7 +17,7 @@ pub use package_identifier::PypiPackageIdentifier;
 use pixi_install_pypi::LockedPypiRecord;
 use pixi_record::PixiRecord;
 pub use pixi_uv_context::UvResolutionContext;
-pub(crate) use platform_rename::align_platform_names;
+pub(crate) use platform_rename::{align_platform_names, shorten_platform_names};
 pub use rattler_lock::Verbatim;
 pub use records_by_name::{
     HasNameVersion, PixiRecordsByName, PypiRecordsByName, UnresolvedPixiRecordsByName,

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -220,6 +220,43 @@ impl LockFileLoadResult {
     }
 }
 
+fn lock_file_for_usage(
+    lock_file_result: LockFileLoadResult,
+    lock_file_usage: LockFileUsage,
+) -> miette::Result<LockFile> {
+    if lock_file_result.is_version_mismatch()
+        && matches!(
+            lock_file_usage,
+            LockFileUsage::Locked | LockFileUsage::Frozen
+        )
+        && let LockFileLoadResult::VersionMismatch {
+            lock_file_version,
+            max_supported_version,
+        } = lock_file_result
+    {
+        #[cfg(feature = "self_update")]
+        let update_instruction = "Try running `pixi self-update` to update to the latest version.";
+        #[cfg(not(feature = "self_update"))]
+        let update_instruction = "Please update pixi to the latest version and try again.";
+
+        let help_message = format!(
+            "Maximum supported version: {} (pixi v{})\n\
+             Cannot continue with --locked or --frozen mode as the lock file cannot be read.\n\
+             {}",
+            max_supported_version,
+            consts::PIXI_VERSION,
+            update_instruction
+        );
+        return Err(LockFileVersionMismatchError {
+            lock_file_version,
+            help_message,
+        }
+        .into());
+    }
+
+    Ok(lock_file_result.into_lock_file_or_empty_with_warning())
+}
+
 impl Workspace {
     /// Ensures that the lock file is up-to-date with the project.
     ///
@@ -238,44 +275,33 @@ impl Workspace {
         progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
         options: UpdateLockFileOptions,
     ) -> miette::Result<(LockFileDerivedData<'_>, bool)> {
-        let lock_file_result = self.load_lock_file().await?;
+        self.update_lock_file_with_input(progress, options, LockFileInput::Workspace)
+            .await
+    }
 
-        // Handle version mismatch - error if --locked or --frozen is set
-        if lock_file_result.is_version_mismatch()
-            && (options.lock_file_usage == LockFileUsage::Locked
-                || options.lock_file_usage == LockFileUsage::Frozen)
-        {
-            // Extract the version info for the error message
-            if let LockFileLoadResult::VersionMismatch {
-                lock_file_version,
-                max_supported_version,
-            } = lock_file_result
-            {
-                #[cfg(feature = "self_update")]
-                let update_instruction =
-                    "Try running `pixi self-update` to update to the latest version.";
-                #[cfg(not(feature = "self_update"))]
-                let update_instruction = "Please update pixi to the latest version and try again.";
+    pub(crate) async fn update_lock_file_from_lock_file(
+        &self,
+        progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
+        options: UpdateLockFileOptions,
+        lock_file: LockFile,
+    ) -> miette::Result<(LockFileDerivedData<'_>, bool)> {
+        self.update_lock_file_with_input(progress, options, LockFileInput::Provided(lock_file))
+            .await
+    }
 
-                let help_message = format!(
-                    "Maximum supported version: {} (pixi v{})\n\
-                         Cannot continue with --locked or --frozen mode as the lock file cannot be read.\n\
-                         {}",
-                    max_supported_version,
-                    consts::PIXI_VERSION,
-                    update_instruction
-                );
-
-                return Err(LockFileVersionMismatchError {
-                    lock_file_version,
-                    help_message,
-                }
-                .into());
+    async fn update_lock_file_with_input(
+        &self,
+        progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
+        options: UpdateLockFileOptions,
+        input: LockFileInput,
+    ) -> miette::Result<(LockFileDerivedData<'_>, bool)> {
+        let persist_lock_file = input.should_persist();
+        let lock_file = match input {
+            LockFileInput::Workspace => {
+                lock_file_for_usage(self.load_lock_file().await?, options.lock_file_usage)?
             }
-        }
-
-        // Load the lock file, displaying warning if there's a version mismatch
-        let lock_file = lock_file_result.into_lock_file_or_empty_with_warning();
+            LockFileInput::Provided(lock_file) => lock_file,
+        };
 
         let needs_format_upgrade = lock_file.version() < rattler_lock::FileFormatVersion::LATEST;
 
@@ -405,7 +431,7 @@ impl Workspace {
 
         // Write the lock file to disk
 
-        if options.lock_file_usage != LockFileUsage::DryRun {
+        if persist_lock_file && options.lock_file_usage != LockFileUsage::DryRun {
             lock_file_derived_data.write_to_disk()?;
         }
 
@@ -514,6 +540,22 @@ pub enum SolveCondaEnvironmentError {
 impl From<ParseChannelError> for SolveCondaEnvironmentError {
     fn from(value: ParseChannelError) -> Self {
         SolveCondaEnvironmentError::ParseChannels(Box::new(value))
+    }
+}
+
+/// Selects the initial resolution and whether an update may be persisted
+/// through the workspace's normal lock-file path.
+enum LockFileInput {
+    /// Load and, when permitted, update the workspace's persistent lock file.
+    Workspace,
+    /// Validate a caller-owned resolution without reading or writing the
+    /// workspace's persistent lock file.
+    Provided(LockFile),
+}
+
+impl LockFileInput {
+    fn should_persist(&self) -> bool {
+        matches!(self, Self::Workspace)
     }
 }
 

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -65,7 +65,6 @@ use pixi_manifest::platform::host::{host_capabilities, host_subdir};
 use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
 pub use registry::{WorkspaceRegistry, WorkspaceRegistryError};
-pub use script_environment::ScriptEnvironmentOptions;
 pub use solve_group::SolveGroup;
 use tokio::sync::Semaphore;
 pub use workspace_mut::WorkspaceMut;

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -570,6 +570,14 @@ impl Workspace {
             .unwrap_or_else(|| self.default_pixi_dir())
     }
 
+    pub(crate) fn with_script_pixi_dir(mut self, path: PathBuf) -> Self {
+        if let WorkspaceStorage::Script { pixi_dir, .. } = &mut self.storage {
+            *pixi_dir = path;
+            self.env_vars = Self::init_env_vars(&self.workspace.value.environments);
+        }
+        self
+    }
+
     /// Create the detached-environments path for this project if it is set in
     /// the config
     fn detached_environments_path(&self) -> Option<PathBuf> {

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -6,6 +6,7 @@ pub mod grouped_environment;
 mod has_project_ref;
 pub mod registry;
 mod repodata;
+mod script_environment;
 mod solve_group;
 pub mod stdlib_variants;
 pub mod virtual_packages;
@@ -64,6 +65,7 @@ use pixi_manifest::platform::host::{host_capabilities, host_subdir};
 use rattler_networking::{LazyClient, s3_middleware};
 use rattler_repodata_gateway::Gateway;
 pub use registry::{WorkspaceRegistry, WorkspaceRegistryError};
+pub use script_environment::ScriptEnvironmentOptions;
 pub use solve_group::SolveGroup;
 use tokio::sync::Semaphore;
 pub use workspace_mut::WorkspaceMut;
@@ -725,6 +727,11 @@ impl Workspace {
             WorkspaceStorage::Project => Some(self.root.join(consts::PROJECT_LOCK_FILE)),
             WorkspaceStorage::Script { lock_file_path, .. } => lock_file_path.clone(),
         }
+    }
+
+    /// Returns whether this workspace was constructed from a PEP 723 script.
+    pub fn is_script(&self) -> bool {
+        matches!(self.storage, WorkspaceStorage::Script { .. })
     }
 
     /// Returns the default environment of the project.

--- a/crates/pixi_core/src/workspace/script_environment.rs
+++ b/crates/pixi_core/src/workspace/script_environment.rs
@@ -1,0 +1,296 @@
+//! Resolution selection for PEP 723 script environments.
+//!
+//! A script's adjacent lock file is optional exact resolution authority. When
+//! it is absent, Pixi keeps a disposable cached resolution under the script's
+//! environment cache directory. Missing, corrupt, or unsupported cache state
+//! is treated as a cache miss.
+
+use std::{path::PathBuf, sync::Arc};
+
+use miette::{Context, IntoDiagnostic};
+use pixi_manifest::HasWorkspaceManifest;
+use rattler_lock::LockFile;
+use serde::{Deserialize, Serialize};
+
+use super::Workspace;
+use crate::{
+    environment::LockFileUsage,
+    lock_file::{LockFileDerivedData, UpdateLockFileOptions},
+};
+
+const CACHE_VERSION: u32 = 1;
+const CACHE_FILE: &str = "script-resolution-v1.json";
+
+#[derive(Serialize, Deserialize)]
+struct StoredResolution {
+    version: u32,
+    lock_file: String,
+}
+
+/// Options for resolving a script environment.
+pub struct ScriptEnvironmentOptions {
+    pub progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
+    pub lock_file_usage: LockFileUsage,
+    pub no_install: bool,
+}
+
+impl Workspace {
+    /// Resolve a script from its adjacent lock file or disposable cache.
+    ///
+    /// This method never writes the adjacent lock file. A resolved change is
+    /// caller-owned until the script environment Module commits it.
+    pub async fn resolve_script_environment(
+        &self,
+        options: ScriptEnvironmentOptions,
+    ) -> miette::Result<LockFileDerivedData<'_>> {
+        if !self.is_script() {
+            return Err(miette::miette!(
+                "script environment resolution requires a PEP 723 workspace"
+            ));
+        }
+
+        let ScriptEnvironmentOptions {
+            progress,
+            lock_file_usage,
+            no_install,
+        } = options;
+        let cache_path = self.pixi_dir().join(CACHE_FILE);
+        let adjacent_lock_exists = self
+            .persistent_lock_file_path()
+            .is_some_and(|path| path.is_file());
+
+        if !adjacent_lock_exists {
+            match lock_file_usage {
+                LockFileUsage::Locked => {
+                    return Err(miette::miette!(
+                        help = "Create one with `pixi lock --script <PATH>`.",
+                        "no lock file exists for the script, but `--locked` was requested"
+                    ));
+                }
+                LockFileUsage::Frozen => {
+                    return Err(miette::miette!(
+                        help = "Create one with `pixi lock --script <PATH>`.",
+                        "no lock file exists for the script, but `--frozen` was requested"
+                    ));
+                }
+                LockFileUsage::Update | LockFileUsage::DryRun => {}
+            }
+        }
+
+        let baseline = if adjacent_lock_exists {
+            let loaded = self.load_lock_file().await?;
+            if matches!(
+                lock_file_usage,
+                LockFileUsage::Locked | LockFileUsage::Frozen
+            ) {
+                loaded.into_lock_file()?
+            } else {
+                loaded.into_lock_file_or_empty_with_warning()
+            }
+        } else {
+            load_cached_resolution(cache_path.clone(), self)
+                .await
+                .unwrap_or_default()
+        };
+
+        let (resolved, _) = self
+            .update_lock_file_from_lock_file(
+                progress,
+                UpdateLockFileOptions {
+                    lock_file_usage,
+                    no_install,
+                    max_concurrent_solves: self.config().max_concurrent_solves(),
+                    ..Default::default()
+                },
+                baseline,
+            )
+            .await?;
+
+        if !adjacent_lock_exists
+            && lock_file_usage != LockFileUsage::DryRun
+            && let Err(error) = store_cached_resolution(cache_path, resolved.as_lock_file()).await
+        {
+            tracing::warn!(
+                %error,
+                "failed to cache the script resolution; the environment remains usable"
+            );
+        }
+
+        Ok(resolved)
+    }
+}
+
+async fn store_cached_resolution(path: PathBuf, lock_file: &LockFile) -> miette::Result<()> {
+    let lock_file = lock_file
+        .render_to_string()
+        .into_diagnostic()
+        .context("failed to serialize the cached script resolution")?;
+    let contents = serde_json::to_vec(&StoredResolution {
+        version: CACHE_VERSION,
+        lock_file,
+    })
+    .into_diagnostic()
+    .context("failed to serialize cached script resolution state")?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to create the script environment cache `{}`",
+                    parent.display()
+                )
+            })?;
+    }
+    pixi_utils::atomic_write::atomic_write(&path, contents)
+        .await
+        .into_diagnostic()
+        .wrap_err_with(|| {
+            format!(
+                "failed to write script resolution cache `{}`",
+                path.display()
+            )
+        })
+}
+
+async fn load_cached_resolution(path: PathBuf, workspace: &Workspace) -> Option<LockFile> {
+    let contents = match tokio::fs::read_to_string(&path).await {
+        Ok(contents) => contents,
+        Err(error) => {
+            tracing::debug!(path = %path.display(), %error, "script resolution cache is unavailable");
+            return None;
+        }
+    };
+    let stored: StoredResolution = match serde_json::from_str(&contents) {
+        Ok(stored) => stored,
+        Err(error) => {
+            tracing::debug!(path = %path.display(), %error, "script resolution cache is invalid");
+            return None;
+        }
+    };
+    if stored.version != CACHE_VERSION {
+        tracing::debug!(
+            path = %path.display(),
+            version = stored.version,
+            "script resolution cache has an unsupported version"
+        );
+        return None;
+    }
+    let lock_file = match LockFile::from_str_with_base_directory(
+        &stored.lock_file,
+        Some(workspace.root()),
+    ) {
+        Ok(lock_file) => lock_file,
+        Err(error) => {
+            tracing::debug!(path = %path.display(), %error, "script resolution cache contains an invalid lock file");
+            return None;
+        }
+    };
+    Some(crate::lock_file::align_platform_names(
+        lock_file,
+        workspace.workspace_manifest(),
+        workspace.root(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use pixi_config::{CacheConfig, Config};
+    use pixi_manifest::script::ScriptManifest;
+    use rattler_conda_types::NamedChannelOrUrl;
+
+    use super::*;
+
+    fn script_workspace(root: &std::path::Path, cache: &std::path::Path) -> Workspace {
+        let path = root.join("example.py");
+        fs_err::write(
+            &path,
+            "# /// script\n# dependencies = []\n# ///\nprint(\"hello\")\n",
+        )
+        .unwrap();
+        let script = ScriptManifest::from_path(path).unwrap().unwrap();
+        Workspace::from_script(
+            script,
+            Config {
+                default_channels: vec![NamedChannelOrUrl::Name("testing".into())],
+                cache: CacheConfig {
+                    exec_environments: Some(cache.to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .value
+    }
+
+    #[tokio::test]
+    async fn cached_resolution_round_trips_and_invalid_state_is_a_miss() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let workspace = script_workspace(root.path(), cache.path());
+        let path = workspace.pixi_dir().join(CACHE_FILE);
+        let lock_file = LockFile::default();
+
+        assert!(
+            load_cached_resolution(path.clone(), &workspace)
+                .await
+                .is_none()
+        );
+        store_cached_resolution(path.clone(), &lock_file)
+            .await
+            .unwrap();
+        let loaded = load_cached_resolution(path.clone(), &workspace)
+            .await
+            .unwrap();
+        assert_eq!(
+            loaded.render_to_string().unwrap(),
+            lock_file.render_to_string().unwrap()
+        );
+
+        for invalid in [
+            "not json".to_owned(),
+            serde_json::json!({
+                "version": CACHE_VERSION + 1,
+                "lock_file": lock_file.render_to_string().unwrap(),
+            })
+            .to_string(),
+            serde_json::json!({
+                "version": CACHE_VERSION,
+                "lock_file": "not a lock file",
+            })
+            .to_string(),
+        ] {
+            fs_err::write(&path, invalid).unwrap();
+            assert!(
+                load_cached_resolution(path.clone(), &workspace)
+                    .await
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_is_not_lock_file_authority() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let workspace = script_workspace(root.path(), cache.path());
+        let path = workspace.pixi_dir().join(CACHE_FILE);
+        store_cached_resolution(path, &LockFile::default())
+            .await
+            .unwrap();
+
+        for lock_file_usage in [LockFileUsage::Locked, LockFileUsage::Frozen] {
+            let error = workspace
+                .resolve_script_environment(ScriptEnvironmentOptions {
+                    progress: None,
+                    lock_file_usage,
+                    no_install: true,
+                })
+                .await
+                .err()
+                .expect("an adjacent lock file is required");
+            assert!(error.to_string().contains("no lock file exists"));
+        }
+    }
+}

--- a/crates/pixi_core/src/workspace/script_environment.rs
+++ b/crates/pixi_core/src/workspace/script_environment.rs
@@ -7,6 +7,7 @@
 
 use std::{path::PathBuf, sync::Arc};
 
+use async_fd_lock::LockWrite;
 use miette::{Context, IntoDiagnostic};
 use pixi_manifest::HasWorkspaceManifest;
 use rattler_lock::LockFile;
@@ -14,8 +15,11 @@ use serde::{Deserialize, Serialize};
 
 use super::Workspace;
 use crate::{
-    environment::LockFileUsage,
-    lock_file::{LockFileDerivedData, UpdateLockFileOptions},
+    environment::{InstallFilter, LockFileUsage},
+    lock_file::{
+        LockFileDerivedData, ReinstallPackages, UpdateLockFileOptions, UpdateMode,
+        shorten_platform_names,
+    },
 };
 
 const CACHE_VERSION: u32 = 1;
@@ -27,6 +31,217 @@ struct StoredResolution {
     lock_file: String,
 }
 
+struct MutationGuard {
+    _guard: async_fd_lock::RwLockWriteGuard<tokio::fs::File>,
+}
+
+impl MutationGuard {
+    async fn acquire(path: PathBuf) -> miette::Result<Self> {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to create the script environment directory `{}`",
+                        parent.display()
+                    )
+                })?;
+        }
+        let file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to open the script environment lock `{}`",
+                    path.display()
+                )
+            })?;
+        let guard = file
+            .lock_write()
+            .await
+            .map_err(std::io::Error::from)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!("failed to lock the script environment `{}`", path.display())
+            })?;
+        Ok(Self { _guard: guard })
+    }
+}
+
+pub(super) struct ScriptChange {
+    script_path: PathBuf,
+    lock_file_path: PathBuf,
+    cache_path: PathBuf,
+    mutation_lock_path: PathBuf,
+    source_before: Vec<u8>,
+    lock_file_before: Option<Vec<u8>>,
+}
+
+pub(super) struct CommitCandidate<'w> {
+    change: ScriptChange,
+    source: String,
+    resolution: LockFileDerivedData<'w>,
+}
+
+pub(super) struct CommittedChange<'w> {
+    source: String,
+    resolution: LockFileDerivedData<'w>,
+}
+
+pub(super) struct ReadyEnvironment<'w> {
+    source: String,
+    resolution: LockFileDerivedData<'w>,
+}
+
+impl ScriptChange {
+    pub(super) fn candidate<'w>(
+        self,
+        source: String,
+        resolution: LockFileDerivedData<'w>,
+    ) -> CommitCandidate<'w> {
+        CommitCandidate {
+            change: self,
+            source,
+            resolution,
+        }
+    }
+
+    pub(super) async fn commit_metadata(self, source: String) -> miette::Result<String> {
+        let _mutation_guard = MutationGuard::acquire(self.mutation_lock_path.clone()).await?;
+        self.ensure_current()?;
+
+        match fs_err::remove_file(&self.cache_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).into_diagnostic().wrap_err_with(|| {
+                    format!(
+                        "failed to invalidate the script resolution cache `{}`",
+                        self.cache_path.display()
+                    )
+                });
+            }
+        }
+        pixi_utils::atomic_write::atomic_write_sync_strict(&self.script_path, &source)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to commit script metadata `{}`",
+                    self.script_path.display()
+                )
+            })?;
+        Ok(source)
+    }
+
+    fn ensure_current(&self) -> miette::Result<()> {
+        let source = fs_err::read(&self.script_path)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to read script metadata `{}`",
+                    self.script_path.display()
+                )
+            })?;
+        let lock_file = read_optional_sync(&self.lock_file_path)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to read script lock file `{}`",
+                    self.lock_file_path.display()
+                )
+            })?;
+        if source != self.source_before || lock_file != self.lock_file_before {
+            return Err(miette::miette!(
+                help = "Retry the command against the updated script.",
+                "the script environment changed while dependencies were being resolved"
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<'w> CommitCandidate<'w> {
+    pub(super) async fn commit(self) -> miette::Result<CommittedChange<'w>> {
+        let _mutation_guard =
+            MutationGuard::acquire(self.change.mutation_lock_path.clone()).await?;
+        self.change.ensure_current()?;
+
+        let lock_file = shorten_platform_names(
+            self.resolution.lock_file.clone(),
+            self.resolution.workspace.workspace_manifest(),
+            self.resolution.workspace.root(),
+        )
+        .render_to_string()
+        .into_diagnostic()
+        .wrap_err("failed to serialize the script lock file")?;
+        pixi_utils::atomic_write::atomic_write_sync_strict(&self.change.script_path, &self.source)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to commit script metadata `{}`",
+                    self.change.script_path.display()
+                )
+            })?;
+        pixi_utils::atomic_write::atomic_write_sync_strict(&self.change.lock_file_path, lock_file)
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to commit script lock file `{}`",
+                    self.change.lock_file_path.display()
+                )
+            })?;
+
+        Ok(CommittedChange {
+            source: self.source,
+            resolution: self.resolution,
+        })
+    }
+}
+
+impl<'w> CommittedChange<'w> {
+    pub(super) fn source(&self) -> &str {
+        &self.source
+    }
+
+    pub(super) async fn ensure_prefix(self, install: bool) -> miette::Result<ReadyEnvironment<'w>> {
+        if install {
+            let environment = self.resolution.workspace.default_environment();
+            if environment.best_declared_platform().is_some() {
+                self.resolution
+                    .prefix(
+                        &environment,
+                        UpdateMode::Revalidate,
+                        &ReinstallPackages::default(),
+                        &InstallFilter::default(),
+                    )
+                    .await?;
+            } else {
+                tracing::info!(
+                    "Skipping prefix installation: no platform supported by environment '{}' matches the current system",
+                    environment.name()
+                );
+            }
+        }
+
+        Ok(ReadyEnvironment {
+            source: self.source,
+            resolution: self.resolution,
+        })
+    }
+}
+
+impl<'w> ReadyEnvironment<'w> {
+    pub(super) fn into_parts(self) -> (String, LockFileDerivedData<'w>) {
+        (self.source, self.resolution)
+    }
+}
+
 /// Options for resolving a script environment.
 pub struct ScriptEnvironmentOptions {
     pub progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
@@ -35,6 +250,45 @@ pub struct ScriptEnvironmentOptions {
 }
 
 impl Workspace {
+    pub(super) async fn begin_script_change(&self) -> miette::Result<(ScriptChange, LockFile)> {
+        let script_path = self.workspace.provenance.path.clone();
+        let lock_file_path = self
+            .persistent_lock_file_path()
+            .ok_or_else(|| miette::miette!("transient scripts cannot commit dependency changes"))?;
+        let cache_path = self.pixi_dir().join(CACHE_FILE);
+        let mutation_lock_path = self.pixi_dir().join(".script-environment.lock");
+        let _mutation_guard = MutationGuard::acquire(mutation_lock_path.clone()).await?;
+        let source_before = tokio::fs::read(&script_path)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read script `{}`", script_path.display()))?;
+        let lock_file_before = read_optional(&lock_file_path)
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| {
+                format!(
+                    "failed to read script lock file `{}`",
+                    lock_file_path.display()
+                )
+            })?;
+        let lock_file = self
+            .load_lock_file()
+            .await?
+            .into_lock_file_or_empty_with_warning();
+
+        Ok((
+            ScriptChange {
+                script_path,
+                lock_file_path,
+                cache_path,
+                mutation_lock_path,
+                source_before,
+                lock_file_before,
+            },
+            lock_file,
+        ))
+    }
+
     /// Resolve a script from its adjacent lock file or disposable cache.
     ///
     /// This method never writes the adjacent lock file. A resolved change is
@@ -117,6 +371,22 @@ impl Workspace {
         }
 
         Ok(resolved)
+    }
+}
+
+async fn read_optional(path: &std::path::Path) -> std::io::Result<Option<Vec<u8>>> {
+    match tokio::fs::read(path).await {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_optional_sync(path: &std::path::Path) -> std::io::Result<Option<Vec<u8>>> {
+    match fs_err::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
     }
 }
 
@@ -292,5 +562,75 @@ mod tests {
                 .expect("an adjacent lock file is required");
             assert!(error.to_string().contains("no lock file exists"));
         }
+    }
+
+    #[tokio::test]
+    async fn metadata_commit_invalidates_cached_resolution() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let workspace = script_workspace(root.path(), cache.path());
+        let cache_path = workspace.pixi_dir().join(CACHE_FILE);
+        store_cached_resolution(cache_path.clone(), &LockFile::default())
+            .await
+            .unwrap();
+        let (change, _) = workspace.begin_script_change().await.unwrap();
+        let source = "# /// script\n# dependencies = [\"rich\"]\n# ///\nprint(\"hello\")\n";
+
+        change.commit_metadata(source.to_owned()).await.unwrap();
+
+        assert_eq!(
+            fs_err::read_to_string(&workspace.workspace.provenance.path).unwrap(),
+            source
+        );
+        assert!(!cache_path.exists());
+    }
+
+    #[tokio::test]
+    async fn metadata_commit_detects_a_concurrent_change() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let workspace = script_workspace(root.path(), cache.path());
+        let (change, _) = workspace.begin_script_change().await.unwrap();
+        let concurrent = "# /// script\n# dependencies = [\"click\"]\n# ///\nprint(\"changed\")\n";
+        fs_err::write(&workspace.workspace.provenance.path, concurrent).unwrap();
+
+        let error = change
+            .commit_metadata(
+                "# /// script\n# dependencies = [\"rich\"]\n# ///\nprint(\"hello\")\n".to_owned(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("script environment changed"));
+        assert_eq!(
+            fs_err::read_to_string(&workspace.workspace.provenance.path).unwrap(),
+            concurrent
+        );
+    }
+
+    #[tokio::test]
+    async fn resolution_is_committed_before_it_can_become_ready() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let workspace = script_workspace(root.path(), cache.path());
+        let (change, _) = workspace.begin_script_change().await.unwrap();
+        let command_dispatcher = workspace.command_dispatcher_builder().unwrap().finish();
+        let resolution = LockFileDerivedData::from_input_lock_file(
+            &workspace,
+            LockFile::default(),
+            command_dispatcher.package_cache().clone(),
+            command_dispatcher,
+            pixi_glob::GlobHashCache::default(),
+        );
+        let source = fs_err::read_to_string(&workspace.workspace.provenance.path).unwrap();
+
+        let committed = change.candidate(source, resolution).commit().await.unwrap();
+        assert!(workspace.lock_file_path().is_file());
+        let ready = committed.ensure_prefix(false).await.unwrap();
+        let (_, resolution) = ready.into_parts();
+        assert_eq!(
+            resolution.as_lock_file().render_to_string().unwrap(),
+            LockFile::default().render_to_string().unwrap()
+        );
     }
 }

--- a/crates/pixi_core/src/workspace/script_environment.rs
+++ b/crates/pixi_core/src/workspace/script_environment.rs
@@ -1,9 +1,10 @@
-//! Resolution selection for PEP 723 script environments.
+//! Environment state for PEP 723 scripts.
 //!
-//! A script's adjacent lock file is optional exact resolution authority. When
-//! it is absent, Pixi keeps a disposable cached resolution under the script's
-//! environment cache directory. Missing, corrupt, or unsupported cache state
-//! is treated as a cache miss.
+//! Script metadata is requirements authority. An adjacent lock file is optional
+//! exact resolution authority; without one, Pixi keeps a disposable cached
+//! resolution under the script's environment cache directory. Missing, corrupt,
+//! or unsupported cache state is a cache miss. Metadata and lock changes use an
+//! optimistic compare-and-commit before prefix installation begins.
 
 use std::{path::PathBuf, sync::Arc};
 
@@ -139,6 +140,16 @@ impl ScriptChange {
         Ok(source)
     }
 
+    async fn commit_resolution<'w>(
+        self,
+        resolution: LockFileDerivedData<'w>,
+    ) -> miette::Result<LockFileDerivedData<'w>> {
+        let _mutation_guard = MutationGuard::acquire(self.mutation_lock_path.clone()).await?;
+        self.ensure_current()?;
+        write_lock_file(&self.lock_file_path, &resolution)?;
+        Ok(resolution)
+    }
+
     fn ensure_current(&self) -> miette::Result<()> {
         let source = fs_err::read(&self.script_path)
             .into_diagnostic()
@@ -172,14 +183,6 @@ impl<'w> CommitCandidate<'w> {
             MutationGuard::acquire(self.change.mutation_lock_path.clone()).await?;
         self.change.ensure_current()?;
 
-        let lock_file = shorten_platform_names(
-            self.resolution.lock_file.clone(),
-            self.resolution.workspace.workspace_manifest(),
-            self.resolution.workspace.root(),
-        )
-        .render_to_string()
-        .into_diagnostic()
-        .wrap_err("failed to serialize the script lock file")?;
         pixi_utils::atomic_write::atomic_write_sync_strict(&self.change.script_path, &self.source)
             .into_diagnostic()
             .wrap_err_with(|| {
@@ -188,14 +191,7 @@ impl<'w> CommitCandidate<'w> {
                     self.change.script_path.display()
                 )
             })?;
-        pixi_utils::atomic_write::atomic_write_sync_strict(&self.change.lock_file_path, lock_file)
-            .into_diagnostic()
-            .wrap_err_with(|| {
-                format!(
-                    "failed to commit script lock file `{}`",
-                    self.change.lock_file_path.display()
-                )
-            })?;
+        write_lock_file(&self.change.lock_file_path, &self.resolution)?;
 
         Ok(CommittedChange {
             source: self.source,
@@ -242,15 +238,11 @@ impl<'w> ReadyEnvironment<'w> {
     }
 }
 
-/// Options for resolving a script environment.
-pub struct ScriptEnvironmentOptions {
-    pub progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
-    pub lock_file_usage: LockFileUsage,
-    pub no_install: bool,
-}
-
 impl Workspace {
-    pub(super) async fn begin_script_change(&self) -> miette::Result<(ScriptChange, LockFile)> {
+    pub(super) async fn begin_script_change(
+        &self,
+        lock_file_usage: LockFileUsage,
+    ) -> miette::Result<(ScriptChange, LockFile)> {
         let script_path = self.workspace.provenance.path.clone();
         let lock_file_path = self
             .persistent_lock_file_path()
@@ -271,10 +263,15 @@ impl Workspace {
                     lock_file_path.display()
                 )
             })?;
-        let lock_file = self
-            .load_lock_file()
-            .await?
-            .into_lock_file_or_empty_with_warning();
+        let loaded = self.load_lock_file().await?;
+        let lock_file = if matches!(
+            lock_file_usage,
+            LockFileUsage::Locked | LockFileUsage::Frozen
+        ) {
+            loaded.into_lock_file()?
+        } else {
+            loaded.into_lock_file_or_empty_with_warning()
+        };
 
         Ok((
             ScriptChange {
@@ -289,25 +286,29 @@ impl Workspace {
         ))
     }
 
-    /// Resolve a script from its adjacent lock file or disposable cache.
+    /// Resolve the lock data used by an operational command.
     ///
-    /// This method never writes the adjacent lock file. A resolved change is
-    /// caller-owned until the script environment Module commits it.
-    pub async fn resolve_script_environment(
+    /// Projects retain their normal persistent lock-file behavior. Scripts use
+    /// an adjacent lock file when one exists and otherwise reuse disposable
+    /// cached resolution state.
+    pub async fn resolve_lock_file(
         &self,
-        options: ScriptEnvironmentOptions,
-    ) -> miette::Result<LockFileDerivedData<'_>> {
+        progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
+        options: UpdateLockFileOptions,
+    ) -> miette::Result<(LockFileDerivedData<'_>, bool)> {
         if !self.is_script() {
-            return Err(miette::miette!(
-                "script environment resolution requires a PEP 723 workspace"
-            ));
+            return self.update_lock_file(progress, options).await;
         }
 
-        let ScriptEnvironmentOptions {
-            progress,
-            lock_file_usage,
-            no_install,
-        } = options;
+        self.resolve_script_lock_file(progress, options).await
+    }
+
+    async fn resolve_script_lock_file(
+        &self,
+        progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
+        options: UpdateLockFileOptions,
+    ) -> miette::Result<(LockFileDerivedData<'_>, bool)> {
+        let lock_file_usage = options.lock_file_usage;
         let cache_path = self.pixi_dir().join(CACHE_FILE);
         let adjacent_lock_exists = self
             .persistent_lock_file_path()
@@ -316,12 +317,22 @@ impl Workspace {
         if !adjacent_lock_exists {
             match lock_file_usage {
                 LockFileUsage::Locked => {
+                    if self.persistent_lock_file_path().is_none() {
+                        return Err(miette::miette!(
+                            "transient scripts cannot be run with `--locked` because they do not have an adjacent lock file"
+                        ));
+                    }
                     return Err(miette::miette!(
                         help = "Create one with `pixi lock --script <PATH>`.",
                         "no lock file exists for the script, but `--locked` was requested"
                     ));
                 }
                 LockFileUsage::Frozen => {
+                    if self.persistent_lock_file_path().is_none() {
+                        return Err(miette::miette!(
+                            "transient scripts cannot be run with `--frozen` because they do not have an adjacent lock file"
+                        ));
+                    }
                     return Err(miette::miette!(
                         help = "Create one with `pixi lock --script <PATH>`.",
                         "no lock file exists for the script, but `--frozen` was requested"
@@ -331,47 +342,61 @@ impl Workspace {
             }
         }
 
-        let baseline = if adjacent_lock_exists {
-            let loaded = self.load_lock_file().await?;
-            if matches!(
-                lock_file_usage,
-                LockFileUsage::Locked | LockFileUsage::Frozen
-            ) {
-                loaded.into_lock_file()?
-            } else {
-                loaded.into_lock_file_or_empty_with_warning()
-            }
+        let (change, baseline) = if adjacent_lock_exists {
+            let (change, lock_file) = self.begin_script_change(lock_file_usage).await?;
+            (Some(change), lock_file)
         } else {
-            load_cached_resolution(cache_path.clone(), self)
-                .await
-                .unwrap_or_default()
+            (
+                None,
+                load_cached_resolution(cache_path.clone(), self)
+                    .await
+                    .unwrap_or_default(),
+            )
         };
 
-        let (resolved, _) = self
-            .update_lock_file_from_lock_file(
-                progress,
-                UpdateLockFileOptions {
-                    lock_file_usage,
-                    no_install,
-                    max_concurrent_solves: self.config().max_concurrent_solves(),
-                    ..Default::default()
-                },
-                baseline,
-            )
+        let (resolved, updated) = self
+            .update_lock_file_from_lock_file(progress, options, baseline)
             .await?;
 
-        if !adjacent_lock_exists
-            && lock_file_usage != LockFileUsage::DryRun
-            && let Err(error) = store_cached_resolution(cache_path, resolved.as_lock_file()).await
-        {
-            tracing::warn!(
-                %error,
-                "failed to cache the script resolution; the environment remains usable"
-            );
-        }
+        let resolved =
+            if adjacent_lock_exists && updated && lock_file_usage != LockFileUsage::DryRun {
+                change
+                    .expect("an adjacent script lock captured its original state")
+                    .commit_resolution(resolved)
+                    .await?
+            } else {
+                if !adjacent_lock_exists
+                    && lock_file_usage != LockFileUsage::DryRun
+                    && let Err(error) =
+                        store_cached_resolution(cache_path, resolved.as_lock_file()).await
+                {
+                    tracing::warn!(
+                        %error,
+                        "failed to cache the script resolution; the environment remains usable"
+                    );
+                }
+                resolved
+            };
 
-        Ok(resolved)
+        Ok((resolved, updated))
     }
+}
+
+fn write_lock_file(
+    path: &std::path::Path,
+    resolution: &LockFileDerivedData<'_>,
+) -> miette::Result<()> {
+    let lock_file = shorten_platform_names(
+        resolution.lock_file.clone(),
+        resolution.workspace.workspace_manifest(),
+        resolution.workspace.root(),
+    )
+    .render_to_string()
+    .into_diagnostic()
+    .wrap_err("failed to serialize the script lock file")?;
+    pixi_utils::atomic_write::atomic_write_sync_strict(path, lock_file)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to commit script lock file `{}`", path.display()))
 }
 
 async fn read_optional(path: &std::path::Path) -> std::io::Result<Option<Vec<u8>>> {
@@ -475,7 +500,7 @@ mod tests {
         let path = root.join("example.py");
         fs_err::write(
             &path,
-            "# /// script\n# dependencies = []\n# ///\nprint(\"hello\")\n",
+            "# /// script\n# dependencies = []\n#\n# [tool.pixi.workspace]\n# platforms = []\n# ///\nprint(\"hello\")\n",
         )
         .unwrap();
         let script = ScriptManifest::from_path(path).unwrap().unwrap();
@@ -552,16 +577,47 @@ mod tests {
 
         for lock_file_usage in [LockFileUsage::Locked, LockFileUsage::Frozen] {
             let error = workspace
-                .resolve_script_environment(ScriptEnvironmentOptions {
-                    progress: None,
-                    lock_file_usage,
-                    no_install: true,
-                })
+                .resolve_lock_file(
+                    None,
+                    UpdateLockFileOptions {
+                        lock_file_usage,
+                        no_install: true,
+                        ..Default::default()
+                    },
+                )
                 .await
                 .err()
                 .expect("an adjacent lock file is required");
             assert!(error.to_string().contains("no lock file exists"));
         }
+    }
+
+    #[tokio::test]
+    async fn operational_resolution_uses_cache_without_creating_a_lock_file() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let workspace = script_workspace(root.path(), cache.path());
+        let cache_path = workspace.pixi_dir().join(CACHE_FILE);
+
+        workspace
+            .resolve_lock_file(
+                None,
+                UpdateLockFileOptions {
+                    lock_file_usage: LockFileUsage::Update,
+                    no_install: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(cache_path.is_file());
+        assert!(!workspace.lock_file_path().exists());
+        assert!(
+            load_cached_resolution(cache_path, &workspace)
+                .await
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -573,7 +629,10 @@ mod tests {
         store_cached_resolution(cache_path.clone(), &LockFile::default())
             .await
             .unwrap();
-        let (change, _) = workspace.begin_script_change().await.unwrap();
+        let (change, _) = workspace
+            .begin_script_change(LockFileUsage::Update)
+            .await
+            .unwrap();
         let source = "# /// script\n# dependencies = [\"rich\"]\n# ///\nprint(\"hello\")\n";
 
         change.commit_metadata(source.to_owned()).await.unwrap();
@@ -590,7 +649,10 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let cache = tempfile::tempdir().unwrap();
         let workspace = script_workspace(root.path(), cache.path());
-        let (change, _) = workspace.begin_script_change().await.unwrap();
+        let (change, _) = workspace
+            .begin_script_change(LockFileUsage::Update)
+            .await
+            .unwrap();
         let concurrent = "# /// script\n# dependencies = [\"click\"]\n# ///\nprint(\"changed\")\n";
         fs_err::write(&workspace.workspace.provenance.path, concurrent).unwrap();
 
@@ -613,7 +675,10 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let cache = tempfile::tempdir().unwrap();
         let workspace = script_workspace(root.path(), cache.path());
-        let (change, _) = workspace.begin_script_change().await.unwrap();
+        let (change, _) = workspace
+            .begin_script_change(LockFileUsage::Update)
+            .await
+            .unwrap();
         let command_dispatcher = workspace.command_dispatcher_builder().unwrap().finish();
         let resolution = LockFileDerivedData::from_input_lock_file(
             &workspace,

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -222,6 +222,24 @@ impl WorkspaceMut {
     /// This is useful if an operation needs to save the changes but still needs
     /// to continue the modification.
     async fn save_inner(&mut self) -> Result<(), std::io::Error> {
+        if self.workspace().is_script() {
+            let (change, _) = self
+                .workspace()
+                .begin_script_change(LockFileUsage::Update)
+                .await
+                .map_err(std::io::Error::other)?;
+            let source = self
+                .workspace_manifest_document
+                .render()
+                .map_err(std::io::Error::other)?;
+            let source = change
+                .commit_metadata(source)
+                .await
+                .map_err(std::io::Error::other)?;
+            self.accept_script_commit(source)?;
+            return Ok(());
+        }
+
         let manifest_path = self.workspace().workspace.provenance.path.clone();
         let new_contents = self
             .workspace_manifest_document
@@ -230,20 +248,6 @@ impl WorkspaceMut {
         pixi_utils::atomic_write::atomic_write(&manifest_path, new_contents).await?;
         self.modified = true;
 
-        if let WorkspaceStorage::Script { manifest, .. } = &mut self
-            .workspace
-            .as_mut()
-            .expect("workspace is not available")
-            .storage
-        {
-            **manifest = ScriptManifest::from_path(&manifest_path)
-                .map_err(std::io::Error::other)?
-                .ok_or_else(|| {
-                    std::io::Error::other(
-                        "saved script no longer contains a PEP 723 metadata block",
-                    )
-                })?;
-        }
         Ok(())
     }
 
@@ -408,9 +412,22 @@ impl WorkspaceMut {
             self.save_inner().await.into_diagnostic()?;
         }
 
-        if *lock_file_update_config != LockFileUsage::Update {
-            if is_script && *lock_file_update_config == LockFileUsage::DryRun {
-                let (change, _) = self.workspace().begin_script_change().await?;
+        let script_has_lock_file = self
+            .workspace()
+            .persistent_lock_file_path()
+            .is_some_and(|path| path.is_file());
+        if *lock_file_update_config != LockFileUsage::Update || (is_script && !script_has_lock_file)
+        {
+            if is_script
+                && matches!(
+                    lock_file_update_config,
+                    LockFileUsage::Update | LockFileUsage::DryRun
+                )
+            {
+                let (change, _) = self
+                    .workspace()
+                    .begin_script_change(*lock_file_update_config)
+                    .await?;
                 let source = self.workspace_manifest_document.render()?;
                 let source = change.commit_metadata(source).await?;
                 self.accept_script_commit(source).into_diagnostic()?;
@@ -419,7 +436,10 @@ impl WorkspaceMut {
         }
 
         let (script_change, original_lock_file) = if is_script {
-            let (change, lock_file) = self.workspace().begin_script_change().await?;
+            let (change, lock_file) = self
+                .workspace()
+                .begin_script_change(*lock_file_update_config)
+                .await?;
             (Some(change), lock_file)
         } else {
             let lock_file = self

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -9,7 +9,7 @@ use crate::lock_file::SolveCondaEnvironmentError;
 use fancy_display::FancyDisplay;
 use indexmap::IndexMap;
 use itertools::Itertools;
-use miette::{IntoDiagnostic, NamedSource};
+use miette::{Context, IntoDiagnostic, NamedSource};
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::{Requirement, VersionOrUrl::VersionSpecifier};
 use pixi_command_dispatcher::{MissingChannelError, SolvePixiEnvironmentError::MissingChannel};
@@ -250,8 +250,43 @@ impl WorkspaceMut {
     /// Save the changes to the workspace manifest to disk and return the
     /// modified [`Workspace`].
     pub async fn save(mut self) -> Result<Workspace, std::io::Error> {
-        self.save_inner().await?;
+        let rendered = self
+            .workspace_manifest_document
+            .render()
+            .map_err(std::io::Error::other)?;
+        let already_committed = self
+            .original
+            .as_ref()
+            .is_some_and(|original| original.source == rendered);
+        if !already_committed {
+            self.save_inner().await?;
+        }
         Ok(self.workspace.take().expect("workspace is not available"))
+    }
+
+    fn accept_script_commit(&mut self, source: String) -> Result<(), std::io::Error> {
+        let script_path = self.workspace().workspace.provenance.path.clone();
+        let script = ScriptManifest::from_path(&script_path)
+            .map_err(std::io::Error::other)?
+            .ok_or_else(|| {
+                std::io::Error::other("committed script no longer contains PEP 723 metadata")
+            })?;
+        if let WorkspaceStorage::Script { manifest, .. } = &mut self
+            .workspace
+            .as_mut()
+            .expect("workspace is not available")
+            .storage
+        {
+            **manifest = script;
+        }
+
+        let manifest = self.workspace().workspace.value.clone();
+        if let Some(original) = &mut self.original {
+            original.manifest = manifest;
+            original.source = source;
+        }
+        self.modified = false;
+        Ok(())
     }
 
     /// Revert the changes made to the workspace manifest and returns the
@@ -364,21 +399,36 @@ impl WorkspaceMut {
             }
         }
 
-        // Save Python-backed manifests before resolving so tools like `pixi
-        // build` and `uv` observe the changes.
-        if matches!(self.kind(), ManifestKind::Pyproject | ManifestKind::Pep723) {
+        let is_script = self.workspace().is_script();
+
+        // A pyproject is build-tool input and must be visible while resolving.
+        // Script metadata is solved from the in-memory workspace and committed
+        // together with its lock file only after the solve succeeds.
+        if matches!(self.kind(), ManifestKind::Pyproject) {
             self.save_inner().await.into_diagnostic()?;
         }
 
         if *lock_file_update_config != LockFileUsage::Update {
+            if is_script && *lock_file_update_config == LockFileUsage::DryRun {
+                let (change, _) = self.workspace().begin_script_change().await?;
+                let source = self.workspace_manifest_document.render()?;
+                let source = change.commit_metadata(source).await?;
+                self.accept_script_commit(source).into_diagnostic()?;
+            }
             return Ok((None, skipped_packages));
         }
 
-        let original_lock_file = self
-            .workspace()
-            .load_lock_file()
-            .await?
-            .into_lock_file_or_empty_with_warning();
+        let (script_change, original_lock_file) = if is_script {
+            let (change, lock_file) = self.workspace().begin_script_change().await?;
+            (Some(change), lock_file)
+        } else {
+            let lock_file = self
+                .workspace()
+                .load_lock_file()
+                .await?
+                .into_lock_file_or_empty_with_warning();
+            (None, lock_file)
+        };
         let affected_environments = self
             .workspace()
             .environments()
@@ -440,6 +490,21 @@ impl WorkspaceMut {
                 .map(|(e, p)| (e.as_str(), p.clone()))
                 .collect(),
         );
+        let solve_dir = if is_script {
+            Some(
+                tempfile::tempdir()
+                    .into_diagnostic()
+                    .wrap_err("failed to create a temporary script solve environment")?,
+            )
+        } else {
+            None
+        };
+        let solve_workspace = solve_dir.as_ref().map(|solve_dir| {
+            self.workspace()
+                .clone()
+                .with_script_pixi_dir(solve_dir.path().join("environment"))
+        });
+        let workspace_for_solve = solve_workspace.as_ref().unwrap_or_else(|| self.workspace());
         let LockFileDerivedData {
             workspace: _, // We don't need the project here
             lock_file,
@@ -453,8 +518,8 @@ impl WorkspaceMut {
             build_caches,
             ..
         } = UpdateContext::builder(
-            self.workspace(),
-            self.workspace().command_dispatcher_builder()?.finish(),
+            workspace_for_solve,
+            workspace_for_solve.command_dispatcher_builder()?.finish(),
         )?
         .with_lock_file(unlocked_lock_file)
         .with_no_install(no_install || dry_run)
@@ -503,13 +568,66 @@ impl WorkspaceMut {
             implicit_constraints.extend(pypi_constraints);
         }
 
-        // Save Python-backed manifests again after applying resolved constraints.
-        if matches!(self.kind(), ManifestKind::Pyproject | ManifestKind::Pep723) {
+        // Save pyproject manifests again after applying resolved constraints.
+        // Script metadata is committed with its resolution below.
+        if matches!(self.kind(), ManifestKind::Pyproject) {
             self.save_inner().await.into_diagnostic()?;
         }
 
-        // Re-wrap the derived data under the longer-lived workspace
-        // reference.
+        if is_script {
+            // Script solves use an isolated environment directory, so discard
+            // all prefix-derived state before touching the real environment.
+            let install_workspace = self.workspace().clone();
+            let command_dispatcher = install_workspace.command_dispatcher_builder()?.finish();
+            let updated_lock_file = LockFileDerivedData::from_input_lock_file(
+                &install_workspace,
+                lock_file,
+                command_dispatcher.package_cache().clone(),
+                command_dispatcher,
+                pixi_glob::GlobHashCache::default(),
+            );
+
+            if dry_run {
+                let lock_file_diff = LockFileDiff::from_lock_files(
+                    &original_lock_file,
+                    &updated_lock_file.into_lock_file(),
+                );
+                return Ok((
+                    Some(UpdateDeps {
+                        implicit_constraints,
+                        lock_file_diff,
+                    }),
+                    skipped_packages,
+                ));
+            }
+
+            let source = self.workspace_manifest_document.render()?;
+            let candidate = script_change
+                .expect("an updating script captured its original state")
+                .candidate(source, updated_lock_file);
+            let committed = candidate.commit().await?;
+            self.accept_script_commit(committed.source().to_owned())
+                .into_diagnostic()?;
+            let install = !no_install
+                && self.workspace().environments().len() == 1
+                && default_environment_is_affected;
+            let ready = committed.ensure_prefix(install).await?;
+            let (_, updated_lock_file) = ready.into_parts();
+            let lock_file_diff = LockFileDiff::from_lock_files(
+                &original_lock_file,
+                &updated_lock_file.into_lock_file(),
+            );
+            return Ok((
+                Some(UpdateDeps {
+                    implicit_constraints,
+                    lock_file_diff,
+                }),
+                skipped_packages,
+            ));
+        }
+
+        // Project workspaces keep the derived solve state and their existing
+        // write-then-install behavior.
         let mut updated_lock_file = LockFileDerivedData::from_input_lock_file(
             self.workspace(),
             lock_file,

--- a/crates/pixi_utils/src/atomic_write.rs
+++ b/crates/pixi_utils/src/atomic_write.rs
@@ -26,10 +26,24 @@ fn temp_file_for(
     let mut builder = tempfile::Builder::new();
     builder.prefix(&prefix);
     #[cfg(unix)]
-    if let Some(p) = _perms {
-        builder.permissions(p);
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        builder.permissions(
+            _perms
+                .clone()
+                .unwrap_or_else(|| std::fs::Permissions::from_mode(0o666)),
+        );
     }
-    builder.tempfile_in(dir)
+    let temp_file = builder.tempfile_in(dir)?;
+    #[cfg(unix)]
+    if let Some(perms) = _perms {
+        // `open(2)` applies the current umask to the requested mode. Restore
+        // the destination's exact permissions before the temporary inode can
+        // be published by rename.
+        fs_err::set_permissions(temp_file.path(), perms)?;
+    }
+    Ok(temp_file)
 }
 
 /// Return the permissions of an existing file at `path`, or `None` if the file
@@ -105,6 +119,18 @@ pub fn atomic_write_sync(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Re
 
     temp_file.persist(path).map_err(|e| e.error)?;
     Ok(())
+}
+
+/// Atomically replace `path`, returning an error instead of falling back to a
+/// truncating write when its parent cannot host a temporary file.
+pub fn atomic_write_sync_strict(path: &Path, contents: impl AsRef<[u8]>) -> std::io::Result<()> {
+    let perms = original_permissions(path)?;
+    let mut temp_file = temp_file_for(path, perms)?;
+    std::io::Write::write_all(&mut temp_file, contents.as_ref())?;
+    temp_file
+        .persist(path)
+        .map(|_| ())
+        .map_err(|error| error.error)
 }
 
 #[cfg(test)]
@@ -185,6 +211,17 @@ mod tests {
 
         // Reset permissions for clean up
         fs_err::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    #[test]
+    fn test_atomic_write_sync_strict_replaces_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("pixi.lock");
+        fs_err::write(&target, b"old").unwrap();
+
+        atomic_write_sync_strict(&target, b"new").unwrap();
+
+        assert_eq!(fs_err::read(&target).unwrap(), b"new");
     }
 
     /// `atomic_write` must not change the mode of an existing file.


### PR DESCRIPTION
Unlocked PEP 723 scripts currently reuse their installed prefix but resolve their Conda and PyPI dependencies again on every invocation. This PR caches the last resolution and passes it through Pixi's existing lock satisfiability checks before resolving again.

```sh
pixi run --script demo.py  # resolves
pixi run --script demo.py  # reuses the cached resolution
```

The cache is disposable and does not act as lockfile authority. An adjacent `demo.py.pixi.lock` takes precedence when present, and `--locked` and `--frozen` still require one. Missing or invalid cache state falls back to resolution without creating an adjacent lockfile.

Lockless dependency edits commit the metadata and invalidate the cache. With an adjacent lockfile, Pixi solves before briefly locking and committing the metadata and resolution. Installation happens afterward, so interruption leaves authoritative state on disk and the existing prefix validation repairs an incomplete environment on the next run. This removes the signal-specific rollback path.

This PR does not add the `pixi update --script` follow-up discussed in #6748.

Closes #6748