### PR TITLE
feat: build source dependencies in conda-script `tool.pixi` tables

### DIFF
--- a/crates/pixi_manifest/src/script/conda/manifest.rs
+++ b/crates/pixi_manifest/src/script/conda/manifest.rs
@@ -169,6 +169,15 @@ impl CondaScriptManifest {
             "platforms",
             toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
         );
+        // Running a conda-script is already gated behind `--experimental`,
+        // which implies the pixi-build preview so source dependencies under
+        // `[tool.pixi.dependencies]` build without further opt-in.
+        let mut preview = toml_edit::Array::new();
+        preview.push("pixi-build");
+        workspace.insert(
+            "preview",
+            toml_edit::Item::Value(toml_edit::Value::Array(preview)),
+        );
         document.insert("workspace", toml_edit::Item::Table(workspace));
 
         if let Some(dependencies) = dependencies {
@@ -473,6 +482,7 @@ mod tests {
         name = "example"
         channels = ["conda-forge"]
         platforms = []
+        preview = ["pixi-build"]
 
         [dependencies]
         python = "3.13.*"
@@ -507,6 +517,7 @@ mod tests {
         name = "example"
         channels = ["conda-forge"]
         platforms = []
+        preview = ["pixi-build"]
         "#);
     }
 

--- a/tests/integration_python/test_conda_script.py
+++ b/tests/integration_python/test_conda_script.py
@@ -269,6 +269,40 @@ sys.exit(1)
     assert not (tmp_pixi_workspace / "marker").exists()
 
 
+SOURCE_DEPENDENCY_BLOCK = f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "simple-app"
+#
+# [dependencies]
+# simple-app = "{{version}}"
+#
+# [tool.pixi.dependencies]
+# simple-app = {{{{ git = "https://github.com/prefix-dev/pixi-build-testsuite.git", subdirectory = "tests/data/pixi_build/minimal-backend-workspaces/pixi-build-python" }}}}
+# /// end-conda-script
+"""
+
+
+@pytest.mark.slow
+def test_a_binary_spec_constrains_a_source_dependency(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """Both features' specs reach the solver as a union: the source spec in
+    `[tool.pixi.dependencies]` provides the candidate and the binary spec in
+    `[dependencies]` constrains its version."""
+    script = tmp_pixi_workspace / "source.code"
+    script.write_text(SOURCE_DEPENDENCY_BLOCK.format(version="0.1.*"))
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        stdout_contains="Build backend works",
+    )
+
+    script.write_text(SOURCE_DEPENDENCY_BLOCK.format(version="0.2.*"))
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="0.2",
+    )
+
+
 @pytest.mark.slow
 def test_lock_writes_an_adjacent_lock_file_with_conditional_dependencies(
     pixi: Path, tmp_pixi_workspace: Path


### PR DESCRIPTION
- `--experimental` implies the **pixi-build preview** for conda-script files (#3751), so git, path and url specs under `[tool.pixi.dependencies]` build without further opt-in
- Adds an integration test for a shape nothing covered before: a binary spec in one feature and a source spec in another reach the solver together, the source provides the candidate and the version constrains it
