### PR TITLE
fix: `pixi-build-ros` python file rebuild

### DIFF
--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -331,9 +331,9 @@ impl GenerateRecipe for RosGenerator {
         &self,
         config: &Self::Config,
         _workdir: impl AsRef<Path>,
-        editable: bool,
+        _editable: bool,
     ) -> miette::Result<Vec<String>> {
-        let mut globs: Vec<&str> = vec![
+        let globs: Vec<&str> = vec![
             "**/*.c",
             "**/*.cpp",
             "**/*.h",

--- a/crates/pixi_build_ros/src/main.rs
+++ b/crates/pixi_build_ros/src/main.rs
@@ -340,6 +340,8 @@ impl GenerateRecipe for RosGenerator {
             "**/*.hpp",
             "**/*.rs",
             "**/*.sh",
+            "**/*.py",
+            "**/*.pyx",
             "package.xml",
             "setup.py",
             "setup.cfg",
@@ -356,10 +358,6 @@ impl GenerateRecipe for RosGenerator {
             "srv/**/*.srv",
             "action/**/*.action",
         ];
-
-        if !editable {
-            globs.extend(["**/*.py", "**/*.pyx"]);
-        }
 
         let mut result: Vec<String> = globs.iter().map(|s| s.to_string()).collect();
         if let Some(extra) = &config.extra_input_globs {


### PR DESCRIPTION
### Description

The editable mode doens't work for the oldschool installation with setup.py. So we're having to revert to a non editable install. Which is already how it works, but due to the automatic editable flag setting from pixi it's not picking up the changes with the python files in the old version. That is fixed now. 

### How Has This Been Tested?

Tested it locally on the exercises of the ROSCon tutorials

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code