### PR TITLE
feat: add the `pixi_script_shell` crate with the mini-shell parser and executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7191,6 +7191,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pixi_script_shell"
+version = "0.1.0"
+dependencies = [
+ "deno_task_shell",
+ "fs-err",
+ "insta",
+ "miette 7.6.0",
+ "nix 0.29.0",
+ "pixi_test_utils",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tokio",
+ "which",
+]
+
+[[package]]
 name = "pixi_spec"
 version = "0.1.0"
 dependencies = [

--- a/crates/pixi_script_shell/Cargo.toml
+++ b/crates/pixi_script_shell/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "pixi_script_shell"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+description = "The mini-shell that runs script entrypoints"
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+deno_task_shell = { workspace = true }
+miette = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "macros", "process"] }
+which = { workspace = true }
+
+[dev-dependencies]
+fs-err = { workspace = true }
+insta = { workspace = true }
+pixi_test_utils = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "process", "rt", "time"] }
+
+[target."cfg(unix)".dependencies]
+nix = { workspace = true, features = ["signal"] }

--- a/crates/pixi_script_shell/src/execute.rs
+++ b/crates/pixi_script_shell/src/execute.rs
@@ -1,0 +1,643 @@
+use std::{
+    collections::HashMap,
+    ffi::OsString,
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    process::{ExitStatus, Stdio},
+};
+
+use deno_task_shell::KillSignal;
+use miette::Diagnostic;
+use thiserror::Error;
+use tokio::process::Child;
+
+use crate::{Command, CommandSequence, QuotedPart, Word, WordPart};
+
+/// Everything an entrypoint runs against: the substitution variables, the
+/// activated environment, the working directory and the signal handle.
+#[derive(Debug, Clone)]
+pub struct ShellContext {
+    /// The `${VAR}` substitution values; an entrypoint defines `SCRIPT` and
+    /// `CACHE`.
+    pub variables: HashMap<String, String>,
+    /// The full environment the commands run in, including the activation
+    /// variables of the solved environment.
+    pub env: HashMap<OsString, OsString>,
+    /// The working directory, left at the directory the tool was invoked
+    /// from.
+    pub cwd: PathBuf,
+    /// The handle the caller forwards signals through. Every running command
+    /// receives them, and dropping the execution kills the command outright.
+    pub kill_signal: KillSignal,
+}
+
+/// A failure while evaluating or running an entrypoint.
+#[derive(Debug, Error, Diagnostic)]
+pub enum ShellExecutionError {
+    #[error("the entrypoint refers to the undefined variable `${{{name}}}`")]
+    #[diagnostic(help("a conda-script entrypoint defines `${{SCRIPT}}` and `${{CACHE}}`"))]
+    UndefinedVariable { name: String },
+
+    #[error("`{argument}` looks like an environment variable assignment")]
+    #[diagnostic(help(
+        "a conda-script entrypoint cannot set environment variables; it only runs commands"
+    ))]
+    EnvAssignment { argument: String },
+
+    #[error("failed to run `{command}`")]
+    Spawn {
+        command: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("`{command}` inside `$(...)` exited with code {code}")]
+    #[diagnostic(help("a failing command inside `$(...)` aborts the entrypoint"))]
+    SubstitutionFailed { command: String, code: i32 },
+
+    #[error("the output of `{command}` inside `$(...)` is not valid UTF-8")]
+    SubstitutionNotUtf8 { command: String },
+}
+
+/// Runs a command sequence, appending `extra_args` to the last command.
+///
+/// Returns the exit code of the sequence: `0` when every command succeeded,
+/// otherwise the code of the command that failed and aborted it.
+pub async fn execute_sequence(
+    sequence: &CommandSequence,
+    extra_args: &[String],
+    context: &ShellContext,
+) -> Result<i32, ShellExecutionError> {
+    let last = sequence.commands.len().saturating_sub(1);
+    for (index, command) in sequence.commands.iter().enumerate() {
+        let mut argv = evaluate_command(command, context).await?;
+        let Some(program) = argv.first().cloned() else {
+            // A command whose words all evaluated to nothing, such as a lone
+            // `$(...)` with empty output, runs nothing and succeeds. The
+            // appended arguments vanish with it; they must never become the
+            // program themselves.
+            continue;
+        };
+        if index == last {
+            argv.extend(extra_args.iter().cloned());
+        }
+        let arguments = &argv[1..];
+        reject_env_assignment(&program)?;
+
+        let mut child = tokio::process::Command::new(resolve_program(&program, context))
+            .args(arguments)
+            .env_clear()
+            .envs(&context.env)
+            .current_dir(&context.cwd)
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|source| ShellExecutionError::Spawn {
+                command: program.clone(),
+                source,
+            })?;
+        let status = wait_forwarding_signals(&mut child, &context.kill_signal, &program).await?;
+        let code = exit_code(&status);
+        if code != 0 {
+            return Ok(code);
+        }
+    }
+    Ok(0)
+}
+
+/// Resolves `program` through the `PATH` of the environment the command runs
+/// in.
+///
+/// Spawning only tries `.exe` on Windows, while conda packages often install
+/// `.bat` or `.cmd` wrappers, so the lookup goes through `which`, which
+/// honours `PATHEXT`. An unresolved name is passed on as is, so the spawn
+/// error still names the missing program.
+fn resolve_program(program: &str, context: &ShellContext) -> OsString {
+    let path = context
+        .env
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("PATH"))
+        .map(|(_, value)| value.clone());
+    which::which_in(program, path, &context.cwd)
+        .map(PathBuf::into_os_string)
+        .unwrap_or_else(|_| OsString::from(program))
+}
+
+/// Waits for `child`, forwarding every signal sent through `kill_signal` to
+/// it.
+///
+/// Windows cannot deliver a signal to a process, so there a signal that
+/// aborts the command kills the child instead.
+async fn wait_forwarding_signals(
+    child: &mut Child,
+    kill_signal: &KillSignal,
+    program: &str,
+) -> Result<ExitStatus, ShellExecutionError> {
+    loop {
+        tokio::select! {
+            status = child.wait() => {
+                return status.map_err(|source| ShellExecutionError::Spawn {
+                    command: program.to_owned(),
+                    source,
+                });
+            }
+            signal = kill_signal.wait_any() => {
+                #[cfg(unix)]
+                if let Some(pid) = child.id() {
+                    forward_signal(pid, signal);
+                }
+                #[cfg(not(unix))]
+                if signal.causes_abort() {
+                    let _ = child.start_kill();
+                }
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn forward_signal(pid: u32, signal: deno_task_shell::SignalKind) {
+    use nix::{
+        sys::signal::{Signal, kill},
+        unistd::Pid,
+    };
+
+    let signo: i32 = signal.into();
+    if let Ok(signal) = Signal::try_from(signo) {
+        // A child that exited in the meantime is reaped by `wait`; nothing
+        // to do about a failed delivery here.
+        let _ = kill(Pid::from_raw(pid as i32), signal);
+    }
+}
+
+/// The exit code of a finished process, with a signal death encoded as
+/// `128 + signal_number` like a POSIX shell reports it.
+fn exit_code(status: &std::process::ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = status.signal() {
+            return 128 + signal;
+        }
+    }
+    1
+}
+
+/// Runs a substituted command sequence, capturing its stdout.
+///
+/// The commands share stderr with the entrypoint; their stdout is
+/// concatenated and a single trailing newline is stripped.
+fn run_substitution<'a>(
+    sequence: &'a CommandSequence,
+    context: &'a ShellContext,
+) -> Pin<Box<dyn Future<Output = Result<String, ShellExecutionError>> + 'a>> {
+    Box::pin(async move {
+        let mut output = Vec::new();
+        for command in &sequence.commands {
+            let argv = evaluate_command(command, context).await?;
+            let Some((program, arguments)) = argv.split_first() else {
+                continue;
+            };
+            reject_env_assignment(program)?;
+
+            // `output()` would force stderr into a pipe and swallow it; the
+            // diagnostics of a failing command belong on the terminal.
+            let mut child = tokio::process::Command::new(resolve_program(program, context))
+                .args(arguments)
+                .env_clear()
+                .envs(&context.env)
+                .current_dir(&context.cwd)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .stdin(Stdio::null())
+                .kill_on_drop(true)
+                .spawn()
+                .map_err(|source| ShellExecutionError::Spawn {
+                    command: program.clone(),
+                    source,
+                })?;
+            let mut stdout = child.stdout.take().expect("stdout was configured as piped");
+            let mut chunk = Vec::new();
+            tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut chunk)
+                .await
+                .map_err(|source| ShellExecutionError::Spawn {
+                    command: program.clone(),
+                    source,
+                })?;
+            let status = wait_forwarding_signals(&mut child, &context.kill_signal, program).await?;
+            if !status.success() {
+                return Err(ShellExecutionError::SubstitutionFailed {
+                    command: program.clone(),
+                    code: exit_code(&status),
+                });
+            }
+            output.extend_from_slice(&chunk);
+        }
+
+        let mut output =
+            String::from_utf8(output).map_err(|_| ShellExecutionError::SubstitutionNotUtf8 {
+                command: display_sequence(sequence),
+            })?;
+        if output.ends_with('\n') {
+            output.pop();
+            if output.ends_with('\r') {
+                output.pop();
+            }
+        }
+        Ok(output)
+    })
+}
+
+async fn evaluate_command(
+    command: &Command,
+    context: &ShellContext,
+) -> Result<Vec<String>, ShellExecutionError> {
+    let mut argv = Vec::new();
+    for word in &command.words {
+        argv.extend(evaluate_word(word, context).await?);
+    }
+    Ok(argv)
+}
+
+/// Evaluates one word into arguments.
+///
+/// Variable values and quoted content never split; only the output of an
+/// unquoted `$(...)` splits on whitespace. A word built solely from
+/// substitutions with empty output vanishes, while a quoted empty string
+/// stays an argument.
+async fn evaluate_word(
+    word: &Word,
+    context: &ShellContext,
+) -> Result<Vec<String>, ShellExecutionError> {
+    let mut arguments: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    for part in &word.parts {
+        match part {
+            WordPart::Literal(text) => current.push_str(text),
+            WordPart::SingleQuoted(text) => {
+                current.push_str(text);
+                quoted = true;
+            }
+            WordPart::Variable(name) => current.push_str(variable(name, context)?),
+            WordPart::DoubleQuoted(parts) => {
+                quoted = true;
+                for part in parts {
+                    match part {
+                        QuotedPart::Literal(text) => current.push_str(text),
+                        QuotedPart::Variable(name) => current.push_str(variable(name, context)?),
+                        QuotedPart::Substitution(sequence) => {
+                            current.push_str(&run_substitution(sequence, context).await?);
+                        }
+                    }
+                }
+            }
+            WordPart::Substitution(sequence) => {
+                let output = run_substitution(sequence, context).await?;
+                if output.starts_with(char::is_whitespace) && !current.is_empty() {
+                    arguments.push(std::mem::take(&mut current));
+                }
+                let mut pieces = output.split_whitespace();
+                if let Some(first) = pieces.next() {
+                    current.push_str(first);
+                    for piece in pieces {
+                        arguments.push(std::mem::take(&mut current));
+                        current.push_str(piece);
+                    }
+                }
+                if output.ends_with(char::is_whitespace) && !current.is_empty() {
+                    arguments.push(std::mem::take(&mut current));
+                }
+            }
+        }
+    }
+    if quoted || !current.is_empty() {
+        arguments.push(current);
+    }
+    Ok(arguments)
+}
+
+fn variable<'a>(name: &str, context: &'a ShellContext) -> Result<&'a str, ShellExecutionError> {
+    context
+        .variables
+        .get(name)
+        .map(String::as_str)
+        .ok_or_else(|| ShellExecutionError::UndefinedVariable {
+            name: name.to_owned(),
+        })
+}
+
+/// Rejects a program that reads as `NAME=value`, the shell syntax for an
+/// environment variable assignment the mini-shell deliberately lacks.
+fn reject_env_assignment(program: &str) -> Result<(), ShellExecutionError> {
+    let Some((name, _)) = program.split_once('=') else {
+        return Ok(());
+    };
+    let mut chars = name.chars();
+    let valid_name = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if valid_name {
+        Err(ShellExecutionError::EnvAssignment {
+            argument: program.to_owned(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+/// A short rendering of a sequence for error messages.
+fn display_sequence(sequence: &CommandSequence) -> String {
+    sequence
+        .commands
+        .iter()
+        .flat_map(|command| command.words.first())
+        .map(|word| {
+            word.parts
+                .iter()
+                .map(|part| match part {
+                    WordPart::Literal(text) | WordPart::SingleQuoted(text) => text.clone(),
+                    WordPart::Variable(name) => format!("${{{name}}}"),
+                    WordPart::DoubleQuoted(_) => "\"...\"".to_owned(),
+                    WordPart::Substitution(_) => "$(...)".to_owned(),
+                })
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join(" && ")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::{path::Path, time::Duration};
+
+    use super::*;
+    use crate::parse_sequence;
+
+    fn context(cwd: &Path, variables: &[(&str, &str)]) -> ShellContext {
+        ShellContext {
+            variables: variables
+                .iter()
+                .map(|(name, value)| (name.to_string(), value.to_string()))
+                .collect(),
+            env: std::env::vars_os().collect(),
+            cwd: cwd.to_owned(),
+            kill_signal: KillSignal::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn programs_resolve_through_the_environment_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let bin = directory.path().join("bin");
+        fs_err::create_dir(&bin).unwrap();
+        let hello = bin.join("hello");
+        fs_err::write(&hello, "#!/bin/sh\n: > marker\n").unwrap();
+        fs_err::set_permissions(&hello, std::os::unix::fs::PermissionsExt::from_mode(0o755))
+            .unwrap();
+        let mut context = context(directory.path(), &[]);
+        context.env = HashMap::from([(OsString::from("PATH"), bin.into_os_string())]);
+
+        let code = run("hello", &[], &context).await.unwrap();
+
+        assert_eq!(code, 0);
+        assert!(directory.path().join("marker").exists());
+    }
+
+    #[tokio::test]
+    async fn a_forwarded_signal_reaches_the_running_command() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+        let kill_signal = context.kill_signal.clone();
+
+        let send_term = async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            kill_signal.send(nix::libc::SIGTERM.into());
+        };
+        let (code, ()) = tokio::join!(run("sleep 30", &[], &context), send_term);
+
+        assert_eq!(code.unwrap(), 143);
+    }
+
+    #[tokio::test]
+    async fn dropping_the_execution_kills_the_running_command() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        // One child process that would leave a marker after a short sleep;
+        // abandoning the execution while it sleeps must take it down.
+        let abandoned = tokio::time::timeout(
+            Duration::from_millis(200),
+            run("sh -c 'sleep 0.5; touch marker'", &[], &context),
+        )
+        .await;
+        assert!(abandoned.is_err());
+
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+        assert!(!directory.path().join("marker").exists());
+    }
+
+    async fn run(
+        input: &str,
+        extra_args: &[&str],
+        context: &ShellContext,
+    ) -> Result<i32, ShellExecutionError> {
+        let sequence = parse_sequence(input).unwrap();
+        let extra_args: Vec<String> = extra_args.iter().map(ToString::to_string).collect();
+        execute_sequence(&sequence, &extra_args, context).await
+    }
+
+    #[tokio::test]
+    async fn a_failing_command_aborts_the_sequence() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        let code = run("false && touch marker", &[], &context).await.unwrap();
+
+        assert_eq!(code, 1);
+        assert!(!directory.path().join("marker").exists());
+    }
+
+    #[tokio::test]
+    async fn arguments_are_appended_to_the_last_command() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        let code = run("true && touch", &["marker"], &context).await.unwrap();
+
+        assert_eq!(code, 0);
+        assert!(directory.path().join("marker").exists());
+    }
+
+    #[tokio::test]
+    async fn unquoted_substitution_output_splits_into_arguments() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        run("touch $(printf 'first  second')", &[], &context)
+            .await
+            .unwrap();
+
+        assert!(directory.path().join("first").exists());
+        assert!(directory.path().join("second").exists());
+    }
+
+    #[tokio::test]
+    async fn quoted_substitution_output_stays_one_argument() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        run("touch \"$(printf 'first second')\"", &[], &context)
+            .await
+            .unwrap();
+
+        assert!(directory.path().join("first second").exists());
+    }
+
+    #[tokio::test]
+    async fn a_trailing_newline_is_stripped_from_substitution_output() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        run("touch prefix-$(printf 'suffix\\n')", &[], &context)
+            .await
+            .unwrap();
+
+        assert!(directory.path().join("prefix-suffix").exists());
+    }
+
+    #[tokio::test]
+    async fn substitutions_nest() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        run("touch $(printf '%s' $(printf 'inner'))", &[], &context)
+            .await
+            .unwrap();
+
+        assert!(directory.path().join("inner").exists());
+    }
+
+    #[tokio::test]
+    async fn variables_substitute_without_splitting() {
+        let directory = tempfile::tempdir().unwrap();
+        let cache = directory.path().join("cache dir");
+        fs_err::create_dir(&cache).unwrap();
+        let context = context(directory.path(), &[("CACHE", cache.to_str().unwrap())]);
+
+        run("touch ${CACHE}/artifact", &[], &context).await.unwrap();
+
+        assert!(cache.join("artifact").exists());
+    }
+
+    #[tokio::test]
+    async fn single_quotes_suppress_substitution() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[("CACHE", "unused")]);
+
+        run("touch '${CACHE}'", &[], &context).await.unwrap();
+
+        assert!(directory.path().join("${CACHE}").exists());
+    }
+
+    #[tokio::test]
+    async fn an_undefined_variable_is_an_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        let error = run("touch ${MISSING}", &[], &context).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            ShellExecutionError::UndefinedVariable { name } if name == "MISSING"
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_failing_substitution_aborts_the_entrypoint() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        let error = run("touch $(false) marker", &[], &context)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ShellExecutionError::SubstitutionFailed { command, code: 1 } if command == "false"
+        ));
+        assert!(!directory.path().join("marker").exists());
+    }
+
+    #[tokio::test]
+    async fn an_environment_assignment_is_rejected() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        let error = run("FOO=bar true", &[], &context).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            ShellExecutionError::EnvAssignment { argument } if argument == "FOO=bar"
+        ));
+    }
+
+    #[tokio::test]
+    async fn whitespace_at_substitution_edges_starts_a_new_argument() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        // `pkg-config`-style output with trailing whitespace must not glue
+        // onto an adjacent literal.
+        run("touch first$(printf ' second ')third", &[], &context)
+            .await
+            .unwrap();
+
+        assert!(directory.path().join("first").exists());
+        assert!(directory.path().join("second").exists());
+        assert!(directory.path().join("third").exists());
+    }
+
+    #[tokio::test]
+    async fn a_signal_death_reports_the_conventional_exit_code() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        // `perl` kills itself with SIGKILL (9); single quotes keep `$$` away
+        // from the mini-shell's substitution syntax.
+        let code = run("perl -e 'kill 9, $$'", &[], &context).await.unwrap();
+
+        assert_eq!(code, 137);
+    }
+
+    #[tokio::test]
+    async fn appended_arguments_never_become_the_program() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        // The last command evaluates to nothing, so the appended arguments
+        // vanish with it instead of being executed themselves.
+        let code = run("$(true)", &["touch", "marker"], &context)
+            .await
+            .unwrap();
+
+        assert_eq!(code, 0);
+        assert!(!directory.path().join("marker").exists());
+    }
+
+    #[tokio::test]
+    async fn a_missing_program_is_an_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let context = context(directory.path(), &[]);
+
+        let error = run("definitely-not-a-real-program-42", &[], &context)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ShellExecutionError::Spawn { .. }));
+    }
+}

