### PR TITLE
fix(test): pin the ROS fixture's macOS compiler to unbreak CI

### DIFF
--- a/tests/data/pixi-build/ros-workspace/pixi.toml
+++ b/tests/data/pixi-build/ros-workspace/pixi.toml
@@ -8,6 +8,12 @@ exclude-newer = "7d"
 platforms = ["osx-arm64", "linux-64", "win-64", "linux-aarch64"]
 preview = ["pixi-build"]
 
+# libc++ 23 dropped `std::wstring_convert`, which robostack-humble's
+# `rosidl_runtime_cpp` header still uses. Drop this once it is fixed upstream.
+[workspace.target.osx.build-variants]
+c_compiler_version = ["22"]
+cxx_compiler_version = ["22"]
+
 [tasks]
 navigator = "ros2 run navigator navigator"
 navigator_py = "ros2 run navigator_py navigator"


### PR DESCRIPTION
### Description

`Pytest | macos aarch64` has been red on main since this morning with no commit to blame. Every ROS C++ build fails on:

```
rosidl_runtime_cpp/traits.hpp:131:8: error: no member named 'wstring_convert' in namespace 'std'
```

clang/libc++ 23 dropped `std::wstring_convert`, which robostack-humble's `rosidl_runtime_cpp` header still uses. Nothing pinned the toolchain: the fixture has no lock file, and `exclude-newer = "7d"` is a sliding window rather than a pin, so clang 23.1.0 just aged into range.

Pinning the compiler variant to 22 brings `libcxx-devel` and `libcxx-headers` down to 22.1.8 with it, and those are what declare `wstring_convert`. `libcxx` itself stays at 23.1.0, but that package ships only the runtime dylib.

Remove the pin once robostack-humble ships a `rosidl_runtime_cpp` that builds against libc++ 23.

### One thing worth a separate look

I first tried pinning the workspace's `exclude-newer` to a fixed date. That constrains a normal dependency solve — verified locally, it then selects clang 22.1.8 — but the build environment for a source package still resolved Clang 23.1.0, so it had no effect on this test. If that is not deliberate, it means a workspace cannot currently pin its build toolchain by date.

### How Has This Been Tested?

CI on this PR, so please watch `Pytest | macos aarch64`. The failure is macOS-specific and I am on Windows, so I could not reproduce it locally.

Locally I checked that the manifest still parses, and that solving `clangxx_osx-arm64 = "22.*"` for osx-arm64 pulls `libcxx-devel` and `libcxx-headers` 22.1.8.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
