### PR TITLE
fix: don't uninstall PyPI files that a conda package now owns

### DIFF
--- a/crates/pixi_install_pypi/src/conda_pypi_clobber.rs
+++ b/crates/pixi_install_pypi/src/conda_pypi_clobber.rs
@@ -207,6 +207,19 @@ impl CondaPrefixPath {
         }
     }
 
+    /// Convert a RECORD entry of an *installed* distribution to the
+    /// prefix-relative form, or `None` if the file lands outside the prefix.
+    ///
+    /// Such entries are relative to the directory holding the `.dist-info`,
+    /// not to the wheel install scheme used by [`Self::from_wheel_record`].
+    fn from_installed_record(site_packages: &Path, record_path: impl AsRef<Path>) -> Option<Self> {
+        let path = normalize_std(&site_packages.join(record_path));
+        match path.components().next() {
+            Some(std::path::Component::Normal(_)) => Some(Self(path)),
+            _ => None,
+        }
+    }
+
     fn as_path(&self) -> &Path {
         &self.0
     }
@@ -229,6 +242,19 @@ impl PypiCondaClobberRegistry {
         Self {
             paths_registry: registry,
         }
+    }
+
+    /// Find the conda package that owns any of the RECORD entries of an
+    /// *installed* distribution whose `.dist-info` sits in `site_packages`.
+    pub(crate) fn conda_owner_of_installed_record<'a>(
+        &self,
+        site_packages: &Path,
+        record_paths: impl IntoIterator<Item = &'a str>,
+    ) -> Option<&rattler_conda_types::PackageName> {
+        record_paths.into_iter().find_map(|record_path| {
+            let path = CondaPrefixPath::from_installed_record(site_packages, record_path)?;
+            self.paths_registry.get(&path)
+        })
     }
 
     /// Check if the installation of the wheels is going to clobber any installed conda package
@@ -436,6 +462,48 @@ mod tests {
                 None
             );
         }
+    }
+
+    /// Entries of an installed distribution are relative to its `.dist-info`
+    /// directory, so they map straight onto conda's prefix-relative form.
+    #[test]
+    fn installed_record_path_is_matched_prefix_relative() {
+        assert_eq!(
+            CondaPrefixPath::from_installed_record(
+                std::path::Path::new("lib/python3.12/site-packages"),
+                "boltons/__init__.py"
+            ),
+            Some(CondaPrefixPath(PathBuf::from(
+                "lib/python3.12/site-packages/boltons/__init__.py"
+            )))
+        );
+    }
+
+    /// Console scripts are recorded as `../../../bin/<script>`: they escape
+    /// site-packages but still land inside the prefix.
+    #[test]
+    fn installed_record_path_escaping_site_packages_is_matched() {
+        assert_eq!(
+            CondaPrefixPath::from_installed_record(
+                std::path::Path::new("lib/python3.12/site-packages"),
+                "../../../bin/prek"
+            ),
+            Some(CondaPrefixPath(PathBuf::from("bin/prek")))
+        );
+    }
+
+    /// Entries that escape the prefix (or are absolute) cannot be conda-owned.
+    #[test]
+    fn installed_record_path_outside_prefix_is_ignored() {
+        let site_packages = std::path::Path::new("lib/python3.12/site-packages");
+        assert_eq!(
+            CondaPrefixPath::from_installed_record(site_packages, "../../../../../bin/prek"),
+            None
+        );
+        assert_eq!(
+            CondaPrefixPath::from_installed_record(site_packages, "/abs/evil"),
+            None
+        );
     }
 
     #[test]

--- a/crates/pixi_install_pypi/src/lib.rs
+++ b/crates/pixi_install_pypi/src/lib.rs
@@ -50,7 +50,10 @@ use uv_python::{Interpreter, PythonEnvironment};
 use uv_resolver::{ExcludeNewer, FlatIndex};
 use uv_types::HashStrategy;
 
-use crate::plan::{CachedWheels, RequiredDists};
+use crate::{
+    install_wheel::read_record_file,
+    plan::{CachedWheels, RequiredDists},
+};
 
 /// Extra data available from the manifest, not the lock file
 #[derive(Clone)]
@@ -155,15 +158,39 @@ pub enum ContinuePyPIPrefixUpdate<'a> {
     Skip,
 }
 
+/// Read the RECORD entries of an installed distribution, or `None` when the
+/// file is missing or unreadable.
+fn read_installed_record(dist: &InstalledDist) -> Option<Vec<String>> {
+    let record_path = dist.install_path().join("RECORD");
+    let mut file = fs_err::File::open(&record_path)
+        .inspect_err(|err| {
+            tracing::debug!("could not open {}: {err}", record_path.display());
+        })
+        .ok()?;
+    read_record_file(&mut file)
+        .inspect_err(|err| {
+            tracing::debug!("could not parse {}: {err}", record_path.display());
+        })
+        .ok()
+        .map(|records| records.into_iter().map(|entry| entry.path).collect())
+}
+
 /// Remove site-packages installed for an outdated interpreter so the next run
 /// starts from a clean slate.
 ///
 /// `layout` describes the old interpreter's install scheme — uv needs it to
 /// resolve and validate the paths recorded in each wheel's `RECORD`. The
 /// caller builds it from the old [`PythonInfo`] plus the env prefix.
