### PR TITLE
feat: write manifest platform names instead of pN aliases

### DIFF
--- a/crates/pixi_core/src/lock_file/platform_rename.rs
+++ b/crates/pixi_core/src/lock_file/platform_rename.rs
@@ -14,11 +14,12 @@
 //! use by another platform in the lockfile. Mismatched or ambiguous entries
 //! pass through unchanged so the satisfiability layer can still flag them.
 //!
-//! The inverse runs at save time: [`shorten_platform_names`] rewrites rich
-//! platforms to short aliases (`p1`, `p2`, ...) so `pixi.lock` keys don't carry
-//! their full descriptive identity names. Because the load-time pass matches by
-//! identity rather than name, those aliases round-trip transparently -- the real
-//! names only ever live in `pixi.toml`.
+//! On disk, `pixi.lock` carries the manifest names verbatim (explicit or
+//! synthesized), so external tools can look up a platform under the same name
+//! the manifest uses. Older pixi versions wrote rich platforms under short
+//! `p1`, `p2`, ... aliases instead; because this pass matches by identity
+//! rather than name, those legacy aliases map back to the manifest names on
+//! load and disappear the next time the lock file is written.
 use std::{collections::HashMap, path::Path};
 
 use pixi_manifest::{PixiPlatform, WorkspaceManifest, platform};
@@ -28,19 +29,22 @@ use rattler_lock::{LockFile, LockedPackage, PlatformData, PlatformName};
 use thiserror::Error;
 
 /// Rewrite locked platform names so they match the manifest's current names
-/// where the identity matches. Returns the original lockfile unchanged when
-/// no renames apply.
+/// where the identity matches. The returned flag is `true` when at least one
+/// entry was renamed: the in-memory lockfile then diverges from the on-disk
+/// one in name only, and the caller may persist the new names without a
+/// re-solve. Returns the original lockfile unchanged (and `false`) when no
+/// renames apply.
 pub(crate) fn align_platform_names(
     lock_file: LockFile,
     manifest: &WorkspaceManifest,
     workspace_root: &Path,
-) -> LockFile {
+) -> (LockFile, bool) {
     let renames = compute_renames(&lock_file, manifest);
     if renames.is_empty() {
-        return lock_file;
+        return (lock_file, false);
     }
     match rebuild_with_renames(&lock_file, &renames, workspace_root) {
-        Ok(rebuilt) => rebuilt,
+        Ok(rebuilt) => (rebuilt, true),
         // The rebuild only fails if the rattler builder or the lock file
         // resolver rejects an input we just read out of a valid lockfile.
         // Log and fall back to the unmodified lockfile so the user still
@@ -50,43 +54,7 @@ pub(crate) fn align_platform_names(
                 "failed to rewrite lockfile platform names against the manifest: {err}; \
                  continuing with the lockfile's original names",
             );
-            lock_file
-        }
-    }
-}
-
-/// Rewrite the lockfile's rich platform names to short, stable aliases (`p1`,
-/// `p2`, ...) before serializing to disk, keeping descriptive identity names
-/// out of `pixi.lock`. Subdir platforms keep their conda subdir name. Numbering
-/// follows the declaration order of the non-subdir platforms in the workspace
-/// manifest, so the aliases are stable as long as that order is. The real names
-/// stay in `pixi.toml`; [`align_platform_names`] restores them by identity on
-/// load. Returns the lockfile unchanged when there are no rich platforms.
-pub(crate) fn shorten_platform_names(
-    lock_file: LockFile,
-    manifest: &WorkspaceManifest,
-    workspace_root: &Path,
-) -> LockFile {
-    let mut renames: HashMap<String, String> = HashMap::new();
-    let mut ordinal = 0usize;
-    for platform in &manifest.workspace.platforms {
-        if platform.is_subdir_platform() {
-            continue;
-        }
-        ordinal += 1;
-        renames.insert(platform.name().as_str().to_string(), format!("p{ordinal}"));
-    }
-    if renames.is_empty() {
-        return lock_file;
-    }
-    match rebuild_with_renames(&lock_file, &renames, workspace_root) {
-        Ok(rebuilt) => rebuilt,
-        Err(err) => {
-            tracing::warn!(
-                "failed to shorten lockfile platform names: {err}; \
-                 writing the lockfile with its full platform names",
-            );
-            lock_file
+            (lock_file, false)
         }
     }
 }
