### PR TITLE
feat(publish): honor the shared `index-config` when indexing a channel

### DIFF
--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -2,7 +2,7 @@ use crate::cli_config::WorkspaceConfig;
 use clap::Parser;
 use miette::{IntoDiagnostic, WrapErr};
 use pixi_config;
-use pixi_config::{Config, ConfigError};
+use pixi_config::{Config, ConfigError, GlobalConfigSource};
 use pixi_consts::consts;
 use pixi_core::WorkspaceLocator;
 use pixi_core::workspace::WorkspaceLocatorError;
@@ -78,6 +78,9 @@ struct ListArgs {
     /// Output in JSON format
     #[arg(long)]
     json: bool,
+
+    #[clap(flatten)]
+    config_source: pixi_config::ConfigSourceCli,
 
     #[clap(flatten)]
     common: CommonArgs,
@@ -160,7 +163,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             child.wait().into_diagnostic()?;
         }
         Subcommand::List(args) => {
-            let mut config = load_config(&args.common)?;
+            let mut config = load_config(&args.common, &args.config_source.source())?;
 
             if let Some(key) = args.key {
                 partial_config(&mut config, &key)?;
@@ -226,15 +229,17 @@ fn determine_project_root(common_args: &CommonArgs) -> miette::Result<Option<Pat
     }
 }
 
