### PR TITLE
fix: skip system CA store for pypi mapping middleware client

### DIFF
--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -354,6 +354,7 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
         "default-channels" => new.default_channels = config.default_channels.clone(),
         "shell" => new.shell = config.shell.clone(),
         "tls-no-verify" => new.tls_no_verify = config.tls_no_verify,
+        "tls-root-certs" => new.tls_root_certs = config.tls_root_certs,
         "offline" => new.offline = config.offline,
         "authentication-override-file" => {
             new.authentication_override_file = config.authentication_override_file.clone()
@@ -370,6 +371,7 @@ fn partial_config(config: &mut Config, key: &str) -> miette::Result<()> {
             let keys = [
                 "default-channels",
                 "tls-no-verify",
+                "tls-root-certs",
                 "offline",
                 "authentication-override-file",
                 "mirrors",

--- a/crates/pypi_mapping/src/lib.rs
+++ b/crates/pypi_mapping/src/lib.rs
@@ -217,7 +217,10 @@ impl PurlDerivationClient {
 
         let wrapped_client = LazyClient::new(move || {
             let client = client.client().clone();
-            ClientBuilder::new(reqwest::Client::new())
+            // DelegateToClient performs the request. The inner reqwest client is
+            // unused for I/O; Client::new() still loads system CAs and panics on
+            // hosts without a CA store even when tls-root-certs = "webpki" (#6825).
+            ClientBuilder::new(unused_mapping_http_client())
                 .with(retry_strategy)
                 .with(cache_strategy)
                 .with(DelegateToClient(client))
@@ -478,4 +481,26 @@ fn replace_pypi_purls(record: &mut RepoDataRecord, purls: impl IntoIterator<Item
         .get_or_insert_with(BTreeSet::new);
     record_purls.retain(|purl| purl.package_type() != "pypi");
     record_purls.extend(purls);
+}
+
+/// Inner client for the mapping middleware stack.
+///
+/// Requests go through [`DelegateToClient`]. This client must not load the
+/// system CA store: `reqwest::Client::new()` panics when none are present
+/// (#6825).
+fn unused_mapping_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
+        .build()
+        .expect("reqwest client without system CA store")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unused_mapping_http_client;
+
+    #[test]
+    fn unused_mapping_http_client_builds_without_system_cas() {
+        drop(unused_mapping_http_client());
+    }
 }


### PR DESCRIPTION
The mapping cache middleware builds a dummy reqwest client so the cache can sit outside the caller's offline stack. `Client::new()` still initializes system CAs, which panics when `tls-root-certs = webpki` on a host without a conventional CA store.

Use `tls_certs_only([])` for that unused inner client. Also list `tls-root-certs` in `pixi config list`.

Fixes #6825.

### How Has This Been Tested?

```
cargo test -p pypi_mapping unused_mapping_http_client_builds_without_system_cas
cargo check -p pixi_cli
```