### PR TITLE
feat: add `--path` to the `pixi add` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6000,6 +6000,7 @@ dependencies = [
  "indicatif",
  "insta",
  "miette 7.6.0",
+ "pathdiff",
  "pep508_rs",
  "percent-encoding",
  "pixi_allocator",

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -33,6 +33,7 @@ insta = { workspace = true, features = [
   "redactions",
   "yaml",
 ] }
+pathdiff = { workspace = true }
 pep508_rs = { workspace = true }
 percent-encoding = { workspace = true }
 pixi_build_backend_passthrough = { workspace = true }

--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -835,6 +835,258 @@ async fn add_dependency_pinning_strategy() {
     assert_eq!(bar_spec, r#"">=1,<2""#);
 }
 
+#[tokio::test]
+async fn add_pypi_path_dependency_rewrites_absolute_manifest_path() {
+    setup_tracing();
+
+    let mut package_database = MockRepoData::default();
+    package_database.add_package(
+        Package::build("python", "3.12.0")
+            .with_subdir(Platform::current())
+            .finish(),
+    );
+    let channel = package_database.into_channel().await.unwrap();
+
+    let pixi = PixiControl::new().unwrap();
+    pixi.init()
+        .with_local_channel(channel.url().to_file_path().unwrap())
+        .with_platforms(vec![Platform::current()])
+        .await
+        .unwrap();
+    pixi.add("python").await.unwrap();
+
+    let package_dir = pixi.workspace_path().join("packages/python package");
+    fs_err::create_dir_all(&package_dir).unwrap();
+    fs_err::write(
+        package_dir.join("pyproject.toml"),
+        "[project]\nname = \"python-package\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    pixi.add_pypi("python-package")
+        .with_path(package_dir.join("pyproject.toml"))
+        .await
+        .unwrap();
+
+    let manifest = pixi.manifest_contents().unwrap();
+    assert!(
+        manifest.contains(r#"python-package = { path = "packages/python package" }"#),
+        "unexpected manifest:\n{manifest}"
+    );
+}
+
+#[tokio::test]
+async fn add_conda_path_dependency_accepts_manifest_files_and_relative_input() {
+    setup_tracing();
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "path-test"
+channels = []
+platforms = ["linux-64"]
+preview = ["pixi-build"]
+"#,
+    )
+    .unwrap();
+    let sources = pixi.workspace_path().join("sources");
+    fs_err::create_dir_all(&sources).unwrap();
+    fs_err::write(
+        sources.join("pixi.toml"),
+        "[workspace]\nchannels = []\nplatforms = [\"linux-64\"]\n\n[package]\nname = \"pixi-source\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    fs_err::write(
+        sources.join("recipe.yaml"),
+        "package:\n  name: recipe-source\n  version: 0.1.0\n",
+    )
+    .unwrap();
+    fs_err::write(
+        sources.join("package.xml"),
+        "<package><name>ros-source</name><version>0.1.0</version></package>",
+    )
+    .unwrap();
+
+    // A relative CLI path is interpreted from the current directory, but is
+    // written relative to the workspace manifest.
+    let relative_pixi_manifest =
+        pathdiff::diff_paths(sources.join("pixi.toml"), std::env::current_dir().unwrap()).unwrap();
+    pixi.add("pixi-source")
+        .with_path(relative_pixi_manifest)
+        .with_feature("local")
+        .await
+        .unwrap();
+    pixi.add("recipe-source")
+        .with_path(sources.join("recipe.yaml"))
+        .with_feature("local")
+        .await
+        .unwrap();
+    pixi.add("ros-source")
+        .with_path(sources.join("package.xml"))
+        .with_feature("local")
+        .await
+        .unwrap();
+
+    let manifest = pixi.manifest_contents().unwrap();
+    for expected in [
+        r#"pixi-source = { path = "sources" }"#,
+        r#"recipe-source = { path = "sources/recipe.yaml" }"#,
+        r#"ros-source = { path = "sources/package.xml" }"#,
+    ] {
+        assert!(
+            manifest.contains(expected),
+            "missing {expected:?} in:\n{manifest}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn add_conda_path_rejects_python_only_pyproject() {
+    setup_tracing();
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "path-test"
+channels = []
+platforms = ["linux-64"]
+"#,
+    )
+    .unwrap();
+    let package_dir = pixi.workspace_path().join("python-package");
+    fs_err::create_dir_all(&package_dir).unwrap();
+    fs_err::write(
+        package_dir.join("pyproject.toml"),
+        "[project]\nname = \"python-package\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let error = pixi
+        .add("python-package")
+        .with_path(package_dir)
+        .await
+        .unwrap_err();
+    let report = format!("{error:?}");
+    assert!(report.contains("--pypi"), "{report}");
+    assert!(!report.contains("preview add pixi-build"), "{report}");
+}
+
+#[tokio::test]
+async fn add_conda_path_dependency_without_preview_has_hint() {
+    setup_tracing();
+
+    let pixi = PixiControl::from_manifest(
+        r#"
+[workspace]
+name = "path-test"
+channels = []
+platforms = ["linux-64"]
+"#,
+    )
+    .unwrap();
+    let package_dir = pixi.workspace_path().join("package");
+    fs_err::create_dir_all(&package_dir).unwrap();
+    fs_err::write(
+        package_dir.join("pixi.toml"),
+        "[workspace]\nchannels = []\nplatforms = [\"linux-64\"]\n\n[package]\nname = \"local-package\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let multiple_error = pixi
+        .add_multiple(vec!["local-package", "other-package"])
+        .with_path(&package_dir)
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{multiple_error:?}").contains("exactly one package name"),
+        "{multiple_error:?}"
+    );
+
+    let error = pixi
+        .add("local-package")
+        .with_path(&package_dir)
+        .await
+        .unwrap_err();
+    let report = format!("{error:?}");
+    assert!(
+        report.contains("pixi workspace preview add pixi-build"),
+        "{report}"
+    );
+    assert!(
+        !pixi
+            .manifest_contents()
+            .unwrap()
+            .contains("local-package =")
+    );
+}
+
+#[tokio::test]
+async fn direct_pixi_manifest_input_is_stored_as_directory() {
+    setup_tracing();
+
+    let backend_override = BackendOverride::from_memory(PassthroughBackend::instantiator());
+    let platform = Platform::current();
+    let pixi = PixiControl::from_manifest(&format!(
+        r#"
+[workspace]
+name = "path-test"
+channels = []
+platforms = ["{platform}"]
+preview = ["pixi-build"]
+"#,
+    ))
+    .unwrap()
+    .with_backend_override(backend_override);
+    let source_dir = TempDir::new().unwrap();
+    let package_dir = source_dir.path().join("local-package");
+    fs_err::create_dir_all(&package_dir).unwrap();
+    fs_err::write(
+        package_dir.join("pixi.toml"),
+        r#"
+[workspace]
+channels = []
+platforms = []
+preview = ["pixi-build"]
+
+[package]
+name = "local-package"
+version = "0.1.0"
+
+[package.build]
+source = { path = "src" }
+backend = { name = "in-memory", version = "*" }
+"#,
+    )
+    .unwrap();
+    fs_err::create_dir_all(package_dir.join("src")).unwrap();
+
+    pixi.add("local-package")
+        .with_path(package_dir.join("pixi.toml"))
+        .await
+        .unwrap();
+
+    let manifest = pixi.manifest_contents().unwrap();
+    let expected_path = pathdiff::diff_paths(&package_dir, pixi.workspace_path())
+        .unwrap()
+        .to_string_lossy()
+        .replace('\\', "/");
+    assert!(
+        manifest.contains(&format!(
+            r#"local-package = {{ path = "{expected_path}" }}"#
+        )),
+        "unexpected manifest:\n{manifest}"
+    );
+    let lock = pixi.lock_file().await.unwrap();
+    assert!(
+        lock.get_conda_source_package("default", platform, "local-package")
+            .is_some()
+    );
+
+    // Force a second installation from the serialized lock file.
+    fs_err::remove_dir_all(pixi.workspace_path().join(".pixi")).unwrap();
+    pixi.install().await.unwrap();
+}
+
 /// The deprecated `--subdir` alias still resolves to the `subdirectory` field.
 #[tokio::test]
 async fn add_git_deps_deprecated_subdir_alias() {

--- a/crates/pixi/tests/integration_rust/add_tests.rs
+++ b/crates/pixi/tests/integration_rust/add_tests.rs
@@ -869,8 +869,9 @@ async fn add_pypi_path_dependency_rewrites_absolute_manifest_path() {
         .unwrap();
 
     let manifest = pixi.manifest_contents().unwrap();
+    let normalized_manifest = manifest.replace('\\', "/").replace('\'', "\"");
     assert!(
-        manifest.contains(r#"python-package = { path = "packages/python package" }"#),
+        normalized_manifest.contains(r#"python-package = { path = "packages/python package" }"#),
         "unexpected manifest:\n{manifest}"
     );
 }
@@ -1066,12 +1067,13 @@ backend = { name = "in-memory", version = "*" }
         .unwrap();
 
     let manifest = pixi.manifest_contents().unwrap();
+    let normalized_manifest = manifest.replace('\\', "/").replace('\'', "\"");
     let expected_path = pathdiff::diff_paths(&package_dir, pixi.workspace_path())
         .unwrap()
         .to_string_lossy()
         .replace('\\', "/");
     assert!(
-        manifest.contains(&format!(
+        normalized_manifest.contains(&format!(
             r#"local-package = {{ path = "{expected_path}" }}"#
         )),
         "unexpected manifest:\n{manifest}"

--- a/crates/pixi/tests/integration_rust/common/builders.rs
+++ b/crates/pixi/tests/integration_rust/common/builders.rs
@@ -241,6 +241,11 @@ impl AddBuilder {
         self
     }
 
+    pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.args.path = Some(path.into());
+        self
+    }
+
     pub fn with_git_rev(mut self, rev: GitRev) -> Self {
         self.args.dependency_config.rev = Some(rev);
         self

--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -548,6 +548,7 @@ impl PixiControl {
                 },
                 config: self.config_cli(),
                 config_source: isolated_config_source(),
+                path: None,
                 editable: false,
                 index: None,
             },

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -7,7 +7,7 @@ use pixi_core::{
 use pixi_manifest::{
     DependencyOverwriteBehavior, FeatureName, HasWorkspaceManifest, KnownPreviewFlag, SpecType,
 };
-use pixi_spec::{GitSpec, SourceSpec, Subdirectory};
+use pixi_spec::{GitSpec, PathSourceSpec, SourceSpec, Subdirectory};
 use rattler_conda_types::{MatchSpec, PackageName};
 
 use crate::workspace::platforms::resolve_platforms;
@@ -48,7 +48,7 @@ pub async fn add_conda_dep(
         .map(|(name, spec)| (name, (spec, spec_type)))
         .collect();
 
-    if let Some(git) = &git_options.git {
+    if git_options.git.is_some() || git_options.path.is_some() {
         if !workspace
             .manifest()
             .workspace
@@ -61,24 +61,34 @@ pub async fn add_conda_dep(
             ));
         }
 
-        let subdirectory = git_options
-            .subdir
-            .clone()
-            .map(Subdirectory::try_from)
-            .transpose()
-            .into_diagnostic()?
-            .unwrap_or_default();
-        source_specs = passed_specs
-            .iter()
-            .map(|(name, (_spec, spec_type))| {
-                let git_spec = GitSpec::new(
-                    git.clone(),
-                    Some(git_options.reference.clone()),
-                    subdirectory.clone(),
-                );
-                (name.clone(), (SourceSpec::from(git_spec), *spec_type))
-            })
-            .collect();
+        if let Some(git) = &git_options.git {
+            let subdirectory = git_options
+                .subdir
+                .clone()
+                .map(Subdirectory::try_from)
+                .transpose()
+                .into_diagnostic()?
+                .unwrap_or_default();
+            source_specs = passed_specs
+                .iter()
+                .map(|(name, (_spec, spec_type))| {
+                    let git_spec = GitSpec::new(
+                        git.clone(),
+                        Some(git_options.reference.clone()),
+                        subdirectory.clone(),
+                    );
+                    (name.clone(), (SourceSpec::from(git_spec), *spec_type))
+                })
+                .collect();
+        } else if let Some(path) = &git_options.path {
+            source_specs = passed_specs
+                .iter()
+                .map(|(name, (_spec, spec_type))| {
+                    let path_spec = PathSourceSpec::new(path.to_string_lossy().to_string());
+                    (name.clone(), (SourceSpec::from(path_spec), *spec_type))
+                })
+                .collect();
+        }
     } else {
         match_specs = passed_specs;
     }

--- a/crates/pixi_api/src/workspace/add/mod.rs
+++ b/crates/pixi_api/src/workspace/add/mod.rs
@@ -84,7 +84,7 @@ pub async fn add_conda_dep(
             source_specs = passed_specs
                 .iter()
                 .map(|(name, (_spec, spec_type))| {
-                    let path_spec = PathSourceSpec::new(path.to_string_lossy().to_string());
+                    let path_spec = PathSourceSpec::new(manifest_path_string(path));
                     (name.clone(), (SourceSpec::from(path_spec), *spec_type))
                 })
                 .collect();
@@ -123,6 +123,10 @@ pub async fn add_conda_dep(
     };
 
     Ok((update_deps, skipped))
+}
+
+fn manifest_path_string(path: &std::path::Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
 }
 
 pub async fn add_pypi_dep(

--- a/crates/pixi_api/src/workspace/add/options.rs
+++ b/crates/pixi_api/src/workspace/add/options.rs
@@ -2,6 +2,7 @@ use pixi_core::environment::LockFileUsage;
 use pixi_manifest::{FeatureName, PixiPlatformName};
 use pixi_spec::GitReference;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use url::Url;
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -18,6 +19,7 @@ pub struct DependencyOptions {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct GitOptions {
     pub git: Option<Url>,
+    pub path: Option<PathBuf>,
     pub reference: GitReference,
     pub subdir: Option<String>,
 }

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -66,18 +66,13 @@ use crate::{
 ///
 /// Local path dependencies can be added with `--path`. Paths are resolved from
 /// the current directory and stored relative to the workspace manifest, so an
-/// absolute input path does not become machine-specific manifest data. A direct
-/// `pixi.toml` or `pyproject.toml` input is stored as its containing directory.
+/// absolute input path does not become machine-specific manifest data.
 ///
 /// - `pixi add mylib --path ../mylib`
-/// - `pixi add mylib --path /absolute/path/to/mylib/pixi.toml`
+/// - `pixi add mylib --path /absolute/path/to/mylib`
 /// - `pixi add recipe-package --path ../recipe/recipe.yaml`
 /// - `pixi add --pypi mylib --path ../mylib`
-/// - `pixi add --pypi mylib --path ../mylib/pyproject.toml --editable`
-///
-/// Conda path dependencies require the `pixi-build` preview feature. If it is
-/// not enabled, pixi offers to enable it when running interactively, or hints at
-/// `pixi workspace preview add pixi-build` otherwise.
+/// - `pixi add --pypi mylib --path ../mylib --editable`
 ///
 /// If the workspace manifest is a `pyproject.toml`, adding a pypi dependency will
 /// add it to the native pyproject `project.dependencies` array or to the native

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -1,6 +1,11 @@
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    io::IsTerminal,
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
+use miette::{Context, IntoDiagnostic};
 use pep508_rs::Requirement;
 use pixi_api::workspace::{DependencyOptions, GitOptions};
 use pixi_config::ConfigCli;
@@ -10,13 +15,15 @@ use pixi_core::{
     environment::LockFileUsage,
     workspace::{PypiDeps, SkippedPackage},
 };
-use pixi_manifest::HasFeaturesIter;
+use pixi_manifest::{
+    HasFeaturesIter, HasWorkspaceManifest, KnownPreviewFlag, PypiDependencyLocation,
+};
 use pixi_pypi_spec::{PixiPypiSource, PixiPypiSpec, PypiPackageName};
 use url::Url;
 
 use crate::{
     cli_config::{DependencyConfig, LockFileUpdateConfig, NoInstallConfig, ScriptWorkspaceConfig},
-    cli_interface::cli_context,
+    cli_interface::{CliInterface, cli_context},
     has_specs::HasSpecs,
 };
 
@@ -56,6 +63,21 @@ use crate::{
 ///
 /// - `pixi add --pypi boto3`
 /// - `pixi add --pypi "boto3==version"`
+///
+/// Local path dependencies can be added with `--path`. Paths are resolved from
+/// the current directory and stored relative to the workspace manifest, so an
+/// absolute input path does not become machine-specific manifest data. A direct
+/// `pixi.toml` or `pyproject.toml` input is stored as its containing directory.
+///
+/// - `pixi add mylib --path ../mylib`
+/// - `pixi add mylib --path /absolute/path/to/mylib/pixi.toml`
+/// - `pixi add recipe-package --path ../recipe/recipe.yaml`
+/// - `pixi add --pypi mylib --path ../mylib`
+/// - `pixi add --pypi mylib --path ../mylib/pyproject.toml --editable`
+///
+/// Conda path dependencies require the `pixi-build` preview feature. If it is
+/// not enabled, pixi offers to enable it when running interactively, or hints at
+/// `pixi workspace preview add pixi-build` otherwise.
 ///
 /// If the workspace manifest is a `pyproject.toml`, adding a pypi dependency will
 /// add it to the native pyproject `project.dependencies` array or to the native
@@ -101,13 +123,17 @@ pub struct Args {
     #[clap(flatten)]
     pub config_source: pixi_config::ConfigSourceCli,
 
+    /// The local path to use when adding a path dependency.
+    #[arg(long, conflicts_with = "git")]
+    pub path: Option<PathBuf>,
+
     /// Whether the pypi requirement should be editable
     #[arg(long, requires = "pypi")]
     pub editable: bool,
 
     /// The PyPI index URL to use for this dependency.
     /// Only applicable when adding pypi dependencies.
-    #[clap(long, requires = "pypi", conflicts_with = "git")]
+    #[clap(long, requires = "pypi", conflicts_with_all = ["git", "path"])]
     pub index: Option<Url>,
 }
 
@@ -160,6 +186,7 @@ impl From<&Args> for GitOptions {
     fn from(args: &Args) -> Self {
         GitOptions {
             git: args.dependency_config.git.clone(),
+            path: args.path.clone(),
             reference: args
                 .dependency_config
                 .rev
@@ -199,6 +226,143 @@ fn map_pypi_requirements_with_index(
         .collect()
 }
 
+fn path_error(path: &Path, message: impl std::fmt::Display) -> miette::Report {
+    miette::miette!("invalid dependency path '{}': {message}", path.display())
+}
+
+/// Resolve a CLI path from the current directory and rewrite it relative to the
+/// workspace manifest. Also verifies that the target is a supported package
+/// manifest (or a directory containing one).
+fn resolve_dependency_path(
+    path: &Path,
+    workspace: &Workspace,
+    pypi: bool,
+) -> miette::Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().into_diagnostic()?.join(path)
+    };
+    let absolute = dunce::canonicalize(&absolute)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("dependency path '{}' does not exist", path.display()))?;
+
+    let manifest = if absolute.is_dir() {
+        if pypi {
+            let pyproject = absolute.join("pyproject.toml");
+            if !pyproject.is_file() {
+                return Err(path_error(
+                    path,
+                    "directory does not contain pyproject.toml",
+                ));
+            }
+            pyproject
+        } else {
+            let pixi = absolute.join("pixi.toml");
+            let pyproject = absolute.join("pyproject.toml");
+            if pixi.is_file() {
+                pixi
+            } else if pyproject.is_file() {
+                pyproject
+            } else {
+                return Err(path_error(
+                    path,
+                    "directory does not contain pixi.toml or pyproject.toml",
+                ));
+            }
+        }
+    } else {
+        let file_name = absolute.file_name().and_then(|name| name.to_str());
+        let supported = if pypi {
+            file_name == Some("pyproject.toml")
+        } else {
+            matches!(
+                file_name,
+                Some("pixi.toml" | "pyproject.toml" | "recipe.yaml" | "recipe.yml" | "package.xml")
+            )
+        };
+        if !supported {
+            return Err(path_error(path, "not a supported package manifest"));
+        }
+        absolute.clone()
+    };
+
+    if !pypi
+        && matches!(
+            manifest.file_name().and_then(|name| name.to_str()),
+            Some("pixi.toml" | "pyproject.toml")
+        )
+    {
+        let contents = fs_err::read_to_string(&manifest).into_diagnostic()?;
+        let document = contents
+            .parse::<toml_edit::DocumentMut>()
+            .into_diagnostic()?;
+        let has_package =
+            if manifest.file_name().and_then(|name| name.to_str()) == Some("pixi.toml") {
+                document.get("package").is_some()
+            } else {
+                document
+                    .get("tool")
+                    .and_then(|tool| tool.get("pixi"))
+                    .and_then(|pixi| pixi.get("package"))
+                    .is_some()
+            };
+        if !has_package {
+            if manifest.file_name().and_then(|name| name.to_str()) == Some("pyproject.toml") {
+                return Err(miette::miette!(
+                    help = "Use `pixi add --pypi NAME --path PATH` for a Python path dependency",
+                    "'{}' is a Python project, not a pixi-build package source",
+                    manifest.display()
+                ));
+            }
+            return Err(miette::miette!(
+                help = "Add a `[package]` section to the package manifest",
+                "'{}' is a pixi workspace, not a pixi-build package source",
+                manifest.display()
+            ));
+        }
+    }
+
+    let dependency_path = match manifest.file_name().and_then(|name| name.to_str()) {
+        Some("pixi.toml" | "pyproject.toml") => manifest
+            .parent()
+            .expect("a canonical manifest path has a parent directory"),
+        _ => &manifest,
+    };
+    let manifest_dir = workspace
+        .workspace
+        .provenance
+        .path
+        .parent()
+        .ok_or_else(|| miette::miette!("workspace manifest has no parent directory"))?;
+    pathdiff::diff_paths(dependency_path, manifest_dir).ok_or_else(|| {
+        miette::miette!(
+            "could not make dependency path '{}' relative to workspace manifest '{}'",
+            dependency_path.display(),
+            workspace.workspace.provenance.path.display()
+        )
+    })
+}
+
+fn pypi_path_deps(package: &str, path: &Path, workspace: &Workspace) -> miette::Result<PypiDeps> {
+    let requirement_text = format!("{package} @ {}", path.to_string_lossy());
+    let requirement = Requirement::parse(&requirement_text, workspace.root()).into_diagnostic()?;
+    let name =
+        PypiPackageName::from_normalized(requirement.name.clone()).with_source(package.to_string());
+    let spec = PixiPypiSpec::try_from(requirement.clone())
+        .map_err(|error| miette::miette!("failed to create path requirement: {error}"))?;
+    Ok([(
+        name,
+        (
+            requirement,
+            Some(spec),
+            Some(PypiDependencyLocation::PixiPypiDependencies),
+        ),
+    )]
+    .into_iter()
+    .collect())
+}
+
 pub async fn execute(args: Args) -> miette::Result<()> {
     args.validate_script_options()?;
     args.dependency_config.warn_deprecated_subdir();
@@ -219,6 +383,61 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         workspace = workspace.with_backend_override(backend_override);
     }
 
+    let resolved_path = if let Some(path) = &args.path {
+        if args.dependency_config.specs.len() != 1 {
+            return Err(miette::miette!("--path requires exactly one package name"));
+        }
+        Some(resolve_dependency_path(
+            path,
+            &workspace,
+            args.dependency_config.pypi,
+        )?)
+    } else {
+        None
+    };
+
+    if resolved_path.is_some()
+        && !args.dependency_config.pypi
+        && !(&workspace)
+            .workspace_manifest()
+            .workspace
+            .preview
+            .is_enabled(KnownPreviewFlag::PixiBuild)
+    {
+        let hint = "Run `pixi workspace preview add pixi-build` to enable the preview flag";
+        let enable = std::io::stdin().is_terminal()
+            && dialoguer::Confirm::new()
+                .with_prompt("Conda path dependencies require the pixi-build preview feature. Enable pixi-build for this workspace?")
+                .default(false)
+                .interact()
+                .into_diagnostic()?;
+        if !enable {
+            return Err(miette::miette!(
+                help = hint,
+                "conda path dependencies are not allowed without enabling the 'pixi-build' preview flag"
+            ));
+        }
+        pixi_api::WorkspaceContext::add_preview_flags(
+            CliInterface {},
+            workspace.workspace.provenance.path.clone(),
+            vec![KnownPreviewFlag::PixiBuild],
+        )
+        .await?;
+        workspace = WorkspaceLocator::for_cli()
+            .with_global_config_source(args.config_source.source())
+            .with_search_start(args.workspace_config.workspace_locator_start())
+            .with_cli_config(args.config.clone())
+            .locate()?;
+        if let Some(backend_override) = args
+            .workspace_config
+            .workspace_config
+            .backend_override
+            .clone()
+        {
+            workspace = workspace.with_backend_override(backend_override);
+        }
+    }
+
     let workspace_ctx = cli_context(workspace.clone());
 
     let (update_deps, skipped, parsed_names): (_, Vec<SkippedPackage>, Vec<String>) =
@@ -226,6 +445,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             DependencyType::CondaDependency(spec_type) => {
                 let git_options = GitOptions {
                     git: args.dependency_config.git.clone(),
+                    path: resolved_path.clone(),
                     reference: args
                         .dependency_config
                         .rev
@@ -251,17 +471,19 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                 (result.0, result.1, names)
             }
             DependencyType::PypiDependency => {
-                let requirements_iter = match args
-                    .dependency_config
-                    .vcs_pep508_requirements(&workspace)
-                    .transpose()?
-                {
-                    Some(vcs_reqs) => vcs_reqs.into_iter(),
-                    None => args.dependency_config.pypi_deps(&workspace)?.into_iter(),
+                let pypi_deps = if let Some(path) = &resolved_path {
+                    pypi_path_deps(&args.dependency_config.specs[0], path, &workspace)?
+                } else {
+                    let requirements_iter = match args
+                        .dependency_config
+                        .vcs_pep508_requirements(&workspace)
+                        .transpose()?
+                    {
+                        Some(vcs_reqs) => vcs_reqs.into_iter(),
+                        None => args.dependency_config.pypi_deps(&workspace)?.into_iter(),
+                    };
+                    map_pypi_requirements_with_index(requirements_iter, args.index.as_ref())?
                 };
-
-                let pypi_deps =
-                    map_pypi_requirements_with_index(requirements_iter, args.index.as_ref())?;
 
                 let names: Vec<String> = pypi_deps
                     .keys()

--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -339,8 +339,12 @@ fn resolve_dependency_path(
     })
 }
 
+fn manifest_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
 fn pypi_path_deps(package: &str, path: &Path, workspace: &Workspace) -> miette::Result<PypiDeps> {
-    let requirement_text = format!("{package} @ {}", path.to_string_lossy());
+    let requirement_text = format!("{package} @ {}", manifest_path_string(path));
     let requirement = Requirement::parse(&requirement_text, workspace.root()).into_diagnostic()?;
     let name =
         PypiPackageName::from_normalized(requirement.name.clone()).with_source(package.to_string());

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -17,8 +17,7 @@ use pixi_manifest::{EnvironmentName, FeatureName, PixiPlatformName, SpecType};
 use pixi_spec::GitReference;
 use rattler_conda_types::ChannelConfig;
 use rattler_conda_types::{Channel, NamedChannelOrUrl};
-use std::collections::HashMap;
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 use url::Url;
 
 use pixi_git::GIT_URL_QUERY_REV_TYPE;

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -151,18 +151,13 @@ be mixed with the conda dependencies
 
 Local path dependencies can be added with `--path`. Paths are resolved from
 the current directory and stored relative to the workspace manifest, so an
-absolute input path does not become machine-specific manifest data. A direct
-`pixi.toml` or `pyproject.toml` input is stored as its containing directory.
+absolute input path does not become machine-specific manifest data.
 
 - `pixi add mylib --path ../mylib`
-- `pixi add mylib --path /absolute/path/to/mylib/pixi.toml`
+- `pixi add mylib --path /absolute/path/to/mylib`
 - `pixi add recipe-package --path ../recipe/recipe.yaml`
 - `pixi add --pypi mylib --path ../mylib`
-- `pixi add --pypi mylib --path ../mylib/pyproject.toml --editable`
-
-Conda path dependencies require the `pixi-build` preview feature. If it is
-not enabled, pixi offers to enable it when running interactively, or hints at
-`pixi workspace preview add pixi-build` otherwise.
+- `pixi add --pypi mylib --path ../mylib --editable`
 
 If the workspace manifest is a `pyproject.toml`, adding a pypi dependency will
 add it to the native pyproject `project.dependencies` array or to the native

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -30,6 +30,8 @@ pixi add [OPTIONS] <SPEC>...
 <br>**default**: `default`
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  The environment for which the dependency should be modified. The dependency is written to the content defined inline on the environment, creating the environment if it does not exist
+- <a id="arg---path" href="#arg---path">`--path <PATH>`</a>
+:  The local path to use when adding a path dependency
 - <a id="arg---editable" href="#arg---editable">`--editable`</a>
 :  Whether the pypi requirement should be editable
 - <a id="arg---index" href="#arg---index">`--index <INDEX>`</a>
@@ -146,6 +148,21 @@ be mixed with the conda dependencies
 
 - `pixi add --pypi boto3`
 - `pixi add --pypi "boto3==version"`
+
+Local path dependencies can be added with `--path`. Paths are resolved from
+the current directory and stored relative to the workspace manifest, so an
+absolute input path does not become machine-specific manifest data. A direct
+`pixi.toml` or `pyproject.toml` input is stored as its containing directory.
+
+- `pixi add mylib --path ../mylib`
+- `pixi add mylib --path /absolute/path/to/mylib/pixi.toml`
+- `pixi add recipe-package --path ../recipe/recipe.yaml`
+- `pixi add --pypi mylib --path ../mylib`
+- `pixi add --pypi mylib --path ../mylib/pyproject.toml --editable`
+
+Conda path dependencies require the `pixi-build` preview feature. If it is
+not enabled, pixi offers to enable it when running interactively, or hints at
+`pixi workspace preview add pixi-build` otherwise.
 
 If the workspace manifest is a `pyproject.toml`, adding a pypi dependency will
 add it to the native pyproject `project.dependencies` array or to the native

--- a/docs/reference/cli/pixi/add_extender
+++ b/docs/reference/cli/pixi/add_extender
@@ -34,6 +34,13 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --branch main --py
 pixi add --git https://github.com/mahmoud/boltons.git boltons --rev e50d4a1 --pypi # (25)!
 pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi # (26)!
 pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pypi --subdirectory boltons # (27)!
+
+# Add local path dependencies
+pixi add my-package --path ../my-package # (29)!
+pixi add my-package --path /absolute/path/to/my-package # (30)!
+pixi add recipe-package --path ../recipe/recipe.yaml # (31)!
+pixi add --pypi python-package --path ../python-package # (32)!
+pixi add --pypi python-package --path ../python-package --editable # (33)!
 ```
 
 1. This will add the `numpy` package to the project with the latest available for the solved environment.
@@ -64,6 +71,11 @@ pixi add --git https://github.com/mahmoud/boltons.git boltons --tag v0.1.0 --pyp
 26. This will add the `boltons` package with the given `git` url and `v0.1.0` tag as `pypi` dependency.
 27. This will add the `boltons` package with the given `git` url, `v0.1.0` tag and the `boltons` folder in the repository as `pypi` dependency.
 28. This will add the `numpy` package to the dependencies defined inline on the environment `dev`, creating the environment if it does not exist.
+29. This will add a local pixi-build package from a directory. Conda path dependencies require the `pixi-build` preview feature.
+30. This will add a local pixi-build package by pointing directly at its directory. Absolute input paths are stored relative to the workspace manifest.
+31. This will add a local conda source package by pointing directly at its `recipe.yaml`. Direct `recipe.yml` and `package.xml` paths are also supported.
+32. This will add a Python project directory as a PyPI path dependency. The directory must contain a `pyproject.toml`.
+33. This will add a Python project directory and install it in editable mode.
 
 !!! tip "Need to specify build strings or hardware-specific packages?"
     For advanced package specifications including build strings, see the [Package Specifications](../../../concepts/package_specifications.md) guide.

--- a/tests/data/pixi-build/ros-workspace/src/navigator/CMakeLists.txt
+++ b/tests/data/pixi-build/ros-workspace/src/navigator/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(navigator)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/tests/data/pixi-build/ros-workspace/src/navigator/src/navigator.cpp
+++ b/tests/data/pixi-build/ros-workspace/src/navigator/src/navigator.cpp
@@ -1,6 +1,8 @@
 #define _USE_MATH_DEFINES
 
 #include <cmath>
+#include <codecvt>
+#include <locale>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/point.hpp"

--- a/tests/data/pixi-build/ros-workspace/src/navigator_implicit/CMakeLists.txt
+++ b/tests/data/pixi-build/ros-workspace/src/navigator_implicit/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(navigator_implicit)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/tests/data/pixi-build/ros-workspace/src/navigator_implicit/src/navigator.cpp
+++ b/tests/data/pixi-build/ros-workspace/src/navigator_implicit/src/navigator.cpp
@@ -1,6 +1,8 @@
 #define _USE_MATH_DEFINES
 
 #include <cmath>
+#include <codecvt>
+#include <locale>
 
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/point.hpp"


### PR DESCRIPTION
### Description

This PR add `pixi add --path`.

It works for both `conda` and `pypi` dependencies. 

If you use it for conda dependencies and the `preview = ["pixi-build"]` flag doesn't exist you'll get an interactive request whether you want to add it.

It accepts `pixi add --path /bla/package/pixi.toml package-name` but will save it as `package-name = { path = "../package" }` as absolute paths don't work nicely in the manifest. 

### How Has This Been Tested?

I've tested it by adding some local package on my machine to a new pixi project and I couldn't break it.
e.g.:
```
pixi add --path ~/dev/pixi pixi
pixi add --path ~/dev/vinca vinca --pypi
pixi add --path ~/dev/ros_ws/src/common/package.xml ros-jazzy-common
```

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Codex


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
