### PR TITLE
fix(release): restore static MSVC CRT in Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,12 @@ jobs:
           toolchain: "1.95.0"
           target: ${{ matrix.target }}
           cache: false
+          # This action defaults to writing RUSTFLAGS=-D warnings into the job
+          # environment. RUSTFLAGS overrides every `[target.*].rustflags` entry
+          # in .cargo/config.toml, which silently dropped `+crt-static` from the
+          # Windows release builds (pixi#6915). Leave the variable alone here;
+          # the "Set build options" step below composes the full value.
+          rustflags: ""
 
       - name: Set build options
         run: pixi run -e release build-options --target ${{ matrix.target }}

--- a/scripts/build_options.py
+++ b/scripts/build_options.py
@@ -1,9 +1,10 @@
 """Determine per-target build settings and write them to GITHUB_ENV.
 
 The pixi binary is built with the same feature set on every target
-(self_update + performance); the only per-target tweak is the jemalloc page
-size for 64 KiB-page aarch64 Linux, see
-https://github.com/prefix-dev/pixi/issues/2936.
+(self_update + performance); the per-target tweaks are the jemalloc page size
+for 64 KiB-page aarch64 Linux (see
+https://github.com/prefix-dev/pixi/issues/2936) and the statically linked CRT
+on Windows.
 
 Usage:
     pixi run -e release build-options --target aarch64-unknown-linux-musl
@@ -13,19 +14,41 @@ import argparse
 import os
 from pathlib import Path
 
+# Cargo picks extra rustc flags from exactly one source: if RUSTFLAGS is set it
+# wins outright and every `[target.*].rustflags` entry in .cargo/config.toml is
+# ignored. The release workflow needs RUSTFLAGS for `-D warnings`, so any flag
+# that config.toml would otherwise contribute has to be repeated here.
+BASE_RUSTFLAGS = ["-D", "warnings"]
+
+# Statically link the MSVC CRT. Without this the binary imports
+# vcruntime140.dll, which is not present in stock Windows Server container
+# images, and pixi.exe fails to start with STATUS_DLL_NOT_FOUND.
+# See https://github.com/prefix-dev/pixi/issues/6915.
+MSVC_RUSTFLAGS = ["-C", "target-feature=+crt-static"]
+
+
+def rustflags_for(target: str) -> list[str]:
+    flags = list(BASE_RUSTFLAGS)
+    if target.endswith("-pc-windows-msvc"):
+        flags += MSVC_RUSTFLAGS
+    return flags
+
+
+def build_env(target: str) -> dict[str, str]:
+    env: dict[str, str] = {"RUSTFLAGS": " ".join(rustflags_for(target))}
+    # aarch64 Linux runners may use 64 KiB pages; jemalloc must be told the
+    # page size at compile time so the binary runs on those hosts.
+    if target.startswith("aarch64-") and "linux" in target:
+        env["JEMALLOC_SYS_WITH_LG_PAGE"] = "16"
+    return env
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Determine build options for a target")
     parser.add_argument("--target", required=True, help="Rust target triple")
     args = parser.parse_args()
 
-    target: str = args.target
-
-    env: dict[str, str] = {}
-    # aarch64 Linux runners may use 64 KiB pages; jemalloc must be told the
-    # page size at compile time so the binary runs on those hosts.
-    if target.startswith("aarch64-") and "linux" in target:
-        env["JEMALLOC_SYS_WITH_LG_PAGE"] = "16"
+    env = build_env(args.target)
 
     for key, value in env.items():
         print(f"{key}={value}")


### PR DESCRIPTION
### Description

Every Windows release since v0.71.1 ships a `pixi.exe` that imports `vcruntime140.dll`. That DLL is missing from stock Windows Server container images, so pixi dies with `STATUS_DLL_NOT_FOUND` (`-1073741515`) and prints nothing.

#6435 moved the release to `actions-rust-lang/setup-rust-toolchain`, which writes `RUSTFLAGS=-D warnings` into the job environment. `RUSTFLAGS` replaces the `[target.*].rustflags` entries in `.cargo/config.toml` instead of merging with them, so `-C target-feature=+crt-static` silently disappeared. Local builds never noticed because nothing sets `RUSTFLAGS` there.

So: tell the action to leave `RUSTFLAGS` alone and compose the full value in `scripts/build_options.py`, which already writes per-target settings to `GITHUB_ENV`.

Fixes #6915

### How Has This Been Tested?

I downloaded the published Windows artifacts and dumped their imports with a throwaway script. v0.70.0 and v0.71.0 are statically linked, v0.71.1, v0.72.0 and v0.78.0 all pull in `vcruntime140.dll`. v0.71.1 is the first tag containing #6435, so the boundary matches.

`build_options.py` now emits `-D warnings -C target-feature=+crt-static` for MSVC targets and just `-D warnings` elsewhere.

I can't run the release workflow itself, so the `rustflags: ""` input deserves a close look. Nothing guards this: if the action changes what it writes, or someone adds a flag to `.cargo/config.toml` for a release target, it silently goes missing again. Happy to add a post-build import check if you want one.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 5)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
