### PR TITLE
fix: bump astral_async_http_range_reader to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "astral_async_http_range_reader"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
+checksum = "1d5ba70a583d0819c44078238014752e85ebca0cb398ab712bbd2e40fb754b80"
 dependencies = [
  "astral-reqwest-middleware",
  "futures",


### PR DESCRIPTION
### Description

Bumps `astral_async_http_range_reader` to 0.11.1 (transitive via `rattler_package_streaming` and `uv-client`).

0.11.0 has a use-after-free: the reader kept a `&'static [u8]` into a memory map owned by the background download task, so once that task stopped (failed range request or dropped future) cached reads touched unmapped memory. A closed state channel also hit an `unreachable!()`. 0.11.1 shares the mapping through an `Arc` and returns `DownloadTaskStopped` instead. See https://github.com/astral-sh/async_http_range_reader/releases/tag/v0.11.1 and astral-sh/uv#21401.

### How Has This Been Tested?

`cargo check --locked -p rattler_package_streaming -p uv-client`. No reproducer for the crash itself.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
