### PR TITLE
fix: show progress for `pixi add` and other commands that solve

### DIFF
--- a/crates/pixi/tests/integration_rust/install_tests.rs
+++ b/crates/pixi/tests/integration_rust/install_tests.rs
@@ -1458,7 +1458,7 @@ async fn test_multiple_prefix_update() {
     let name = group.name();
     let prefix = group.prefix();
 
-    let command_dispatcher = project.command_dispatcher_builder().unwrap().finish();
+    let command_dispatcher = project.command_dispatcher_builder(None).unwrap().finish();
 
     let current_pixi_platform = pixi_manifest::PixiPlatform::from_subdir(current_platform);
     let variant_config = group

--- a/crates/pixi_api/src/context.rs
+++ b/crates/pixi_api/src/context.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use indexmap::{IndexMap, IndexSet};
 use miette::IntoDiagnostic;
@@ -49,6 +50,7 @@ impl<I: Interface> DefaultContext<I> {
 pub struct WorkspaceContext<I: Interface> {
     interface: I,
     workspace: Workspace,
+    progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
 }
 
 impl<I: Interface> WorkspaceContext<I> {
@@ -56,7 +58,16 @@ impl<I: Interface> WorkspaceContext<I> {
         Self {
             interface,
             workspace,
+            progress: None,
         }
+    }
+
+    /// Reports solve, download and install progress of every operation this
+    /// context performs. Consumers that are not driving a terminal leave this
+    /// unset and the work stays silent.
+    pub fn with_progress(mut self, progress: Arc<pixi_reporters::TopLevelProgress>) -> Self {
+        self.progress = Some(progress);
+        self
     }
 
     pub fn workspace(&self) -> &Workspace {
@@ -64,7 +75,17 @@ impl<I: Interface> WorkspaceContext<I> {
     }
 
     pub fn workspace_mut(&self) -> miette::Result<WorkspaceMut> {
-        self.workspace.clone().modify().into_diagnostic()
+        Ok(self.attach_progress(self.workspace.clone().modify().into_diagnostic()?))
+    }
+
+    /// Hands this context's reporter to `workspace` so the solves, downloads
+    /// and installs it triggers are visible. Every `WorkspaceMut` this context
+    /// hands out must go through here, or that work runs silently.
+    fn attach_progress(&self, workspace: WorkspaceMut) -> WorkspaceMut {
+        match &self.progress {
+            Some(progress) => workspace.with_progress(progress.clone()),
+            None => workspace,
+        }
     }
 
     pub async fn init(interface: I, options: InitOptions) -> miette::Result<Workspace> {
@@ -379,6 +400,7 @@ impl<I: Interface> WorkspaceContext<I> {
             explicit,
             no_install,
             lock_file_usage,
+            self.progress.as_ref(),
         )
         .await
     }
@@ -488,7 +510,7 @@ impl<I: Interface> WorkspaceContext<I> {
         spec_type: SpecType,
         dep_options: DependencyOptions,
     ) -> Result<(), RemoveError> {
-        let workspace_mut = self.workspace.clone().modify()?;
+        let workspace_mut = self.attach_progress(self.workspace.clone().modify()?);
         Box::pin(crate::workspace::remove::remove_conda_deps(
             workspace_mut,
             specs,
@@ -503,7 +525,7 @@ impl<I: Interface> WorkspaceContext<I> {
         pypi_deps: PypiDeps,
         options: DependencyOptions,
     ) -> Result<(), RemoveError> {
-        let workspace_mut = self.workspace.clone().modify()?;
+        let workspace_mut = self.attach_progress(self.workspace.clone().modify()?);
         Box::pin(crate::workspace::remove::remove_pypi_deps(
             workspace_mut,
             pypi_deps,
@@ -522,6 +544,7 @@ impl<I: Interface> WorkspaceContext<I> {
             &self.workspace,
             options,
             lock_file_usage,
+            self.progress.as_ref(),
         )
         .await
     }

--- a/crates/pixi_api/src/workspace/list/mod.rs
+++ b/crates/pixi_api/src/workspace/list/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use itertools::Itertools;
 use miette::IntoDiagnostic;
@@ -22,6 +23,7 @@ mod package;
 use package::PackageExt;
 pub use package::{Package, PackageKind};
 
+#[expect(clippy::too_many_arguments)]
 pub async fn list(
     workspace: &Workspace,
     regex: Option<String>,
@@ -30,12 +32,17 @@ pub async fn list(
     explicit: bool,
     no_install: bool,
     lock_file_usage: LockFileUsage,
+    progress: Option<&Arc<pixi_reporters::TopLevelProgress>>,
 ) -> miette::Result<Vec<Package>> {
     let environment = workspace.environment_from_name_or_env_var(environment)?;
 
+    // Held across the solve so the package table is not written over bars that
+    // have finished but are still rendered.
+    let _clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(progress);
+
     let lock_file = workspace
         .update_lock_file(
-            None,
+            progress.cloned(),
             UpdateLockFileOptions {
                 lock_file_usage,
                 no_install,

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -5,6 +5,7 @@ use pixi_core::{
     environment::{LockFileUsage, get_update_lock_file_and_prefixes},
     lock_file::{ReinstallEnvironment, UpdateMode},
 };
+use std::sync::Arc;
 
 use crate::interface::Interface;
 
@@ -17,6 +18,7 @@ pub async fn reinstall<I: Interface>(
     workspace: &Workspace,
     options: ReinstallOptions,
     lock_file_usage: LockFileUsage,
+    progress: Option<&Arc<pixi_reporters::TopLevelProgress>>,
 ) -> miette::Result<()> {
     // Install either:
     //
@@ -44,7 +46,7 @@ pub async fn reinstall<I: Interface>(
     get_update_lock_file_and_prefixes(
         &environments,
         options.target_platform.as_ref(),
-        Some(pixi_reporters::TopLevelProgress::from_global()),
+        progress.cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,

--- a/crates/pixi_api/src/workspace/remove/mod.rs
+++ b/crates/pixi_api/src/workspace/remove/mod.rs
@@ -85,6 +85,7 @@ pub async fn remove_conda_deps(
             &options.feature,
         )?;
     }
+    let progress = workspace.progress().cloned();
     let workspace = workspace.save().await.map_err(RemoveError::Save)?;
 
     // TODO: update all environments touched by this feature defined.
@@ -92,7 +93,7 @@ pub async fn remove_conda_deps(
     if options.lock_file_usage == LockFileUsage::Update {
         get_update_lock_file_and_prefix(
             &workspace.default_environment(),
-            None,
+            progress,
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
                 lock_file_usage: options.lock_file_usage,
@@ -121,6 +122,7 @@ pub async fn remove_pypi_deps(
             .remove_pypi_dependency(name, &options.platforms, &options.feature)?;
     }
 
+    let progress = workspace.progress().cloned();
     let workspace = workspace.save().await.map_err(RemoveError::Save)?;
 
     // TODO: update all environments touched by this feature defined.
@@ -128,7 +130,7 @@ pub async fn remove_pypi_deps(
     if options.lock_file_usage == LockFileUsage::Update {
         get_update_lock_file_and_prefix(
             &workspace.default_environment(),
-            None,
+            progress,
             UpdateMode::Revalidate,
             UpdateLockFileOptions {
                 lock_file_usage: options.lock_file_usage,

--- a/crates/pixi_api/src/workspace/workspace/channel.rs
+++ b/crates/pixi_api/src/workspace/workspace/channel.rs
@@ -52,7 +52,7 @@ pub async fn add<I: Interface>(
     // TODO: Update all environments touched by the features defined.
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage: options.lock_file_usage,
@@ -95,7 +95,7 @@ pub async fn remove<I: Interface>(
     // Try to update the lock file without the removed channels
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage: options.lock_file_usage,
@@ -136,7 +136,7 @@ pub async fn set<I: Interface>(
     // Update the lock file with the new channel configuration
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage: options.lock_file_usage,

--- a/crates/pixi_api/src/workspace/workspace/platform.rs
+++ b/crates/pixi_api/src/workspace/workspace/platform.rs
@@ -53,7 +53,7 @@ pub async fn edit<I: Interface>(
 
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,
@@ -87,7 +87,7 @@ pub async fn move_platform<I: Interface>(
 
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,
@@ -179,7 +179,7 @@ pub async fn add_auto_detected<I: Interface>(
 
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,
@@ -253,7 +253,7 @@ pub async fn add<I: Interface>(
     // Try to update the lock file with the new channels
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,
@@ -309,7 +309,7 @@ pub async fn remove<I: Interface>(
 
     get_update_lock_file_and_prefix(
         &workspace.workspace().default_environment(),
-        None,
+        workspace.progress().cloned(),
         UpdateMode::Revalidate,
         UpdateLockFileOptions {
             lock_file_usage,

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -2,10 +2,7 @@ use std::collections::HashSet;
 
 use clap::Parser;
 use pep508_rs::Requirement;
-use pixi_api::{
-    WorkspaceContext,
-    workspace::{DependencyOptions, GitOptions},
-};
+use pixi_api::workspace::{DependencyOptions, GitOptions};
 use pixi_config::ConfigCli;
 use pixi_consts::consts;
 use pixi_core::{
@@ -19,7 +16,7 @@ use url::Url;
 
 use crate::{
     cli_config::{DependencyConfig, LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig},
-    cli_interface::CliInterface,
+    cli_interface::cli_context,
     has_specs::HasSpecs,
 };
 
@@ -222,7 +219,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         workspace = workspace.with_backend_override(backend_override);
     }
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
+    let workspace_ctx = cli_context(workspace.clone());
 
     let (update_deps, skipped, parsed_names): (_, Vec<SkippedPackage>, Vec<String>) =
         match args.dependency_config.dependency_type() {

--- a/crates/pixi_cli/src/cli_interface.rs
+++ b/crates/pixi_cli/src/cli_interface.rs
@@ -1,5 +1,18 @@
 use miette::IntoDiagnostic;
-use pixi_api::Interface;
+use pixi_api::{Interface, WorkspaceContext};
+use pixi_core::Workspace;
+
+/// Builds the [`WorkspaceContext`] every CLI command works through.
+///
+/// Attaching the progress reporter here rather than at each call site is what
+/// keeps commands like `pixi add` from silently downloading gigabytes: every
+/// context method that solves reports through it without the command having to
+/// opt in. `search` is the exception, because it builds its own gateway rather
+/// than going through the command dispatcher.
+pub fn cli_context(workspace: Workspace) -> WorkspaceContext<CliInterface> {
+    WorkspaceContext::new(CliInterface {}, workspace)
+        .with_progress(pixi_reporters::TopLevelProgress::from_global())
+}
 
 #[derive(Default)]
 pub struct CliInterface {}

--- a/crates/pixi_cli/src/list.rs
+++ b/crates/pixi_cli/src/list.rs
@@ -5,10 +5,7 @@ use comfy_table::{Cell, CellAlignment, ContentArrangement, Table, presets::NOTHI
 use console::Style;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
-use pixi_api::{
-    WorkspaceContext,
-    workspace::{Package, PackageKind},
-};
+use pixi_api::workspace::{Package, PackageKind};
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_manifest::PixiPlatformName;
@@ -19,7 +16,7 @@ use crate::{
     cli_config::{
         LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig, script_lock_file_usage,
     },
-    cli_interface::CliInterface,
+    cli_interface::cli_context,
 };
 
 // an enum to sort by size or name
@@ -230,7 +227,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             .unwrap_or_else(|| Platform::current().to_string()),
     };
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
+    let workspace_ctx = cli_context(workspace.clone());
     let mut packages_to_output = workspace_ctx
         .list_packages(
             args.regex,

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -64,9 +64,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Use the silent version here since update_lock_file() will display the warning.
     let original_lock_file = workspace.load_lock_file().await?.into_lock_file_or_empty();
     let progress = pixi_reporters::TopLevelProgress::from_global();
+    // Scoped so the bars are cleared before the diff or the JSON is printed.
+    let clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(Some(&progress));
     let (LockFileDerivedData { lock_file, .. }, lock_updated) = workspace
         .update_lock_file(
-            Some(progress),
+            Some(progress.clone()),
             UpdateLockFileOptions {
                 lock_file_usage: if args.dry_run {
                     LockFileUsage::DryRun
@@ -79,6 +81,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             },
         )
         .await?;
+    drop(clear_progress);
 
     // Determine the diff between the old and new lock file.
     let diff = LockFileDiff::from_lock_files(&original_lock_file, &lock_file);

--- a/crates/pixi_cli/src/publish/mod.rs
+++ b/crates/pixi_cli/src/publish/mod.rs
@@ -620,13 +620,9 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         multi_progress,
         anchor_pb,
     ));
-    let command_dispatcher = progress
-        .clone()
-        .register_with(
-            workspace
-                .command_dispatcher_builder()?
-                .with_cache_dirs(cache_dirs),
-        )
+    let command_dispatcher = workspace
+        .command_dispatcher_builder(Some(&progress))?
+        .with_cache_dirs(cache_dirs)
         .finish();
 
     // Resolve the CLI subdirs to the platforms the workspace declares for them,

--- a/crates/pixi_cli/src/reinstall.rs
+++ b/crates/pixi_cli/src/reinstall.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use pixi_api::WorkspaceContext;
 use pixi_api::workspace::ReinstallOptions;
 use pixi_config::ConfigCli;
 use pixi_core::WorkspaceLocator;
@@ -7,7 +6,7 @@ use pixi_core::lock_file::{ReinstallEnvironment, ReinstallPackages};
 use pixi_manifest::PixiPlatformName;
 
 use crate::cli_config::WorkspaceConfig;
-use crate::cli_interface::CliInterface;
+use crate::cli_interface::cli_context;
 use crate::shared::install_platform::resolve_install_platform;
 
 /// Re-install an environment, both updating the lock file and re-installing the environment.
@@ -84,7 +83,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         target_platform,
     };
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
     workspace_ctx.reinstall(options, lock_file_usage).await?;
 
     Ok(())

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -2,10 +2,7 @@ mod error;
 
 use clap::Parser;
 use indexmap::IndexMap;
-use pixi_api::{
-    WorkspaceContext,
-    workspace::{DependencyOptions, RemoveError},
-};
+use pixi_api::workspace::{DependencyOptions, RemoveError};
 use pixi_config::ConfigCli;
 use pixi_core::{DependencyType, WorkspaceLocator, environment::LockFileUsage};
 use pixi_manifest::HasWorkspaceManifest;
@@ -13,7 +10,7 @@ use pixi_manifest::HasWorkspaceManifest;
 use crate::{cli_config::LockFileUpdateConfig, has_specs::HasSpecs};
 use crate::{
     cli_config::{DependencyConfig, NoInstallConfig, ScriptWorkspaceConfig},
-    cli_interface::CliInterface,
+    cli_interface::cli_context,
 };
 
 use error::DependencyRemovalError;
@@ -102,7 +99,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         ),
     };
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
+    let workspace_ctx = cli_context(workspace.clone());
 
     let dependency_type = args.dependency_config.dependency_type();
     let feature = args.dependency_config.feature_name();

--- a/crates/pixi_cli/src/search.rs
+++ b/crates/pixi_cli/src/search.rs
@@ -7,8 +7,8 @@ use clap::Parser;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use miette::{IntoDiagnostic, Report};
+use pixi_api::DefaultContext;
 use pixi_api::workspace::platforms::resolve_platforms;
-use pixi_api::{DefaultContext, WorkspaceContext};
 use pixi_config::default_channel_config;
 use pixi_core::{WorkspaceLocator, workspace::WorkspaceLocatorError};
 use pixi_manifest::{FeaturesExt, HasWorkspaceManifest, PixiPlatformName};
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::{
     cli_config::{ChannelsConfig, WorkspaceConfig},
-    cli_interface::CliInterface,
+    cli_interface::{CliInterface, cli_context},
 };
 
 /// Search a conda package
@@ -168,7 +168,7 @@ pub async fn execute_impl<W: Write>(
 
     let result = if let Some(workspace) = workspace {
         await_in_progress("searching packages...", |_| async {
-            WorkspaceContext::new(CliInterface {}, workspace)
+            cli_context(workspace)
                 .search(matchspec, channels, platforms, fuzzy_limit)
                 .await
         })

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -24,7 +24,10 @@ use pixi_core::{
     workspace::{Environment, virtual_packages::EnvironmentRunnability},
 };
 
-use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
+use crate::{
+    cli_config::WorkspaceConfig,
+    cli_interface::{CliInterface, cli_context},
+};
 
 #[derive(Parser, Debug)]
 pub enum Operation {
@@ -401,7 +404,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
+    let workspace_ctx = cli_context(workspace.clone());
 
     match args.operation {
         Operation::Add(args) => add_task(workspace_ctx, args).await,

--- a/crates/pixi_cli/src/tree.rs
+++ b/crates/pixi_cli/src/tree.rs
@@ -92,9 +92,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         args.workspace_config.script.is_some(),
         workspace.lock_file_path().is_file(),
     )?;
+    // Scoped so the bars are cleared before the output is printed.
+    let progress = pixi_reporters::TopLevelProgress::from_global();
+    let clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(Some(&progress));
     let lock_file = workspace
         .update_lock_file(
-            Some(pixi_reporters::TopLevelProgress::from_global()),
+            Some(progress.clone()),
             UpdateLockFileOptions {
                 lock_file_usage,
                 no_install: args.no_install_config.no_install,
@@ -106,6 +109,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .wrap_err("Failed to update lock file")?
         .0
         .into_lock_file();
+    drop(clear_progress);
 
     let workspace_platforms = (&workspace)
         .workspace_manifest()

--- a/crates/pixi_cli/src/update.rs
+++ b/crates/pixi_cli/src/update.rs
@@ -167,18 +167,21 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     // Update the packages in the lock file.
     let progress = pixi_reporters::TopLevelProgress::from_global();
-    let dispatcher = progress
-        .clone()
-        .register_with(workspace.command_dispatcher_builder()?)
+    let dispatcher = workspace
+        .command_dispatcher_builder(Some(&progress))?
         .finish();
-    let updated_lock_file = UpdateContext::builder(&workspace, dispatcher)?
-        .with_lock_file(relaxed_lock_file.clone())
-        .with_no_install(args.no_install)
-        .with_update_targets(specs.packages.clone())
-        .finish()
-        .await?
-        .update()
-        .await?;
+    // Scoped so the bars are cleared before the diff or the JSON is printed.
+    let updated_lock_file = {
+        let _clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(Some(&progress));
+        UpdateContext::builder(&workspace, dispatcher)?
+            .with_lock_file(relaxed_lock_file.clone())
+            .with_no_install(args.no_install)
+            .with_update_targets(specs.packages.clone())
+            .finish()
+            .await?
+            .update()
+            .await?
+    };
 
     // If we're doing a dry-run, we don't want to write the lock file.
     if !args.dry_run {

--- a/crates/pixi_cli/src/upgrade.rs
+++ b/crates/pixi_cli/src/upgrade.rs
@@ -81,7 +81,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .locate()?
         .with_cli_config(args.config.clone());
 
-    let mut workspace = workspace.modify()?;
+    // One reporter for the whole command: the per-feature solves below and the
+    // `--json --dry-run` solve further down share it instead of each stacking
+    // their own set of bars onto the global multi-progress.
+    let progress = pixi_reporters::TopLevelProgress::from_global();
+    let mut workspace = workspace.modify()?.with_progress(progress.clone());
 
     let features = {
         if let Some(environment_arg) = &args.specs.environment {
@@ -263,10 +267,11 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         if args.dry_run {
             // Compute a combined diff by solving once against the final in-memory manifest
             // without writing to disk, then revert. Reuse the already-loaded original lock file.
-            let progress = pixi_reporters::TopLevelProgress::from_global();
-            let dispatcher = progress
-                .clone()
-                .register_with(workspace.workspace().command_dispatcher_builder()?)
+            let _clear_progress =
+                pixi_reporters::TopLevelProgress::clear_when_done(Some(&progress));
+            let dispatcher = workspace
+                .workspace()
+                .command_dispatcher_builder(Some(&progress))?
                 .finish();
             let derived = UpdateContext::builder(workspace.workspace(), dispatcher)?
                 .with_lock_file(original_lock_file.clone())

--- a/crates/pixi_cli/src/workspace/activation.rs
+++ b/crates/pixi_cli/src/workspace/activation.rs
@@ -8,7 +8,7 @@ use pixi_manifest::{EnvironmentName, FeatureName, HasWorkspaceManifest, TargetSe
 
 use crate::{
     cli_config::{WorkspaceConfig, feature_from_flags},
-    cli_interface::CliInterface,
+    cli_interface::{CliInterface, cli_context},
 };
 
 /// Commands to manage the activation of environments: the scripts that run
@@ -209,7 +209,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
 
     match args.command {
         Command::Script(script_args) => match script_args.command {

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use clap::Parser;
 use fancy_display::FancyDisplay;
 use miette::IntoDiagnostic;
-use pixi_api::{WorkspaceContext, workspace::ChannelOptions};
+use pixi_api::workspace::ChannelOptions;
 use pixi_config::ConfigCli;
 use pixi_core::{WorkspaceLocator, environment::LockFileUsage};
 use pixi_manifest::{EnvironmentName, FeatureName};
@@ -11,7 +11,7 @@ use rattler_conda_types::NamedChannelOrUrl;
 
 use crate::{
     cli_config::{LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig},
-    cli_interface::CliInterface,
+    cli_interface::cli_context,
 };
 
 /// Commands to manage workspace channels.
@@ -138,7 +138,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let is_script = args.workspace_config.script.is_some();
     let lock_file_exists = workspace.lock_file_path().is_file();
     let channel_config = workspace.channel_config();
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
 
     match args.command {
         Command::Add(add_args) => {

--- a/crates/pixi_cli/src/workspace/description.rs
+++ b/crates/pixi_cli/src/workspace/description.rs
@@ -2,10 +2,9 @@ use std::io::Write;
 
 use clap::Parser;
 use miette::IntoDiagnostic;
-use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
 
-use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
+use crate::{cli_config::WorkspaceConfig, cli_interface::cli_context};
 
 /// Commands to manage workspace description.
 #[derive(Parser, Debug)]
@@ -48,7 +47,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
 
     match args.command {
         Command::Get => {

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -4,13 +4,12 @@ use clap::Parser;
 use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
-use pixi_api::WorkspaceContext;
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_manifest::EnvironmentName;
 use pixi_manifest::HasFeaturesIter;
 
-use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
+use crate::{cli_config::WorkspaceConfig, cli_interface::cli_context};
 
 /// Commands to manage workspace environments.
 #[derive(Parser, Debug)]
@@ -84,7 +83,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_ignore_unused_feature_warnings(matches!(args.command, Command::Add(_)))
         .locate()?;
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
 
     match args.command {
         Command::List(list_args) => {

--- a/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
+++ b/crates/pixi_cli/src/workspace/export/conda_explicit_spec.rs
@@ -209,9 +209,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         args.workspace_config.script.is_some(),
         workspace.lock_file_path().is_file(),
     )?;
+    // Scoped so the bars are cleared before the output is printed.
+    let progress = pixi_reporters::TopLevelProgress::from_global();
+    let clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(Some(&progress));
     let lock_file = workspace
         .update_lock_file(
-            Some(pixi_reporters::TopLevelProgress::from_global()),
+            Some(progress.clone()),
             UpdateLockFileOptions {
                 lock_file_usage,
                 no_install: args.no_install_config.no_install,
@@ -222,6 +225,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .await?
         .0
         .into_lock_file();
+    drop(clear_progress);
 
     let mut environments = Vec::new();
     if let Some(env_names) = args.environment {

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -5,11 +5,10 @@ use fancy_display::FancyDisplay;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use miette::IntoDiagnostic;
-use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
 use pixi_manifest::{Feature, FeatureName};
 
-use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
+use crate::{cli_config::WorkspaceConfig, cli_interface::cli_context};
 
 /// Commands to manage workspace features.
 #[derive(Parser, Debug)]
@@ -55,7 +54,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
 
     match args.command {
         Command::List(list_args) => {
@@ -130,7 +129,7 @@ mod tests {
             "#,
         )
         .unwrap();
-        let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+        let workspace_ctx = cli_context(workspace);
 
         let features = workspace_ctx.list_features().await;
 

--- a/crates/pixi_cli/src/workspace/name.rs
+++ b/crates/pixi_cli/src/workspace/name.rs
@@ -2,10 +2,9 @@ use std::io::Write;
 
 use clap::Parser;
 use miette::IntoDiagnostic;
-use pixi_api::WorkspaceContext;
 use pixi_core::WorkspaceLocator;
 
-use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
+use crate::{cli_config::WorkspaceConfig, cli_interface::cli_context};
 
 /// Commands to manage workspace name.
 #[derive(Parser, Debug)]
@@ -45,7 +44,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .locate()?;
 
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace);
+    let workspace_ctx = cli_context(workspace);
 
     match args.command {
         Command::Get => writeln!(std::io::stdout(), "{}", workspace_ctx.name().await)

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -19,7 +19,7 @@ use rattler_conda_types::{GenericVirtualPackage, PackageName, Platform, Version}
 
 use crate::{
     cli_config::{ScriptWorkspaceConfig, script_lock_file_usage},
-    cli_interface::CliInterface,
+    cli_interface::{CliInterface, cli_context},
 };
 
 /// Commands to manage workspace platforms.
@@ -508,7 +508,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         args.workspace_config.script.is_some(),
         workspace.lock_file_path().is_file(),
     )?;
-    let workspace_ctx = WorkspaceContext::new(CliInterface {}, workspace.clone());
+    let workspace_ctx = cli_context(workspace.clone());
 
     match args.command {
         Command::Add(args) => execute_add(&workspace_ctx, args, lock_file_usage).await,

--- a/crates/pixi_cli/src/workspace/preview.rs
+++ b/crates/pixi_cli/src/workspace/preview.rs
@@ -10,7 +10,10 @@ use pixi_core::{Workspace, WorkspaceLocator, WorkspaceLocatorError};
 use pixi_manifest::KnownPreviewFlag;
 use strum::VariantNames;
 
-use crate::{cli_config::WorkspaceConfig, cli_interface::CliInterface};
+use crate::{
+    cli_config::WorkspaceConfig,
+    cli_interface::{CliInterface, cli_context},
+};
 
 /// Commands to manage workspace preview flags.
 #[derive(Parser, Debug)]
@@ -100,7 +103,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             .await
         }
         Command::List => {
-            let workspace_ctx = WorkspaceContext::new(CliInterface {}, located?);
+            let workspace_ctx = cli_context(located?);
             let mut stdout = std::io::stdout();
             for flag in workspace_ctx.preview_flags().await {
                 writeln!(stdout, "{flag}")

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -933,6 +933,10 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
         }
     }
 
+    // Held across the solve and install so the caller's summary output is not
+    // written over bars that have finished but are still rendered.
+    let _clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(progress.as_ref());
+
     // Make sure the project is in a sane state
     sanity_check_workspace(workspace).await?;
 

--- a/crates/pixi_core/src/lock_file/satisfiability/tests.rs
+++ b/crates/pixi_core/src/lock_file/satisfiability/tests.rs
@@ -95,7 +95,7 @@ async fn verify_lock_file_satisfiability(
     let temp_pixi_dir = tempfile::tempdir().unwrap();
     let command_dispatcher = {
         let command_dispatcher = project
-            .command_dispatcher_builder()
+            .command_dispatcher_builder(None)
             .unwrap()
             .with_cache_dirs(CacheDirs::new(
                 pixi_path::AbsPathBuf::new(temp_pixi_dir.path())

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -306,11 +306,7 @@ impl Workspace {
         let glob_hash_cache = GlobHashCache::default();
 
         // Construct a command dispatcher to run the tasks.
-        let mut builder = self.command_dispatcher_builder()?;
-        if let Some(progress) = progress {
-            builder = progress.register_with(builder);
-        }
-        let command_dispatcher = builder.finish();
+        let command_dispatcher = self.command_dispatcher_builder(progress.as_ref())?.finish();
 
         // Get the package cache from the dispatcher.
         let package_cache = command_dispatcher.package_cache().clone();

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -1111,8 +1111,16 @@ impl Workspace {
 
     /// Returns a pre-filled command dispatcher builder. Seeds a
     /// [`RayonPrimer`](crate::rayon_primer::RayonPrimer) in the install /
-    /// solve / instantiate-backend reporter slots; UI reporters override.
-    pub fn command_dispatcher_builder(&self) -> miette::Result<CommandDispatcherBuilder> {
+    /// solve / instantiate-backend reporter slots, then lets `progress`
+    /// override them with the terminal reporters.
+    ///
+    /// `progress` is mandatory so that no dispatcher can be constructed
+    /// without deciding whether its work is visible to the user. Pass `None`
+    /// only for genuinely silent paths; `grep` for it to find them all.
+    pub fn command_dispatcher_builder(
+        &self,
+        progress: Option<&Arc<pixi_reporters::TopLevelProgress>>,
+    ) -> miette::Result<CommandDispatcherBuilder> {
         let cache_dir = AbsPathBuf::new(pixi_config::get_cache_dir()?)
             .expect("cache dir is not absolute")
             .into_assume_dir();
@@ -1138,7 +1146,7 @@ impl Workspace {
             .into_assume_dir();
 
         let rayon_primer = std::sync::Arc::new(crate::rayon_primer::RayonPrimer::default());
-        Ok(CommandDispatcher::builder()
+        let builder = CommandDispatcher::builder()
             .with_gateway(self.repodata_gateway()?.clone())
             .with_cache_dirs(cache_dirs)
             .with_root_dir(root_dir)
@@ -1166,7 +1174,13 @@ impl Workspace {
             .with_pixi_install_reporter(rayon_primer.clone())
             .with_pixi_solve_reporter(rayon_primer.clone())
             .with_instantiate_backend_reporter(rayon_primer)
-            .with_tool_platform(tool_platform, tool_virtual_packages))
+            .with_tool_platform(tool_platform, tool_virtual_packages);
+
+        // Registered last so the terminal reporters win over the primers above.
+        Ok(match progress {
+            Some(progress) => progress.clone().register_with(builder),
+            None => builder,
+        })
     }
 
     fn lazy_client_and_authenticated_client(

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -80,6 +80,10 @@ pub struct WorkspaceMut {
 
     // The parsed toml document.
     workspace_manifest_document: ManifestDocument,
+
+    // Reports solve, download and install progress to the user. `None` keeps
+    // the work silent, which is what non-terminal consumers want.
+    progress: Option<Arc<pixi_reporters::TopLevelProgress>>,
 }
 
 impl WorkspaceMut {
@@ -130,6 +134,7 @@ impl WorkspaceMut {
 
             workspace: Some(workspace),
             workspace_manifest_document,
+            progress: None,
         })
     }
 
@@ -167,7 +172,20 @@ impl WorkspaceMut {
 
             workspace: Some(workspace),
             workspace_manifest_document,
+            progress: None,
         })
+    }
+
+    /// Reports the progress of any solve, download or install this instance
+    /// triggers. Without it the work runs silently.
+    pub fn with_progress(mut self, progress: Arc<pixi_reporters::TopLevelProgress>) -> Self {
+        self.progress = Some(progress);
+        self
+    }
+
+    /// The progress reporter attached with [`Self::with_progress`], if any.
+    pub fn progress(&self) -> Option<&Arc<pixi_reporters::TopLevelProgress>> {
+        self.progress.as_ref()
     }
 
     /// Returns the kind of manifest this workspace is derived from.
@@ -476,6 +494,10 @@ impl WorkspaceMut {
                 .map(|(e, p)| (e.as_str(), p.clone()))
                 .collect(),
         );
+        // Held across the solve and install so the caller's summary output is
+        // not written over bars that have finished but are still rendered.
+        let _clear_progress = pixi_reporters::TopLevelProgress::clear_when_done(self.progress());
+
         let LockFileDerivedData {
             workspace: _, // We don't need the project here
             lock_file,
@@ -490,7 +512,9 @@ impl WorkspaceMut {
             ..
         } = UpdateContext::builder(
             self.workspace(),
-            self.workspace().command_dispatcher_builder()?.finish(),
+            self.workspace()
+                .command_dispatcher_builder(self.progress.as_ref())?
+                .finish(),
         )?
         .with_lock_file(unlocked_lock_file)
         .with_no_install(no_install || dry_run)

--- a/crates/pixi_reporters/src/lib.rs
+++ b/crates/pixi_reporters/src/lib.rs
@@ -124,6 +124,17 @@ impl TopLevelProgress {
             .with_gateway_reporter(self.clone())
     }
 
+    /// Clears this reporter's bars when the returned guard is dropped,
+    /// including when the work ends in an error.
+    ///
+    /// A reporter that outlives the work it reports on -- one held for the
+    /// duration of a command rather than a single call -- leaves finished bars
+    /// rendered on stderr, and whatever the caller prints next is written over
+    /// them. Hold this guard across the work to avoid that.
+    pub fn clear_when_done(progress: Option<&Arc<Self>>) -> ClearWhenDone {
+        ClearWhenDone(progress.cloned())
+    }
+
     /// Clear the current progress bars without tearing down the reporter.
     pub fn on_clear(&self) {
         self.conda_solve_reporter.clear();
@@ -265,6 +276,19 @@ impl BuildBackendMetadataReporter for TopLevelProgress {
     fn on_finished(&self, id: OperationId, _failed: bool) {
         if let Some(bar) = self.backend_metadata_bars.lock().remove(&id) {
             self.conda_solve_reporter.finish(bar);
+        }
+    }
+}
+
+/// Clears the progress bars of the reporter it was created from once it goes
+/// out of scope. See [`TopLevelProgress::clear_when_done`].
+#[must_use = "the bars are cleared when this guard drops, so it must be bound"]
+pub struct ClearWhenDone(Option<Arc<TopLevelProgress>>);
+
+impl Drop for ClearWhenDone {
+    fn drop(&mut self) {
+        if let Some(progress) = &self.0 {
+            progress.on_clear();
         }
     }
 }

--- a/crates/pixi_reporters/src/repodata_reporter.rs
+++ b/crates/pixi_reporters/src/repodata_reporter.rs
@@ -510,6 +510,9 @@ fn width_boundary(line: &str, width: usize) -> usize {
 }
 
 struct RepodataReporterInner {
+    /// Used to swap in a fresh bar in [`RepodataReporterInner::clear`], since
+    /// a bar that has been finished can never be shown again.
+    multi_progress: MultiProgress,
     pb: ProgressBar,
     title: Option<String>,
     downloads: Arc<RwLock<Vec<TrackedDownload>>>,
@@ -529,9 +532,10 @@ impl RepodataReporter {
         progress_bar_placement: ProgressBarPlacement,
         title: String,
     ) -> Self {
-        let pb = progress_bar_placement.insert(multi_progress, ProgressBar::hidden());
+        let pb = progress_bar_placement.insert(multi_progress.clone(), ProgressBar::hidden());
         Self {
             inner: Arc::new(RwLock::new(RepodataReporterInner {
+                multi_progress,
                 pb,
                 title: Some(title),
                 downloads: Arc::new(RwLock::new(Vec::new())),
@@ -543,8 +547,30 @@ impl RepodataReporter {
 
 impl RepodataReporterInner {
     pub fn clear(&mut self) {
-        self.pb.finish_and_clear();
+        let downloads = self.downloads.read();
+        if downloads.is_empty() {
+            return;
+        }
+
+        // Downloads in flight hold an index into `downloads`, so dropping the
+        // entries under them would panic the next progress callback. Leave the
+        // bar up and let a later clear take care of it.
+        if downloads.iter().any(|download| download.finished.is_none()) {
+            drop(downloads);
+            self.update();
+            return;
+        }
+        drop(downloads);
         self.downloads.write().clear();
+
+        // A finished bar can never be shown again, so swap in a fresh hidden
+        // one and restore the title for whatever phase comes next.
+        self.title = Some(self.pb.prefix());
+        let new_pb = self
+            .multi_progress
+            .insert_after(&self.pb, ProgressBar::hidden());
+        self.pb.finish_and_clear();
+        self.pb = new_pb;
     }
 
     fn on_unsupported_repodata_revision(&mut self, message: &UnsupportedRepodataRevision) {


### PR DESCRIPTION
### Description

`pixi add` currently fetches repodata, solves and installs without a single progress bar, and so do `remove`, `list`, `upgrade`, `workspace channel add/remove` and `workspace platform add/remove`.

This PR solves that


### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude


### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
