### PR TITLE
feat: install script environments without running

### DIFF
--- a/crates/pixi/tests/integration_rust/common/mod.rs
+++ b/crates/pixi/tests/integration_rust/common/mod.rs
@@ -778,10 +778,13 @@ impl PixiControl {
         InstallBuilder {
             args: Args {
                 environment: None,
-                workspace_config: WorkspaceConfig {
-                    manifest_path: Some(self.manifest_path()),
-                    backend_override: self.backend_override.clone(),
-                    workspace: None,
+                workspace_config: ScriptWorkspaceConfig {
+                    workspace_config: WorkspaceConfig {
+                        manifest_path: Some(self.manifest_path()),
+                        backend_override: self.backend_override.clone(),
+                        workspace: None,
+                    },
+                    script: None,
                 },
                 lock_file_usage: LockFileUsageConfig {
                     frozen: false,

--- a/crates/pixi_api/src/workspace/reinstall/mod.rs
+++ b/crates/pixi_api/src/workspace/reinstall/mod.rs
@@ -2,7 +2,7 @@ use fancy_display::FancyDisplay;
 use itertools::Itertools;
 use pixi_core::{
     InstallFilter, UpdateLockFileOptions, Workspace,
-    environment::{LockFileUsage, get_update_lock_file_and_prefixes},
+    environment::{LockFileSource, LockFileUsage, get_lock_file_and_prefixes},
     lock_file::{ReinstallEnvironment, UpdateMode},
 };
 use std::sync::Arc;
@@ -43,17 +43,17 @@ pub async fn reinstall<I: Interface>(
         .collect::<Result<Vec<_>, _>>()?;
 
     // Update the prefixes by reinstalling `options.reinstall_packages`
-    get_update_lock_file_and_prefixes(
+    get_lock_file_and_prefixes(
         &environments,
         options.target_platform.as_ref(),
         progress.cloned(),
         UpdateMode::Revalidate,
-        UpdateLockFileOptions {
+        LockFileSource::Update(UpdateLockFileOptions {
             lock_file_usage,
             no_install: false,
             max_concurrent_solves: workspace.config().max_concurrent_solves(),
             ..Default::default()
-        },
+        }),
         options.reinstall_packages,
         &InstallFilter::default(),
     )

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -4,9 +4,7 @@ use itertools::Itertools;
 use pixi_config::ConfigCli;
 use pixi_core::{
     UpdateLockFileOptions, WorkspaceLocator,
-    environment::{
-        InstallFilter, get_resolved_lock_file_and_prefixes, get_update_lock_file_and_prefixes,
-    },
+    environment::{InstallFilter, LockFileSource, get_lock_file_and_prefixes},
     lock_file::{LockFileDerivedData, PackageFilterNames, ReinstallPackages, UpdateMode},
 };
 use pixi_manifest::PixiPlatformName;
@@ -188,36 +186,26 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Resolve the lock data and install the selected prefixes. Scripts use an
     // adjacent lock file when one exists. Otherwise, they use the cached
     // resolution. Other workspaces update their persistent lock file.
-    let options = UpdateLockFileOptions {
+    let update_lock_file_options = UpdateLockFileOptions {
         lock_file_usage: args.lock_file_usage.to_usage(),
         no_install: false,
         max_concurrent_solves: workspace.config().max_concurrent_solves(),
         ..Default::default()
     };
-    let (LockFileDerivedData { lock_file, .. }, prefixes) =
+    let (LockFileDerivedData { lock_file, .. }, prefixes) = get_lock_file_and_prefixes(
+        &environments,
+        target_platform.as_ref(),
+        Some(pixi_reporters::TopLevelProgress::from_global()),
+        UpdateMode::Revalidate,
         if args.workspace_config.script.is_some() {
-            get_resolved_lock_file_and_prefixes(
-                &environments,
-                target_platform.as_ref(),
-                Some(pixi_reporters::TopLevelProgress::from_global()),
-                UpdateMode::Revalidate,
-                options,
-                ReinstallPackages::default(),
-                &filter,
-            )
-            .await?
+            LockFileSource::Resolve(update_lock_file_options)
         } else {
-            get_update_lock_file_and_prefixes(
-                &environments,
-                target_platform.as_ref(),
-                Some(pixi_reporters::TopLevelProgress::from_global()),
-                UpdateMode::Revalidate,
-                options,
-                ReinstallPackages::default(),
-                &filter,
-            )
-            .await?
-        };
+            LockFileSource::Update(update_lock_file_options)
+        },
+        ReinstallPackages::default(),
+        &filter,
+    )
+    .await?;
 
     // Message what's installed
     let mut message = console::style(console::Emoji("✔ ", "")).green().to_string();

--- a/crates/pixi_cli/src/install.rs
+++ b/crates/pixi_cli/src/install.rs
@@ -4,13 +4,15 @@ use itertools::Itertools;
 use pixi_config::ConfigCli;
 use pixi_core::{
     UpdateLockFileOptions, WorkspaceLocator,
-    environment::{InstallFilter, get_update_lock_file_and_prefixes},
+    environment::{
+        InstallFilter, get_resolved_lock_file_and_prefixes, get_update_lock_file_and_prefixes,
+    },
     lock_file::{LockFileDerivedData, PackageFilterNames, ReinstallPackages, UpdateMode},
 };
 use pixi_manifest::PixiPlatformName;
 use std::fmt::Write;
 
-use crate::cli_config::WorkspaceConfig;
+use crate::cli_config::ScriptWorkspaceConfig;
 use crate::shared::install_platform::resolve_install_platform;
 use pixi_manifest::platform::host::host_baseline;
 
@@ -33,13 +35,18 @@ use pixi_manifest::platform::host::host_baseline;
 ///
 /// You can use `pixi reinstall` to reinstall all environments, one environment
 /// or just some packages of an environment.
+///
+/// `pixi install --script` installs a PEP 723 script's environment without
+/// running the script. It uses the same environment as `pixi run --script`.
+/// Pixi updates an adjacent lock file when one exists. Otherwise, it updates
+/// the cached resolution.
 #[derive(Parser, Debug)]
 pub struct Args {
     #[clap(flatten)]
     pub config_source: pixi_config::ConfigSourceCli,
 
     #[clap(flatten)]
-    pub workspace_config: WorkspaceConfig,
+    pub workspace_config: ScriptWorkspaceConfig,
 
     #[clap(flatten)]
     pub lock_file_usage: crate::LockFileUsageConfig,
@@ -80,7 +87,36 @@ pub struct Args {
 
 const SKIP_CUTOFF: usize = 5;
 
+impl Args {
+    /// Rejects workspace environment selectors when installing a script.
+    fn validate_script_options(&self) -> miette::Result<()> {
+        if self.workspace_config.script.is_none() {
+            return Ok(());
+        }
+
+        let mut unsupported = Vec::new();
+        if self.environment.is_some() {
+            unsupported.push("--environment");
+        }
+        if self.all {
+            unsupported.push("--all");
+        }
+
+        if unsupported.is_empty() {
+            Ok(())
+        } else {
+            Err(miette::miette!(
+                help = "A PEP 723 script has one implicit default environment.",
+                "`pixi install --script` does not support {}",
+                unsupported.join(", ")
+            ))
+        }
+    }
+}
+
 pub async fn execute(args: Args) -> miette::Result<()> {
+    args.validate_script_options()?;
+
     let mut workspace = WorkspaceLocator::for_cli()
         .with_global_config_source(args.config_source.source())
         .with_search_start(args.workspace_config.workspace_locator_start())
@@ -88,7 +124,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_cli_config(args.config.clone());
 
     // Apply backend override if provided (primarily for testing)
-    if let Some(backend_override) = args.workspace_config.backend_override.clone() {
+    if let Some(backend_override) = args
+        .workspace_config
+        .workspace_config
+        .backend_override
+        .clone()
+    {
         workspace = workspace.with_backend_override(backend_override);
     }
 
@@ -144,22 +185,39 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .skip_with_deps(args.skip_with_deps.clone().unwrap_or_default())
         .target_packages(args.only.clone().unwrap_or_default());
 
-    // Update the prefixes by installing all packages
-    let (LockFileDerivedData { lock_file, .. }, _) = get_update_lock_file_and_prefixes(
-        &environments,
-        target_platform.as_ref(),
-        Some(pixi_reporters::TopLevelProgress::from_global()),
-        UpdateMode::Revalidate,
-        UpdateLockFileOptions {
-            lock_file_usage: args.lock_file_usage.to_usage(),
-            no_install: false,
-            max_concurrent_solves: workspace.config().max_concurrent_solves(),
-            ..Default::default()
-        },
-        ReinstallPackages::default(),
-        &filter,
-    )
-    .await?;
+    // Resolve the lock data and install the selected prefixes. Scripts use an
+    // adjacent lock file when one exists. Otherwise, they use the cached
+    // resolution. Other workspaces update their persistent lock file.
+    let options = UpdateLockFileOptions {
+        lock_file_usage: args.lock_file_usage.to_usage(),
+        no_install: false,
+        max_concurrent_solves: workspace.config().max_concurrent_solves(),
+        ..Default::default()
+    };
+    let (LockFileDerivedData { lock_file, .. }, prefixes) =
+        if args.workspace_config.script.is_some() {
+            get_resolved_lock_file_and_prefixes(
+                &environments,
+                target_platform.as_ref(),
+                Some(pixi_reporters::TopLevelProgress::from_global()),
+                UpdateMode::Revalidate,
+                options,
+                ReinstallPackages::default(),
+                &filter,
+            )
+            .await?
+        } else {
+            get_update_lock_file_and_prefixes(
+                &environments,
+                target_platform.as_ref(),
+                Some(pixi_reporters::TopLevelProgress::from_global()),
+                UpdateMode::Revalidate,
+                options,
+                ReinstallPackages::default(),
+                &filter,
+            )
+            .await?
+        };
 
     // Message what's installed
     let mut message = console::style(console::Emoji("✔ ", "")).green().to_string();
@@ -169,12 +227,17 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         || args.only.as_ref().is_some_and(|v| !v.is_empty());
 
     if let Ok(Some(environment)) = environments.iter().at_most_one() {
-        write!(
-            &mut message,
-            "The {} environment has been installed",
-            environment.name().fancy_display(),
-        )
-        .expect("failed to write into message buffer");
+        if args.workspace_config.script.is_some() {
+            write!(&mut message, "The script environment has been installed")
+                .expect("failed to write into message buffer");
+        } else {
+            write!(
+                &mut message,
+                "The {} environment has been installed",
+                environment.name().fancy_display(),
+            )
+            .expect("failed to write into message buffer");
+        }
 
         if skip_opts {
             // Use the platform the install actually targeted (honoring a
@@ -251,7 +314,18 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .expect("failed to write into message buffer");
     }
 
-    if let Ok(Some(path)) = workspace.config().detached_environments_dir() {
+    if args.workspace_config.script.is_some() {
+        // Script environments live in the cache, not in the workspace, so the
+        // location is not otherwise discoverable.
+        if let Some(prefix) = prefixes.first() {
+            write!(
+                &mut message,
+                " at '{}'",
+                console::style(prefix.root().display()).bold()
+            )
+            .expect("failed to write into message buffer");
+        }
+    } else if let Ok(Some(path)) = workspace.config().detached_environments_dir() {
         write!(
             &mut message,
             " in '{}'",
@@ -263,4 +337,34 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     eprintln!("{message}.");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use clap::Parser;
+
+    use super::Args;
+
+    #[test]
+    fn accepts_a_script_workspace() {
+        let args = Args::try_parse_from(["install", "--script", "example.py"]).unwrap();
+        assert_eq!(
+            args.workspace_config.script.as_deref(),
+            Some(Path::new("example.py"))
+        );
+        assert!(args.validate_script_options().is_ok());
+    }
+
+    #[test]
+    fn rejects_environment_selectors_with_a_script() {
+        for selector in [["--environment", "test"].as_slice(), ["--all"].as_slice()] {
+            let args =
+                Args::try_parse_from(["install", "--script", "example.py"].iter().chain(selector))
+                    .unwrap();
+            let error = args.validate_script_options().unwrap_err();
+            assert!(error.to_string().contains(selector[0]), "{error}");
+        }
+    }
 }

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -588,6 +588,7 @@ mod tests {
         let expected = [
             "pixi add",
             "pixi init",
+            "pixi install",
             "pixi list",
             "pixi lock",
             "pixi remove",

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -842,7 +842,7 @@ impl InstallFilter {
 
 /// Update the prefix if it doesn't exist or if it is not up-to-date.
 ///
-/// To updated multiple prefixes at once, use [`get_update_lock_file_and_prefixes`].
+/// To update multiple prefixes at once, use [`get_lock_file_and_prefixes`].
 pub async fn get_update_lock_file_and_prefix<'env>(
     environment: &Environment<'env>,
     progress: Option<std::sync::Arc<pixi_reporters::TopLevelProgress>>,
@@ -851,12 +851,12 @@ pub async fn get_update_lock_file_and_prefix<'env>(
     reinstall_packages: ReinstallPackages,
     filter: &InstallFilter,
 ) -> miette::Result<(LockFileDerivedData<'env>, Prefix)> {
-    let (lock_file, prefixes) = get_update_lock_file_and_prefixes(
+    let (lock_file, prefixes) = get_lock_file_and_prefixes(
         std::slice::from_ref(environment),
         None,
         progress.clone(),
         update_mode,
-        update_lock_file_options,
+        LockFileSource::Update(update_lock_file_options),
         reinstall_packages,
         filter,
     )
@@ -870,6 +870,14 @@ pub async fn get_update_lock_file_and_prefix<'env>(
     ))
 }
 
+/// Chooses how installation obtains lock data.
+pub enum LockFileSource {
+    /// Updates the workspace's persistent lock file.
+    Update(UpdateLockFileOptions),
+    /// Uses storage-aware operational resolution, including the script cache.
+    Resolve(UpdateLockFileOptions),
+}
+
 /// Update all the specified prefixes if it doesn't exist or if it is not
 /// up-to-date.
 ///
@@ -878,72 +886,14 @@ pub async fn get_update_lock_file_and_prefix<'env>(
 /// the host-virtual-package satisfaction check. That's how
 /// `pixi install --platform <name>` materialises an environment for a
 /// subdir the local machine can't actually run.
-pub async fn get_update_lock_file_and_prefixes<'env>(
+pub async fn get_lock_file_and_prefixes<'env>(
     environments: &[Environment<'env>],
     target_platform: Option<&PixiPlatformName>,
     progress: Option<std::sync::Arc<pixi_reporters::TopLevelProgress>>,
     update_mode: UpdateMode,
-    update_lock_file_options: UpdateLockFileOptions,
-    reinstall_packages: ReinstallPackages,
-    filter: &InstallFilter,
-) -> miette::Result<(LockFileDerivedData<'env>, Vec<Prefix>)> {
-    get_lock_file_and_prefixes(
-        environments,
-        target_platform,
-        progress,
-        update_mode,
-        reinstall_packages,
-        filter,
-        LockFileSource::Workspace(update_lock_file_options),
-    )
-    .await
-}
-
-/// Resolves lock data and installs the specified environments.
-///
-/// For scripts, Pixi updates an adjacent lock file when one exists. Otherwise,
-/// it uses and updates the cached resolution.
-///
-/// The environment list must not be empty. When `target_platform` is set,
-/// every environment must declare that platform.
-pub async fn get_resolved_lock_file_and_prefixes<'env>(
-    environments: &[Environment<'env>],
-    target_platform: Option<&PixiPlatformName>,
-    progress: Option<std::sync::Arc<pixi_reporters::TopLevelProgress>>,
-    update_mode: UpdateMode,
-    update_lock_file_options: UpdateLockFileOptions,
-    reinstall_packages: ReinstallPackages,
-    filter: &InstallFilter,
-) -> miette::Result<(LockFileDerivedData<'env>, Vec<Prefix>)> {
-    get_lock_file_and_prefixes(
-        environments,
-        target_platform,
-        progress,
-        update_mode,
-        reinstall_packages,
-        filter,
-        LockFileSource::Script(update_lock_file_options),
-    )
-    .await
-}
-
-/// Chooses how installation obtains lock data.
-enum LockFileSource {
-    /// Updates the workspace's persistent lock file.
-    Workspace(UpdateLockFileOptions),
-    /// Uses a script's adjacent lock file or cached resolution.
-    Script(UpdateLockFileOptions),
-}
-
-/// Installs environments using workspace or script lock-file behavior.
-async fn get_lock_file_and_prefixes<'env>(
-    environments: &[Environment<'env>],
-    target_platform: Option<&PixiPlatformName>,
-    progress: Option<std::sync::Arc<pixi_reporters::TopLevelProgress>>,
-    update_mode: UpdateMode,
-    reinstall_packages: ReinstallPackages,
-    filter: &InstallFilter,
     lock_file_source: LockFileSource,
+    reinstall_packages: ReinstallPackages,
+    filter: &InstallFilter,
 ) -> miette::Result<(LockFileDerivedData<'env>, Vec<Prefix>)> {
     if environments.is_empty() {
         return Err(miette::miette!("No environments provided to install."));
@@ -951,10 +901,9 @@ async fn get_lock_file_and_prefixes<'env>(
 
     let workspace = environments[0].workspace();
 
-    let update_lock_file_options = match &lock_file_source {
-        LockFileSource::Workspace(options) | LockFileSource::Script(options) => options,
+    let no_install = match &lock_file_source {
+        LockFileSource::Update(options) | LockFileSource::Resolve(options) => options.no_install,
     };
-    let no_install = update_lock_file_options.no_install;
     for env in environments {
         // A `--platform` the environment doesn't list is a membership error.
         // With no platform requested, defer to the install path's minimum fallback.
@@ -1006,19 +955,13 @@ async fn get_lock_file_and_prefixes<'env>(
     store_credentials_from_requirements(requirements);
 
     // Ensure that the lock file is up-to-date
-    let options = UpdateLockFileOptions {
-        lock_file_usage: update_lock_file_options.lock_file_usage,
-        no_install,
-        max_concurrent_solves: update_lock_file_options.max_concurrent_solves,
-        ..Default::default()
-    };
     let mut lock_file = match lock_file_source {
-        LockFileSource::Workspace(_) => {
+        LockFileSource::Update(options) => {
             workspace
                 .update_lock_file(progress.clone(), options)
                 .await?
         }
-        LockFileSource::Script(_) => {
+        LockFileSource::Resolve(options) => {
             workspace
                 .resolve_lock_file(progress.clone(), options)
                 .await?

--- a/crates/pixi_core/src/environment/mod.rs
+++ b/crates/pixi_core/src/environment/mod.rs
@@ -887,12 +887,73 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
     reinstall_packages: ReinstallPackages,
     filter: &InstallFilter,
 ) -> miette::Result<(LockFileDerivedData<'env>, Vec<Prefix>)> {
+    get_lock_file_and_prefixes(
+        environments,
+        target_platform,
+        progress,
+        update_mode,
+        reinstall_packages,
+        filter,
+        LockFileSource::Workspace(update_lock_file_options),
+    )
+    .await
+}
+
+/// Resolves lock data and installs the specified environments.
+///
+/// For scripts, Pixi updates an adjacent lock file when one exists. Otherwise,
+/// it uses and updates the cached resolution.
+///
+/// The environment list must not be empty. When `target_platform` is set,
+/// every environment must declare that platform.
+pub async fn get_resolved_lock_file_and_prefixes<'env>(
+    environments: &[Environment<'env>],
+    target_platform: Option<&PixiPlatformName>,
+    progress: Option<std::sync::Arc<pixi_reporters::TopLevelProgress>>,
+    update_mode: UpdateMode,
+    update_lock_file_options: UpdateLockFileOptions,
+    reinstall_packages: ReinstallPackages,
+    filter: &InstallFilter,
+) -> miette::Result<(LockFileDerivedData<'env>, Vec<Prefix>)> {
+    get_lock_file_and_prefixes(
+        environments,
+        target_platform,
+        progress,
+        update_mode,
+        reinstall_packages,
+        filter,
+        LockFileSource::Script(update_lock_file_options),
+    )
+    .await
+}
+
+/// Chooses how installation obtains lock data.
+enum LockFileSource {
+    /// Updates the workspace's persistent lock file.
+    Workspace(UpdateLockFileOptions),
+    /// Uses a script's adjacent lock file or cached resolution.
+    Script(UpdateLockFileOptions),
+}
+
+/// Installs environments using workspace or script lock-file behavior.
+async fn get_lock_file_and_prefixes<'env>(
+    environments: &[Environment<'env>],
+    target_platform: Option<&PixiPlatformName>,
+    progress: Option<std::sync::Arc<pixi_reporters::TopLevelProgress>>,
+    update_mode: UpdateMode,
+    reinstall_packages: ReinstallPackages,
+    filter: &InstallFilter,
+    lock_file_source: LockFileSource,
+) -> miette::Result<(LockFileDerivedData<'env>, Vec<Prefix>)> {
     if environments.is_empty() {
         return Err(miette::miette!("No environments provided to install."));
     }
 
     let workspace = environments[0].workspace();
 
+    let update_lock_file_options = match &lock_file_source {
+        LockFileSource::Workspace(options) | LockFileSource::Script(options) => options,
+    };
     let no_install = update_lock_file_options.no_install;
     for env in environments {
         // A `--platform` the environment doesn't list is a membership error.
@@ -945,18 +1006,25 @@ pub async fn get_update_lock_file_and_prefixes<'env>(
     store_credentials_from_requirements(requirements);
 
     // Ensure that the lock file is up-to-date
-    let mut lock_file = workspace
-        .update_lock_file(
-            progress.clone(),
-            UpdateLockFileOptions {
-                lock_file_usage: update_lock_file_options.lock_file_usage,
-                no_install,
-                max_concurrent_solves: update_lock_file_options.max_concurrent_solves,
-                ..Default::default()
-            },
-        )
-        .await?
-        .0;
+    let options = UpdateLockFileOptions {
+        lock_file_usage: update_lock_file_options.lock_file_usage,
+        no_install,
+        max_concurrent_solves: update_lock_file_options.max_concurrent_solves,
+        ..Default::default()
+    };
+    let mut lock_file = match lock_file_source {
+        LockFileSource::Workspace(_) => {
+            workspace
+                .update_lock_file(progress.clone(), options)
+                .await?
+        }
+        LockFileSource::Script(_) => {
+            workspace
+                .resolve_lock_file(progress.clone(), options)
+                .await?
+        }
+    }
+    .0;
     // Pin the override so the downstream prefix helpers see it without a
     // fresh parameter on every call.
     lock_file.target_platform = target_platform.cloned();

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -7,8 +7,8 @@ while the resolved environment stays in Pixi's cache instead of a workspace
 next to the script.
 
 Script commands use `--script <PATH>`. The same `init`, `run`, `add`, `remove`,
-`lock`, and `update` commands used for workspaces can therefore operate on
-either a manifest or a standalone file.
+`install`, `lock`, and `update` commands used for workspaces can therefore
+operate on either a manifest or a standalone file.
 
 ## Make a script self-contained
 
@@ -198,11 +198,24 @@ pixi update --script earthquakes.py
 ```
 
 Without an adjacent lock file, this replaces the cached resolution. The next
-run updates the cached environment to match it. This cache state is disposable.
-Removing it causes Pixi to resolve the script again.
+`run` or `install` updates the cached environment to match it. This cache state
+is disposable. Removing it causes Pixi to resolve the script again.
 
 When an adjacent lock file exists, `update` writes the new resolution there
 instead.
+
+## Install without running
+
+Use `pixi install` to install the script's environment without running the
+script.
+
+```console
+pixi install --script earthquakes.py
+```
+
+This installs the same cached environment that `pixi run --script` would use
+and prints its location. Run this during a container build or before going
+offline to install the environment ahead of time.
 
 ## Inspect and export
 

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -87,6 +87,8 @@ pixi install [OPTIONS]
 :  The path to `pixi.toml`, `pyproject.toml`, or the workspace directory
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
+- <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
+:  The path to a Python script containing PEP 723 metadata
 
 ## Description
 Install an environment, both updating the lock file and installing the environment.
@@ -100,6 +102,8 @@ If you want to install all environments, you can use the `--all` flag.
 Running `pixi install` is not required before running other commands like `pixi run` or `pixi shell`. These commands will automatically install the environment if it is not already installed.
 
 You can use `pixi reinstall` to reinstall all environments, one environment or just some packages of an environment.
+
+`pixi install --script` installs a PEP 723 script's environment without running the script. It uses the same environment as `pixi run --script`. Pixi updates an adjacent lock file when one exists. Otherwise, it updates the cached resolution.
 
 
 --8<-- "docs/reference/cli/pixi/install_extender:example"

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -429,6 +429,12 @@ print("SCRIPT-RAN")
         cwd=tmp_pixi_workspace,
         env=env,
     )
+
+    # Updating changes the resolution but leaves the installed environment unchanged.
+    package_records = list(exec_cache.glob("*/envs/default/conda-meta/package-*.json"))
+    assert len(package_records) == 1
+    assert json.loads(package_records[0].read_text())["version"] == "0.1.0"
+
     verify_cli_command(
         [pixi, "run", "--script", script],
         cwd=tmp_pixi_workspace,
@@ -439,6 +445,60 @@ print("SCRIPT-RAN")
     package_records = list(exec_cache.glob("*/envs/default/conda-meta/package-*.json"))
     assert len(package_records) == 1
     assert json.loads(package_records[0].read_text())["version"] == "0.2.0"
+    assert not script.with_name("example.py.pixi.lock").exists()
+    assert_no_workspace_state_created(tmp_pixi_workspace)
+
+
+@pytest.mark.slow
+def test_pixi_install_script_installs_without_running(
+    pixi: Path, tmp_pixi_workspace: Path, channels: Path
+) -> None:
+    exec_cache = tmp_pixi_workspace / "script-exec-cache"
+    env = {"PIXI_CACHE_EXEC_ENVIRONMENTS_DIR": str(exec_cache)}
+    channel = tmp_pixi_workspace / "channel"
+    shutil.copytree(channels / "multiple_versions_channel_1", channel)
+    script = tmp_pixi_workspace / "example.py"
+    script.write_text(
+        f'''# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["{channel.as_uri()}", "{CONDA_FORGE_CHANNEL}"]
+# platforms = ["{CURRENT_PLATFORM}"]
+#
+# [tool.pixi.dependencies]
+# package = "0.1.*"
+# ///
+from pathlib import Path
+
+Path("script-ran").touch()
+print("SCRIPT-RAN")
+'''
+    )
+
+    verify_cli_command(
+        [pixi, "install", "--script", script],
+        cwd=tmp_pixi_workspace,
+        env=env,
+        stdout_excludes="SCRIPT-RAN",
+        stderr_contains="script environment has been installed at",
+    )
+    assert not (tmp_pixi_workspace / "script-ran").exists()
+
+    package_records = list(exec_cache.glob("*/envs/default/conda-meta/package-*.json"))
+    assert len(package_records) == 1
+    assert json.loads(package_records[0].read_text())["version"] == "0.1.0"
+
+    # Running reuses the environment created by install.
+    verify_cli_command(
+        [pixi, "run", "--script", script],
+        cwd=tmp_pixi_workspace,
+        env=env,
+        stdout_contains="SCRIPT-RAN",
+    )
+    assert (tmp_pixi_workspace / "script-ran").exists()
+    assert len(list(exec_cache.glob("*/envs/default"))) == 1
+
     assert not script.with_name("example.py.pixi.lock").exists()
     assert_no_workspace_state_created(tmp_pixi_workspace)
 


### PR DESCRIPTION
I originally thought `pixi update --script` (#6893) was enough for tools that manage PEP 723 script environments. However, it only refreshes the resolution, but it does not materialize the environment. Today, the only command that does both is `pixi run --script`, which also executes the script.

These changes add `pixi install --script <PATH>` to materialize the same environment that `pixi run --script` would use, _without running user code_. It reuses the existing script resolution cache or adjacent lock file and the shared install path and does not introduce another script environment model.

The lifecycle is now explicit where:

- `pixi update --script` selects newer compatible versions (metadata only)
- `pixi install --script` reconciles and materializes the environment without broadly upgrading
- `pixi run --script` same as above, but then runs user code after installing.

For example, this makes it possible to replace uv in marimo's `--sandbox` flow and use Pixi to install and manage packages without requiring uv. Working branch in marimo:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/5432603a-3d11-434e-92dc-db54cc52b236" />