--- a/crates/pixi_script_shell/src/lib.rs
+++ b/crates/pixi_script_shell/src/lib.rs
@@ -1,0 +1,58 @@
+//! The mini-shell a `conda-script` entrypoint runs in: whitespace
+//! splitting, single and double quotes, `${VAR}` substitution, recursive
+//! `$(...)` command substitution and `&&` sequencing. Nothing else: no
+//! pipes, redirects, globbing, `||`, `;`, subshells or environment variable
+//! assignments. Commands are spawned directly, never through a system shell.
+
+mod execute;
+mod parse;
+
+pub use execute::{ShellContext, ShellExecutionError, execute_sequence};
+pub use parse::{ShellParseError, ShellParseErrorKind, parse_sequence};
+
+/// A chain of commands separated by `&&`; a failing command aborts it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSequence {
+    /// The commands in execution order.
+    pub commands: Vec<Command>,
+}
+
+/// One command: a program and its arguments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Command {
+    /// The whitespace-separated words; the first evaluates to the program.
+    pub words: Vec<Word>,
+}
+
+/// One whitespace-delimited word, a concatenation of parts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Word {
+    /// The parts the word concatenates.
+    pub parts: Vec<WordPart>,
+}
+
+/// A part of a word.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WordPart {
+    /// Unquoted literal text.
+    Literal(String),
+    /// Single-quoted text: no substitution happens inside.
+    SingleQuoted(String),
+    /// Double-quoted text: substitutions apply, the result stays one word.
+    DoubleQuoted(Vec<QuotedPart>),
+    /// A bare `${VAR}`; the value is inserted without splitting.
+    Variable(String),
+    /// A bare `$(...)`; the output is split into words on whitespace.
+    Substitution(CommandSequence),
+}
+
+/// A part of a double-quoted string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuotedPart {
+    /// Literal text.
+    Literal(String),
+    /// A `${VAR}` substitution.
+    Variable(String),
+    /// A `$(...)` substitution; the output stays part of the single word.
+    Substitution(CommandSequence),
+}

