### PR TITLE
refactor(pixi-build-cmake): name the build directory once

### DIFF
--- a/crates/pixi_build_cmake/src/build_script.j2
+++ b/crates/pixi_build_cmake/src/build_script.j2
@@ -4,7 +4,6 @@
 {% endmacro -%}
 
 {# - Set up common variables -#}
-{%- set build_dir = "build" -%}
 {%- set library_prefix =  "%LIBRARY_PREFIX%" if build_platform == "windows" else "$PREFIX" -%}
 
 {# `${PYTHON_ARG:+...}` and `%PYTHON_ARG%` both vanish when the probe below
@@ -50,9 +49,9 @@ fi
 {% if is_cmd_exe -%}
 if not exist {{ build_dir }} mkdir {{ build_dir }}
 {% else -%}
-mkdir -p build
+mkdir -p {{ build_dir }}
 {% endif -%}
-pushd build
+pushd {{ build_dir }}
 
 {# Windows -#}
 {% if is_cmd_exe -%}

--- a/crates/pixi_build_cmake/src/build_script.rs
+++ b/crates/pixi_build_cmake/src/build_script.rs
@@ -6,6 +6,9 @@ pub struct BuildScriptContext {
     pub build_platform: BuildPlatform,
     pub source_dir: String,
     pub extra_args: Vec<String>,
+    /// Directory the build tree is configured in, relative to the work
+    /// directory the script runs in.
+    pub build_dir: &'static str,
 }
 
 #[derive(Copy, Clone, Serialize)]
@@ -32,6 +35,7 @@ mod test {
     use rstest::*;
 
     use super::*;
+    use crate::inputs;
 
     #[rstest]
     fn test_build_script(
@@ -42,6 +46,7 @@ mod test {
             build_platform,
             source_dir: String::from("my-prefix-dir"),
             extra_args: extra_args.clone(),
+            build_dir: inputs::NINJA_BUILD_DIR,
         };
         let script = context.render();
 
@@ -66,6 +71,7 @@ mod test {
             build_platform,
             source_dir: String::from("/src/demo"),
             extra_args: vec![],
+            build_dir: inputs::NINJA_BUILD_DIR,
         }
         .render()
     }

--- a/crates/pixi_build_cmake/src/inputs.rs
+++ b/crates/pixi_build_cmake/src/inputs.rs
@@ -32,7 +32,7 @@ use std::{
     process::{Command, Output},
 };
 
-const NINJA_BUILD_DIR: &str = "build";
+pub const NINJA_BUILD_DIR: &str = "build";
 const PIXI_CACHE_DIR: &str = ".pixi";
 const CMAKE_HOME_DIRECTORY_KEY: &str = "CMAKE_HOME_DIRECTORY:INTERNAL=";
 const CMAKE_MAKE_PROGRAM_KEY: &str = "CMAKE_MAKE_PROGRAM:FILEPATH=";

--- a/crates/pixi_build_cmake/src/main.rs
+++ b/crates/pixi_build_cmake/src/main.rs
@@ -117,6 +117,7 @@ impl GenerateRecipe for CMakeGenerator {
             },
             source_dir: manifest_root.display().to_string(),
             extra_args: config.extra_args.clone(),
+            build_dir: inputs::NINJA_BUILD_DIR,
         }
         .render();
 


### PR DESCRIPTION
The build script created and entered `build` by writing the name out, next to a template variable holding the same name and the NINJA_BUILD_DIR constant that the input tracking uses to find the tree again afterwards. Three spellings of one name, and the two in the template were already out of step: the Windows branch used the variable, while the Unix branch and the shared `pushd` did not.

Nothing misbehaves today, as all three say `build`. Changing one of them is what breaks: the input tracking would go looking for a tree the script no longer creates, and no test would notice.

The constant is now the single definition and reaches the template through the context, the way the source directory already does. The rendered scripts are unchanged.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude, Codex

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