+///
+/// A distribution whose `RECORD` is now owned by a conda package only loses
+/// its stale `.dist-info`, leaving the conda files in place.
+/// `site_packages_relative` is `site_packages` relative to the prefix root,
+/// the form conda's `paths.json` uses.
 async fn uninstall_outdated_site_packages(
     layout: &uv_install_wheel::Layout,
+    prefix: &Prefix,
     site_packages: &Path,
+    site_packages_relative: &Path,
 ) -> miette::Result<()> {
     let mut dist_dirs = Vec::new();
     for entry in fs_err::read_dir(site_packages).into_diagnostic()? {
@@ -207,7 +234,41 @@ async fn uninstall_outdated_site_packages(
         })
         .collect::<Vec<_>>();
 
+    if installed.is_empty() {
+        return Ok(());
+    }
+
+    // Reading every path of every installed conda package is expensive, so only
+    // do it once we know there is something to uninstall.
+    let conda_paths = match prefix.find_installed_packages() {
+        Ok(conda_packages) => PypiCondaClobberRegistry::with_conda_packages(&conda_packages),
+        Err(err) => {
+            // Best-effort: an empty registry keeps the previous behaviour.
+            tracing::debug!(
+                "could not determine the installed conda packages of {}: {err}",
+                prefix.root().display()
+            );
+            PypiCondaClobberRegistry::default()
+        }
+    };
+
     for dist_info in installed {
+        // Never delete files that a conda package now owns.
+        if let Some(record_paths) = read_installed_record(&dist_info)
+            && let Some(conda_package) = conda_paths.conda_owner_of_installed_record(
+                site_packages_relative,
+                record_paths.iter().map(String::as_str),
+            )
+        {
+            tracing::debug!(
+                "not uninstalling the files of '{}': they are owned by conda package '{}'; removing its stale metadata only",
+                dist_info.name(),
+                conda_package.as_normalized(),
+            );
+            fs_err::remove_dir_all(dist_info.install_path()).into_diagnostic()?;
+            continue;
+        }
+
         uv_installer::uninstall(&dist_info, layout)
             .await
             .expect("uninstallation of old site-packages failed");
@@ -250,7 +311,13 @@ pub async fn on_python_interpreter_change<'a>(
             let site_packages_path = prefix.root().join(&old.site_packages_path);
             if site_packages_path.exists() {
                 let layout = layout_from_python_info(prefix, old);
-                uninstall_outdated_site_packages(&layout, &site_packages_path).await?;
+                uninstall_outdated_site_packages(
+                    &layout,
+                    prefix,
+                    &site_packages_path,
+                    &old.site_packages_path,
+                )
+                .await?;
             }
             Ok(ContinuePyPIPrefixUpdate::Skip)
         }
@@ -259,7 +326,13 @@ pub async fn on_python_interpreter_change<'a>(
                 let site_packages_path = prefix.root().join(&old.site_packages_path);
                 if site_packages_path.exists() {
                     let layout = layout_from_python_info(prefix, old);
-                    uninstall_outdated_site_packages(&layout, &site_packages_path).await?;
+                    uninstall_outdated_site_packages(
+                        &layout,
+                        prefix,
+                        &site_packages_path,
+                        &old.site_packages_path,
+                    )
+                    .await?;
                 }
             }
             Ok(ContinuePyPIPrefixUpdate::Continue(new))
@@ -269,7 +342,13 @@ pub async fn on_python_interpreter_change<'a>(
                 let site_packages_path = prefix.root().join(&info.site_packages_path);
                 if site_packages_path.exists() {
                     let layout = layout_from_python_info(prefix, info);
-                    uninstall_outdated_site_packages(&layout, &site_packages_path).await?;
+                    uninstall_outdated_site_packages(
+                        &layout,
+                        prefix,
+                        &site_packages_path,
+                        &info.site_packages_path,
+                    )
+                    .await?;
                 }
                 return Ok(ContinuePyPIPrefixUpdate::Skip);
             }


### PR DESCRIPTION
### Description

Moving a PyPI dependency to the conda side leaves the package half-deleted: the `.py` files are gone but some data files survive.

When that was the last PyPI dependency of the environment, `on_python_interpreter_change` sees an empty set of PyPI records and cleans out site-packages. The old PyPI `.dist-info` is still sitting there, and its RECORD lists exactly the paths the conda package just wrote, so we uninstall the freshly installed conda files. Only the files that differ between the two versions survive, which matches the symptoms in the issue.

Before uninstalling a distribution we now look up its RECORD entries in the conda paths registry we already build for the clobber warnings. If a conda package owns any of them, only the stale `.dist-info` is removed and the files are left alone. The registry is built after we know there is something to uninstall, so the common "environment has no PyPI dependencies" path does not pay for it on every run (~15 ms on a 109-package env).

Entries of an *installed* distribution need slightly different handling than a wheel RECORD: they are relative to the directory holding the `.dist-info` and the PEP 427 `.data/<scheme>/...` entries have already been spread out by the installer. Hence `from_installed_record` next to `from_wheel_record`.

Fixes #6902

### How Has This Been Tested?

`cargo test -p pixi_install_pypi`, with three new unit tests for mapping installed-RECORD entries onto conda's prefix-relative form: a plain entry, a `../../../bin/<script>` console script that escapes site-packages but stays inside the prefix, and entries that escape the prefix or are absolute.

I did not manage to build an integration test for the full move-to-conda flow, so that path is reasoned about rather than verified. Please check it closely.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