-fn load_config(common_args: &CommonArgs) -> miette::Result<Config> {
+/// Load the configuration the given arguments select, taking the global layer
+/// from `source`.
+fn load_config(common_args: &CommonArgs, source: &GlobalConfigSource) -> miette::Result<Config> {
     let ret = if common_args.system {
         Config::load_system()
     } else if common_args.global {
-        Config::load_global()
+        Config::load_global_with(source)
     } else if let Some(root) = determine_project_root(common_args)? {
-        Config::load(&root)
+        Config::load_with(&root, source)
     } else {
-        Config::load_global()
+        Config::load_global_with(source)
     };
 
     Ok(ret)
@@ -298,7 +303,8 @@ fn alter_config(
                     let channel = NamedChannelOrUrl::from_str(&input)
                         .into_diagnostic()
                         .context("invalid channel name")?;
-                    let mut new_channels = load_config(common_args)?.default_channels;
+                    let mut new_channels =
+                        load_config(common_args, &GlobalConfigSource::Search)?.default_channels;
                     if is_prepend {
                         new_channels.insert(0, channel);
                     } else {
@@ -354,6 +360,7 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
         }
         "mirrors" => new.mirrors = config.mirrors.clone(),
         "repodata-config" => new.repodata_config = config.repodata_config.clone(),
+        "index-config" => new.index_config = config.index_config.clone(),
         "pypi-config" => new.pypi_config = config.pypi_config.clone(),
         "proxy-config" => new.proxy_config = config.proxy_config.clone(),
         "allow-symbolic-links" => new.allow_symbolic_links = config.allow_symbolic_links,
@@ -367,6 +374,7 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
                 "authentication-override-file",
                 "mirrors",
                 "repodata-config",
+                "index-config",
                 "pypi-config",
                 "proxy-config",
                 "allow-symbolic-links",

--- a/crates/pixi_cli/src/publish/mod.rs
+++ b/crates/pixi_cli/src/publish/mod.rs
@@ -22,7 +22,7 @@ use pixi_command_dispatcher::{
     ComputeResultExt, CondaPackageFormat, EnvironmentRef, EnvironmentSpec, EphemeralEnv,
     keys::{ResolveSourcePackageKey, ResolveSourcePackageSpec, SourceBuildKey, SourceBuildSpec},
 };
-use pixi_config::{ConfigCli, PackageFormatAndCompression};
+use pixi_config::{ConfigCli, IndexChannelConfig, IndexConfig, PackageFormatAndCompression};
 use pixi_core::{
     Workspace, WorkspaceLocator, environment::sanity_check_workspace, workspace::DiscoveryStart,
 };
@@ -374,6 +374,9 @@ pub struct PublishContext {
     /// Whether pixi runs in offline mode. Uploading to a remote channel is
     /// refused in offline mode; local filesystem targets still work.
     pub offline: bool,
+
+    /// Indexing options, resolved per channel once the target is known.
+    pub index_config: IndexConfig,
 }
 
 impl PublishContext {
@@ -397,6 +400,7 @@ impl PublishContext {
             skip_existing,
             generate_attestation,
             offline: config.offline(),
+            index_config: config.index_config.clone(),
         })
     }
 }
@@ -1492,13 +1496,28 @@ async fn upload_to_artifactory(
         .await
 }
 
+/// The indexing options for `target`, a channel URL or an absolute path.
+///
+/// `IndexConfig` leaves every option unset by default, so pixi's own defaults
+/// fill the gaps: a channel published without any `index-config` is indexed
+/// exactly as it was before the key was honored.
+fn index_options(config: &IndexConfig, target: &str) -> IndexChannelConfig {
+    let mut resolved = config.resolve(target);
+    resolved.write_zst.get_or_insert(true);
+    resolved.write_shards.get_or_insert(true);
+    resolved
+}
+
 /// Upload packages to S3 and run indexing.
 async fn upload_to_s3(
     url: &Url,
     package_paths: &[PathBuf],
     ctx: &PublishContext,
 ) -> miette::Result<()> {
-    use rattler_index::{IndexS3Config, ensure_channel_initialized_s3, index_s3};
+    use rattler_index::{
+        ChannelMetadata, IndexS3Config, ensure_channel_initialized_s3,
+        index_s3_with_channel_metadata,
+    };
     use rattler_upload::upload::upload_package_to_s3;
     use std::collections::HashSet;
 
@@ -1563,6 +1582,8 @@ async fn upload_to_s3(
 
     tracing::info!("Successfully uploaded packages to S3, running indexing...");
 
+    let options = index_options(&ctx.index_config, url.as_str());
+
     for subdir in subdirs {
         let target_platform = subdir
             .parse::<Platform>()
@@ -1573,10 +1594,10 @@ async fn upload_to_s3(
             credentials: resolved_credentials.clone(),
             target_platform: Some(target_platform),
             repodata_patch: None,
-            write_zst: true,
-            write_shards: true,
-            repodata_revisions: vec![],
-            package_revision_assignment: Default::default(),
+            write_zst: options.write_zst.unwrap_or(true),
+            write_shards: options.write_shards.unwrap_or(true),
+            repodata_revisions: options.repodata_revisions.clone().unwrap_or_default(),
+            package_revision_assignment: options.package_revision_assignment.unwrap_or_default(),
             // `--force` may have replaced an existing artifact under its old
             // filename; only a forced index re-extracts its metadata.
             force: ctx.force,
@@ -1587,7 +1608,7 @@ async fn upload_to_s3(
             precondition_checks: rattler_index::PreconditionChecks::Enabled,
         };
 
-        index_s3(index_config)
+        index_s3_with_channel_metadata(index_config, ChannelMetadata::from_index_config(&options))
             .await
             .map_err(|e| miette::miette!("Failed to index S3 channel: {}", e))?;
     }
@@ -1601,7 +1622,10 @@ async fn upload_to_local_filesystem_channel(
     package_paths: &[PathBuf],
     ctx: &PublishContext,
 ) -> miette::Result<()> {
-    use rattler_index::{IndexFsConfig, ensure_channel_initialized_fs, index_fs};
+    use rattler_index::{
+        ChannelMetadata, IndexFsConfig, ensure_channel_initialized_fs,
+        index_fs_with_channel_metadata,
+    };
     use std::collections::HashSet;
 
     tracing::info!(
@@ -1643,6 +1667,8 @@ async fn upload_to_local_filesystem_channel(
 
     tracing::info!("Indexing local channel at {}", target_dir.display());
 
+    let options = index_options(&ctx.index_config, &target_dir.to_string_lossy());
+
     for subdir in subdirs {
         let target_platform = subdir
             .parse::<Platform>()
@@ -1652,10 +1678,10 @@ async fn upload_to_local_filesystem_channel(
             channel: target_dir.to_path_buf(),
             target_platform: Some(target_platform),
             repodata_patch: None,
-            write_zst: true,
-            write_shards: true,
-            repodata_revisions: vec![],
-            package_revision_assignment: Default::default(),
+            write_zst: options.write_zst.unwrap_or(true),
+            write_shards: options.write_shards.unwrap_or(true),
+            repodata_revisions: options.repodata_revisions.clone().unwrap_or_default(),
+            package_revision_assignment: options.package_revision_assignment.unwrap_or_default(),
             // `--force` may have replaced an existing artifact under its old
             // filename; only a forced index re-extracts its metadata.
             force: ctx.force,
@@ -1665,7 +1691,7 @@ async fn upload_to_local_filesystem_channel(
             multi_progress: None,
         };
 
-        index_fs(index_config)
+        index_fs_with_channel_metadata(index_config, ChannelMetadata::from_index_config(&options))
             .await
             .map_err(|e| miette::miette!("Failed to index channel: {}", e))?;
     }
@@ -1679,6 +1705,36 @@ mod tests {
 
     use super::*;
     use rattler_conda_types::{compression_level::CompressionLevel, package::CondaArchiveType};
+
+    #[test]
+    fn index_options_fall_back_to_pixis_own_defaults() {
+        let options = index_options(&IndexConfig::default(), "s3://bucket");
+
+        // An unconfigured publish indexes exactly as it did before
+        // `index-config` was honored.
+        assert_eq!(options.write_zst, Some(true));
+        assert_eq!(options.write_shards, Some(true));
+        assert_eq!(options.repodata_revisions, None);
+    }
+
+    #[test]
+    fn index_options_let_the_config_turn_a_default_off() {
+        let config: IndexConfig = serde_json::from_str(
+            r#"{"write-zst": false, "s3://bucket/staging": {"base-url": "https://cdn.example"}}"#,
+        )
+        .unwrap();
+
+        let staging = index_options(&config, "s3://bucket/staging");
+        assert_eq!(staging.write_zst, Some(false));
+        assert_eq!(staging.base_url.as_deref(), Some("https://cdn.example"));
+        // Untouched by the config, so pixi's default still applies.
+        assert_eq!(staging.write_shards, Some(true));
+
+        // A channel the per-channel entry does not name keeps only the
+        // defaults.
+        let stable = index_options(&config, "s3://bucket/stable");
+        assert_eq!(stable.base_url, None);
+    }
 
     #[test]
     fn parse_variant_accepts_single_and_comma_list() {

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -786,6 +786,7 @@ impl ConfigCliPrompt {
 // tolerant `Deserialize` impl that pixi used to maintain locally —
 // unknown/deprecated keys (e.g. `disable-jlap`) are silently consumed
 // and surface as `serde_ignored` warnings.
+pub use rattler_config::config::index::{IndexChannelConfig, IndexConfig};
 pub use rattler_config::config::repodata_config::{RepodataChannelConfig, RepodataConfig};
 
 #[derive(Parser, Debug, Default, Clone)]
@@ -1188,6 +1189,11 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "RepodataConfig::is_empty")]
     pub repodata_config: RepodataConfig,
 
+    /// Options for the channels `pixi publish` indexes, with per-channel
+    /// overrides keyed by channel URL or path.
+    #[serde(default, skip_serializing_if = "IndexConfig::is_empty")]
+    pub index_config: IndexConfig,
+
     /// Configuration for PyPI packages.
     #[serde(default)]
     #[serde(skip_serializing_if = "PyPIConfig::is_default")]
@@ -1299,6 +1305,7 @@ impl Default for Config {
             loaded_from: Vec::new(),
             channel_config: default_channel_config(),
             repodata_config: RepodataConfig::default(),
+            index_config: IndexConfig::default(),
             pypi_config: PyPIConfig::default(),
             s3_options: S3OptionsMap::default(),
             detached_environments: None,
@@ -1341,9 +1348,9 @@ impl rattler_config::config::Config for Config {
 
 /// Folds the keys shared by all rattler-based tools into pixi's own layering.
 ///
-/// Keys pixi does not model (like `index-config`) are dropped silently: a
-/// shared file serves every rattler-based tool, so a key meant for another
-/// one of them is not a mistake.
+/// Keys pixi does not model are dropped silently: a shared file serves every
+/// rattler-based tool, so a key meant for another one of them is not a
+/// mistake.
 impl From<CommonConfig> for Config {
     fn from(common: CommonConfig) -> Self {
         Self {
@@ -1356,6 +1363,7 @@ impl From<CommonConfig> for Config {
             }),
             mirrors: common.mirrors.into_iter().collect(),
             repodata_config: common.repodata_config,
+            index_config: common.index_config,
             s3_options: common.s3_options,
             concurrency: common.concurrency,
             proxy_config: common.proxy_config,
@@ -1958,6 +1966,10 @@ impl Config {
             "detached-environments",
             "experimental",
             "experimental.use-environment-activation-cache",
+            "index-config",
+            "index-config.base-url",
+            "index-config.write-shards",
+            "index-config.write-zst",
             "mirrors",
             "offline",
             "pinning-strategy",
@@ -2028,6 +2040,10 @@ impl Config {
                 .repodata_config
                 .merge_config(&other.repodata_config)
                 .expect("RepodataConfig::merge_config is infallible"),
+            index_config: self
+                .index_config
+                .merge_config(&other.index_config)
+                .expect("IndexConfig::merge_config is infallible"),
             pypi_config: self.pypi_config.merge(other.pypi_config),
             s3_options: S3OptionsMap(
                 self.s3_options
@@ -2280,6 +2296,36 @@ impl Config {
                     .map(Platform::from_str)
                     .transpose()
                     .into_diagnostic()?;
+            }
+            key if key.starts_with("index-config") => {
+                if key == "index-config" {
+                    self.index_config = value
+                        .map(|v| serde_json::de::from_str(&v))
+                        .transpose()
+                        .into_diagnostic()?
+                        .unwrap_or_default();
+                    return Ok(());
+                } else if !key.starts_with("index-config.") {
+                    return Err(err);
+                }
+
+                let subkey = key.strip_prefix("index-config.").unwrap();
+                match subkey {
+                    "write-zst" => {
+                        self.index_config.default.write_zst =
+                            value.map(|v| v.parse()).transpose().into_diagnostic()?;
+                    }
+                    "write-shards" => {
+                        self.index_config.default.write_shards =
+                            value.map(|v| v.parse()).transpose().into_diagnostic()?;
+                    }
+                    "base-url" => {
+                        self.index_config.default.base_url = value;
+                    }
+                    // The remaining keys are lists or per-channel tables; set
+                    // them through the whole `index-config` table instead.
+                    _ => return Err(err),
+                }
             }
             key if key.starts_with("repodata-config") => {
                 if key == "repodata-config" {
@@ -3176,6 +3222,17 @@ UNUSED = "unused"
                     RepodataChannelConfig::default(),
                 )]),
             },
+            index_config: IndexConfig {
+                default: IndexChannelConfig {
+                    write_zst: Some(false),
+                    write_shards: Some(false),
+                    ..IndexChannelConfig::default()
+                },
+                per_channel: HashMap::from([(
+                    "s3://bucket/staging".to_string(),
+                    IndexChannelConfig::default(),
+                )]),
+            },
             run_post_link_scripts: Some(RunPostLinkScripts::Insecure),
             allow_symbolic_links: Some(true),
             allow_hard_links: Some(true),
@@ -3228,6 +3285,66 @@ UNUSED = "unused"
         assert_eq!(config.pinning_strategy, None);
         assert_eq!(config.shell, ShellConfig::default());
         assert_eq!(config.loaded_from, vec![path]);
+    }
+
+    #[test]
+    fn test_from_shared_path_keeps_index_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs_err::write(
+            &path,
+            r#"
+            [index-config]
+            write-zst = false
+
+            [index-config."s3://bucket/staging"]
+            write-shards = false
+            "#,
+        )
+        .unwrap();
+
+        let config = Config::from_shared_path(&path).unwrap();
+
+        // The default applies everywhere, the per-channel entry only to the
+        // channel it names.
+        let staging = config.index_config.resolve("s3://bucket/staging");
+        assert_eq!(staging.write_zst, Some(false));
+        assert_eq!(staging.write_shards, Some(false));
+
+        let other = config.index_config.resolve("s3://bucket/stable");
+        assert_eq!(other.write_zst, Some(false));
+        assert_eq!(other.write_shards, None);
+    }
+
+    #[test]
+    fn test_index_config_merges_across_layers() {
+        let shared = Config {
+            index_config: IndexConfig {
+                default: IndexChannelConfig {
+                    write_zst: Some(false),
+                    write_shards: Some(false),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let pixi = Config {
+            index_config: IndexConfig {
+                default: IndexChannelConfig {
+                    write_shards: Some(true),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let merged = shared.merge_config(pixi).index_config.resolve("s3://any");
+        // The pixi layer wins where it sets a key, the shared one survives
+        // where it does not.
+        assert_eq!(merged.write_shards, Some(true));
+        assert_eq!(merged.write_zst, Some(false));
     }
 
     #[test]

--- a/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
+++ b/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pixi_config/src/lib.rs
-assertion_line: 3037
 expression: debug
 ---
 Config {
@@ -84,6 +83,18 @@ Config {
                 true,
             ),
             disable_sharded: None,
+        },
+        per_channel: {},
+    },
+    index_config: IndexConfig {
+        default: IndexChannelConfig {
+            write_zst: None,
+            write_shards: None,
+            repodata_revisions: None,
+            package_revision_assignment: None,
+            base_url: None,
+            notices: None,
+            channel_relations: None,
         },
         per_channel: {},
     },

--- a/docs/reference/cli/pixi/config/list.md
+++ b/docs/reference/cli/pixi/config/list.md
@@ -22,6 +22,13 @@ pixi config list [OPTIONS] [KEY]
 :  Output in JSON format
 
 ## Config Options
+- <a id="arg---no-config" href="#arg---no-config">`--no-config`</a>
+:  Don't read system or user-level configuration files. Project-local `<project>/.pixi/config.toml` is still loaded
+<br>**env**: `PIXI_NO_CONFIG`
+<br>**default**: `false`
+- <a id="arg---config-file" href="#arg---config-file">`--config-file <PATH>`</a>
+:  Load configuration from this file instead of searching system and user-level paths. Project-local `<project>/.pixi/config.toml` is still merged on top
+<br>**env**: `PIXI_CONFIG_FILE`
 - <a id="arg---local" href="#arg---local">`--local (-l)`</a>
 :  Operation on project-local configuration
 - <a id="arg---global" href="#arg---global">`--global (-g)`</a>

--- a/docs/reference/pixi_configuration.md
+++ b/docs/reference/pixi_configuration.md
@@ -61,7 +61,7 @@ To find the locations where `pixi` looks for configuration files, run
 ### Configuration shared with other rattler-based tools
 
 The `rattler` locations are read by every rattler-based tool, so a setting placed there applies to Pixi and `rattler-build` alike.
-They accept only the options that all of these tools understand, such as `default-channels`, `mirrors`, `s3-options` and `concurrency`.
+They accept only the options that all of these tools understand, such as `default-channels`, `mirrors`, `s3-options`, `index-config` and `concurrency`.
 Options that only Pixi knows, like `shell` or `detached-environments`, belong in a `pixi` location; in a `rattler` file Pixi ignores them and warns about it.
 
 ### Skipping or overriding config discovery
@@ -345,6 +345,22 @@ The above settings can be overridden on a per-channel basis by specifying a chan
 
 ```toml title="config.toml"
 --8<-- "docs/source_files/pixi_config_tomls/main_config.toml:prefix-repodata-config"
+```
+
+### `index-config`
+
+Options for the channels `pixi publish` indexes.
+They are ignored when publishing to a server that indexes on its own, such as prefix.dev, and only apply to the targets Pixi indexes itself: S3 URLs and local filesystem channels.
+
+```toml title="config.toml"
+--8<-- "docs/source_files/pixi_config_tomls/main_config.toml:index-config"
+```
+
+The above settings can be overridden per channel by using the channel URL or absolute path as the key.
+The longest matching prefix wins, so a general entry can be narrowed for one channel below it.
+
+```toml title="config.toml"
+--8<-- "docs/source_files/pixi_config_tomls/main_config.toml:per-channel-index-config"
 ```
 
 ### `pypi-config`

--- a/docs/source_files/pixi_config_tomls/main_config.toml
+++ b/docs/source_files/pixi_config_tomls/main_config.toml
@@ -81,6 +81,21 @@ disable-zstd = true  # don't try to download repodata.json.zst
 disable-sharded = false
 # --8<-- [end:prefix-repodata-config]
 
+# --8<-- [start:index-config]
+[index-config]
+# write repodata.json.zst next to repodata.json
+write-zst = true
+# write sharded repodata
+write-shards = true
+# the info.base_url written to the generated repodata
+base-url = "https://cdn.example.com/my-channel"
+
+# --8<-- [end:index-config]
+# --8<-- [start:per-channel-index-config]
+[index-config."s3://my-bucket/staging"]
+write-shards = false
+# --8<-- [end:per-channel-index-config]
+
 # --8<-- [start:pypi-config]
 [pypi-config]
 # Main index url

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -588,6 +588,51 @@ def test_config_shared_layer(pixi: Path, tmp_path: Path) -> None:
     )
 
 
+def test_config_list_honors_the_config_source_flags(pixi: Path, tmp_path: Path) -> None:
+    """`config list` can be pointed at one file or told to skip discovery."""
+    env = isolated_config_env(tmp_path)
+    (Path(env["RATTLER_HOME"]) / "config.toml").write_text(
+        'default-channels = ["shared-channel"]\n'
+    )
+    only = tmp_path / "only.toml"
+    only.write_text('default-channels = ["only-channel"]\n')
+
+    # Without a flag the discovered shared file shows up.
+    verify_cli_command([pixi, "config", "list"], env=env, stdout_contains="shared-channel")
+    # `--config-file` replaces the discovered layers with just that file.
+    verify_cli_command(
+        [pixi, "config", "list", "--config-file", only],
+        env=env,
+        stdout_contains="only-channel",
+        stdout_excludes="shared-channel",
+    )
+    # `PIXI_CONFIG_FILE` is the same switch by environment variable.
+    verify_cli_command(
+        [pixi, "config", "list"],
+        env=env | {"PIXI_CONFIG_FILE": str(only)},
+        stdout_contains="only-channel",
+        stdout_excludes="shared-channel",
+    )
+    # `--no-config` drops them all.
+    verify_cli_command(
+        [pixi, "config", "list", "--no-config"], env=env, stdout_excludes="shared-channel"
+    )
+
+
+def test_config_index_config_from_the_shared_layer(pixi: Path, tmp_path: Path) -> None:
+    """`index-config` is a shared key, so a `rattler` file may set it."""
+    env = isolated_config_env(tmp_path)
+    (Path(env["RATTLER_HOME"]) / "config.toml").write_text(
+        "[index-config]\nwrite-zst = false\n\n"
+        '[index-config."s3://bucket/staging"]\nwrite-shards = false\n'
+    )
+
+    listed = verify_cli_command([pixi, "config", "list"], env=env).stdout
+    config = tomli.loads(listed)
+    assert config["index-config"]["write-zst"] is False
+    assert config["index-config"]["s3://bucket/staging"]["write-shards"] is False
+
+
 def test_config_append_extends_the_visible_list(pixi: Path, tmp_path: Path) -> None:
     """`config append` extends the list the user sees, exactly once, for both
     the keys that replace lower layers and the ones that concatenate."""


### PR DESCRIPTION
### Description

`pixi publish` indexes S3 and local filesystem channels itself, but it hardcoded the options it handed to `rattler-index`. It now reads them from `index-config`, the key every rattler-based tool shares, so a channel can be indexed the same way no matter which tool writes it.

### How Has This Been Tested?

Added tests

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
