### PR TITLE
feat: edit conda-script files with `pixi add` and friends

### DIFF
--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -156,7 +156,7 @@ impl Args {
             Ok(())
         } else {
             Err(miette::miette!(
-                help = "A PEP 723 script has one implicit default run environment.",
+                help = "A script has one implicit default run environment.",
                 "`pixi add --script` does not support {}",
                 unsupported.join(", ")
             ))
@@ -454,6 +454,20 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         {
             workspace = workspace.with_backend_override(backend_override);
         }
+    }
+
+    if workspace.is_conda_script() && !args.dependency_config.platforms.is_empty() {
+        return Err(miette::miette!(
+            help = "restrict a dependency with a `when` condition in the block instead",
+            "conda-script blocks do not support platform-specific dependency tables"
+        ));
+    }
+
+    if workspace.is_conda_script() && args.dependency_config.git.is_some() {
+        return Err(miette::miette!(
+            help = "the specification keeps `[dependencies]` to registry packages; add the git spec under `[tool.pixi.dependencies]` by editing the block",
+            "conda-script `[dependencies]` do not support git specs"
+        ));
     }
 
     let workspace_ctx = cli_context(workspace.clone());

--- a/crates/pixi_cli/src/cli_config.rs
+++ b/crates/pixi_cli/src/cli_config.rs
@@ -59,7 +59,9 @@ pub struct ScriptWorkspaceConfig {
     #[clap(flatten)]
     pub workspace_config: WorkspaceConfig,
 
-    /// The path to a Python script containing PEP 723 metadata.
+    /// The path to a script with an embedded manifest: a Python script
+    /// containing PEP 723 metadata, or a file of any language containing a
+    /// `/// conda-script` block.
     ///
     /// `pixi run` also accepts an HTTP(S) URL or `-` to read the script from stdin.
     #[arg(long, short = 's', global = true, conflicts_with_all = ["manifest_path", "workspace"], help_heading = consts::CLAP_GLOBAL_OPTIONS)]

--- a/crates/pixi_cli/src/conda_script.rs
+++ b/crates/pixi_cli/src/conda_script.rs
@@ -12,7 +12,7 @@ use pixi_core::{
     },
 };
 use pixi_manifest::WithWarnings;
-use pixi_manifest::script::conda::{CondaScriptError, CondaScriptManifest};
+use pixi_manifest::script::conda::CondaScriptManifest;
 use pixi_script_shell::{ShellContext, execute_sequence, parse_sequence};
 use pixi_task::get_task_env;
 use tracing::Level;
@@ -25,38 +25,14 @@ use crate::{
 
 /// Reads the `conda-script` block of a local `--script` file.
 ///
-/// Returns `Ok(None)` when the file has no block or when a malformed block
-/// appears in a Python file, so the caller falls back to the PEP 723 path: a
-/// Python script may contain an accidental line ending in the opening
-/// marker, say inside an indented docstring, and must keep working as it did
-/// before the conda-script format existed. When `surface_errors` is set (the
-/// caller passed `--experimental`) or the file cannot be a PEP 723 script
-/// anyway, a block error is reported instead.
+/// See [`CondaScriptManifest::detect_with_fallback`] for the fallback
+/// behavior; `surface_errors` is set when the caller passed
+/// `--experimental`.
 pub(crate) fn detect_with_fallback(
     path: &Path,
     surface_errors: bool,
 ) -> miette::Result<Option<CondaScriptManifest>> {
-    match CondaScriptManifest::from_path(path) {
-        Ok(manifest) => Ok(manifest),
-        Err(error @ CondaScriptError::Io(_)) => Err(Report::new(error)),
-        Err(error) => {
-            let is_python = path
-                .extension()
-                .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| {
-                    extension.eq_ignore_ascii_case("py") || extension.eq_ignore_ascii_case("pyw")
-                });
-            if surface_errors || !is_python {
-                Err(Report::new(error))
-            } else {
-                tracing::debug!(
-                    "ignoring a malformed conda-script block in {}: {error}",
-                    path.display()
-                );
-                Ok(None)
-            }
-        }
-    }
+    CondaScriptManifest::detect_with_fallback(path, surface_errors).map_err(Report::new)
 }
 
 /// Whether the contents carry a conda-script block, well-formed or not.

