### PR TITLE
feat: run conda-script files via `pixi run --experimental --script`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6462,6 +6462,7 @@ dependencies = [
  "pixi_pypi_spec",
  "pixi_record",
  "pixi_reporters",
+ "pixi_script_shell",
  "pixi_spec",
  "pixi_task",
  "pixi_test_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ pixi_pypi_spec = { path = "crates/pixi_pypi_spec" }
 pixi_python_status = { path = "crates/pixi_python_status" }
 pixi_record = { path = "crates/pixi_record" }
 pixi_reporters = { path = "crates/pixi_reporters" }
+pixi_script_shell = { path = "crates/pixi_script_shell" }
 pixi_spec = { path = "crates/pixi_spec" }
 pixi_spec_containers = { path = "crates/pixi_spec_containers" }
 pixi_stable_hash = { path = "crates/pixi_stable_hash" }

--- a/crates/pixi_cli/Cargo.toml
+++ b/crates/pixi_cli/Cargo.toml
@@ -62,6 +62,7 @@ pixi_progress = { workspace = true }
 pixi_pypi_spec = { workspace = true }
 pixi_record = { workspace = true }
 pixi_reporters = { workspace = true }
+pixi_script_shell = { workspace = true }
 pixi_spec = { workspace = true }
 pixi_task = { workspace = true }
 pixi_utils = { workspace = true, default-features = false }

--- a/crates/pixi_cli/src/conda_script.rs
+++ b/crates/pixi_cli/src/conda_script.rs
@@ -1,0 +1,252 @@
+use std::{collections::HashMap, ffi::OsString, path::Path};
+
+use deno_task_shell::KillSignal;
+use miette::{IntoDiagnostic, NamedSource, Report};
+use pixi_core::{
+    Workspace,
+    environment::sanity_check_workspace,
+    lock_file::{ReinstallPackages, UpdateLockFileOptions, UpdateMode},
+    workspace::virtual_packages::{
+        EnvironmentRunnability, classify_environment_runnability,
+        verify_current_platform_can_run_environment, verify_run_platform,
+    },
+};
+use pixi_manifest::WithWarnings;
+use pixi_manifest::script::conda::{CondaScriptError, CondaScriptManifest};
+use pixi_script_shell::{ShellContext, execute_sequence, parse_sequence};
+use pixi_task::get_task_env;
+use tracing::Level;
+
+use crate::{
+    process_exit,
+    run::{Args, run_future_forwarding_signals},
+    shared::install_platform::resolve_install_platform,
+};
+
+/// Reads the `conda-script` block of a local `--script` file.
+///
+/// Returns `Ok(None)` when the file has no block or when a malformed block
+/// appears in a Python file, so the caller falls back to the PEP 723 path: a
+/// Python script may contain an accidental line ending in the opening
+/// marker, say inside an indented docstring, and must keep working as it did
+/// before the conda-script format existed. When `surface_errors` is set (the
+/// caller passed `--experimental`) or the file cannot be a PEP 723 script
+/// anyway, a block error is reported instead.
+pub(crate) fn detect_with_fallback(
+    path: &Path,
+    surface_errors: bool,
+) -> miette::Result<Option<CondaScriptManifest>> {
+    match CondaScriptManifest::from_path(path) {
+        Ok(manifest) => Ok(manifest),
+        Err(error @ CondaScriptError::Io(_)) => Err(Report::new(error)),
+        Err(error) => {
+            let is_python = path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| {
+                    extension.eq_ignore_ascii_case("py") || extension.eq_ignore_ascii_case("pyw")
+                });
+            if surface_errors || !is_python {
+                Err(Report::new(error))
+            } else {
+                tracing::debug!(
+                    "ignoring a malformed conda-script block in {}: {error}",
+                    path.display()
+                );
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Whether the contents carry a conda-script block, well-formed or not.
+///
+/// Transient script sources use this to explain that conda-script files only
+/// run from local paths, instead of reporting a missing PEP 723 block.
+pub(crate) fn looks_like_conda_script(contents: &[u8]) -> bool {
+    !matches!(
+        CondaScriptManifest::from_source("conda-script-probe", contents),
+        Ok(None)
+    )
+}
+
+/// Solves and installs the environment of a `conda-script` file, then runs
+/// its entrypoint through the mini-shell with the CLI arguments appended.
+pub(crate) async fn execute_run(
+    manifest: CondaScriptManifest,
+    args: Args,
+    config: pixi_config::Config,
+) -> miette::Result<()> {
+    let script_path = manifest.path().to_owned();
+    let entrypoint = manifest.metadata().entrypoint.clone();
+
+    let WithWarnings {
+        value: workspace,
+        warnings,
+    } = Workspace::from_conda_script(manifest, config)?;
+    for warning in warnings {
+        tracing::warn!("{warning}");
+    }
+    sanity_check_workspace(&workspace).await?;
+
+    let environment = workspace.default_environment();
+    let allow_installs = args.lock_and_install_config.allow_installs();
+    let user_platform = resolve_install_platform(&workspace, args.platform.as_ref())?;
+    let run_platform = user_platform
+        .clone()
+        .or_else(|| environment.installed_resolved_platform_name());
+    let best_declared_platform = environment.named_or_best_declared_platform(run_platform.as_ref());
+    if allow_installs
+        && best_declared_platform.is_none()
+        && let Some(name) = user_platform.as_ref()
+    {
+        return Err(miette::miette!(
+            "platform '{}' is not part of environment '{}'",
+            name,
+            environment.name(),
+        ));
+    }
+    if allow_installs {
+        environment.emit_emulation_warning();
+    }
+
+    // Select and parse the entrypoint before solving, so a syntax error or a
+    // missing platform key surfaces without waiting for the environment.
+    let activation_platform = best_declared_platform
+        .cloned()
+        .unwrap_or_else(|| environment.activation_platform());
+    let subdir = activation_platform.subdir();
+    let Some(command) = entrypoint.select(subdir) else {
+        return Err(miette::miette!(
+            help = "add a matching key to the `entrypoint` table, for example `unix`, `win` or the exact platform",
+            "the entrypoint has no command for platform '{subdir}'"
+        ));
+    };
+    let sequence = parse_sequence(command).map_err(|error| {
+        Report::new(error).with_source_code(NamedSource::new("entrypoint", command.to_owned()))
+    })?;
+
+    let progress = pixi_reporters::TopLevelProgress::from_global();
+    let mut lock_file = workspace
+        .resolve_lock_file(
+            Some(progress.clone()),
+            UpdateLockFileOptions {
+                lock_file_usage: args.lock_and_install_config.lock_file_usage()?,
+                no_install: args.lock_and_install_config.no_install(),
+                max_concurrent_solves: workspace.config().max_concurrent_solves(),
+                ..Default::default()
+            },
+        )
+        .await?
+        .0;
+    lock_file.target_platform = user_platform.clone();
+
+    if allow_installs && user_platform.is_none() {
+        let runnability =
+            classify_environment_runnability(&environment, Some(lock_file.as_lock_file()));
+        if runnability == EnvironmentRunnability::Unsupported {
+            return Err(
+                match verify_current_platform_can_run_environment(
+                    &environment,
+                    Some(lock_file.as_lock_file()),
+                ) {
+                    Err(err) => err.into(),
+                    Ok(()) => environment.unsupported_platform_error().into(),
+                },
+            );
+        }
+    }
+
+    let print_command = |command: &str| {
+        if tracing::enabled!(Level::WARN) {
+            let file_name = script_path
+                .file_name()
+                .expect("an absolute script path always has a file name")
+                .to_string_lossy();
+            pixi_progress::println!(
+                "{}{}{}{}{}",
+                console::Emoji("✨ ", ""),
+                console::style("Pixi script (").bold(),
+                console::style(file_name).green().bold(),
+                console::style("): ").bold(),
+                command,
+            );
+        }
+    };
+
+    // A dry run stops after solving: nothing gets installed or executed.
+    if args.dry_run {
+        progress.on_clear();
+        lock_file.command_dispatcher.clear_filesystem_caches().await;
+        pixi_progress::println!(
+            "{}{}\n\n",
+            console::Emoji("🌵 ", ""),
+            console::style("Dry-run mode enabled - no tasks will be executed.")
+                .yellow()
+                .bold()
+        );
+        print_command(command);
+        return Ok(());
+    }
+
+    if allow_installs {
+        lock_file
+            .prefix(
+                &environment,
+                UpdateMode::QuickValidate,
+                &ReinstallPackages::default(),
+                &pixi_core::environment::InstallFilter::default(),
+            )
+            .await?;
+        verify_run_platform(&environment, user_platform.as_ref())?;
+    }
+    progress.on_clear();
+    lock_file.command_dispatcher.clear_filesystem_caches().await;
+
+    let command_env = get_task_env(
+        &environment,
+        &activation_platform,
+        args.clean_env,
+        Some(lock_file.as_lock_file()),
+        workspace.config().force_activate(),
+        workspace.config().experimental_activation_cache_usage(),
+    )
+    .await?;
+
+    print_command(command);
+
+    let cache_dir = workspace.pixi_dir().join("cache");
+    fs_err::create_dir_all(&cache_dir).into_diagnostic()?;
+    let script = script_path
+        .into_os_string()
+        .into_string()
+        .map_err(|_| miette::miette!("the script path must contain only valid UTF-8 characters"))?;
+    let cache = cache_dir
+        .into_os_string()
+        .into_string()
+        .map_err(|_| miette::miette!("the cache path must contain only valid UTF-8 characters"))?;
+
+    // Signals pixi receives reach the entrypoint's processes, and the guard
+    // terminates them when pixi stops for any other reason.
+    let kill_signal = KillSignal::default();
+    let _drop_guard = kill_signal.clone().drop_guard();
+    let context = ShellContext {
+        variables: HashMap::from([("SCRIPT".to_owned(), script), ("CACHE".to_owned(), cache)]),
+        env: command_env
+            .into_iter()
+            .map(|(key, value)| (OsString::from(key), OsString::from(value)))
+            .collect(),
+        cwd: std::env::current_dir().into_diagnostic()?,
+        kill_signal: kill_signal.clone(),
+    };
+    let code = run_future_forwarding_signals(
+        kill_signal,
+        execute_sequence(&sequence, &args.task, &context),
+    )
+    .await
+    .map_err(Report::new)?;
+    if code != 0 {
+        process_exit::exit_with_code(code);
+    }
+    Ok(())
+}

--- a/crates/pixi_cli/src/init.rs
+++ b/crates/pixi_cli/src/init.rs
@@ -182,6 +182,15 @@ async fn initialize_script(
     channels: Option<Vec<NamedChannelOrUrl>>,
 ) -> miette::Result<()> {
     let path = std::path::absolute(path).into_diagnostic()?;
+    // A file with a conda-script block must not get a PEP 723 block on top;
+    // the two kinds cannot coexist in one file.
+    if path.is_file() && crate::conda_script::detect_with_fallback(&path, false)?.is_some() {
+        return Err(miette::miette!(
+            help = "a file can carry either a PEP 723 block or a conda-script block, not both",
+            "{} is already a conda-script",
+            path.display()
+        ));
+    }
     let channels = channels
         .unwrap_or_default()
         .into_iter()

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -26,6 +26,7 @@ pub mod cli_config;
 pub mod cli_interface;
 pub mod command_info;
 pub mod completion;
+mod conda_script;
 pub mod config;
 pub mod exec;
 pub mod global;

--- a/crates/pixi_cli/src/lock.rs
+++ b/crates/pixi_cli/src/lock.rs
@@ -43,11 +43,33 @@ pub struct Args {
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
-    let mut workspace = WorkspaceLocator::for_cli()
-        .with_global_config_source(args.config_source.source())
-        .with_search_start(args.workspace_config.workspace_locator_start())
-        .with_cli_config(args.config.clone())
-        .locate()?;
+    let conda_script = match args.workspace_config.script.as_deref() {
+        Some(path) => crate::conda_script::detect_with_fallback(path, false)?,
+        None => None,
+    };
+    let mut workspace = if let Some(manifest) = conda_script {
+        let root = manifest
+            .path()
+            .parent()
+            .expect("an absolute script path always has a parent")
+            .to_owned();
+        let config = pixi_config::Config::load_with(&root, &args.config_source.source())
+            .merge_config(args.config.clone().into());
+        let pixi_manifest::WithWarnings {
+            value: workspace,
+            warnings,
+        } = pixi_core::Workspace::from_conda_script(manifest, config)?;
+        for warning in warnings {
+            tracing::warn!("{warning}");
+        }
+        workspace
+    } else {
+        WorkspaceLocator::for_cli()
+            .with_global_config_source(args.config_source.source())
+            .with_search_start(args.workspace_config.workspace_locator_start())
+            .with_cli_config(args.config.clone())
+            .locate()?
+    };
 
     // Apply backend override if provided (primarily for testing)
     if let Some(backend_override) = args

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -75,6 +75,15 @@ pub struct Args {
     #[arg(long = "executable", short = 'x')]
     pub executable: bool,
 
+    /// Enable experimental `--script` features; currently the `conda-script`
+    /// block.
+    ///
+    /// The flag has no effect for PEP 723 scripts, so a shebang line can
+    /// pass it unconditionally. Setting `experimental.conda-script` in the
+    /// configuration opts in without the flag, with a warning on every run.
+    #[arg(long, requires = "script")]
+    pub experimental: bool,
+
     #[clap(flatten)]
     pub workspace_config: ScriptWorkspaceConfig,
 
@@ -168,6 +177,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
 
     let cli_config = args
         .activation_config
+        .clone()
         .merge_config(args.config.clone().into());
 
     let is_script = args.workspace_config.script.is_some();
@@ -235,11 +245,45 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             stdin_script_command = Some(prepared.command);
             workspace
         }
-        Some(RunScriptInput::Local(path)) => WorkspaceLocator::for_cli()
-            .with_global_config_source(global_config_source)
-            .with_search_start(pixi_core::workspace::DiscoveryStart::Script(path))
-            .with_cli_config(cli_config)
-            .locate()?,
+        Some(RunScriptInput::Local(path)) => {
+            let root = std::path::absolute(&path)
+                .into_diagnostic()?
+                .parent()
+                .expect("an absolute script path always has a parent")
+                .to_owned();
+            let config = pixi_config::Config::load_with(&root, &global_config_source)
+                .merge_config(cli_config.clone());
+            // The configuration option opts in for every run, so the flag is
+            // only needed when it is unset.
+            let opted_in = args.experimental || config.experimental_conda_script();
+            // A conda-script block takes this file off the PEP 723 path; a
+            // file with both kinds of block is rejected by the detection.
+            if let Some(manifest) = crate::conda_script::detect_with_fallback(&path, opted_in)? {
+                if !opted_in {
+                    return Err(miette::miette!(
+                        help = "conda-script support is experimental; opt in with `pixi config set experimental.conda-script true --global`, or add `--experimental` to this run",
+                        "{} contains a conda-script block",
+                        path.display()
+                    ));
+                }
+                if !args.experimental {
+                    eprintln!(
+                        "{}Running {} through `experimental.conda-script`, a draft format that may still change",
+                        console::style(console::Emoji("⚠️ ", "warning: ")).yellow(),
+                        path.display(),
+                    );
+                }
+                if not_hidden {
+                    global_multi_progress().set_draw_target(ProgressDrawTarget::stderr_with_hz(20));
+                }
+                return crate::conda_script::execute_run(manifest, args, config).await;
+            }
+            WorkspaceLocator::for_cli()
+                .with_global_config_source(global_config_source)
+                .with_search_start(pixi_core::workspace::DiscoveryStart::Script(path))
+                .with_cli_config(cli_config)
+                .locate()?
+        }
         None => WorkspaceLocator::for_cli()
             .with_global_config_source(global_config_source)
             .with_search_start(args.workspace_config.workspace_locator_start())
@@ -875,4 +919,17 @@ async fn listen_and_forward_all_signals(kill_signal: KillSignal) {
         )
     }
     futures::future::join_all(futures).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Args;
+
+    #[test]
+    fn experimental_requires_a_script() {
+        assert!(Args::try_parse_from(["run", "--experimental", "--script", "main.c"]).is_ok());
+        assert!(Args::try_parse_from(["run", "--experimental", "task"]).is_err());
+    }
 }

--- a/crates/pixi_cli/src/run_script.rs
+++ b/crates/pixi_cli/src/run_script.rs
@@ -93,7 +93,16 @@ pub(crate) fn prepare_stdin_script(
         root.to_owned(),
         "stdin",
     )?
-    .ok_or_else(|| miette::miette!("stdin does not contain a PEP 723 metadata block"))?;
+    .ok_or_else(|| {
+        if crate::conda_script::looks_like_conda_script(&contents) {
+            miette::miette!(
+                help = "conda-script blocks run from local files: save the script and run `pixi run --experimental --script <PATH>`",
+                "conda-script blocks are not supported on stdin"
+            )
+        } else {
+            miette::miette!("stdin does not contain a PEP 723 metadata block")
+        }
+    })?;
     let contents =
         String::from_utf8(contents).expect("ScriptManifest validates the complete script as UTF-8");
     Ok(PreparedStdinScript {
@@ -159,11 +168,18 @@ pub(crate) async fn prepare_remote_script(
         cache_name.clone(),
     )?
     .ok_or_else(|| {
-        miette::miette!(
-            help =
-                "Download the script and initialize it locally with `pixi init --script <PATH>`.",
-            "the remote script at {safe_original_url} does not contain a PEP 723 metadata block"
-        )
+        if crate::conda_script::looks_like_conda_script(&contents) {
+            miette::miette!(
+                help = "conda-script blocks run from local files: download the script and run `pixi run --experimental --script <PATH>`",
+                "the remote script at {safe_original_url} contains a conda-script block, which only runs from a local file"
+            )
+        } else {
+            miette::miette!(
+                help =
+                    "Download the script and initialize it locally with `pixi init --script <PATH>`.",
+                "the remote script at {safe_original_url} does not contain a PEP 723 metadata block"
+            )
+        }
     })?;
 
     Ok(PreparedRemoteScript {

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -952,6 +952,13 @@ pub struct ExperimentalConfig {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_environment_activation_cache: Option<bool>,
+
+    /// The option to opt into running `conda-script` files without passing
+    /// `--experimental` on every invocation. The format follows a draft
+    /// proposal and may still change.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conda_script: Option<bool>,
 }
 
 impl ExperimentalConfig {
@@ -960,14 +967,19 @@ impl ExperimentalConfig {
             use_environment_activation_cache: other
                 .use_environment_activation_cache
                 .or(self.use_environment_activation_cache),
+            conda_script: other.conda_script.or(self.conda_script),
         }
     }
     pub fn use_environment_activation_cache(&self) -> bool {
         self.use_environment_activation_cache.unwrap_or(false)
     }
 
+    pub fn conda_script(&self) -> bool {
+        self.conda_script.unwrap_or(false)
+    }
+
     pub fn is_default(&self) -> bool {
-        self.use_environment_activation_cache.is_none()
+        self.use_environment_activation_cache.is_none() && self.conda_script.is_none()
     }
 }
 
@@ -1468,6 +1480,7 @@ impl From<ConfigCli> for Config {
                 } else {
                     None
                 },
+                conda_script: None,
             },
             pinning_strategy: cli.pinning_strategy,
             allow_symbolic_links: cli.no_symbolic_links.then_some(false),
@@ -1965,6 +1978,7 @@ impl Config {
             "default-channels",
             "detached-environments",
             "experimental",
+            "experimental.conda-script",
             "experimental.use-environment-activation-cache",
             "index-config",
             "index-config.base-url",
@@ -2165,6 +2179,11 @@ impl Config {
 
     pub fn experimental_activation_cache_usage(&self) -> bool {
         self.experimental.use_environment_activation_cache()
+    }
+
+    /// Whether `conda-script` files may run without `--experimental`.
+    pub fn experimental_conda_script(&self) -> bool {
+        self.experimental.conda_script()
     }
 
     /// Retrieve the value for the max_concurrent_solves field.
@@ -2477,6 +2496,10 @@ impl Config {
                 match subkey {
                     "use-environment-activation-cache" => {
                         self.experimental.use_environment_activation_cache =
+                            value.map(|v| v.parse()).transpose().into_diagnostic()?;
+                    }
+                    "conda-script" => {
+                        self.experimental.conda_script =
                             value.map(|v| v.parse()).transpose().into_diagnostic()?;
                     }
                     _ => return Err(err),
@@ -3188,6 +3211,7 @@ UNUSED = "unused"
             pinning_strategy: Some(PinningStrategy::NoPin),
             experimental: ExperimentalConfig {
                 use_environment_activation_cache: Some(true),
+                conda_script: None,
             },
             loaded_from: Vec::from([PathBuf::from_str("test").unwrap()]),
             shell: ShellConfig {
@@ -3761,6 +3785,13 @@ UNUSED = "unused"
             config.experimental.use_environment_activation_cache,
             Some(true)
         );
+
+        // Test experimental.conda-script
+        config
+            .set("experimental.conda-script", Some("true".to_string()))
+            .unwrap();
+        assert_eq!(config.experimental.conda_script, Some(true));
+        assert!(config.experimental_conda_script());
 
         // Test more repodata-config options
         // disable-jlap has been removed — setting it should error

--- a/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
+++ b/crates/pixi_config/src/snapshots/pixi_config__tests__config_merge_multiple.snap
@@ -141,6 +141,7 @@ Config {
     },
     experimental: ExperimentalConfig {
         use_environment_activation_cache: None,
+        conda_script: None,
     },
     concurrency: ConcurrencyConfig {
         solves: 1,

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -831,6 +831,17 @@ impl<'p> LockFileDerivedData<'p> {
         {
             return;
         }
+        // A conda-script block has no `platforms` key and no editing support,
+        // so the PEP 723 remedies would send its users after commands that
+        // reject the file.
+        if self.workspace.is_conda_script() {
+            tracing::warn!(
+                "a conda-script cannot declare platforms, so {} records this machine's \
+                 virtual packages and reproduces only on machines that provide them.",
+                lock_file_path.display(),
+            );
+            return;
+        }
         let script = self.workspace.workspace.provenance.absolute_path();
         tracing::warn!(
             "the script declares no platforms, so {} records this machine's virtual packages.\n\

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -13,7 +13,7 @@ mod workspace_mut;
 mod workspace_script;
 
 use self::errors::VariantsError;
-use self::workspace_script::WorkspaceScript;
+use self::workspace_script::{ScriptSource, WorkspaceScript};
 #[cfg(not(windows))]
 use std::os::unix::fs::symlink;
 use std::{
@@ -42,11 +42,15 @@ use pixi_command_dispatcher::{CacheDirs, CommandDispatcher, CommandDispatcherBui
 use pixi_config::{CacheKind, Config, RunPostLinkScripts};
 use pixi_consts::consts;
 use pixi_diff::LockFileDiff;
+use pixi_manifest::script::conda::CondaScriptManifest;
 use pixi_manifest::{
     AssociateProvenance, BuildVariantSource, EnvironmentName, Environments, FeaturesExt,
     HasWorkspaceManifest, LoadManifestsError, ManifestKind, ManifestProvenance, Manifests,
     PackageManifest, PixiPlatform, PixiPlatformName, PrioritizedChannel, SpecType, WithProvenance,
-    WithWarnings, WorkspaceManifest, script::ScriptManifest,
+    WithWarnings, WorkspaceManifest,
+    script::ScriptManifest,
+    toml::{ExternalWorkspaceProperties, FromTomlStr, PackageDefaults, TomlManifest},
+    utils::WithSourceCode,
 };
 use pixi_path::AbsPathBuf;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
@@ -206,6 +210,10 @@ pub enum ScriptWorkspaceError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Manifest(#[from] pixi_manifest::script::ScriptManifestError),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CondaScriptManifest(Box<WithSourceCode<pixi_manifest::TomlError, miette::NamedSource<String>>>),
 
     #[error("failed to resolve the script environment cache directory: {0}")]
     CacheDirectory(String),
@@ -509,6 +517,76 @@ impl Workspace {
         .with_warnings(warnings))
     }
 
+    /// Construct an isolated workspace for a local `conda-script` file.
+    ///
+    /// `config` must include both the selected global configuration and CLI
+    /// overrides, like [`Workspace::from_script`].
+    pub fn from_conda_script(
+        script: CondaScriptManifest,
+        config: Config,
+    ) -> Result<WithWarnings<Self>, ScriptWorkspaceError> {
+        let script_path = script.path().to_owned();
+        let root = script_path
+            .parent()
+            .expect("an absolute script path always has a parent")
+            .to_owned();
+        // The diagnostics of this step point into the synthesized document,
+        // not the script; the source name says so.
+        let source_name = format!("{} (synthesized manifest)", script_path.display());
+        let source = script.synthetic_manifest().map_err(|error| {
+            ScriptWorkspaceError::CondaScriptManifest(Box::new(WithSourceCode {
+                error: pixi_manifest::TomlError::from(error),
+                source: miette::NamedSource::new(&source_name, script.toml().to_owned()),
+            }))
+        })?;
+
+        let (mut manifest, package, warnings) = TomlManifest::from_toml_str(&source)
+            .and_then(|manifest| {
+                manifest.into_workspace_manifest(
+                    ExternalWorkspaceProperties::default(),
+                    PackageDefaults::default(),
+                    &root,
+                )
+            })
+            .map_err(|error| {
+                ScriptWorkspaceError::CondaScriptManifest(Box::new(WithSourceCode {
+                    error,
+                    source: miette::NamedSource::new(&source_name, source),
+                }))
+            })?;
+        debug_assert!(
+            package.is_none(),
+            "a synthetic conda-script manifest never defines a package"
+        );
+
+        let cache_root = config
+            .cache_dir_for(CacheKind::ExecEnvironments)
+            .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?;
+        let workspace_script = WorkspaceScript::for_local_conda_script(script, &cache_root);
+        let lock_file_path = workspace_script
+            .lock_file_path()
+            .expect("a local script has an adjacent lock-file path");
+        set_implicit_script_platforms(
+            &mut manifest.workspace,
+            implicit_script_platforms(Some(&lock_file_path))?,
+        );
+
+        // The provenance kind only matters for flows that re-read or edit the
+        // manifest, which conda-script workspaces reject; PEP 723 is the
+        // closest embedded-metadata kind.
+        let workspace =
+            manifest.with_provenance(ManifestProvenance::new(script_path, ManifestKind::Pep723));
+
+        Ok(WithWarnings::from(Self::from_parsed(
+            workspace,
+            None,
+            root,
+            config,
+            WorkspaceStorage::Script(workspace_script),
+        ))
+        .with_warnings(warnings))
+    }
+
     /// Construct an isolated workspace for a transient PEP 723 script.
     pub fn from_transient_script(
         script: ScriptManifest,
@@ -677,10 +755,22 @@ impl Workspace {
         let WorkspaceStorage::Script(script) = &self.storage else {
             return false;
         };
-        script
-            .manifest()
-            .workspace_config()
-            .is_ok_and(|config| !config.platforms_explicit)
+        match script.source() {
+            ScriptSource::Pep723(manifest) => manifest
+                .workspace_config()
+                .is_ok_and(|config| !config.platforms_explicit),
+            // A conda-script block has no `platforms` key at all.
+            ScriptSource::CondaScript(_) => true,
+        }
+    }
+
+    /// `true` when this workspace was constructed from a conda-script file.
+    pub fn is_conda_script(&self) -> bool {
+        matches!(
+            &self.storage,
+            WorkspaceStorage::Script(script)
+                if matches!(script.source(), ScriptSource::CondaScript(_))
+        )
     }
 
     /// Create the detached-environments path for this project if it is set in
@@ -2132,6 +2222,71 @@ platforms = []
         )
         .unwrap()
         .value
+    }
+
+    #[test]
+    fn conda_script_workspace_merges_tool_pixi_into_the_default_environment() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let path = root.path().join("example.c");
+        fs_err::write(
+            &path,
+            r#"// /// conda-script
+// channels = ["testing"]
+// entrypoint = "run ${SCRIPT}"
+//
+// [dependencies]
+// zlib = "1.3.*"
+//
+// [tool.pixi.pypi-dependencies]
+// requests = ">=2"
+// /// end-conda-script
+"#,
+        )
+        .unwrap();
+        let script = CondaScriptManifest::from_path(&path).unwrap().unwrap();
+
+        let workspace = Workspace::from_conda_script(
+            script,
+            Config {
+                cache: CacheConfig {
+                    exec_environments: Some(cache.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .value;
+
+        let manifest = &workspace.workspace.value;
+        assert_eq!(
+            manifest
+                .workspace
+                .channels
+                .iter()
+                .map(|channel| channel.channel.to_string())
+                .collect::<Vec<_>>(),
+            ["testing"]
+        );
+        assert_eq!(manifest.environments.iter().count(), 1);
+        assert_eq!(manifest.all_features().count(), 2);
+        let default_environment = workspace.default_environment();
+        assert!(
+            default_environment
+                .pypi_dependencies(None)
+                .contains_key(&PypiPackageName::from_str("requests").unwrap()),
+            "the tool.pixi feature must reach the default environment"
+        );
+        assert!(
+            !manifest.workspace.platforms.is_empty(),
+            "a conda-script workspace resolves for the machine it runs on"
+        );
+        assert!(workspace.script_platforms_are_implicit());
+        assert_eq!(
+            workspace.lock_file_path(),
+            root.path().join("example.c.pixi.lock")
+        );
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -33,7 +33,7 @@ use crate::{
     lock_file::{LockFileDerivedData, ReinstallPackages, UpdateContext, UpdateMode},
     workspace::{
         MatchSpecs, NON_SEMVER_PACKAGES, PypiDeps, SkippedPackage, SourceSpecs, UpdateDeps,
-        WorkspaceStorage, grouped_environment::GroupedEnvironment,
+        WorkspaceStorage, grouped_environment::GroupedEnvironment, workspace_script::ScriptSource,
     },
 };
 
@@ -96,10 +96,27 @@ impl WorkspaceMut {
         let contents = workspace.workspace.provenance.read()?.into_inner();
 
         let workspace_manifest_document = match &workspace.storage {
-            WorkspaceStorage::Script(script) => {
-                ManifestDocument::from_script(script.manifest().clone())
-                    .expect("a loaded script must remain valid")
-            }
+            WorkspaceStorage::Script(script) => match script.source() {
+                ScriptSource::Pep723(manifest) => {
+                    ManifestDocument::from_script((**manifest).clone())
+                        .expect("a loaded script must remain valid")
+                }
+                ScriptSource::CondaScript(manifest) => {
+                    return Err(Box::new(WithSourceCode {
+                        error: TomlError::Generic(
+                            pixi_manifest::GenericError::new(
+                                "conda-script files cannot be edited by pixi",
+                            )
+                            .with_help("edit the `/// conda-script` block in the file directly"),
+                        ),
+                        source: NamedSource::new(
+                            manifest.path().to_string_lossy(),
+                            Arc::from(contents.as_str()),
+                        ),
+                    })
+                    .into());
+                }
+            },
             WorkspaceStorage::Project => {
                 let toml = match DocumentMut::from_str(&contents) {
                     Ok(document) => TomlDocument::new(document),

--- a/crates/pixi_core/src/workspace/workspace_script.rs
+++ b/crates/pixi_core/src/workspace/workspace_script.rs
@@ -5,6 +5,7 @@ use std::{
 
 use miette::{Context, IntoDiagnostic};
 use pixi_manifest::script::ScriptManifest;
+use pixi_manifest::script::conda::CondaScriptManifest;
 use rattler_lock::LockFile;
 use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh3::xxh3_64;
@@ -25,6 +26,14 @@ struct CachedResolution {
     lock_file: String,
 }
 
+/// The parsed manifest of a script workspace: a PEP 723 Python script or a
+/// `conda-script` code file.
+#[derive(Debug, Clone)]
+pub(super) enum ScriptSource {
+    Pep723(Box<ScriptManifest>),
+    CondaScript(Box<CondaScriptManifest>),
+}
+
 /// Describes where a script reads and writes workspace state.
 ///
 /// Every script has a parsed manifest and a cache directory. A local script
@@ -33,7 +42,7 @@ struct CachedResolution {
 /// lock file may keep its last resolution in the cache directory.
 #[derive(Debug, Clone)]
 pub(super) struct WorkspaceScript {
-    manifest: Box<ScriptManifest>,
+    source: ScriptSource,
     pixi_dir: PathBuf,
 
     /// The adjacent lock-file path for a local script.
@@ -45,7 +54,17 @@ impl WorkspaceScript {
         let pixi_dir = cache_root.join(local_cache_name(manifest.path()));
         let lock_file_path = Some(local_lock_file_path(manifest.path()));
         Self {
-            manifest: Box::new(manifest),
+            source: ScriptSource::Pep723(Box::new(manifest)),
+            pixi_dir,
+            lock_file_path,
+        }
+    }
+
+    pub(super) fn for_local_conda_script(manifest: CondaScriptManifest, cache_root: &Path) -> Self {
+        let pixi_dir = cache_root.join(local_cache_name(manifest.path()));
+        let lock_file_path = Some(local_lock_file_path(manifest.path()));
+        Self {
+            source: ScriptSource::CondaScript(Box::new(manifest)),
             pixi_dir,
             lock_file_path,
         }
@@ -59,21 +78,26 @@ impl WorkspaceScript {
         root: &Path,
     ) -> Self {
         Self {
-            manifest: Box::new(manifest),
+            source: ScriptSource::Pep723(Box::new(manifest)),
             pixi_dir: cache_root.join(transient_cache_name(cache_name, cache_key, root)),
             lock_file_path: None,
         }
     }
 
-    pub(super) fn manifest(&self) -> &ScriptManifest {
-        &self.manifest
+    pub(super) fn source(&self) -> &ScriptSource {
+        &self.source
     }
 
     pub(super) fn replace_manifest(&mut self, new_manifest: ScriptManifest) {
         if self.lock_file_path.is_some() {
             self.lock_file_path = Some(local_lock_file_path(new_manifest.path()));
         }
-        *self.manifest = new_manifest;
+        match &mut self.source {
+            ScriptSource::Pep723(manifest) => **manifest = new_manifest,
+            ScriptSource::CondaScript(_) => {
+                unreachable!("conda-script workspaces reject manifest edits when they are opened")
+            }
+        }
     }
 
     pub(super) fn pixi_dir(&self) -> &Path {

--- a/crates/pixi_manifest/src/lib.rs
+++ b/crates/pixi_manifest/src/lib.rs
@@ -39,7 +39,7 @@ pub use discovery::{
     PixiVersionMismatchError, WorkspaceDiscoverer, WorkspaceDiscoveryError,
 };
 pub use environment::{Environment, EnvironmentName, NewEnvironment};
-pub use error::{DependencyError, TomlError};
+pub use error::{DependencyError, GenericError, TomlError};
 pub use feature::{Feature, FeatureName};
 pub use features_ext::FeaturesExt;
 pub use has_features_iter::HasFeaturesIter;

--- a/crates/pixi_manifest/src/script/conda/manifest.rs
+++ b/crates/pixi_manifest/src/script/conda/manifest.rs
@@ -129,7 +129,80 @@ impl CondaScriptManifest {
         fs_err::write(&self.path, self.render_metadata(metadata))?;
         Ok(())
     }
+
+    /// Renders the metadata as a `pixi.toml` document.
+    ///
+    /// The dependency tables are spliced in verbatim from the block, so the
+    /// specs reach the manifest parser exactly as written. `[dependencies]`
+    /// fills the default feature while `[tool.pixi.dependencies]` and
+    /// `[tool.pixi.pypi-dependencies]` become a separate feature of the
+    /// default environment, which merges the two spec sets the way pixi
+    /// merges features: both specs of a package reach the solver.
+    pub fn synthetic_manifest(&self) -> Result<String, toml_edit::TomlError> {
+        let mut block: toml_edit::DocumentMut = self.toml.parse()?;
+        let channels = block
+            .remove("channels")
+            .expect("`channels` is required by the metadata model");
+        let dependencies = block.remove("dependencies");
+        let mut pixi = block
+            .get_mut("tool")
+            .and_then(toml_edit::Item::as_table_like_mut)
+            .and_then(|tool| tool.get_mut("pixi"))
+            .and_then(toml_edit::Item::as_table_like_mut);
+        let pixi_dependencies = pixi.as_mut().and_then(|pixi| pixi.remove("dependencies"));
+        let pixi_pypi_dependencies = pixi
+            .as_mut()
+            .and_then(|pixi| pixi.remove("pypi-dependencies"));
+
+        let name = self
+            .path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .filter(|stem| !stem.is_empty())
+            .unwrap_or("script");
+
+        let mut document = toml_edit::DocumentMut::new();
+        let mut workspace = toml_edit::Table::new();
+        workspace.insert("name", toml_edit::value(name));
+        workspace.insert("channels", channels);
+        workspace.insert(
+            "platforms",
+            toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
+        );
+        document.insert("workspace", toml_edit::Item::Table(workspace));
+
+        if let Some(dependencies) = dependencies {
+            document.insert("dependencies", dependencies);
+        }
+
+        if pixi_dependencies.is_some() || pixi_pypi_dependencies.is_some() {
+            let mut tool_pixi = toml_edit::Table::new();
+            tool_pixi.set_implicit(true);
+            if let Some(pixi_dependencies) = pixi_dependencies {
+                tool_pixi.insert("dependencies", pixi_dependencies);
+            }
+            if let Some(pixi_pypi_dependencies) = pixi_pypi_dependencies {
+                tool_pixi.insert("pypi-dependencies", pixi_pypi_dependencies);
+            }
+            let mut feature = toml_edit::Table::new();
+            feature.set_implicit(true);
+            feature.insert("tool-pixi", toml_edit::Item::Table(tool_pixi));
+            document.insert("feature", toml_edit::Item::Table(feature));
+
+            let mut default = toml_edit::Array::new();
+            default.push("tool-pixi");
+            let mut environments = toml_edit::Table::new();
+            environments.insert(
+                "default",
+                toml_edit::Item::Value(toml_edit::Value::Array(default)),
+            );
+            document.insert("environments", toml_edit::Item::Table(environments));
+        }
+
+        Ok(document.to_string())
+    }
 }
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -366,6 +439,75 @@ mod tests {
         let empty = directory.path().join("empty.c");
         fs_err::write(&empty, "int main(void) { return 0; }\n").unwrap();
         assert!(CondaScriptManifest::from_path(&empty).unwrap().is_none());
+    }
+
+    #[test]
+    fn renders_a_synthetic_pixi_manifest() {
+        let manifest = parse(
+            r#"// /// conda-script
+// channels = ["conda-forge"]
+// entrypoint = "python ${SCRIPT}"
+//
+// [dependencies]
+// python = "3.13.*"
+// simple-app = "0.1.*"
+// gcc = { version = "*", when = "__unix" }
+// pytorch = {
+//   version = ">=2.4",
+//   build = "*cuda*",
+// }
+//
+// [tool.pixi.dependencies]
+// simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
+//
+// [tool.pixi.pypi-dependencies]
+// requests = ">=2"
+// /// end-conda-script
+"#,
+        )
+        .unwrap()
+        .unwrap();
+
+        insta::assert_snapshot!(manifest.synthetic_manifest().unwrap(), @r##"
+        [workspace]
+        name = "example"
+        channels = ["conda-forge"]
+        platforms = []
+
+        [dependencies]
+        python = "3.13.*"
+        simple-app = "0.1.*"
+        gcc = { version = "*", when = "__unix" }
+        pytorch = {
+          version = ">=2.4",
+          build = "*cuda*",
+        }
+
+        [feature.tool-pixi.dependencies]
+        simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
+
+        [feature.tool-pixi.pypi-dependencies]
+        requests = ">=2"
+
+        [environments]
+        default = ["tool-pixi"]
+        "##);
+    }
+
+    #[test]
+    fn a_synthetic_manifest_without_tool_pixi_has_no_feature() {
+        let manifest = parse(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# /// end-conda-script\n",
+        )
+        .unwrap()
+        .unwrap();
+
+        insta::assert_snapshot!(manifest.synthetic_manifest().unwrap(), @r#"
+        [workspace]
+        name = "example"
+        channels = ["conda-forge"]
+        platforms = []
+        "#);
     }
 
     #[test]

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -21,6 +21,8 @@ pixi run [OPTIONS] [TASK]...
 ## Options
 - <a id="arg---executable" href="#arg---executable">`--executable (-x)`</a>
 :  Execute the command as an executable without resolving Pixi tasks
+- <a id="arg---experimental" href="#arg---experimental">`--experimental`</a>
+:  Enable experimental `--script` features; currently the `conda-script` block
 - <a id="arg---environment" href="#arg---environment">`--environment (-e) <ENVIRONMENT>`</a>
 :  The environment to run the task in
 - <a id="arg---platform" href="#arg---platform">`--platform (-p) <PLATFORM>`</a>

--- a/tests/integration_python/test_conda_script.py
+++ b/tests/integration_python/test_conda_script.py
@@ -1,0 +1,327 @@
+import json
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from .common import CONDA_FORGE_CHANNEL, CURRENT_PLATFORM, ExitCode, verify_cli_command
+
+PYTHON_ARGV_SCRIPT = f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}}"
+#
+# [dependencies]
+# python = "3.13.*"
+# /// end-conda-script
+import json, os, sys
+
+print(json.dumps({{"argv": sys.argv[1:], "cwd": os.getcwd(), "file": __file__}}))
+"""
+
+
+def json_payload(stdout: str) -> dict[str, object]:
+    return json.loads(next(line for line in stdout.splitlines() if line.startswith("{")))
+
+
+def test_run_requires_the_experimental_flag(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "example.code"
+    script.write_text(PYTHON_ARGV_SCRIPT)
+
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains=["conda-script block", "--experimental"],
+    )
+
+
+def test_the_config_option_replaces_the_experimental_flag(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    script = tmp_pixi_workspace / "example.code"
+    script.write_text(
+        "# /// conda-script\n"
+        '# channels = ["conda-forge"]\n'
+        '# entrypoint = "python ${SCRIPT} | tee log"\n'
+        "# /// end-conda-script\n"
+    )
+    config = tmp_pixi_workspace / ".pixi" / "config.toml"
+    config.write_text(
+        config.read_text().replace("[experimental]\n", "[experimental]\nconda-script = true\n")
+    )
+
+    # The entrypoint is rejected, so the run got past the experimental gate.
+    verify_cli_command(
+        [pixi, "run", "--script", script, "--dry-run"],
+        ExitCode.FAILURE,
+        stderr_contains=["experimental.conda-script", "pipes are not supported"],
+    )
+
+
+def test_experimental_requires_a_script(pixi: Path) -> None:
+    verify_cli_command(
+        [pixi, "run", "--experimental", "task"],
+        ExitCode.INCORRECT_USAGE,
+        stderr_contains="--script",
+    )
+
+
+def test_rejects_a_file_with_both_block_kinds(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "example.py"
+    script.write_text(
+        "# /// script\n"
+        "# dependencies = []\n"
+        "# ///\n"
+        "# /// conda-script\n"
+        '# channels = ["conda-forge"]\n'
+        '# entrypoint = "python ${SCRIPT}"\n'
+        "# /// end-conda-script\n"
+    )
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="both a PEP 723",
+    )
+
+
+def test_pep723_routing_is_unchanged(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "example.py"
+    script.write_text("print('hello')\n")
+
+    # A Python file without any block reports the PEP 723 error, with and
+    # without the flag, which has no effect for them.
+    for command in (
+        [pixi, "run", "--script", script],
+        [pixi, "run", "--experimental", "--script", script],
+    ):
+        verify_cli_command(
+            command,
+            ExitCode.FAILURE,
+            stderr_contains="does not contain a PEP 723 metadata block",
+        )
+
+
+def test_a_stray_marker_in_a_python_file_stays_on_the_pep723_path(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    script = tmp_pixi_workspace / "example.py"
+    script.write_text('"""\n    # /// conda-script\n"""\nprint()\n')
+
+    # Without the flag the malformed pseudo-block must not break the file.
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="does not contain a PEP 723 metadata block",
+    )
+    # With the flag the block error surfaces.
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="no closing",
+    )
+
+
+def test_init_refuses_a_conda_script_file(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "example.py"
+    contents = (
+        "# /// conda-script\n"
+        '# channels = ["conda-forge"]\n'
+        '# entrypoint = "python ${SCRIPT}"\n'
+        "# /// end-conda-script\n"
+    )
+    script.write_text(contents)
+
+    # Prepending a PEP 723 block would leave a file with both kinds that no
+    # command accepts anymore.
+    verify_cli_command(
+        [pixi, "init", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="already a conda-script",
+    )
+    assert script.read_text() == contents
+
+
+def test_stdin_reports_conda_script_blocks(pixi: Path) -> None:
+    verify_cli_command(
+        [pixi, "run", "--script", "-"],
+        ExitCode.FAILURE,
+        stderr_contains="not supported on stdin",
+        stdin=(
+            "# /// conda-script\n"
+            '# channels = ["conda-forge"]\n'
+            '# entrypoint = "python ${SCRIPT}"\n'
+            "# /// end-conda-script\n"
+        ),
+    )
+
+
+def test_entrypoint_syntax_errors_are_reported(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "example.code"
+    script.write_text(
+        "# /// conda-script\n"
+        '# channels = ["conda-forge"]\n'
+        '# entrypoint = "python ${SCRIPT} | tee log"\n'
+        "# /// end-conda-script\n"
+    )
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script, "--dry-run"],
+        ExitCode.FAILURE,
+        stderr_contains="pipes are not supported",
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(sys.platform == "win32", reason="signals are a Unix concept")
+def test_a_signal_sent_to_pixi_reaches_the_entrypoint(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """A SIGTERM delivered to pixi itself, say by a supervisor, is forwarded
+    to the entrypoint's process instead of orphaning it."""
+    script = tmp_pixi_workspace / "signal.code"
+    started = tmp_pixi_workspace / "started"
+    terminated = tmp_pixi_workspace / "terminated"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "sh -c \\"trap 'touch {terminated}' TERM; touch {started}; sleep 30 & wait\\""
+#
+# [dependencies]
+# coreutils = "*"
+# /// end-conda-script
+""")
+
+    process = subprocess.Popen([pixi, "run", "--experimental", "--script", script])
+    try:
+        deadline = time.monotonic() + 600
+        while not started.exists():
+            assert process.poll() is None, "pixi exited before the entrypoint started"
+            assert time.monotonic() < deadline, "the entrypoint never started"
+            time.sleep(0.2)
+
+        process.send_signal(signal.SIGTERM)
+        process.wait(timeout=30)
+    finally:
+        if process.poll() is None:
+            process.kill()
+
+    deadline = time.monotonic() + 10
+    while not terminated.exists() and time.monotonic() < deadline:
+        time.sleep(0.1)
+    assert terminated.exists(), "the entrypoint's process never received the forwarded SIGTERM"
+
+
+@pytest.mark.slow
+def test_arguments_and_working_directory_reach_the_entrypoint(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    script = tmp_pixi_workspace / "scripts" / "example.code"
+    script.parent.mkdir()
+    script.write_text(PYTHON_ARGV_SCRIPT)
+    invocation_dir = tmp_pixi_workspace / "elsewhere"
+    invocation_dir.mkdir()
+
+    output = verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script, "first", "--second"],
+        cwd=invocation_dir,
+    )
+
+    payload = json_payload(output.stdout)
+    assert payload["argv"] == ["first", "--second"]
+    assert payload["cwd"] == str(invocation_dir)
+    assert payload["file"] == str(script)
+    assert not (script.parent / "example.code.pixi.lock").exists()
+
+
+@pytest.mark.slow
+def test_the_cache_directory_persists_between_runs(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "counter.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}} ${{CACHE}}"
+#
+# [dependencies]
+# python = "3.13.*"
+# /// end-conda-script
+import pathlib, sys
+
+counter = pathlib.Path(sys.argv[1]) / "counter"
+runs = int(counter.read_text()) + 1 if counter.exists() else 1
+counter.write_text(str(runs))
+print(f"run {{runs}}")
+""")
+
+    # The cache is keyed by the absolute script path, which a reused pytest
+    # temp directory repeats, so assert on the increment rather than on
+    # absolute counts.
+    first = verify_cli_command([pixi, "run", "--experimental", "--script", script])
+    count = re.search(r"run (\d+)", first.stdout)
+    assert count is not None
+    runs = int(count.group(1))
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        stdout_contains=f"run {runs + 1}",
+    )
+
+
+@pytest.mark.slow
+def test_a_failing_entrypoint_propagates_its_exit_code(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    script = tmp_pixi_workspace / "fails.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}} && python -c 'open(\\"marker\\", \\"w\\").close()'"
+#
+# [dependencies]
+# python = "3.13.*"
+# /// end-conda-script
+import sys
+
+print("about to fail")
+sys.exit(1)
+""")
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        ExitCode.FAILURE,
+        stdout_contains="about to fail",
+        cwd=tmp_pixi_workspace,
+    )
+    assert not (tmp_pixi_workspace / "marker").exists()
+
+
+@pytest.mark.slow
+def test_lock_writes_an_adjacent_lock_file_with_conditional_dependencies(
+    pixi: Path, tmp_pixi_workspace: Path
+) -> None:
+    script = tmp_pixi_workspace / "when.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python -c 'print(1234)'"
+#
+# [dependencies]
+# python = "3.13.*"
+# zlib = {{ version = "*", when = "__unix" }}
+# vc = {{ version = "*", when = "__win" }}
+# /// end-conda-script
+""")
+    lock_file = tmp_pixi_workspace / "when.code.pixi.lock"
+
+    verify_cli_command([pixi, "lock", "--script", script])
+
+    assert lock_file.exists()
+    locked = lock_file.read_text()
+    if CURRENT_PLATFORM.startswith("win"):
+        assert "/vc-" in locked
+        assert "/zlib-" not in locked
+    else:
+        assert "/zlib-" in locked
+        assert "/vc-" not in locked
+
+    # A run next to the lock file consumes it.
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script, "--frozen"],
+        stdout_contains="1234",
+    )


### PR DESCRIPTION
`pixi run --script FILE` runs conda-script files (#3751) end to end.

- `--experimental` gates the new path and has no effect for PEP 723 scripts, so `#!/usr/bin/env -S pixi run --experimental --script` works for both block kinds
- `pixi config set experimental.conda-script true --global` opts in without the flag and warns on every run instead, so the error points at that command
- `[dependencies]` fills the default feature and `[tool.pixi.*]` becomes a second feature of the default environment
- The environment resolves for the machine, an adjacent lock file wins when present, and `pixi lock --script FILE` writes `FILE.pixi.lock` for conda-script files too
- The entrypoint runs through the mini-shell with `${SCRIPT}` and `${CACHE}` defined and the working directory left at the invocation directory
- Signals pixi receives are forwarded to the entrypoint, and its processes are terminated when pixi stops, the same as for tasks