@@ -271,7 +239,7 @@ mod tests {
     use rattler_conda_types::Platform;
     use rattler_lock::{LockFile, PlatformData, PlatformName};
 
-    use super::{align_platform_names, shorten_platform_names};
+    use super::align_platform_names;
 
     fn manifest(source: &str) -> WorkspaceManifest {
         WorkspaceManifest::from_toml_str_with_base_dir(source, Path::new("")).unwrap()
@@ -294,11 +262,13 @@ mod tests {
         builder.finish()
     }
 
-    /// On save, rich platforms are aliased to `p1`, `p2`, ... in workspace
-    /// declaration order; subdir platforms keep their name. The aliases
-    /// round-trip back to the manifest names via the identity-based load pass.
+    /// Older pixi versions wrote rich platforms to disk under short `p1`,
+    /// `p2`, ... aliases in workspace declaration order. The identity-based
+    /// load pass maps those legacy aliases back to the manifest names, so
+    /// such lock files keep working without a re-solve and pick up the real
+    /// names on their next write.
     #[test]
-    fn shorten_aliases_rich_platforms_in_declaration_order() {
+    fn legacy_pn_aliases_align_to_manifest_names() {
         let manifest = manifest(
             r#"
             [workspace]
@@ -314,7 +284,7 @@ mod tests {
         let mut builder = LockFile::builder()
             .with_platforms(vec![
                 PlatformData {
-                    name: PlatformName::try_from("mac").unwrap(),
+                    name: PlatformName::try_from("p1").unwrap(),
                     subdir: Platform::OsxArm64,
                     virtual_packages: vec!["__osx=13.5".to_string()],
                 },
@@ -324,7 +294,7 @@ mod tests {
                     virtual_packages: vec![],
                 },
                 PlatformData {
-                    name: PlatformName::try_from("gpu").unwrap(),
+                    name: PlatformName::try_from("p2").unwrap(),
                     subdir: Platform::Linux64,
                     virtual_packages: vec!["__cuda=12.0".to_string()],
                 },
@@ -334,19 +304,9 @@ mod tests {
         builder.set_options("default", rattler_lock::SolveOptions::default());
         let lock = builder.finish();
 
-        let shortened = shorten_platform_names(lock, &manifest, Path::new("/"));
+        let (restored, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
-        // `mac` is the first non-subdir entry, `gpu` the second; `linux-64`
-        // is a subdir platform and keeps its name.
-        assert!(shortened.platform("p1").is_some());
-        assert!(shortened.platform("p2").is_some());
-        assert!(shortened.platform("linux-64").is_some());
-        assert!(shortened.platform("mac").is_none());
-        assert!(shortened.platform("gpu").is_none());
-
-        // The load pass restores the manifest names by identity, so the
-        // aliases never escape `pixi.lock`.
-        let restored = align_platform_names(shortened, &manifest, Path::new("/"));
+        assert!(renamed, "legacy aliases must be reported as a divergence");
         assert!(restored.platform("mac").is_some());
         assert!(restored.platform("gpu").is_some());
         assert!(restored.platform("linux-64").is_some());
@@ -373,8 +333,9 @@ mod tests {
             vec!["__cuda=12.0".to_string()],
         );
 
-        let aligned = align_platform_names(lock, &manifest, Path::new("/"));
+        let (aligned, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
+        assert!(renamed, "the rename must be reported as a divergence");
         assert!(
             aligned.platform("gpu-linux").is_some(),
             "renamed entry should be queryable under the workspace name",
@@ -404,9 +365,13 @@ mod tests {
             vec!["__cuda=12.0".to_string()],
         );
 
-        let aligned = align_platform_names(lock, &manifest, Path::new("/"));
+        let (aligned, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
         // The manifest has no `__cuda` entry, so no rename can apply.
+        assert!(
+            !renamed,
+            "no divergence may be reported when nothing renames"
+        );
         assert!(aligned.platform("leftover").is_some());
     }
 
@@ -447,10 +412,11 @@ mod tests {
         builder.set_options("default", rattler_lock::SolveOptions::default());
         let lock = builder.finish();
 
-        let aligned = align_platform_names(lock, &manifest, Path::new("/"));
+        let (aligned, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
         // Both rows survive under their original names: the colliding
         // rename was skipped rather than overwriting.
+        assert!(!renamed);
         assert!(aligned.platform("gpu-linux").is_some());
         assert!(aligned.platform("linux-64-cuda").is_some());
     }
@@ -484,8 +450,9 @@ mod tests {
             ],
         );
 
-        let aligned = align_platform_names(lock, &manifest, Path::new("/"));
+        let (aligned, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
+        assert!(renamed);
         assert!(aligned.platform("gpu-linux").is_some());
         assert!(aligned.platform("linux-64-cuda").is_none());
     }
@@ -505,10 +472,11 @@ mod tests {
             "#,
         );
         // `build-tool` is referenced only from the source record's
-        // `build_packages`, not from any environment.
+        // `build_packages`, not from any environment. The lock row is keyed
+        // by the legacy `p1` alias so the load pass has to rename it.
         let lock_source = r#"version: 7
 platforms:
-- name: gpu
+- name: p1
   subdir: linux-64
   virtual-packages:
   - __cuda=12.0
@@ -517,7 +485,7 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     packages:
-      gpu:
+      p1:
       - conda_source: my-package[12345678] @ git+https://github.com/example/my-package.git?tag=v0.1.0#abc123def456abc123def456abc123def456abc1
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
@@ -531,10 +499,11 @@ packages:
         let lock = LockFile::from_str_with_base_directory(lock_source, Some(Path::new("/")))
             .expect("fixture lockfile should parse");
 
-        let shortened = shorten_platform_names(lock, &manifest, Path::new("/"));
+        let (aligned, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
-        assert!(shortened.platform("p1").is_some(), "rename should apply");
-        let rendered = shortened
+        assert!(renamed);
+        assert!(aligned.platform("gpu").is_some(), "rename should apply");
+        let rendered = aligned
             .render_to_string()
             .expect("rebuilt lockfile should serialize");
         assert!(
@@ -559,10 +528,11 @@ packages:
             "#,
         );
         // `host-tool` is referenced only from the source record's
-        // `host_packages`, not from any environment.
+        // `host_packages`, not from any environment. The lock row is keyed
+        // by the legacy `p1` alias so the load pass has to rename it.
         let lock_source = r#"version: 7
 platforms:
-- name: gpu
+- name: p1
   subdir: linux-64
   virtual-packages:
   - __cuda=12.0
@@ -571,7 +541,7 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     packages:
-      gpu:
+      p1:
       - conda_source: my-package[12345678] @ git+https://github.com/example/my-package.git?tag=v0.1.0#abc123def456abc123def456abc123def456abc1
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/host-tool-1.0.0-h0.conda
@@ -585,10 +555,11 @@ packages:
         let lock = LockFile::from_str_with_base_directory(lock_source, Some(Path::new("/")))
             .expect("fixture lockfile should parse");
 
-        let shortened = shorten_platform_names(lock, &manifest, Path::new("/"));
+        let (aligned, renamed) = align_platform_names(lock, &manifest, Path::new("/"));
 
-        assert!(shortened.platform("p1").is_some(), "rename should apply");
-        let rendered = shortened
+        assert!(renamed);
+        assert!(aligned.platform("gpu").is_some(), "rename should apply");
+        let rendered = aligned
             .render_to_string()
             .expect("rebuilt lockfile should serialize");
         assert!(

--- a/crates/pixi_core/src/lock_file/satisfiability/tests.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/tests.rs
@@ -79,10 +79,11 @@ async fn verify_lock_file_satisfiability(
     uv_configuration::initialize_rayon_once();
 
     // Mirror production's load path (`Workspace::load_lock_file`): align the
-    // lockfile's platform names to the manifest by identity, so short on-disk
-    // aliases like `p1` resolve to the workspace platform names the rest of
-    // this check matches against.
-    let aligned_lock_file = crate::lock_file::platform_rename::align_platform_names(
+    // lockfile's platform names to the manifest by identity, so stale names
+    // (a manifest rename, or the legacy `pN` aliases of older pixi versions)
+    // resolve to the workspace platform names the rest of this check matches
+    // against.
+    let (aligned_lock_file, _renamed) = crate::lock_file::platform_rename::align_platform_names(
         lock_file.clone(),
         project.workspace_manifest(),
         project.root(),

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -94,7 +94,16 @@ use crate::{
 #[derive(Debug)]
 pub enum LockFileLoadResult {
     /// The lock file was successfully loaded
-    Loaded(LockFile),
+    Loaded {
+        lock_file: LockFile,
+        /// `true` when the load-time pass renamed at least one platform to
+        /// match the manifest (a manifest rename, or legacy `pN` aliases
+        /// written by older pixi versions). The loaded lock file then
+        /// diverges from the on-disk one in platform names only, and a
+        /// writing command should persist the new names even when nothing
+        /// needs re-solving.
+        platform_names_realigned: bool,
+    },
     /// The lock file version is newer than what is supported
     VersionMismatch {
         lock_file_version: u64,
@@ -128,7 +137,7 @@ impl LockFileLoadResult {
     /// This ensures that version mismatches are caught and reported as errors.
     pub fn into_lock_file(self) -> miette::Result<LockFile> {
         match self {
-            Self::Loaded(lock_file) => Ok(lock_file),
+            Self::Loaded { lock_file, .. } => Ok(lock_file),
             Self::VersionMismatch {
                 lock_file_version,
                 max_supported_version,
@@ -164,7 +173,7 @@ impl LockFileLoadResult {
     /// as if it doesn't exist.
     pub fn into_lock_file_or_empty(self) -> LockFile {
         match self {
-            Self::Loaded(lock_file) => lock_file,
+            Self::Loaded { lock_file, .. } => lock_file,
             Self::VersionMismatch { .. } => LockFile::default(),
         }
     }
@@ -172,6 +181,19 @@ impl LockFileLoadResult {
     /// Check if this result represents a version mismatch.
     pub fn is_version_mismatch(&self) -> bool {
         matches!(self, Self::VersionMismatch { .. })
+    }
+
+    /// `true` when the loaded lock file's platform names were rewritten to
+    /// match the manifest and therefore diverge from the on-disk file. See
+    /// [`LockFileLoadResult::Loaded`].
+    pub fn platform_names_realigned(&self) -> bool {
+        matches!(
+            self,
+            Self::Loaded {
+                platform_names_realigned: true,
+                ..
+            }
+        )
     }
 
     /// Extract the lock file, displaying a warning for version mismatches and treating them as missing.
@@ -185,7 +207,7 @@ impl LockFileLoadResult {
     /// stop execution (unless --locked or --frozen is set, which is handled elsewhere).
     pub fn into_lock_file_or_empty_with_warning(self) -> LockFile {
         match self {
-            Self::Loaded(lock_file) => lock_file,
+            Self::Loaded { lock_file, .. } => lock_file,
             Self::VersionMismatch {
                 lock_file_version,
                 max_supported_version,
@@ -275,6 +297,7 @@ impl Workspace {
         }
 
         // Load the lock file, displaying warning if there's a version mismatch
+        let platform_names_realigned = lock_file_result.platform_names_realigned();
         let lock_file = lock_file_result.into_lock_file_or_empty_with_warning();
 
         let needs_format_upgrade = lock_file.version() < rattler_lock::FileFormatVersion::LATEST;
@@ -332,6 +355,26 @@ impl Workspace {
             // build_caches even if empty, in case conda_prefix needs them.
             derived.uv_context = outdated.uv_context;
             derived.build_caches = outdated.build_caches;
+
+            // The load pass renamed platforms to match the manifest (a
+            // manifest rename, or the legacy `pN` aliases older pixi
+            // versions wrote). The packages are untouched, so nothing needs
+            // re-solving, but the on-disk file still carries the old names:
+            // persist the aligned names so consumers of `pixi.lock` see the
+            // same names the manifest uses. `--locked` never writes; the
+            // divergence is name-only, so its satisfiability is unaffected.
+            // An old-format lock file is skipped as well: writing it back
+            // would silently upgrade the format without the re-solve that
+            // fills the fields the old format didn't store.
+            if platform_names_realigned
+                && !needs_format_upgrade
+                && options.lock_file_usage.allow_updates()
+            {
+                if options.lock_file_usage != LockFileUsage::DryRun {
+                    derived.write_to_disk()?;
+                }
+                return Ok((derived, true));
+            }
             return Ok((derived, false));
         }
 
@@ -425,7 +468,10 @@ impl Workspace {
     /// - `.into_lock_file_or_empty_with_warning()` - displays warning and continues
     pub async fn load_lock_file(&self) -> miette::Result<LockFileLoadResult> {
         let Some(lock_file_path) = self.persistent_lock_file_path() else {
-            return Ok(LockFileLoadResult::Loaded(LockFile::default()));
+            return Ok(LockFileLoadResult::Loaded {
+                lock_file: LockFile::default(),
+                platform_names_realigned: false,
+            });
         };
         let manifest = self.workspace_manifest().clone();
         let workspace_root = self.root().to_path_buf();
@@ -440,14 +486,20 @@ impl Workspace {
                         // pixi.toml shouldn't have to re-solve to use the
                         // existing locked packages, and downstream code
                         // (satisfiability, environment lookup, install) sees
-                        // the workspace-current names directly.
-                        crate::lock_file::platform_rename::align_platform_names(
-                            lock,
-                            &manifest,
-                            &workspace_root,
-                        )
+                        // the workspace-current names directly. The same pass
+                        // maps the legacy `pN` aliases older pixi versions
+                        // wrote to disk back to the manifest names.
+                        let (lock_file, platform_names_realigned) =
+                            crate::lock_file::platform_rename::align_platform_names(
+                                lock,
+                                &manifest,
+                                &workspace_root,
+                            );
+                        LockFileLoadResult::Loaded {
+                            lock_file,
+                            platform_names_realigned,
+                        }
                     })
-                    .map(LockFileLoadResult::Loaded)
                     .or_else(|err| match err {
                         ParseCondaLockError::IncompatibleVersion {
                             lock_file_version,
@@ -468,7 +520,10 @@ impl Workspace {
             .await
             .unwrap_or_else(|e| Err(e).into_diagnostic())
         } else {
-            Ok(LockFileLoadResult::Loaded(LockFile::default()))
+            Ok(LockFileLoadResult::Loaded {
+                lock_file: LockFile::default(),
+                platform_names_realigned: false,
+            })
         }
     }
 }
@@ -702,14 +757,7 @@ impl<'p> LockFileDerivedData<'p> {
         let lock_file_path = self.workspace.persistent_lock_file_path().ok_or_else(|| {
             miette::miette!("transient script workspaces cannot write lock files")
         })?;
-        // Shorten rich platform names to `p1`, `p2`, ... on disk; the load-time
-        // pass restores the manifest names by identity.
-        let lock_file = crate::lock_file::platform_rename::shorten_platform_names(
-            self.lock_file.clone(),
-            self.workspace.workspace_manifest(),
-            self.workspace.root(),
-        );
-        lock_file
+        self.lock_file
             .to_path(&lock_file_path)
             .into_diagnostic()
             .context("failed to write lock file to disk")

--- a/docs/workspace/multi_platform_configuration.md
+++ b/docs/workspace/multi_platform_configuration.md
@@ -133,11 +133,15 @@ platforms = ["linux-64-cuda-12-0"]  # the synthesized name for the entry above
 ```
 
 !!! note "Platform names in `pixi.lock`"
-    Rich platforms are written to `pixi.lock` under short aliases (`p1`, `p2`,
-    ...) instead of their full names, to keep the lock file compact. Pixi maps
-    these back to the manifest entries by their contents (subdir plus declared
-    virtual packages) when the lock file is read, so the aliases never need to
-    be understood by hand. The real names stay in `pixi.toml`.
+    Platforms are written to `pixi.lock` under the same name the manifest
+    uses (explicit or synthesized), so tools that consume the lock file can
+    look up a platform by its manifest name. Renaming a platform in
+    `pixi.toml` never requires a re-solve: Pixi matches the locked entries to
+    the manifest by their contents (subdir plus declared virtual packages)
+    when the lock file is read, and the next `pixi lock` rewrites just the
+    names. Lock files from older Pixi versions that used short aliases
+    (`p1`, `p2`, ...) are matched the same way and updated on their next
+    write.
 
 ### Adding the current machine
 

--- a/tests/integration_python/test_workspace_platform.py
+++ b/tests/integration_python/test_workspace_platform.py
@@ -12,7 +12,9 @@ commits. Heavy install/publish flows that don't fit pytest live in
   block at the top of `pixi.lock` is rewritten regardless of `--no-install`)
 
 To keep the suite fast everything uses `--no-install` and a manifest with no
-channels/dependencies so no network is involved.
+channels/dependencies so no network is involved. The one exception is the
+`--locked` legacy-alias test, which installs an empty environment (still
+offline) because `--locked` satisfiability is exactly what it verifies.
 """
 
 from __future__ import annotations
@@ -70,6 +72,22 @@ def _lockfile_platforms(workspace_dir: Path) -> list[str | dict[str, Any]]:
     assert lock.exists(), f"expected lockfile at {lock}"
     data = yaml.safe_load(lock.read_text())
     return data.get("platforms", [])
+
+
+def _alias_platform_in_lockfile(workspace_dir: Path, real_name: str, alias: str) -> None:
+    """Rewrite `pixi.lock` so the platform row named `real_name` is keyed by
+    `alias` instead, mimicking the short `pN` aliases older pixi versions
+    wrote to disk for rich platforms."""
+    lock_path = workspace_dir / "pixi.lock"
+    data = yaml.safe_load(lock_path.read_text())
+    for platform in data.get("platforms", []):
+        if isinstance(platform, dict) and platform.get("name") == real_name:
+            platform["name"] = alias
+    for env in (data.get("environments") or {}).values():
+        packages = env.get("packages") or {}
+        if real_name in packages:
+            packages[alias] = packages.pop(real_name)
+    lock_path.write_text(yaml.safe_dump(data))
 
 
 def _run_platform(
@@ -609,17 +627,96 @@ def test_lockfile_records_custom_platform_and_vps(pixi: Path, tmp_pixi_workspace
         "--no-install",
     )
     lock_platforms = _lockfile_platforms(tmp_pixi_workspace)
-    # Rich platforms are written under a short alias (e.g. `p1`) rather than
-    # their manifest name; they are matched back to `gpu-linux` by identity
-    # (subdir + virtual packages) when the lock file is read.
+    # Rich platforms are written under their manifest name so that lockfile
+    # consumers (e.g. pixi-pack) can look a platform up by the same name the
+    # manifest uses.
     entry = next(
         p
         for p in lock_platforms
         if isinstance(p, dict) and "__cuda=12.0" in p.get("virtual-packages", [])
     )
     assert entry["subdir"] == "linux-64"
-    assert entry["name"] != "gpu-linux"
-    assert entry["name"].startswith("p")
+    assert entry["name"] == "gpu-linux"
+
+
+def test_install_locked_succeeds_with_legacy_platform_aliases(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """A lockfile written by an older pixi keys rich platforms by short
+    aliases (`p1`). Such a lockfile is still satisfiable -- the alias is
+    matched back to the manifest platform by identity (subdir + virtual
+    packages) -- so `pixi install --locked` succeeds and, because `--locked`
+    never writes, leaves the file byte-for-byte untouched."""
+    manifest = _seed_workspace(tmp_pixi_workspace)
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "add",
+        "gpu-linux=linux-64",
+        "--cuda",
+        "12.0",
+        "--no-install",
+    )
+    _alias_platform_in_lockfile(tmp_pixi_workspace, "gpu-linux", "p1")
+    lock_path = tmp_pixi_workspace / "pixi.lock"
+    before = lock_path.read_text()
+
+    verify_cli_command(
+        [str(pixi), "install", "--locked", "--manifest-path", str(manifest)],
+    )
+
+    assert lock_path.read_text() == before, "--locked must not rewrite the lock file"
+
+
+def test_lock_rewrites_legacy_platform_aliases(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """`pixi lock` on an otherwise up-to-date lockfile that still uses the
+    legacy short aliases rewrites the platform names to the manifest names
+    without re-solving anything."""
+    manifest = _seed_workspace(tmp_pixi_workspace)
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "add",
+        "gpu-linux=linux-64",
+        "--cuda",
+        "12.0",
+        "--no-install",
+    )
+    _alias_platform_in_lockfile(tmp_pixi_workspace, "gpu-linux", "p1")
+
+    verify_cli_command([str(pixi), "lock", "--manifest-path", str(manifest)])
+
+    names = [
+        p if isinstance(p, str) else p["name"] for p in _lockfile_platforms(tmp_pixi_workspace)
+    ]
+    assert "gpu-linux" in names
+    assert "p1" not in names
+
+
+def test_lock_rewrites_renamed_platform_without_resolve(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    """Renaming a platform in `pixi.toml` must not require a re-solve: the
+    locked row is matched by identity, and `pixi lock` persists the new name."""
+    manifest = _seed_workspace(tmp_pixi_workspace)
+    _run_platform(
+        pixi,
+        tmp_pixi_workspace,
+        "add",
+        "gpu-linux=linux-64",
+        "--cuda",
+        "12.0",
+        "--no-install",
+    )
+    manifest.write_text(manifest.read_text().replace('"gpu-linux"', '"cuda-linux"'))
+
+    verify_cli_command([str(pixi), "lock", "--manifest-path", str(manifest)])
+
+    names = [
+        p if isinstance(p, str) else p["name"] for p in _lockfile_platforms(tmp_pixi_workspace)
+    ]
+    assert "cuda-linux" in names
+    assert "gpu-linux" not in names
 
 
 def test_lockfile_records_removed_platform_lazy_pruning(

--- a/typos.toml
+++ b/typos.toml
@@ -15,5 +15,9 @@ ignore-hidden = false
 _placehold = "_placehold"
 intoto = "intoto"
 plt-setp = "plt.setp"
-pn = "pn"
 solvePnPRansac = "solvePnPRansac"
+
+[default.extend-words]
+# The short platform aliases (`p1`, `p2`, ...) older pixi versions wrote to
+# `pixi.lock` are referred to as `pN` in identifiers and docs.
+pn = "pn"


### PR DESCRIPTION
### Description

Rich platforms were serialized to pixi.lock under short `p1`, `p2`, ... aliases, so external tools like `pixi-pack` could not resolve a platform by the name the manifest uses without re-deriving the mapping.

This PR changes this back to the real names similar to what `pixi info` will show the users. 

It keeps existing lockfiles with the `pN` syntax as satisfied, only on any write to the lockfile will the names be changed. e.g. `pixi lock`.

### How Has This Been Tested?

Tested it on the `pixi/examples`

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