--- a/crates/pixi_cli/src/list.rs
+++ b/crates/pixi_cli/src/list.rs
@@ -203,7 +203,7 @@ pub struct Args {
 pub async fn execute(args: Args) -> miette::Result<()> {
     if args.workspace_config.script.is_some() && args.environment.is_some() {
         return Err(miette::miette!(
-            help = "A PEP 723 script has one implicit default run environment.",
+            help = "A script has one implicit default run environment.",
             "`pixi list --script` does not support --environment"
         ));
     }

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -70,7 +70,7 @@ impl Args {
             Ok(())
         } else {
             Err(miette::miette!(
-                help = "A PEP 723 script has one implicit default run environment.",
+                help = "A script has one implicit default run environment.",
                 "`pixi remove --script` does not support {}",
                 unsupported.join(", ")
             ))
@@ -87,6 +87,13 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_search_start(args.workspace_config.workspace_locator_start())
         .with_cli_config(args.config.clone())
         .locate()?;
+
+    if workspace.is_conda_script() && !args.dependency_config.platforms.is_empty() {
+        return Err(miette::miette!(
+            help = "restrict a dependency with a `when` condition in the block instead",
+            "conda-script blocks do not support platform-specific dependency tables"
+        ));
+    }
 
     let dependency_options = DependencyOptions {
         feature: args.dependency_config.feature_name(),

--- a/crates/pixi_core/src/workspace/discovery.rs
+++ b/crates/pixi_core/src/workspace/discovery.rs
@@ -7,7 +7,10 @@ use pixi_consts::consts;
 use pixi_manifest::{
     ExplicitManifestError, LoadManifestsError, Manifests, TomlError, WarningWithSource,
     WithWarnings, WorkspaceDiscoveryError,
-    script::{ScriptManifest, ScriptManifestError},
+    script::{
+        ScriptManifest, ScriptManifestError,
+        conda::{CondaScriptError, CondaScriptManifest},
+    },
     utils::WithSourceCode,
 };
 use thiserror::Error;
@@ -155,11 +158,21 @@ pub enum WorkspaceLocatorError {
 
     #[error(transparent)]
     #[diagnostic(transparent)]
+    CondaScript(#[from] Box<CondaScriptError>),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
     ScriptWorkspace(#[from] ScriptWorkspaceError),
 
     #[error("{} does not contain a PEP 723 metadata block", path.display())]
     #[diagnostic(help("Initialize it with `pixi init --script {}`.", path.display()))]
     MissingScriptMetadata { path: PathBuf },
+
+    #[error("{} does not contain a conda-script block", path.display())]
+    #[diagnostic(help(
+        "a script of this language carries its manifest in a `/// conda-script` comment block"
+    ))]
+    MissingCondaScriptBlock { path: PathBuf },
 }
 
 impl WorkspaceLocator {
@@ -373,6 +386,40 @@ impl WorkspaceLocator {
         let DiscoveryStart::Script(path) = self.start else {
             unreachable!("the script selection was checked before loading")
         };
+
+        if let Some(script) =
+            CondaScriptManifest::detect_with_fallback(&path, false).map_err(Box::new)?
+        {
+            let root = script
+                .path()
+                .parent()
+                .expect("an absolute script path always has a parent");
+            let config =
+                Config::load_with(root, &self.global_config_source).merge_config(self.cli_config);
+            let WithWarnings {
+                value: workspace,
+                warnings,
+            } = Workspace::from_conda_script(script, config)?;
+
+            if self.emit_warnings {
+                for warning in warnings {
+                    tracing::warn!("{warning}");
+                }
+            }
+
+            return Ok(workspace);
+        }
+
+        let is_python = path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| {
+                extension.eq_ignore_ascii_case("py") || extension.eq_ignore_ascii_case("pyw")
+            });
+        if !is_python {
+            return Err(WorkspaceLocatorError::MissingCondaScriptBlock { path });
+        }
+
         let script = ScriptManifest::from_path(&path)?
             .ok_or_else(|| WorkspaceLocatorError::MissingScriptMetadata { path })?;
         let root = script
@@ -544,10 +591,11 @@ mod test {
     fn script_selection_never_initializes_or_rewrites_a_file() {
         let directory = tempdir().unwrap();
 
-        // A path that is not a Python file is rejected on its extension, so a
-        // value meant for another option cannot select an unrelated file.
+        // A non-Python file without a block is reported as missing its
+        // conda-script block, so a value meant for another option cannot
+        // select an unrelated file.
         let unrelated = directory.path().join("notes.txt");
-        fs_err::write(&unrelated, "not a Python script\n").unwrap();
+        fs_err::write(&unrelated, "not a script\n").unwrap();
 
         let error = WorkspaceLocator::for_cli()
             .with_script(&unrelated)
@@ -555,11 +603,11 @@ mod test {
             .unwrap_err();
         assert!(matches!(
             error,
-            WorkspaceLocatorError::Script(ScriptManifestError::NotAPythonScript { .. })
+            WorkspaceLocatorError::MissingCondaScriptBlock { .. }
         ));
         assert_eq!(
             fs_err::read_to_string(&unrelated).unwrap(),
-            "not a Python script\n"
+            "not a script\n"
         );
 
         // A Python file without a metadata block is reported as such, and is

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -571,11 +571,10 @@ impl Workspace {
             implicit_script_platforms(Some(&lock_file_path))?,
         );
 
-        // The provenance kind only matters for flows that re-read or edit the
-        // manifest, which conda-script workspaces reject; PEP 723 is the
-        // closest embedded-metadata kind.
-        let workspace =
-            manifest.with_provenance(ManifestProvenance::new(script_path, ManifestKind::Pep723));
+        let workspace = manifest.with_provenance(ManifestProvenance::new(
+            script_path,
+            ManifestKind::CondaScript,
+        ));
 
         Ok(WithWarnings::from(Self::from_parsed(
             workspace,
@@ -2270,13 +2269,13 @@ platforms = []
             ["testing"]
         );
         assert_eq!(manifest.environments.iter().count(), 1);
-        assert_eq!(manifest.all_features().count(), 2);
+        assert_eq!(manifest.all_features().count(), 1);
         let default_environment = workspace.default_environment();
         assert!(
             default_environment
                 .pypi_dependencies(None)
                 .contains_key(&PypiPackageName::from_str("requests").unwrap()),
-            "the tool.pixi feature must reach the default environment"
+            "`tool.pixi.pypi-dependencies` must reach the default environment"
         );
         assert!(
             !manifest.workspace.platforms.is_empty(),

--- a/crates/pixi_core/src/workspace/workspace_mut.rs
+++ b/crates/pixi_core/src/workspace/workspace_mut.rs
@@ -19,7 +19,9 @@ use pixi_manifest::{
     AddDependencyOutcome, DependencyOverwriteBehavior, FeatureName, FeaturesExt, HasFeaturesIter,
     LoadManifestsError, ManifestDocument, ManifestKind, PixiPlatformName, PypiDependencyLocation,
     SpecType, TargetSelector, TomlError, WorkspaceManifest, WorkspaceManifestMut,
-    script::ScriptManifest, toml::TomlDocument, utils::WithSourceCode,
+    script::{ScriptManifest, conda::CondaScriptManifest},
+    toml::TomlDocument,
+    utils::WithSourceCode,
 };
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 use pixi_spec::PixiSpec;
@@ -102,19 +104,21 @@ impl WorkspaceMut {
                         .expect("a loaded script must remain valid")
                 }
                 ScriptSource::CondaScript(manifest) => {
-                    return Err(Box::new(WithSourceCode {
-                        error: TomlError::Generic(
-                            pixi_manifest::GenericError::new(
-                                "conda-script files cannot be edited by pixi",
-                            )
-                            .with_help("edit the `/// conda-script` block in the file directly"),
-                        ),
-                        source: NamedSource::new(
-                            manifest.path().to_string_lossy(),
-                            Arc::from(contents.as_str()),
-                        ),
-                    })
-                    .into());
+                    match ManifestDocument::from_conda_script((**manifest).clone()) {
+                        Ok(document) => document,
+                        Err(error) => {
+                            return Err(Box::new(WithSourceCode {
+                                error: TomlError::Generic(pixi_manifest::GenericError::new(
+                                    error.to_string(),
+                                )),
+                                source: NamedSource::new(
+                                    manifest.path().to_string_lossy(),
+                                    Arc::from(contents.as_str()),
+                                ),
+                            })
+                            .into());
+                        }
+                    }
                 }
             },
             WorkspaceStorage::Project => {
@@ -135,8 +139,8 @@ impl WorkspaceMut {
                     ManifestKind::Pyproject => ManifestDocument::PyProjectToml(toml),
                     ManifestKind::Pixi => ManifestDocument::PixiToml(toml),
                     ManifestKind::MojoProject => ManifestDocument::MojoProjectToml(toml),
-                    ManifestKind::Pep723 => {
-                        unreachable!("PEP 723 workspaces use script storage")
+                    ManifestKind::Pep723 | ManifestKind::CondaScript => {
+                        unreachable!("script workspaces use script storage")
                     }
                 }
             }
@@ -180,7 +184,9 @@ impl WorkspaceMut {
             ManifestKind::Pyproject => ManifestDocument::PyProjectToml(toml),
             ManifestKind::Pixi => ManifestDocument::PixiToml(toml),
             ManifestKind::MojoProject => ManifestDocument::MojoProjectToml(toml),
-            ManifestKind::Pep723 => unreachable!("templates cannot be PEP 723 scripts"),
+            ManifestKind::Pep723 | ManifestKind::CondaScript => {
+                unreachable!("templates cannot be scripts")
+            }
         };
 
         Ok(Self {
@@ -307,14 +313,29 @@ impl WorkspaceMut {
             .expect("workspace is not available")
             .storage
         {
-            let manifest = ScriptManifest::from_path(&manifest_path)
-                .map_err(std::io::Error::other)?
-                .ok_or_else(|| {
-                    std::io::Error::other(
-                        "saved script no longer contains a PEP 723 metadata block",
-                    )
-                })?;
-            script.replace_manifest(manifest);
+            let source = match script.source() {
+                ScriptSource::Pep723(_) => {
+                    let manifest = ScriptManifest::from_path(&manifest_path)
+                        .map_err(std::io::Error::other)?
+                        .ok_or_else(|| {
+                            std::io::Error::other(
+                                "saved script no longer contains a PEP 723 metadata block",
+                            )
+                        })?;
+                    ScriptSource::Pep723(Box::new(manifest))
+                }
+                ScriptSource::CondaScript(_) => {
+                    let manifest = CondaScriptManifest::from_path(&manifest_path)
+                        .map_err(std::io::Error::other)?
+                        .ok_or_else(|| {
+                            std::io::Error::other(
+                                "saved script no longer contains a conda-script block",
+                            )
+                        })?;
+                    ScriptSource::CondaScript(Box::new(manifest))
+                }
+            };
+            script.replace_manifest(source);
         }
         Ok(())
     }

--- a/crates/pixi_core/src/workspace/workspace_script.rs
+++ b/crates/pixi_core/src/workspace/workspace_script.rs
@@ -88,16 +88,15 @@ impl WorkspaceScript {
         &self.source
     }
 
-    pub(super) fn replace_manifest(&mut self, new_manifest: ScriptManifest) {
+    pub(super) fn replace_manifest(&mut self, new_source: ScriptSource) {
         if self.lock_file_path.is_some() {
-            self.lock_file_path = Some(local_lock_file_path(new_manifest.path()));
+            let path = match &new_source {
+                ScriptSource::Pep723(manifest) => manifest.path(),
+                ScriptSource::CondaScript(manifest) => manifest.path(),
+            };
+            self.lock_file_path = Some(local_lock_file_path(path));
         }
-        match &mut self.source {
-            ScriptSource::Pep723(manifest) => **manifest = new_manifest,
-            ScriptSource::CondaScript(_) => {
-                unreachable!("conda-script workspaces reject manifest edits when they are opened")
-            }
-        }
+        self.source = new_source;
     }
 
     pub(super) fn pixi_dir(&self) -> &Path {

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -123,8 +123,8 @@ impl Manifests {
             ManifestKind::Pyproject => PyProjectManifest::deserialize(&mut toml)
                 .map_err(TomlError::from)
                 .and_then(|manifest| manifest.into_workspace_manifest(manifest_dir)),
-            ManifestKind::Pep723 => {
-                unreachable!("PEP 723 scripts are loaded through the script manifest adapter")
+            ManifestKind::Pep723 | ManifestKind::CondaScript => {
+                unreachable!("scripts are loaded through the script manifest adapter")
             }
         };
 
@@ -247,7 +247,9 @@ enum RequiresPixiCheck {
 /// full deserialization.
 fn check_requires_pixi_early(toml: &toml_span::Value<'_>, kind: ManifestKind) -> RequiresPixiCheck {
     let pointer = match kind {
-        ManifestKind::Pixi | ManifestKind::MojoProject => "/workspace/requires-pixi",
+        ManifestKind::Pixi | ManifestKind::MojoProject | ManifestKind::CondaScript => {
+            "/workspace/requires-pixi"
+        }
         ManifestKind::Pyproject | ManifestKind::Pep723 => "/tool/pixi/workspace/requires-pixi",
     };
     let Some(value) = toml.pointer(pointer) else {
@@ -593,7 +595,7 @@ impl WorkspaceDiscoverer {
                         continue;
                     }
                 }
-                ManifestKind::Pep723 => {
+                ManifestKind::Pep723 | ManifestKind::CondaScript => {
                     unreachable!("workspace discovery does not infer arbitrary scripts")
                 }
             };

--- a/crates/pixi_manifest/src/manifests/document.rs
+++ b/crates/pixi_manifest/src/manifests/document.rs
@@ -13,7 +13,10 @@ use crate::{
     PypiDependencyLocation, SpecType, TargetSelector, Task, TomlError,
     error::GenericError,
     manifests::table_name::TableName,
-    script::{ScriptManifest, ScriptManifestDocument, ScriptManifestError},
+    script::{
+        ScriptManifest, ScriptManifestDocument, ScriptManifestError,
+        conda::{CondaScriptError, CondaScriptManifest, CondaScriptManifestDocument},
+    },
     toml::TomlDocument,
     utils::WithSourceCode,
 };
@@ -25,6 +28,7 @@ pub enum ManifestDocument {
     PixiToml(TomlDocument),
     MojoProjectToml(TomlDocument),
     Pep723(ScriptManifestDocument),
+    CondaScript(Box<CondaScriptManifestDocument>),
 }
 
 impl fmt::Display for ManifestDocument {
@@ -34,6 +38,7 @@ impl fmt::Display for ManifestDocument {
             ManifestDocument::PixiToml(document) => write!(f, "{document}"),
             ManifestDocument::MojoProjectToml(document) => write!(f, "{document}"),
             ManifestDocument::Pep723(document) => write!(f, "{document}"),
+            ManifestDocument::CondaScript(document) => write!(f, "{document}"),
         }
     }
 }
@@ -54,6 +59,25 @@ pub enum ManifestDocumentError {
 
     #[error("{} does not contain a PEP 723 metadata block", .0.display())]
     MissingPep723(PathBuf),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CondaScript(#[from] CondaScriptError),
+
+    #[error("{} does not contain a conda-script block", .0.display())]
+    MissingCondaScript(PathBuf),
+}
+
+/// An error that is returned when rendering an editable manifest document.
+#[derive(Debug, Error, Diagnostic)]
+pub enum ManifestRenderError {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Script(#[from] ScriptManifestError),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CondaScript(#[from] CondaScriptError),
 }
 
 impl ManifestDocument {
@@ -62,13 +86,21 @@ impl ManifestDocument {
         Ok(Self::Pep723(ScriptManifestDocument::new(script)?))
     }
 
+    /// Construct an editable document from a parsed conda-script manifest.
+    pub fn from_conda_script(script: CondaScriptManifest) -> Result<Self, CondaScriptError> {
+        Ok(Self::CondaScript(Box::new(
+            CondaScriptManifestDocument::new(script)?,
+        )))
+    }
+
     /// Render the editable document back into its source format.
-    pub fn render(&self) -> Result<String, ScriptManifestError> {
+    pub fn render(&self) -> Result<String, ManifestRenderError> {
         match self {
             ManifestDocument::PyProjectToml(document)
             | ManifestDocument::PixiToml(document)
             | ManifestDocument::MojoProjectToml(document) => Ok(document.to_string()),
-            ManifestDocument::Pep723(document) => document.render(),
+            ManifestDocument::Pep723(document) => Ok(document.render()?),
+            ManifestDocument::CondaScript(document) => Ok(document.render()?),
         }
     }
 
@@ -126,6 +158,12 @@ impl ManifestDocument {
                 .ok_or_else(|| ManifestDocumentError::MissingPep723(provenance.path.clone()))?;
             return Ok(ManifestDocument::from_script(script)?);
         }
+        if provenance.kind == ManifestKind::CondaScript {
+            let script = CondaScriptManifest::from_path(&provenance.path)?.ok_or_else(|| {
+                ManifestDocumentError::MissingCondaScript(provenance.path.clone())
+            })?;
+            return Ok(ManifestDocument::from_conda_script(script)?);
+        }
 
         // Read the contents of the file
         let contents = provenance.read()?.into_inner();
@@ -149,7 +187,9 @@ impl ManifestDocument {
             ManifestKind::Pyproject => Ok(ManifestDocument::PyProjectToml(toml)),
             ManifestKind::Pixi => Ok(ManifestDocument::PixiToml(toml)),
             ManifestKind::MojoProject => Ok(ManifestDocument::MojoProjectToml(toml)),
-            ManifestKind::Pep723 => unreachable!("PEP 723 manifests are parsed above"),
+            ManifestKind::Pep723 | ManifestKind::CondaScript => {
+                unreachable!("script manifests are parsed above")
+            }
         }
     }
 
@@ -160,6 +200,7 @@ impl ManifestDocument {
             ManifestDocument::PixiToml(_) => ManifestKind::Pixi,
             ManifestDocument::MojoProjectToml(_) => ManifestKind::MojoProject,
             ManifestDocument::Pep723(_) => ManifestKind::Pep723,
+            ManifestDocument::CondaScript(_) => ManifestKind::CondaScript,
         }
     }
 
@@ -176,6 +217,7 @@ impl ManifestDocument {
             }
             ManifestDocument::PixiToml(_) => None,
             ManifestDocument::MojoProjectToml(_) => None,
+            ManifestDocument::CondaScript(_) => None,
         }
     }
 
@@ -185,6 +227,7 @@ impl ManifestDocument {
             ManifestDocument::PixiToml(document) => document,
             ManifestDocument::MojoProjectToml(document) => document,
             ManifestDocument::Pep723(document) => document.document_mut(),
+            ManifestDocument::CondaScript(document) => document.document_mut(),
         }
     }
 
@@ -195,6 +238,7 @@ impl ManifestDocument {
             ManifestDocument::PixiToml(document) => document,
             ManifestDocument::MojoProjectToml(document) => document,
             ManifestDocument::Pep723(document) => document.document(),
+            ManifestDocument::CondaScript(document) => document.document(),
         }
     }
 
@@ -251,6 +295,7 @@ impl ManifestDocument {
             ManifestDocument::PixiToml(document) => document.as_table_mut(),
             ManifestDocument::MojoProjectToml(document) => document.as_table_mut(),
             ManifestDocument::Pep723(document) => document.document_mut().as_table_mut(),
+            ManifestDocument::CondaScript(document) => document.document_mut().as_table_mut(),
         }
     }
 
@@ -535,8 +580,10 @@ impl ManifestDocument {
         //  - When a specific platform is requested, as markers are not supported (https://github.com/prefix-dev/pixi/issues/2149)
         //  - When an editable install is requested
         //  - When a dependency-specific index must be preserved
-        if matches!(self, ManifestDocument::PixiToml(_))
-            || matches!(location, Some(PypiDependencyLocation::PixiPypiDependencies))
+        if matches!(
+            self,
+            ManifestDocument::PixiToml(_) | ManifestDocument::CondaScript(_)
+        ) || matches!(location, Some(PypiDependencyLocation::PixiPypiDependencies))
             || target.is_some()
             || editable.is_some_and(|e| e)
             || pixi_requirement.is_some_and(|requirement| requirement.index().is_some())

--- a/crates/pixi_manifest/src/manifests/provenance.rs
+++ b/crates/pixi_manifest/src/manifests/provenance.rs
@@ -58,6 +58,7 @@ impl ManifestProvenance {
             ManifestKind::Pyproject => Ok(ManifestSource::PyProjectToml(contents)),
             ManifestKind::MojoProject => Ok(ManifestSource::MojoProjectToml(contents)),
             ManifestKind::Pep723 => Ok(ManifestSource::Pep723(contents)),
+            ManifestKind::CondaScript => Ok(ManifestSource::CondaScript(contents)),
         }
     }
 
@@ -87,6 +88,7 @@ pub enum ManifestKind {
     Pyproject,
     MojoProject,
     Pep723,
+    CondaScript,
 }
 
 impl ManifestKind {
@@ -106,7 +108,7 @@ impl ManifestKind {
             ManifestKind::Pixi => consts::WORKSPACE_MANIFEST,
             ManifestKind::Pyproject => consts::PYPROJECT_MANIFEST,
             ManifestKind::MojoProject => consts::MOJOPROJECT_MANIFEST,
-            ManifestKind::Pep723 => "<script>",
+            ManifestKind::Pep723 | ManifestKind::CondaScript => "<script>",
         }
     }
 

--- a/crates/pixi_manifest/src/manifests/source.rs
+++ b/crates/pixi_manifest/src/manifests/source.rs
@@ -7,6 +7,7 @@ pub enum ManifestSource<S> {
     PixiToml(S),
     MojoProjectToml(S),
     Pep723(S),
+    CondaScript(S),
 }
 
 impl<S> AsRef<S> for ManifestSource<S> {
@@ -16,6 +17,7 @@ impl<S> AsRef<S> for ManifestSource<S> {
             ManifestSource::PixiToml(source) => source,
             ManifestSource::MojoProjectToml(source) => source,
             ManifestSource::Pep723(source) => source,
+            ManifestSource::CondaScript(source) => source,
         }
     }
 }
@@ -28,6 +30,7 @@ impl<S> ManifestSource<S> {
             ManifestSource::PixiToml(source) => source,
             ManifestSource::MojoProjectToml(source) => source,
             ManifestSource::Pep723(source) => source,
+            ManifestSource::CondaScript(source) => source,
         }
     }
 
@@ -38,6 +41,7 @@ impl<S> ManifestSource<S> {
             ManifestSource::PixiToml(_) => ManifestKind::Pixi,
             ManifestSource::MojoProjectToml(_) => ManifestKind::MojoProject,
             ManifestSource::Pep723(_) => ManifestKind::Pep723,
+            ManifestSource::CondaScript(_) => ManifestKind::CondaScript,
         }
     }
 
@@ -48,6 +52,7 @@ impl<S> ManifestSource<S> {
             ManifestSource::PixiToml(source) => ManifestSource::PixiToml(f(source)),
             ManifestSource::MojoProjectToml(source) => ManifestSource::MojoProjectToml(f(source)),
             ManifestSource::Pep723(source) => ManifestSource::Pep723(f(source)),
+            ManifestSource::CondaScript(source) => ManifestSource::CondaScript(f(source)),
         }
     }
 

--- a/crates/pixi_manifest/src/script/conda/document.rs
+++ b/crates/pixi_manifest/src/script/conda/document.rs
@@ -1,0 +1,310 @@
+use std::fmt;
+
+use toml_edit::{DocumentMut, Item, Table};
+
+use super::{CondaScriptError, CondaScriptManifest};
+use crate::toml::TomlDocument;
+
+/// An editable `conda-script` manifest presented using `pixi.toml` semantics.
+///
+/// The TOML document is synthetic: it exposes the block's `channels`,
+/// `[dependencies]` and `[tool.pixi.pypi-dependencies]` tables through the
+/// same shape as a `pixi.toml`, which is what pixi's manifest editors
+/// operate on. Rendering syncs the edits back into the comment block while
+/// preserving the code around it.
+#[derive(Debug, Clone)]
+pub struct CondaScriptManifestDocument {
+    script: CondaScriptManifest,
+    document: TomlDocument,
+}
+
+impl CondaScriptManifestDocument {
+    pub fn new(script: CondaScriptManifest) -> Result<Self, CondaScriptError> {
+        let block = script.metadata_document()?;
+
+        let mut document = DocumentMut::new();
+        let mut workspace = Table::new();
+        if let Some(channels) = block.get("channels") {
+            workspace.insert("channels", channels.clone());
+        }
+        document.insert("workspace", Item::Table(workspace));
+        if let Some(dependencies) = block.get("dependencies") {
+            document.insert("dependencies", dependencies.clone());
+        }
+        if let Some(pypi_dependencies) = block
+            .get("tool")
+            .and_then(Item::as_table_like)
+            .and_then(|tool| tool.get("pixi"))
+            .and_then(Item::as_table_like)
+            .and_then(|pixi| pixi.get("pypi-dependencies"))
+        {
+            document.insert("pypi-dependencies", pypi_dependencies.clone());
+        }
+
+        Ok(Self {
+            script,
+            document: TomlDocument::new(document),
+        })
+    }
+
+    pub fn document(&self) -> &TomlDocument {
+        &self.document
+    }
+
+    pub fn document_mut(&mut self) -> &mut TomlDocument {
+        &mut self.document
+    }
+
+    /// Renders the edits back into the full file contents.
+    ///
+    /// The result is validated as a `conda-script` block, so an edit the
+    /// block schema rejects (say a git spec under `[dependencies]`) errors
+    /// here instead of writing an unreadable file.
+    pub fn render(&self) -> Result<String, CondaScriptError> {
+        let mut block = self.script.metadata_document()?;
+        let document = self.document.as_document();
+
+        match document.get("dependencies") {
+            Some(dependencies) => {
+                insert_if_changed(&mut block, "dependencies", dependencies);
+            }
+            None => {
+                block.remove("dependencies");
+            }
+        }
+
+        let workspace = document.get("workspace").and_then(Item::as_table_like);
+        if let Some(channels) = workspace.and_then(|workspace| workspace.get("channels")) {
+            // The block's `channels` only takes strings; a channel with a
+            // priority arrives as a table and has no representation.
+            let has_priority = channels
+                .as_array()
+                .is_some_and(|array| array.iter().any(|value| !value.is_str()));
+            if has_priority {
+                return Err(CondaScriptError::UnsupportedEdit {
+                    key: "channel priorities".to_owned(),
+                });
+            }
+            insert_if_changed(&mut block, "channels", channels);
+        }
+        // The editable document never starts out with `platforms`; its
+        // presence means an editor tried to write a key the block cannot
+        // hold.
+        if workspace
+            .and_then(|workspace| workspace.get("platforms"))
+            .is_some()
+        {
+            return Err(CondaScriptError::UnsupportedEdit {
+                key: "platforms".to_owned(),
+            });
+        }
+
+        match document.get("pypi-dependencies") {
+            Some(pypi_dependencies) => {
+                let unchanged = block
+                    .get("tool")
+                    .and_then(Item::as_table_like)
+                    .and_then(|tool| tool.get("pixi"))
+                    .and_then(Item::as_table_like)
+                    .and_then(|pixi| pixi.get("pypi-dependencies"))
+                    .is_some_and(|existing| existing.to_string() == pypi_dependencies.to_string());
+                if !unchanged {
+                    insert_tool_pixi(&mut block, "pypi-dependencies", pypi_dependencies.clone());
+                }
+            }
+            None => {
+                remove_tool_pixi(&mut block, "pypi-dependencies");
+            }
+        }
+
+        let rendered = self.script.render_metadata(&block);
+        CondaScriptManifest::from_source(self.script.path(), rendered.as_bytes())?;
+        Ok(rendered)
+    }
+}
+
+impl fmt::Display for CondaScriptManifestDocument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.render().map_err(|_| fmt::Error)?)
+    }
+}
+
+/// Replaces a top-level item only when the edit actually changed it.
+///
+/// Re-inserting an unchanged item would drop the comments attached to its
+/// key, so an edit elsewhere in the block must not touch it.
+fn insert_if_changed(block: &mut DocumentMut, key: &str, item: &Item) {
+    let unchanged = block
+        .get(key)
+        .is_some_and(|existing| existing.to_string() == item.to_string());
+    if !unchanged {
+        block.insert(key, item.clone());
+    }
+}
+
+fn insert_tool_pixi(block: &mut DocumentMut, key: &str, item: Item) {
+    if block.get("tool").is_none() {
+        let mut tool = Table::new();
+        tool.set_implicit(true);
+        block.insert("tool", Item::Table(tool));
+    }
+    let Some(tool) = block.get_mut("tool").and_then(Item::as_table_like_mut) else {
+        return;
+    };
+    if tool.get("pixi").is_none() {
+        let mut pixi = Table::new();
+        pixi.set_implicit(true);
+        tool.insert("pixi", Item::Table(pixi));
+    }
+    if let Some(pixi) = tool.get_mut("pixi").and_then(Item::as_table_like_mut) {
+        pixi.insert(key, item);
+    }
+}
+
+fn remove_tool_pixi(block: &mut DocumentMut, key: &str) {
+    let Some(tool) = block.get_mut("tool").and_then(Item::as_table_like_mut) else {
+        return;
+    };
+    if let Some(pixi) = tool.get_mut("pixi").and_then(Item::as_table_like_mut) {
+        pixi.remove(key);
+        if pixi.is_empty() {
+            tool.remove("pixi");
+        }
+    }
+    if tool.is_empty() {
+        block.remove("tool");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use pixi_test_utils::format_diagnostic;
+
+    use super::*;
+
+    fn document(contents: &str) -> CondaScriptManifestDocument {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("example.c");
+        let manifest = CondaScriptManifest::from_source(path, contents.as_bytes())
+            .unwrap()
+            .unwrap();
+        CondaScriptManifestDocument::new(manifest).unwrap()
+    }
+
+    const SOURCE: &str = r#"#include <zlib.h>
+// /// conda-script
+// channels = ["conda-forge"]
+// entrypoint = "run ${SCRIPT}"
+//
+// [dependencies]
+// gcc = "*"
+// /// end-conda-script
+int main(void) { return 0; }
+"#;
+
+    #[test]
+    fn exposes_the_block_with_pixi_toml_semantics() {
+        let document = document(SOURCE);
+        insta::assert_snapshot!(document.document().to_string(), @r#"
+        [workspace]
+        channels = ["conda-forge"]
+
+        [dependencies]
+        gcc = "*"
+        "#);
+    }
+
+    #[test]
+    fn renders_dependency_edits_into_the_block() {
+        let mut document = document(SOURCE);
+        document
+            .document_mut()
+            .get_or_insert_nested_table(&["dependencies"])
+            .unwrap()
+            .insert("zlib", toml_edit::value("1.3.*"));
+        insta::assert_snapshot!(document.render().unwrap(), @r#"
+        #include <zlib.h>
+        // /// conda-script
+        // channels = ["conda-forge"]
+        // entrypoint = "run ${SCRIPT}"
+        //
+        // [dependencies]
+        // gcc = "*"
+        // zlib = "1.3.*"
+        // /// end-conda-script
+        int main(void) { return 0; }
+        "#);
+    }
+
+    #[test]
+    fn renders_pypi_edits_under_tool_pixi() {
+        let mut document = document(SOURCE);
+        document
+            .document_mut()
+            .get_or_insert_nested_table(&["pypi-dependencies"])
+            .unwrap()
+            .insert("requests", toml_edit::value(">=2"));
+        insta::assert_snapshot!(document.render().unwrap(), @r#"
+        #include <zlib.h>
+        // /// conda-script
+        // channels = ["conda-forge"]
+        // entrypoint = "run ${SCRIPT}"
+        //
+        // [dependencies]
+        // gcc = "*"
+        //
+        // [tool.pixi.pypi-dependencies]
+        // requests = ">=2"
+        // /// end-conda-script
+        int main(void) { return 0; }
+        "#);
+    }
+
+    #[test]
+    fn an_edit_elsewhere_keeps_comments_on_untouched_keys() {
+        let mut document = document(
+            "# /// conda-script\n# # the channels comment\n# channels = [\"conda-forge\"]\n# entrypoint = \"run ${SCRIPT}\"\n#\n# [dependencies]\n# gcc = \"*\"\n# /// end-conda-script\n",
+        );
+        document
+            .document_mut()
+            .get_or_insert_nested_table(&["dependencies"])
+            .unwrap()
+            .insert("zlib", toml_edit::value("1.3.*"));
+        insta::assert_snapshot!(document.render().unwrap(), @r#"
+        # /// conda-script
+        # # the channels comment
+        # channels = ["conda-forge"]
+        # entrypoint = "run ${SCRIPT}"
+        #
+        # [dependencies]
+        # gcc = "*"
+        # zlib = "1.3.*"
+        # /// end-conda-script
+        "#);
+    }
+
+    #[test]
+    fn rejects_edits_the_block_schema_does_not_allow() {
+        let mut document = document(SOURCE);
+        let mut git = toml_edit::InlineTable::new();
+        git.insert("git", "https://github.com/org/repo.git".into());
+        document
+            .document_mut()
+            .get_or_insert_nested_table(&["dependencies"])
+            .unwrap()
+            .insert("demo", toml_edit::value(git));
+        let error = document.render().unwrap_err();
+        insta::assert_snapshot!(format_diagnostic(&error), @r#"
+         × Unexpected keys, expected only 'version', 'build', 'build-number', 'channel', 'subdir', 'extras', 'flags', 'md5', 'sha256', 'url', 'when'
+         ╰─▶ Unexpected keys, expected only 'version', 'build', 'build-number', 'channel', 'subdir', 'extras', 'flags', 'md5', 'sha256', 'url', 'when'
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:8:13]
+        7 │ // gcc = "*"
+        8 │ // demo = { git = "https://github.com/org/repo.git" }
+          ·             ─┬─
+          ·              ╰── 'git' was not expected here
+        9 │ // /// end-conda-script
+          ╰────
+        "#);
+    }
+}

--- a/crates/pixi_manifest/src/script/conda/error.rs
+++ b/crates/pixi_manifest/src/script/conda/error.rs
@@ -23,6 +23,13 @@ pub enum CondaScriptError {
     #[error("a file containing a conda-script block must be valid UTF-8")]
     #[diagnostic(help("the block holds TOML, which is defined to be UTF-8"))]
     Utf8(#[from] std::str::Utf8Error),
+
+    #[error(transparent)]
+    TomlEdit(#[from] toml_edit::TomlError),
+
+    #[error("conda-script blocks do not support `{key}`")]
+    #[diagnostic(help("a conda-script resolves for the machine it runs on"))]
+    UnsupportedEdit { key: String },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/pixi_manifest/src/script/conda/manifest.rs
+++ b/crates/pixi_manifest/src/script/conda/manifest.rs
@@ -9,7 +9,7 @@ use toml_edit::DocumentMut;
 use super::{
     CondaScriptError, CondaScriptMetadata,
     envelope::{self, CLOSING_MARKER, OPENING_MARKER},
-    error::{EnvelopeError, MetadataError},
+    error::{EnvelopeError, EnvelopeErrorKind, MetadataError},
 };
 use crate::script::block::{LineEnding, serialize_block};
 
@@ -90,6 +90,52 @@ impl CondaScriptManifest {
         }))
     }
 
+    /// Reads the `conda-script` block of a script file, tolerating a
+    /// malformed block in a Python file.
+    ///
+    /// Returns `Ok(None)` when the file has no block or when a malformed
+    /// block appears in a Python file, so the caller falls back to the PEP
+    /// 723 path: a Python script may contain an accidental line ending in
+    /// the opening marker, say inside an indented docstring, and must keep
+    /// working as it did before the conda-script format existed. When
+    /// `surface_errors` is set or the file cannot be a PEP 723 script
+    /// anyway, a block error is reported instead.
+    pub fn detect_with_fallback(
+        path: &Path,
+        surface_errors: bool,
+    ) -> Result<Option<Self>, CondaScriptError> {
+        match Self::from_path(path) {
+            Ok(manifest) => Ok(manifest),
+            Err(error @ CondaScriptError::Io(_)) => Err(error),
+            Err(error) => {
+                let is_python = path
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                    .is_some_and(|extension| {
+                        extension.eq_ignore_ascii_case("py")
+                            || extension.eq_ignore_ascii_case("pyw")
+                    });
+                // A file with both block kinds is not a stray marker but a
+                // real conflict; editing or running it as PEP 723 would
+                // maintain a file `pixi run` refuses.
+                let both_kinds = matches!(
+                    &error,
+                    CondaScriptError::Envelope(envelope)
+                        if matches!(envelope.kind, EnvelopeErrorKind::BothBlockKinds { .. })
+                );
+                if surface_errors || !is_python || both_kinds {
+                    Err(error)
+                } else {
+                    tracing::debug!(
+                        "ignoring a malformed conda-script block in {}: {error}",
+                        path.display()
+                    );
+                    Ok(None)
+                }
+            }
+        }
+    }
+
     /// The absolute path of the script file.
     pub fn path(&self) -> &Path {
         &self.path
@@ -134,10 +180,10 @@ impl CondaScriptManifest {
     ///
     /// The dependency tables are spliced in verbatim from the block, so the
     /// specs reach the manifest parser exactly as written. `[dependencies]`
-    /// fills the default feature while `[tool.pixi.dependencies]` and
-    /// `[tool.pixi.pypi-dependencies]` become a separate feature of the
-    /// default environment, which merges the two spec sets the way pixi
-    /// merges features: both specs of a package reach the solver.
+    /// and `[tool.pixi.pypi-dependencies]` fill the default feature while
+    /// `[tool.pixi.dependencies]` becomes a separate feature of the default
+    /// environment, which merges the two spec sets the way pixi merges
+    /// features: both specs of a package reach the solver.
     pub fn synthetic_manifest(&self) -> Result<String, toml_edit::TomlError> {
         let mut block: toml_edit::DocumentMut = self.toml.parse()?;
         let channels = block
@@ -175,14 +221,15 @@ impl CondaScriptManifest {
             document.insert("dependencies", dependencies);
         }
 
-        if pixi_dependencies.is_some() || pixi_pypi_dependencies.is_some() {
+        if let Some(pixi_pypi_dependencies) = pixi_pypi_dependencies {
+            document.insert("pypi-dependencies", pixi_pypi_dependencies);
+        }
+
+        if pixi_dependencies.is_some() {
             let mut tool_pixi = toml_edit::Table::new();
             tool_pixi.set_implicit(true);
             if let Some(pixi_dependencies) = pixi_dependencies {
                 tool_pixi.insert("dependencies", pixi_dependencies);
-            }
-            if let Some(pixi_pypi_dependencies) = pixi_pypi_dependencies {
-                tool_pixi.insert("pypi-dependencies", pixi_pypi_dependencies);
             }
             let mut feature = toml_edit::Table::new();
             feature.set_implicit(true);
@@ -486,11 +533,11 @@ mod tests {
         [feature.tool-pixi.dependencies]
         simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
 
-        [feature.tool-pixi.pypi-dependencies]
-        requests = ">=2"
-
         [environments]
         default = ["tool-pixi"]
+
+        [pypi-dependencies]
+        requests = ">=2"
         "##);
     }
 

--- a/crates/pixi_manifest/src/script/conda/mod.rs
+++ b/crates/pixi_manifest/src/script/conda/mod.rs
@@ -6,12 +6,14 @@
 //! closes with the prefix followed by `/// end-conda-script`. The content is
 //! TOML 1.1, which allows multiline inline tables.
 
+mod document;
 mod entrypoint;
 mod envelope;
 mod error;
 mod manifest;
 mod metadata;
 
+pub use document::CondaScriptManifestDocument;
 pub use entrypoint::{Entrypoint, EntrypointSelector};
 pub use error::{CondaScriptError, EnvelopeError, MetadataError};
 pub use manifest::CondaScriptManifest;

--- a/docs/reference/cli/pixi/add.md
+++ b/docs/reference/cli/pixi/add.md
@@ -109,7 +109,7 @@ pixi add [OPTIONS] <SPEC>...
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 Adds dependencies to the workspace

--- a/docs/reference/cli/pixi/install.md
+++ b/docs/reference/cli/pixi/install.md
@@ -88,7 +88,7 @@ pixi install [OPTIONS]
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 Install an environment, both updating the lock file and installing the environment.

--- a/docs/reference/cli/pixi/list.md
+++ b/docs/reference/cli/pixi/list.md
@@ -62,7 +62,7 @@ pixi list [OPTIONS] [REGEX]
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 List the packages of the current workspace

--- a/docs/reference/cli/pixi/lock.md
+++ b/docs/reference/cli/pixi/lock.md
@@ -75,6 +75,6 @@ pixi lock [OPTIONS]
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 --8<-- "docs/reference/cli/pixi/lock_extender:example"

--- a/docs/reference/cli/pixi/remove.md
+++ b/docs/reference/cli/pixi/remove.md
@@ -103,7 +103,7 @@ pixi remove [OPTIONS] <SPEC>...
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 Removes dependencies from the workspace.

--- a/docs/reference/cli/pixi/run.md
+++ b/docs/reference/cli/pixi/run.md
@@ -104,7 +104,7 @@ pixi run [OPTIONS] [TASK]...
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 Runs task in the pixi environment.

--- a/docs/reference/cli/pixi/tree.md
+++ b/docs/reference/cli/pixi/tree.md
@@ -51,7 +51,7 @@ pixi tree [OPTIONS] [REGEX]
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 Show a tree of workspace dependencies

--- a/docs/reference/cli/pixi/update.md
+++ b/docs/reference/cli/pixi/update.md
@@ -82,7 +82,7 @@ pixi update [OPTIONS] [PACKAGES]...
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 ## Description
 Updates dependencies to newer compatible versions.

--- a/docs/reference/cli/pixi/workspace/channel/index.md
+++ b/docs/reference/cli/pixi/workspace/channel/index.md
@@ -36,6 +36,6 @@ pixi workspace channel [OPTIONS] <COMMAND>
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 --8<-- "docs/reference/cli/pixi/workspace/channel_extender:example"

--- a/docs/reference/cli/pixi/workspace/export/conda-environment.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-environment.md
@@ -44,6 +44,6 @@ pixi workspace export conda-environment [OPTIONS] [OUTPUT_PATH]
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 --8<-- "docs/reference/cli/pixi/workspace/export/conda-environment_extender:example"

--- a/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
+++ b/docs/reference/cli/pixi/workspace/export/conda-explicit-spec.md
@@ -92,6 +92,6 @@ pixi workspace export conda-explicit-spec [OPTIONS] <OUTPUT_DIR>
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 --8<-- "docs/reference/cli/pixi/workspace/export/conda-explicit-spec_extender:example"

--- a/docs/reference/cli/pixi/workspace/platform/index.md
+++ b/docs/reference/cli/pixi/workspace/platform/index.md
@@ -38,6 +38,6 @@ pixi workspace platform [OPTIONS] <COMMAND>
 - <a id="arg---workspace" href="#arg---workspace">`--workspace (-w) <WORKSPACE>`</a>
 :  Name of the workspace
 - <a id="arg---script" href="#arg---script">`--script (-s) <SCRIPT>`</a>
-:  The path to a Python script containing PEP 723 metadata
+:  The path to a script with an embedded manifest: a Python script containing PEP 723 metadata, or a file of any language containing a `/// conda-script` block
 
 --8<-- "docs/reference/cli/pixi/workspace/platform_extender:example"

--- a/tests/integration_python/test_conda_script.py
+++ b/tests/integration_python/test_conda_script.py
@@ -325,3 +325,134 @@ def test_lock_writes_an_adjacent_lock_file_with_conditional_dependencies(
         [pixi, "run", "--experimental", "--script", script, "--frozen"],
         stdout_contains="1234",
     )
+
+
+def test_add_edits_the_block_and_locks(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "tool.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "main"
+#
+# [dependencies]
+# zlib = "*"
+# /// end-conda-script
+body
+""")
+
+    # An adjacent lock file makes the edit commands update it in place.
+    verify_cli_command([pixi, "lock", "--script", script])
+    lock_file = tmp_pixi_workspace / "tool.code.pixi.lock"
+    assert "/xz-" not in lock_file.read_text()
+
+    verify_cli_command([pixi, "add", "--script", script, "--no-install", "xz"])
+
+    contents = script.read_text()
+    assert re.search(r"^# xz = \">=", contents, re.MULTILINE)
+    # The code around the block stays untouched.
+    assert contents.endswith("body\n")
+    assert "/xz-" in lock_file.read_text()
+
+    verify_cli_command(
+        [pixi, "list", "--script", script, "--no-install"],
+        stdout_contains=["xz", "zlib"],
+    )
+    verify_cli_command(
+        [pixi, "tree", "--script", script, "--no-install"],
+        stdout_contains="zlib",
+    )
+    verify_cli_command([pixi, "update", "--script", script, "--no-install"])
+
+
+def test_add_pypi_writes_the_tool_pixi_table(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "pypi.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}}"
+#
+# [dependencies]
+# python = "3.13.*"
+# /// end-conda-script
+print("hi")
+""")
+
+    verify_cli_command([pixi, "add", "--script", script, "--no-install", "--pypi", "six"])
+
+    contents = script.read_text()
+    assert "# [tool.pixi.pypi-dependencies]" in contents
+    assert re.search(r"^# six = ", contents, re.MULTILINE)
+
+
+def test_add_rejects_options_outside_the_block_schema(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "guards.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "main"
+# /// end-conda-script
+""")
+
+    verify_cli_command(
+        [pixi, "add", "--script", script, "--platform", "linux-64", "zlib"],
+        ExitCode.FAILURE,
+        stderr_contains="`when` condition",
+    )
+    verify_cli_command(
+        [
+            pixi,
+            "add",
+            "--script",
+            script,
+            "--git",
+            "https://github.com/prefix-dev/pixi-build-testsuite.git",
+            "simple-app",
+        ],
+        ExitCode.FAILURE,
+        stderr_contains="tool.pixi.dependencies",
+    )
+
+
+def test_add_rejects_a_file_with_both_block_kinds(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "both.py"
+    script.write_text(
+        "# /// script\n"
+        "# dependencies = []\n"
+        "# ///\n"
+        "# /// conda-script\n"
+        '# channels = ["conda-forge"]\n'
+        '# entrypoint = "python ${SCRIPT}"\n'
+        "# /// end-conda-script\n"
+    )
+
+    verify_cli_command(
+        [pixi, "add", "--script", script, "numpy"],
+        ExitCode.FAILURE,
+        stderr_contains="both a PEP 723",
+    )
+
+
+def test_a_blockless_file_reports_the_missing_block(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "plain.sh"
+    script.write_text("echo plain\n")
+
+    verify_cli_command(
+        [pixi, "list", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="does not contain a conda-script block",
+    )
+
+
+def test_add_then_remove_pypi_round_trips(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "roundtrip.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}}"
+#
+# [dependencies]
+# python = "3.13.*"
+# /// end-conda-script
+""")
+
+    verify_cli_command([pixi, "add", "--script", script, "--no-install", "--pypi", "six"])
+    assert "six" in script.read_text()
+
+    verify_cli_command([pixi, "remove", "--script", script, "--no-install", "--pypi", "six"])
+    assert "six" not in script.read_text()


### PR DESCRIPTION
`--script` looks for a conda-script block before assuming a PEP 723 script, so every `--script` command accepts both kinds of file, not only `pixi run`.

- `pixi add` and `pixi remove` write into the block: conda packages go to `[dependencies]`, `--pypi` packages to `[tool.pixi.pypi-dependencies]`. The comment prefix and the code around the block are left alone
- `pixi list`, `tree`, `lock`, `update` and the `pixi workspace` subcommands read the environment of a conda-script file
- `--platform` and `--git` are refused for conda-script files, since the spec allows neither platform tables nor git specs in `[dependencies]`; the errors point at `when` conditions and `[tool.pixi.dependencies]`
- A non-Python `--script` file without a block says so, instead of "not a Python script", and a file with both block kinds is rejected by every command