--- a/crates/pixi_script_shell/src/parse.rs
+++ b/crates/pixi_script_shell/src/parse.rs
@@ -1,0 +1,716 @@
+use std::{iter::Peekable, str::CharIndices};
+
+use miette::{Diagnostic, SourceSpan};
+use thiserror::Error;
+
+use crate::{Command, CommandSequence, QuotedPart, Word, WordPart};
+
+/// A syntax error in an entrypoint command string.
+///
+/// The label spans the offending part of the command string; attach the
+/// string with [`miette::Report::with_source_code`] to render it.
+#[derive(Debug, Clone, Error, Diagnostic)]
+#[error("{kind}")]
+pub struct ShellParseError {
+    /// What is wrong.
+    pub kind: ShellParseErrorKind,
+    /// Where in the command string.
+    #[label("{kind}")]
+    pub span: SourceSpan,
+}
+
+/// The kinds of entrypoint syntax errors.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ShellParseErrorKind {
+    #[error("`$` must be followed by `{{NAME}}` or `(`")]
+    BareDollar,
+
+    #[error(
+        "`${{...}}` must contain a variable name of letters, digits and underscores, starting with a letter or underscore"
+    )]
+    InvalidVariableName,
+
+    #[error("unterminated `${{...}}`")]
+    UnterminatedVariable,
+
+    #[error("unterminated `$(...)`")]
+    UnterminatedSubstitution,
+
+    #[error("unterminated single-quoted string")]
+    UnterminatedSingleQuote,
+
+    #[error("unterminated double-quoted string")]
+    UnterminatedDoubleQuote,
+
+    #[error("`&` is only valid as the `&&` sequencer")]
+    LoneAmpersand,
+
+    #[error("pipes are not supported in a conda-script entrypoint")]
+    Pipe,
+
+    #[error("`;` is not supported in a conda-script entrypoint; sequence commands with `&&`")]
+    Semicolon,
+
+    #[error("redirects are not supported in a conda-script entrypoint")]
+    Redirect,
+
+    #[error("backticks are not supported in a conda-script entrypoint; substitute with `$(...)`")]
+    Backtick,
+
+    #[error("expected a command")]
+    ExpectedCommand,
+
+    #[error("unexpected `)`")]
+    UnexpectedParen,
+
+    #[error("`$(...)` substitutions nest too deeply")]
+    TooDeeplyNested,
+}
+
+/// The maximum `$(...)` nesting depth; parsing recurses per level, so an
+/// unbounded depth would overflow the stack instead of reporting an error.
+const MAX_SUBSTITUTION_DEPTH: usize = 64;
+
+/// Parses an entrypoint command string into a command sequence.
+pub fn parse_sequence(input: &str) -> Result<CommandSequence, ShellParseError> {
+    let mut parser = Parser {
+        input,
+        chars: input.char_indices().peekable(),
+    };
+    let sequence = parser.sequence(None, 0)?;
+    Ok(sequence)
+}
+
+struct Parser<'a> {
+    input: &'a str,
+    chars: Peekable<CharIndices<'a>>,
+}
+
+impl Parser<'_> {
+    fn peek(&mut self) -> Option<(usize, char)> {
+        self.chars.peek().copied()
+    }
+
+    fn next(&mut self) -> Option<(usize, char)> {
+        self.chars.next()
+    }
+
+    fn error(&self, kind: ShellParseErrorKind, start: usize, len: usize) -> ShellParseError {
+        ShellParseError {
+            kind,
+            span: SourceSpan::new(start.into(), len),
+        }
+    }
+
+    /// Parses commands until the end of input, or until `)` when
+    /// `substitution_start` marks an enclosing `$(`.
+    fn sequence(
+        &mut self,
+        substitution_start: Option<usize>,
+        depth: usize,
+    ) -> Result<CommandSequence, ShellParseError> {
+        let mut commands = Vec::new();
+        let mut words = Vec::new();
+        let end;
+        loop {
+            while self.peek().is_some_and(|(_, c)| c.is_whitespace()) {
+                self.next();
+            }
+            match self.peek() {
+                None => {
+                    if let Some(start) = substitution_start {
+                        return Err(self.error(
+                            ShellParseErrorKind::UnterminatedSubstitution,
+                            start,
+                            2,
+                        ));
+                    }
+                    end = self.input.len();
+                    break;
+                }
+                Some((offset, ')')) => {
+                    if substitution_start.is_none() {
+                        return Err(self.error(ShellParseErrorKind::UnexpectedParen, offset, 1));
+                    }
+                    self.next();
+                    end = offset;
+                    break;
+                }
+                Some((offset, '&')) => {
+                    self.next();
+                    if self.peek().is_some_and(|(_, c)| c == '&') {
+                        self.next();
+                        if words.is_empty() {
+                            return Err(self.error(
+                                ShellParseErrorKind::ExpectedCommand,
+                                offset,
+                                2,
+                            ));
+                        }
+                        commands.push(Command {
+                            words: std::mem::take(&mut words),
+                        });
+                    } else {
+                        return Err(self.error(ShellParseErrorKind::LoneAmpersand, offset, 1));
+                    }
+                }
+                Some((offset, '|')) => {
+                    return Err(self.error(ShellParseErrorKind::Pipe, offset, 1));
+                }
+                Some((offset, ';')) => {
+                    return Err(self.error(ShellParseErrorKind::Semicolon, offset, 1));
+                }
+                Some((offset, '<' | '>')) => {
+                    return Err(self.error(ShellParseErrorKind::Redirect, offset, 1));
+                }
+                Some((offset, '`')) => {
+                    return Err(self.error(ShellParseErrorKind::Backtick, offset, 1));
+                }
+                Some(_) => words.push(self.word(depth)?),
+            }
+        }
+
+        if !words.is_empty() {
+            commands.push(Command { words });
+        } else {
+            // The sequence is empty or ends in `&&`.
+            return Err(self.error(ShellParseErrorKind::ExpectedCommand, end, 0));
+        }
+        Ok(CommandSequence { commands })
+    }
+
+    fn word(&mut self, depth: usize) -> Result<Word, ShellParseError> {
+        let mut parts = Vec::new();
+        let mut literal = String::new();
+        loop {
+            match self.peek() {
+                None => break,
+                Some((_, c)) if c.is_whitespace() => break,
+                Some((_, '&' | ')' | '|' | ';' | '<' | '>' | '`')) => break,
+                Some((offset, '\'')) => {
+                    flush(&mut parts, &mut literal);
+                    self.next();
+                    parts.push(WordPart::SingleQuoted(self.single_quoted(offset)?));
+                }
+                Some((offset, '"')) => {
+                    flush(&mut parts, &mut literal);
+                    self.next();
+                    parts.push(WordPart::DoubleQuoted(self.double_quoted(offset, depth)?));
+                }
+                Some((offset, '$')) => {
+                    flush(&mut parts, &mut literal);
+                    self.next();
+                    parts.push(match self.dollar(offset, depth)? {
+                        Dollar::Variable(name) => WordPart::Variable(name),
+                        Dollar::Substitution(sequence) => WordPart::Substitution(sequence),
+                    });
+                }
+                Some((_, c)) => {
+                    self.next();
+                    literal.push(c);
+                }
+            }
+        }
+        flush(&mut parts, &mut literal);
+        Ok(Word { parts })
+    }
+
+    fn single_quoted(&mut self, open: usize) -> Result<String, ShellParseError> {
+        let mut content = String::new();
+        loop {
+            match self.next() {
+                None => {
+                    return Err(self.error(ShellParseErrorKind::UnterminatedSingleQuote, open, 1));
+                }
+                Some((_, '\'')) => return Ok(content),
+                Some((_, c)) => content.push(c),
+            }
+        }
+    }
+
+    fn double_quoted(
+        &mut self,
+        open: usize,
+        depth: usize,
+    ) -> Result<Vec<QuotedPart>, ShellParseError> {
+        let mut parts = Vec::new();
+        let mut literal = String::new();
+        loop {
+            match self.peek() {
+                None => {
+                    return Err(self.error(ShellParseErrorKind::UnterminatedDoubleQuote, open, 1));
+                }
+                Some((_, '"')) => {
+                    self.next();
+                    break;
+                }
+                Some((offset, '$')) => {
+                    if !literal.is_empty() {
+                        parts.push(QuotedPart::Literal(std::mem::take(&mut literal)));
+                    }
+                    self.next();
+                    parts.push(match self.dollar(offset, depth)? {
+                        Dollar::Variable(name) => QuotedPart::Variable(name),
+                        Dollar::Substitution(sequence) => QuotedPart::Substitution(sequence),
+                    });
+                }
+                Some((_, c)) => {
+                    self.next();
+                    literal.push(c);
+                }
+            }
+        }
+        if !literal.is_empty() {
+            parts.push(QuotedPart::Literal(literal));
+        }
+        Ok(parts)
+    }
+
+    /// Parses what follows a consumed `$` at `dollar`.
+    fn dollar(&mut self, dollar: usize, depth: usize) -> Result<Dollar, ShellParseError> {
+        match self.peek() {
+            Some((_, '{')) => {
+                self.next();
+                let mut name = String::new();
+                loop {
+                    match self.peek() {
+                        None => {
+                            return Err(self.error(
+                                ShellParseErrorKind::UnterminatedVariable,
+                                dollar,
+                                2,
+                            ));
+                        }
+                        Some((end, '}')) => {
+                            self.next();
+                            if !is_valid_variable_name(&name) {
+                                return Err(self.error(
+                                    ShellParseErrorKind::InvalidVariableName,
+                                    dollar,
+                                    end + 1 - dollar,
+                                ));
+                            }
+                            return Ok(Dollar::Variable(name));
+                        }
+                        Some((_, c)) => {
+                            self.next();
+                            name.push(c);
+                        }
+                    }
+                }
+            }
+            Some((_, '(')) => {
+                self.next();
+                if depth >= MAX_SUBSTITUTION_DEPTH {
+                    return Err(self.error(ShellParseErrorKind::TooDeeplyNested, dollar, 2));
+                }
+                Ok(Dollar::Substitution(
+                    self.sequence(Some(dollar), depth + 1)?,
+                ))
+            }
+            _ => Err(self.error(ShellParseErrorKind::BareDollar, dollar, 1)),
+        }
+    }
+}
+
+enum Dollar {
+    Variable(String),
+    Substitution(CommandSequence),
+}
+
+fn flush(parts: &mut Vec<WordPart>, literal: &mut String) {
+    if !literal.is_empty() {
+        parts.push(WordPart::Literal(std::mem::take(literal)));
+    }
+}
+
+fn is_valid_variable_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use pixi_test_utils::format_parse_error;
+
+    use super::*;
+
+    fn parse_err(input: &str) -> String {
+        format_parse_error(input, parse_sequence(input).unwrap_err())
+    }
+
+    #[test]
+    fn parses_the_canonical_compile_and_run_entrypoint() {
+        let sequence = parse_sequence(
+            "gcc -o ${CACHE}/main ${SCRIPT} $(pkg-config --cflags --libs glib-2.0) && ${CACHE}/main",
+        )
+        .unwrap();
+
+        insta::assert_debug_snapshot!(sequence, @r#"
+        CommandSequence {
+            commands: [
+                Command {
+                    words: [
+                        Word {
+                            parts: [
+                                Literal(
+                                    "gcc",
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                Literal(
+                                    "-o",
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                Variable(
+                                    "CACHE",
+                                ),
+                                Literal(
+                                    "/main",
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                Variable(
+                                    "SCRIPT",
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                Substitution(
+                                    CommandSequence {
+                                        commands: [
+                                            Command {
+                                                words: [
+                                                    Word {
+                                                        parts: [
+                                                            Literal(
+                                                                "pkg-config",
+                                                            ),
+                                                        ],
+                                                    },
+                                                    Word {
+                                                        parts: [
+                                                            Literal(
+                                                                "--cflags",
+                                                            ),
+                                                        ],
+                                                    },
+                                                    Word {
+                                                        parts: [
+                                                            Literal(
+                                                                "--libs",
+                                                            ),
+                                                        ],
+                                                    },
+                                                    Word {
+                                                        parts: [
+                                                            Literal(
+                                                                "glib-2.0",
+                                                            ),
+                                                        ],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                },
+                Command {
+                    words: [
+                        Word {
+                            parts: [
+                                Variable(
+                                    "CACHE",
+                                ),
+                                Literal(
+                                    "/main",
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        "#);
+    }
+
+    #[test]
+    fn quotes_group_and_suppress() {
+        let sequence =
+            parse_sequence(r#"run '${SCRIPT} literal' "quoted ${VAR} $(inner cmd)" tail"#).unwrap();
+
+        insta::assert_debug_snapshot!(sequence, @r#"
+        CommandSequence {
+            commands: [
+                Command {
+                    words: [
+                        Word {
+                            parts: [
+                                Literal(
+                                    "run",
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                SingleQuoted(
+                                    "${SCRIPT} literal",
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                DoubleQuoted(
+                                    [
+                                        Literal(
+                                            "quoted ",
+                                        ),
+                                        Variable(
+                                            "VAR",
+                                        ),
+                                        Literal(
+                                            " ",
+                                        ),
+                                        Substitution(
+                                            CommandSequence {
+                                                commands: [
+                                                    Command {
+                                                        words: [
+                                                            Word {
+                                                                parts: [
+                                                                    Literal(
+                                                                        "inner",
+                                                                    ),
+                                                                ],
+                                                            },
+                                                            Word {
+                                                                parts: [
+                                                                    Literal(
+                                                                        "cmd",
+                                                                    ),
+                                                                ],
+                                                            },
+                                                        ],
+                                                    },
+                                                ],
+                                            },
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        },
+                        Word {
+                            parts: [
+                                Literal(
+                                    "tail",
+                                ),
+                            ],
+                        },
+                    ],
+                },
+            ],
+        }
+        "#);
+    }
+
+    #[test]
+    fn ampersands_split_commands_without_surrounding_whitespace() {
+        let sequence = parse_sequence("a&&b").unwrap();
+        assert_eq!(sequence.commands.len(), 2);
+        assert_eq!(
+            sequence.commands[1].words[0].parts,
+            [WordPart::Literal("b".to_owned())]
+        );
+    }
+
+    #[test]
+    fn rejects_a_bare_dollar() {
+        insta::assert_snapshot!(parse_err("echo $HOME"), @"
+         × `$` must be followed by `{NAME}` or `(`
+          ╭─[pixi.toml:1:6]
+        1 │ echo $HOME
+          ·      ┬
+          ·      ╰── `$` must be followed by `{NAME}` or `(`
+          ╰────
+        ");
+    }
+
+    #[test]
+    fn rejects_an_invalid_variable_name() {
+        insta::assert_snapshot!(parse_err("echo ${1BAD}"), @"
+         × `${...}` must contain a variable name of letters, digits and underscores, starting with a letter or underscore
+          ╭─[pixi.toml:1:6]
+        1 │ echo ${1BAD}
+          ·      ───┬───
+          ·         ╰── `${...}` must contain a variable name of letters, digits and underscores, starting with a letter or underscore
+          ╰────
+        ");
+    }
+
+    #[test]
+    fn rejects_unterminated_constructs() {
+        insta::assert_snapshot!(parse_err("echo ${HOME"), @"
+         × unterminated `${...}`
+          ╭─[pixi.toml:1:6]
+        1 │ echo ${HOME
+          ·      ─┬
+          ·       ╰── unterminated `${...}`
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("echo $(inner"), @"
+         × unterminated `$(...)`
+          ╭─[pixi.toml:1:6]
+        1 │ echo $(inner
+          ·      ─┬
+          ·       ╰── unterminated `$(...)`
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("echo 'open"), @"
+         × unterminated single-quoted string
+          ╭─[pixi.toml:1:6]
+        1 │ echo 'open
+          ·      ┬
+          ·      ╰── unterminated single-quoted string
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("echo \"open"), @r#"
+         × unterminated double-quoted string
+          ╭─[pixi.toml:1:6]
+        1 │ echo "open
+          ·      ┬
+          ·      ╰── unterminated double-quoted string
+          ╰────
+        "#);
+    }
+
+    #[test]
+    fn rejects_everything_outside_the_grammar() {
+        insta::assert_snapshot!(parse_err("a | b"), @"
+         × pipes are not supported in a conda-script entrypoint
+          ╭─[pixi.toml:1:3]
+        1 │ a | b
+          ·   ┬
+          ·   ╰── pipes are not supported in a conda-script entrypoint
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a || b"), @"
+         × pipes are not supported in a conda-script entrypoint
+          ╭─[pixi.toml:1:3]
+        1 │ a || b
+          ·   ┬
+          ·   ╰── pipes are not supported in a conda-script entrypoint
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a ; b"), @"
+         × `;` is not supported in a conda-script entrypoint; sequence commands with `&&`
+          ╭─[pixi.toml:1:3]
+        1 │ a ; b
+          ·   ┬
+          ·   ╰── `;` is not supported in a conda-script entrypoint; sequence commands with `&&`
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a > file"), @"
+         × redirects are not supported in a conda-script entrypoint
+          ╭─[pixi.toml:1:3]
+        1 │ a > file
+          ·   ┬
+          ·   ╰── redirects are not supported in a conda-script entrypoint
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a < file"), @"
+         × redirects are not supported in a conda-script entrypoint
+          ╭─[pixi.toml:1:3]
+        1 │ a < file
+          ·   ┬
+          ·   ╰── redirects are not supported in a conda-script entrypoint
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a & b"), @"
+         × `&` is only valid as the `&&` sequencer
+          ╭─[pixi.toml:1:3]
+        1 │ a & b
+          ·   ┬
+          ·   ╰── `&` is only valid as the `&&` sequencer
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a `b`"), @"
+         × backticks are not supported in a conda-script entrypoint; substitute with `$(...)`
+          ╭─[pixi.toml:1:3]
+        1 │ a `b`
+          ·   ┬
+          ·   ╰── backticks are not supported in a conda-script entrypoint; substitute with `$(...)`
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a )"), @"
+         × unexpected `)`
+          ╭─[pixi.toml:1:3]
+        1 │ a )
+          ·   ┬
+          ·   ╰── unexpected `)`
+          ╰────
+        ");
+    }
+
+    #[test]
+    fn rejects_too_deeply_nested_substitutions() {
+        let mut input = String::from("echo ");
+        for _ in 0..100 {
+            input.push_str("$(a ");
+        }
+        input.push_str(&")".repeat(100));
+        let error = parse_sequence(&input).unwrap_err();
+        assert_eq!(error.kind, ShellParseErrorKind::TooDeeplyNested);
+
+        let mut nested_ok = String::from("echo ");
+        for _ in 0..20 {
+            nested_ok.push_str("$(a ");
+        }
+        nested_ok.push_str(&")".repeat(20));
+        assert!(parse_sequence(&nested_ok).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_commands() {
+        insta::assert_snapshot!(parse_err(""), @"
+        × expected a command
+         ╭─[pixi.toml:1:1]
+         ╰────
+        ");
+        insta::assert_snapshot!(parse_err("a &&"), @"
+         × expected a command
+          ╭─[pixi.toml:1:5]
+        1 │ a &&
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("&& a"), @"
+         × expected a command
+          ╭─[pixi.toml:1:1]
+        1 │ && a
+          · ─┬
+          ·  ╰── expected a command
+          ╰────
+        ");
+        insta::assert_snapshot!(parse_err("echo $()"), @"
+         × expected a command
+          ╭─[pixi.toml:1:8]
+        1 │ echo $()
+          ·        ▲
+          ·        ╰── expected a command
+          ╰────
+        ");
+    }
+}


### PR DESCRIPTION
The entrypoint of a `conda-script` block (#3751) runs in a minimal, fully specified shell instead of `deno_task_shell`.
The idea is that this eventually moves to rattler and is used by conda and maybe mamba as well

The parser supports whitespace splitting, single and double quotes, `${VAR}`, recursive `$(...)` command substitution and `&&`.

Signals sent through the kill signal reach the running command, and dropping the execution kills it, so no process outlives pixi.

