### PR TITLE
feat: share the `tool.pixi` allowlist between script kinds

### DIFF
--- a/crates/pixi_cli/src/add.rs
+++ b/crates/pixi_cli/src/add.rs
@@ -458,8 +458,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     if workspace.is_conda_script() && !args.dependency_config.platforms.is_empty() {
         return Err(miette::miette!(
-            help = "restrict a dependency with a `when` condition in the block instead",
-            "conda-script blocks do not support platform-specific dependency tables"
+            help = "restrict the dependency with a `when` condition in `[dependencies]`, or write `[tool.pixi.target.<platform>.dependencies]` by hand",
+            "`--platform` cannot edit a conda-script block"
         ));
     }
 

--- a/crates/pixi_cli/src/remove/mod.rs
+++ b/crates/pixi_cli/src/remove/mod.rs
@@ -90,8 +90,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
 
     if workspace.is_conda_script() && !args.dependency_config.platforms.is_empty() {
         return Err(miette::miette!(
-            help = "restrict a dependency with a `when` condition in the block instead",
-            "conda-script blocks do not support platform-specific dependency tables"
+            help = "restrict the dependency with a `when` condition in `[dependencies]`, or write `[tool.pixi.target.<platform>.dependencies]` by hand",
+            "`--platform` cannot edit a conda-script block"
         ));
     }
 

--- a/crates/pixi_core/src/lock_file/update.rs
+++ b/crates/pixi_core/src/lock_file/update.rs
@@ -831,13 +831,12 @@ impl<'p> LockFileDerivedData<'p> {
         {
             return;
         }
-        // A conda-script block has no `platforms` key and no editing support,
-        // so the PEP 723 remedies would send its users after commands that
-        // reject the file.
+        // A conda-script block declares its platforms by hand, so the PEP 723
+        // remedy would send its users after a command that rejects the file.
         if self.workspace.is_conda_script() {
             tracing::warn!(
-                "a conda-script cannot declare platforms, so {} records this machine's \
-                 virtual packages and reproduces only on machines that provide them.",
+                "the script declares no platforms, so {} records this machine's virtual packages.\n\
+                 Add `platforms` under `[tool.pixi.workspace]` in the block to declare them explicitly.",
                 lock_file_path.display(),
             );
             return;

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -13,7 +13,7 @@ mod workspace_mut;
 mod workspace_script;
 
 use self::errors::VariantsError;
-use self::workspace_script::{ScriptSource, WorkspaceScript};
+use self::workspace_script::{ScriptSource, WorkspaceScript, local_lock_file_path};
 #[cfg(not(windows))]
 use std::os::unix::fs::symlink;
 use std::{
@@ -47,10 +47,7 @@ use pixi_manifest::{
     AssociateProvenance, BuildVariantSource, EnvironmentName, Environments, FeaturesExt,
     HasWorkspaceManifest, LoadManifestsError, ManifestKind, ManifestProvenance, Manifests,
     PackageManifest, PixiPlatform, PixiPlatformName, PrioritizedChannel, SpecType, WithProvenance,
-    WithWarnings, WorkspaceManifest,
-    script::ScriptManifest,
-    toml::{ExternalWorkspaceProperties, FromTomlStr, PackageDefaults, TomlManifest},
-    utils::WithSourceCode,
+    WithWarnings, WorkspaceManifest, script::ScriptManifest,
 };
 use pixi_path::AbsPathBuf;
 use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
@@ -213,7 +210,7 @@ pub enum ScriptWorkspaceError {
 
     #[error(transparent)]
     #[diagnostic(transparent)]
-    CondaScriptManifest(Box<WithSourceCode<pixi_manifest::TomlError, miette::NamedSource<String>>>),
+    CondaScript(#[from] Box<pixi_manifest::script::conda::CondaScriptError>),
 
     #[error("failed to resolve the script environment cache directory: {0}")]
     CacheDirectory(String),
@@ -231,9 +228,9 @@ pub enum ScriptWorkspaceError {
 
 /// Install the platforms picked for a script that declares none.
 ///
-/// `use_platform_composition` is decided while parsing, and a script's
-/// synthetic manifest parses with an empty `platforms`, which reads as "every
-/// platform is a bare subdir". Composition would then resolve an environment's
+/// `use_platform_composition` is decided while parsing, and a script without
+/// `platforms` parses with an empty set, which reads as "every platform is a
+/// bare subdir". Composition would then resolve an environment's
 /// platform by *subdir name* and never find the rich platform injected here, so
 /// the flag is recomputed for the platforms actually installed.
 fn set_implicit_script_platforms(
@@ -530,46 +527,21 @@ impl Workspace {
             .parent()
             .expect("an absolute script path always has a parent")
             .to_owned();
-        // The diagnostics of this step point into the synthesized document,
-        // not the script; the source name says so.
-        let source_name = format!("{} (synthesized manifest)", script_path.display());
-        let source = script.synthetic_manifest().map_err(|error| {
-            ScriptWorkspaceError::CondaScriptManifest(Box::new(WithSourceCode {
-                error: pixi_manifest::TomlError::from(error),
-                source: miette::NamedSource::new(&source_name, script.toml().to_owned()),
-            }))
-        })?;
-
-        let (mut manifest, package, warnings) = TomlManifest::from_toml_str(&source)
-            .and_then(|manifest| {
-                manifest.into_workspace_manifest(
-                    ExternalWorkspaceProperties::default(),
-                    PackageDefaults::default(),
-                    &root,
-                )
-            })
-            .map_err(|error| {
-                ScriptWorkspaceError::CondaScriptManifest(Box::new(WithSourceCode {
-                    error,
-                    source: miette::NamedSource::new(&source_name, source),
-                }))
-            })?;
-        debug_assert!(
-            package.is_none(),
-            "a synthetic conda-script manifest never defines a package"
-        );
+        let script_config = script.workspace_config().map_err(Box::new)?;
+        let implicit_platforms = if script_config.platforms_explicit {
+            None
+        } else {
+            let lock_file_path = local_lock_file_path(&script_path);
+            Some(implicit_script_platforms(Some(&lock_file_path))?)
+        };
+        let (manifest, warnings) = script
+            .into_workspace_manifest(implicit_platforms)
+            .map_err(Box::new)?;
 
         let cache_root = config
             .cache_dir_for(CacheKind::ExecEnvironments)
             .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?;
         let workspace_script = WorkspaceScript::for_local_conda_script(script, &cache_root);
-        let lock_file_path = workspace_script
-            .lock_file_path()
-            .expect("a local script has an adjacent lock-file path");
-        set_implicit_script_platforms(
-            &mut manifest.workspace,
-            implicit_script_platforms(Some(&lock_file_path))?,
-        );
 
         let workspace = manifest.with_provenance(ManifestProvenance::new(
             script_path,
@@ -758,8 +730,9 @@ impl Workspace {
             ScriptSource::Pep723(manifest) => manifest
                 .workspace_config()
                 .is_ok_and(|config| !config.platforms_explicit),
-            // A conda-script block has no `platforms` key at all.
-            ScriptSource::CondaScript(_) => true,
+            ScriptSource::CondaScript(manifest) => manifest
+                .workspace_config()
+                .is_ok_and(|config| !config.platforms_explicit),
         }
     }
 
@@ -2269,13 +2242,18 @@ platforms = []
             ["testing"]
         );
         assert_eq!(manifest.environments.iter().count(), 1);
-        assert_eq!(manifest.all_features().count(), 1);
         let default_environment = workspace.default_environment();
         assert!(
             default_environment
                 .pypi_dependencies(None)
                 .contains_key(&PypiPackageName::from_str("requests").unwrap()),
             "`tool.pixi.pypi-dependencies` must reach the default environment"
+        );
+        assert!(
+            default_environment
+                .combined_dependencies(None)
+                .contains_key(&PackageName::from_str("zlib").unwrap()),
+            "the block's `[dependencies]` must reach the default environment"
         );
         assert!(
             !manifest.workspace.platforms.is_empty(),
@@ -2286,6 +2264,52 @@ platforms = []
             workspace.lock_file_path(),
             root.path().join("example.c.pixi.lock")
         );
+    }
+
+    #[test]
+    fn conda_script_workspace_honours_declared_platforms() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        let path = root.path().join("example.c");
+        fs_err::write(
+            &path,
+            r#"// /// conda-script
+// channels = ["testing"]
+// entrypoint = "run ${SCRIPT}"
+//
+// [tool.pixi.workspace]
+// platforms = ["linux-64", "win-64"]
+// /// end-conda-script
+"#,
+        )
+        .unwrap();
+        let script = CondaScriptManifest::from_path(&path).unwrap().unwrap();
+
+        let workspace = Workspace::from_conda_script(
+            script,
+            Config {
+                cache: CacheConfig {
+                    exec_environments: Some(cache.path().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .value;
+
+        assert_eq!(
+            workspace
+                .workspace
+                .value
+                .workspace
+                .platforms
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["linux-64", "win-64"]
+        );
+        assert!(!workspace.script_platforms_are_implicit());
     }
 
     #[test]

--- a/crates/pixi_core/src/workspace/workspace_script.rs
+++ b/crates/pixi_core/src/workspace/workspace_script.rs
@@ -279,7 +279,7 @@ impl LockFileDerivedData<'_> {
     }
 }
 
-fn local_lock_file_path(script_path: &Path) -> PathBuf {
+pub(super) fn local_lock_file_path(script_path: &Path) -> PathBuf {
     let mut file_name = script_path
         .file_name()
         .expect("an absolute script path always has a file name")

--- a/crates/pixi_manifest/src/discovery.rs
+++ b/crates/pixi_manifest/src/discovery.rs
@@ -228,7 +228,7 @@ pub struct InvalidRequiresPixiError {
 }
 
 /// Result of the early `requires-pixi` check.
-enum RequiresPixiCheck {
+pub(crate) enum RequiresPixiCheck {
     /// Field is absent or the current pixi version satisfies the constraint.
     Satisfied,
     /// The current pixi version does not satisfy the constraint.
@@ -245,12 +245,15 @@ enum RequiresPixiCheck {
 
 /// Extract and check the `requires-pixi` field from a parsed TOML tree before
 /// full deserialization.
-fn check_requires_pixi_early(toml: &toml_span::Value<'_>, kind: ManifestKind) -> RequiresPixiCheck {
+pub(crate) fn check_requires_pixi_early(
+    toml: &toml_span::Value<'_>,
+    kind: ManifestKind,
+) -> RequiresPixiCheck {
     let pointer = match kind {
-        ManifestKind::Pixi | ManifestKind::MojoProject | ManifestKind::CondaScript => {
-            "/workspace/requires-pixi"
+        ManifestKind::Pixi | ManifestKind::MojoProject => "/workspace/requires-pixi",
+        ManifestKind::Pyproject | ManifestKind::Pep723 | ManifestKind::CondaScript => {
+            "/tool/pixi/workspace/requires-pixi"
         }
-        ManifestKind::Pyproject | ManifestKind::Pep723 => "/tool/pixi/workspace/requires-pixi",
     };
     let Some(value) = toml.pointer(pointer) else {
         return RequiresPixiCheck::Satisfied;

--- a/crates/pixi_manifest/src/script/conda/error.rs
+++ b/crates/pixi_manifest/src/script/conda/error.rs
@@ -1,10 +1,11 @@
 use std::{fmt, ops::Range, path::PathBuf, sync::Arc};
 
 use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode};
-use pixi_toml::TomlDiagnostic;
 use thiserror::Error;
 
-use crate::script::block::BlockSourceMap;
+use crate::{
+    InvalidRequiresPixiError, PixiVersionMismatchError, TomlError, script::block::BlockSourceMap,
+};
 
 /// Errors produced while reading a `conda-script` file.
 #[derive(Debug, Error, Diagnostic)]
@@ -16,6 +17,14 @@ pub enum CondaScriptError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     Metadata(#[from] Box<MetadataError>),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PixiVersionMismatch(#[from] Box<PixiVersionMismatchError>),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidRequiresPixi(#[from] Box<InvalidRequiresPixiError>),
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -31,8 +40,10 @@ pub enum CondaScriptError {
     #[diagnostic(help("the file already carries a `/// conda-script` block"))]
     AlreadyInitialized { path: PathBuf },
 
-    #[error("conda-script blocks do not support `{key}`")]
-    #[diagnostic(help("a conda-script resolves for the machine it runs on"))]
+    #[error("conda-script blocks do not support editing `{key}`")]
+    #[diagnostic(help(
+        "the block's `channels` take plain names; `platforms` are declared by hand under `[tool.pixi.workspace]`"
+    ))]
     UnsupportedEdit { key: String },
 }
 
@@ -151,11 +162,11 @@ impl Diagnostic for EnvelopeError {
     }
 }
 
-/// Invalid TOML inside a `conda-script` block, with spans mapped back into
-/// the original file.
+/// Invalid metadata inside a `conda-script` block, with spans mapped back
+/// into the original file.
 #[derive(Debug)]
 pub struct MetadataError {
-    pub(crate) error: TomlDiagnostic,
+    pub(crate) error: TomlError,
     pub(crate) source: NamedSource<Arc<str>>,
     pub(crate) source_map: BlockSourceMap,
 }

--- a/crates/pixi_manifest/src/script/conda/manifest.rs
+++ b/crates/pixi_manifest/src/script/conda/manifest.rs
@@ -3,15 +3,31 @@ use std::{
     sync::Arc,
 };
 
+use indexmap::{IndexMap, IndexSet};
 use miette::NamedSource;
-use toml_edit::DocumentMut;
+use toml_edit::{DocumentMut, Item};
+use toml_span::{Span, Spanned};
 
 use super::{
     CondaScriptError, CondaScriptMetadata, CondaScriptTemplate,
     envelope::{self, CLOSING_MARKER, OPENING_MARKER},
     error::{EnvelopeError, EnvelopeErrorKind, MetadataError},
+    metadata::ParsedBlock,
 };
-use crate::script::block::{LineEnding, extract_script_header, serialize_block};
+use crate::{
+    EnvironmentName, FeatureName, InvalidRequiresPixiError, PixiPlatform, PixiVersionMismatchError,
+    TomlError, Warning, WorkspaceManifest,
+    discovery::RequiresPixiCheck,
+    script::{
+        ScriptWorkspaceConfig,
+        block::{BlockSourceMap, LineEnding, extract_script_header, serialize_block},
+    },
+    toml::{ExternalWorkspaceProperties, PackageDefaults, TomlEnvironmentList, TomlFeature},
+    utils::PixiSpanned,
+};
+
+/// The feature that carries `tool.pixi.dependencies` in the workspace.
+const TOOL_PIXI_FEATURE: &str = "tool-pixi";
 
 /// A code file containing a `conda-script` metadata block.
 #[derive(Debug, Clone)]
@@ -23,6 +39,8 @@ pub struct CondaScriptManifest {
     prelude: String,
     postlude: String,
     line_ending: LineEnding,
+    source: Arc<str>,
+    source_map: BlockSourceMap,
 }
 
 impl CondaScriptManifest {
@@ -147,17 +165,40 @@ impl CondaScriptManifest {
             }
         };
 
-        let metadata = match CondaScriptMetadata::from_toml_str(&block.metadata) {
-            Ok(metadata) => metadata,
-            Err(mut errors) => {
+        let parsed = match ParsedBlock::from_toml_str(&block.metadata) {
+            Ok(parsed) => parsed,
+            Err(error) => {
                 return Err(Box::new(MetadataError {
-                    error: errors.errors.remove(0).into(),
+                    error,
                     source: NamedSource::new(source_name, source),
                     source_map: block.source_map,
                 })
                 .into());
             }
         };
+        match parsed.requires_pixi {
+            RequiresPixiCheck::Satisfied => {}
+            RequiresPixiCheck::Mismatch {
+                requires_pixi,
+                span,
+            } => {
+                return Err(Box::new(PixiVersionMismatchError {
+                    requires_pixi,
+                    source_code: NamedSource::new(source_name, source),
+                    span: block.source_map.span(span.offset(), span.len(), 0),
+                })
+                .into());
+            }
+            RequiresPixiCheck::Invalid { span, parse_error } => {
+                return Err(Box::new(InvalidRequiresPixiError {
+                    source_code: NamedSource::new(source_name, source),
+                    span: block.source_map.span(span.offset(), span.len(), 0),
+                    parse_error,
+                })
+                .into());
+            }
+        }
+        let metadata = parsed.metadata;
 
         Ok(Some(Self {
             path,
@@ -167,6 +208,8 @@ impl CondaScriptManifest {
             prelude: block.prelude,
             postlude: block.postlude,
             line_ending: LineEnding::detect(contents),
+            source,
+            source_map: block.source_map,
         }))
     }
 
@@ -256,77 +299,120 @@ impl CondaScriptManifest {
         Ok(())
     }
 
-    /// Renders the metadata as a `pixi.toml` document.
+    /// Whether the block pins channels and platforms itself.
     ///
-    /// The dependency tables are spliced in verbatim from the block, so the
-    /// specs reach the manifest parser exactly as written. `[dependencies]`
-    /// and `[tool.pixi.pypi-dependencies]` fill the default feature while
-    /// `[tool.pixi.dependencies]` becomes a separate feature of the default
-    /// environment, which merges the two spec sets the way pixi merges
-    /// features: both specs of a package reach the solver.
-    pub fn synthetic_manifest(&self) -> Result<String, toml_edit::TomlError> {
-        let mut block: toml_edit::DocumentMut = self.toml.parse()?;
-        let channels = block
-            .remove("channels")
-            .expect("`channels` is required by the metadata model");
-        let dependencies = block.remove("dependencies");
-        let mut pixi = block
-            .get_mut("tool")
-            .and_then(toml_edit::Item::as_table_like_mut)
-            .and_then(|tool| tool.get_mut("pixi"))
-            .and_then(toml_edit::Item::as_table_like_mut);
-        let pixi_dependencies = pixi.as_mut().and_then(|pixi| pixi.remove("dependencies"));
-        let pixi_pypi_dependencies = pixi
-            .as_mut()
-            .and_then(|pixi| pixi.remove("pypi-dependencies"));
+    /// Channels are always explicit, the block requires them. Platforms are
+    /// explicit when `tool.pixi.workspace.platforms` is declared; otherwise
+    /// the script resolves for the machine it runs on.
+    pub fn workspace_config(&self) -> Result<ScriptWorkspaceConfig, CondaScriptError> {
+        let metadata = self.metadata_document()?;
+        let platforms_explicit = metadata
+            .get("tool")
+            .and_then(Item::as_table_like)
+            .and_then(|tool| tool.get("pixi"))
+            .and_then(Item::as_table_like)
+            .and_then(|pixi| pixi.get("workspace"))
+            .and_then(Item::as_table_like)
+            .is_some_and(|workspace| workspace.contains_key("platforms"));
+        Ok(ScriptWorkspaceConfig {
+            channels_explicit: true,
+            platforms_explicit,
+        })
+    }
 
-        let name = self
+    /// The workspace the script resolves in.
+    ///
+    /// `tool.pixi` is the manifest, with the block's `[dependencies]` as its
+    /// dependency table, where the `--script` editors expect them.
+    /// `tool.pixi.dependencies` move into a feature of the default
+    /// environment, so a package named in both merges the way pixi merges
+    /// features: both specs reach the solver. The workspace is named after
+    /// the file.
+    pub fn into_workspace_manifest(
+        &self,
+        implicit_platforms: Option<IndexSet<PixiPlatform>>,
+    ) -> Result<(WorkspaceManifest, Vec<Warning>), CondaScriptError> {
+        let ParsedBlock {
+            dependencies,
+            mut manifest,
+            ..
+        } = ParsedBlock::from_toml_str(&self.toml).map_err(|error| self.metadata_error(error))?;
+
+        let workspace = &mut manifest
+            .workspace
+            .as_mut()
+            .expect("the block parser always sets a workspace")
+            .value;
+        workspace.name = Some(self.name().to_owned());
+        if let Some(platforms) = implicit_platforms {
+            workspace.platforms = Spanned {
+                value: platforms,
+                span: Span::default(),
+            };
+        }
+
+        let pixi_dependencies = std::mem::replace(&mut manifest.dependencies, dependencies);
+        if let Some(pixi_dependencies) = pixi_dependencies {
+            let feature = TomlFeature {
+                dependencies: Some(pixi_dependencies),
+                ..TomlFeature::default()
+            };
+            manifest.feature = Some(PixiSpanned {
+                span: None,
+                value: IndexMap::from([(
+                    PixiSpanned {
+                        span: None,
+                        value: FeatureName::from(TOOL_PIXI_FEATURE.to_owned()),
+                    },
+                    feature,
+                )]),
+            });
+            manifest.environments = Some(PixiSpanned {
+                span: None,
+                value: IndexMap::from([(
+                    EnvironmentName::Default,
+                    TomlEnvironmentList::Seq(Spanned {
+                        value: vec![Spanned {
+                            value: TOOL_PIXI_FEATURE.to_owned(),
+                            span: Span::default(),
+                        }],
+                        span: Span::default(),
+                    }),
+                )]),
+            });
+        }
+
+        let root = self
             .path
+            .parent()
+            .expect("an absolute script path always has a parent");
+        let (workspace, package, warnings) = manifest
+            .into_workspace_manifest(
+                ExternalWorkspaceProperties::default(),
+                PackageDefaults::default(),
+                root,
+            )
+            .map_err(|error| self.metadata_error(error))?;
+        debug_assert!(package.is_none(), "a script never defines a package");
+        Ok((workspace, warnings))
+    }
+
+    /// The workspace name: the file stem, or `script` for a file without one.
+    fn name(&self) -> &str {
+        self.path
             .file_stem()
             .and_then(|stem| stem.to_str())
             .filter(|stem| !stem.is_empty())
-            .unwrap_or("script");
+            .unwrap_or("script")
+    }
 
-        let mut document = toml_edit::DocumentMut::new();
-        let mut workspace = toml_edit::Table::new();
-        workspace.insert("name", toml_edit::value(name));
-        workspace.insert("channels", channels);
-        workspace.insert(
-            "platforms",
-            toml_edit::Item::Value(toml_edit::Value::Array(toml_edit::Array::new())),
-        );
-        document.insert("workspace", toml_edit::Item::Table(workspace));
-
-        if let Some(dependencies) = dependencies {
-            document.insert("dependencies", dependencies);
-        }
-
-        if let Some(pixi_pypi_dependencies) = pixi_pypi_dependencies {
-            document.insert("pypi-dependencies", pixi_pypi_dependencies);
-        }
-
-        if pixi_dependencies.is_some() {
-            let mut tool_pixi = toml_edit::Table::new();
-            tool_pixi.set_implicit(true);
-            if let Some(pixi_dependencies) = pixi_dependencies {
-                tool_pixi.insert("dependencies", pixi_dependencies);
-            }
-            let mut feature = toml_edit::Table::new();
-            feature.set_implicit(true);
-            feature.insert("tool-pixi", toml_edit::Item::Table(tool_pixi));
-            document.insert("feature", toml_edit::Item::Table(feature));
-
-            let mut default = toml_edit::Array::new();
-            default.push("tool-pixi");
-            let mut environments = toml_edit::Table::new();
-            environments.insert(
-                "default",
-                toml_edit::Item::Value(toml_edit::Value::Array(default)),
-            );
-            document.insert("environments", toml_edit::Item::Table(environments));
-        }
-
-        Ok(document.to_string())
+    fn metadata_error(&self, error: TomlError) -> CondaScriptError {
+        Box::new(MetadataError {
+            error,
+            source: NamedSource::new(self.path.to_string_lossy(), Arc::clone(&self.source)),
+            source_map: self.source_map.clone(),
+        })
+        .into()
     }
 }
 
@@ -335,11 +421,13 @@ mod tests {
     use std::str::FromStr;
 
     use pixi_pypi_spec::PypiPackageName;
+    use pixi_spec::PixiSpec;
     use pixi_test_utils::format_diagnostic;
-    use rattler_conda_types::PackageName;
+    use rattler_conda_types::{PackageName, Platform};
 
     use super::super::Entrypoint;
     use super::*;
+    use crate::{KnownPreviewFlag, PixiPlatform, SpecType};
 
     /// A name for the source in diagnostics; `from_source` is given the
     /// contents directly and never reads this path.
@@ -500,6 +588,9 @@ mod tests {
 # [dependencies]
 # python = "3.13.*"
 #
+# [tool.pixi.workspace]
+# preview = ["pixi-build"]
+#
 # [tool.pixi.dependencies]
 # simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
 #
@@ -514,16 +605,114 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let pixi = &manifest.metadata().pixi;
-        let simple_app = pixi
-            .dependencies
+        let (workspace, warnings) = manifest.into_workspace_manifest(None).unwrap();
+        assert!(warnings.is_empty());
+        let target = workspace.default_feature().targets.default();
+        let simple_app = workspace
+            .feature(&FeatureName::from(TOOL_PIXI_FEATURE.to_owned()))
+            .unwrap()
+            .targets
+            .default()
+            .run_dependencies()
+            .unwrap()
             .get(&PackageName::new_unchecked("simple-app"))
             .unwrap();
-        assert!(simple_app.is_source());
+        assert!(simple_app.iter().any(PixiSpec::is_source));
         assert!(
-            pixi.pypi_dependencies
+            target
+                .pypi_dependencies
+                .as_ref()
+                .unwrap()
                 .contains_key(&PypiPackageName::from_str("requests").unwrap())
         );
+    }
+
+    #[test]
+    fn tool_pixi_tables_reach_the_workspace() {
+        let manifest = parse(
+            r#"# /// conda-script
+# channels = ["conda-forge"]
+# entrypoint = "python ${SCRIPT}"
+#
+# [tool.pixi.workspace]
+# platforms = ["linux-64", "win-64"]
+# exclude-newer = "2025-01-01"
+#
+# [tool.pixi.activation.env]
+# GREETING = "hello"
+#
+# [tool.pixi.constraints]
+# openssl = ">=3"
+#
+# [tool.pixi.exclude-newer]
+# zlib = "0d"
+#
+# [tool.pixi.target.win-64.dependencies]
+# vc = "*"
+# /// end-conda-script
+"#,
+        )
+        .unwrap()
+        .unwrap();
+
+        let (workspace, warnings) = manifest.into_workspace_manifest(None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(
+            workspace
+                .workspace
+                .platforms
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["linux-64", "win-64"]
+        );
+        assert!(workspace.workspace.exclude_newer.is_some());
+        assert!(
+            workspace
+                .workspace
+                .exclude_newer_package_overrides
+                .contains_key(&PackageName::new_unchecked("zlib"))
+        );
+        let feature = workspace.default_feature();
+        assert_eq!(
+            feature
+                .targets
+                .default()
+                .activation
+                .as_ref()
+                .and_then(|activation| activation.env.as_ref())
+                .and_then(|env| env.get("GREETING"))
+                .map(String::as_str),
+            Some("hello")
+        );
+        assert!(feature.targets.default().constraints.is_some());
+        let vc = PackageName::new_unchecked("vc");
+        let has_vc = |platform: Platform| {
+            feature
+                .run_dependencies(Some(&PixiPlatform::from(platform)))
+                .is_some_and(|dependencies| dependencies.contains_key(&vc))
+        };
+        assert!(has_vc(Platform::Win64));
+        assert!(!has_vc(Platform::Linux64));
+    }
+
+    #[test]
+    fn workspace_config_reports_declared_platforms() {
+        let implicit = parse(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# /// end-conda-script\n",
+        )
+        .unwrap()
+        .unwrap();
+        let config = implicit.workspace_config().unwrap();
+        assert!(config.channels_explicit);
+        assert!(!config.platforms_explicit);
+
+        let explicit = parse(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.workspace]\n# platforms = [\"linux-64\"]\n# /// end-conda-script\n",
+        )
+        .unwrap()
+        .unwrap();
+        assert!(explicit.workspace_config().unwrap().platforms_explicit);
     }
 
     #[test]
@@ -569,7 +758,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_a_synthetic_pixi_manifest() {
+    fn tool_pixi_dependencies_form_a_feature_of_the_default_environment() {
         let manifest = parse(
             r#"// /// conda-script
 // channels = ["conda-forge"]
@@ -579,62 +768,102 @@ mod tests {
 // python = "3.13.*"
 // simple-app = "0.1.*"
 // gcc = { version = "*", when = "__unix" }
-// pytorch = {
-//   version = ">=2.4",
-//   build = "*cuda*",
-// }
+//
+// [tool.pixi.workspace]
+// preview = ["pixi-build"]
 //
 // [tool.pixi.dependencies]
 // simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
-//
-// [tool.pixi.pypi-dependencies]
-// requests = ">=2"
 // /// end-conda-script
 "#,
         )
         .unwrap()
         .unwrap();
 
-        insta::assert_snapshot!(manifest.synthetic_manifest().unwrap(), @r##"
-        [workspace]
-        name = "example"
-        channels = ["conda-forge"]
-        platforms = []
+        let (workspace, warnings) = manifest.into_workspace_manifest(None).unwrap();
+        assert!(warnings.is_empty());
+        assert_eq!(workspace.workspace.name.as_deref(), Some("example"));
+        assert_eq!(
+            workspace
+                .workspace
+                .channels
+                .iter()
+                .map(|channel| channel.channel.to_string())
+                .collect::<Vec<_>>(),
+            ["conda-forge"]
+        );
+        assert!(workspace.workspace.platforms.is_empty());
+        assert!(
+            workspace
+                .workspace
+                .preview
+                .is_enabled(KnownPreviewFlag::PixiBuild)
+        );
 
-        [dependencies]
-        python = "3.13.*"
-        simple-app = "0.1.*"
-        gcc = { version = "*", when = "__unix" }
-        pytorch = {
-          version = ">=2.4",
-          build = "*cuda*",
-        }
+        let tool_pixi_feature = FeatureName::from(TOOL_PIXI_FEATURE.to_owned());
+        assert_eq!(workspace.environments.iter().count(), 1);
+        assert!(
+            workspace
+                .default_environment()
+                .features
+                .contains(&tool_pixi_feature)
+        );
 
-        [feature.tool-pixi.dependencies]
-        simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
-
-        [environments]
-        default = ["tool-pixi"]
-
-        [pypi-dependencies]
-        requests = ">=2"
-        "##);
+        let simple_app = PackageName::new_unchecked("simple-app");
+        let block = workspace.default_feature().targets.default();
+        assert!(block.has_dependency(&simple_app, SpecType::Run, None));
+        assert!(block.has_dependency(&PackageName::new_unchecked("gcc"), SpecType::Run, None));
+        let pixi = workspace
+            .feature(&tool_pixi_feature)
+            .unwrap()
+            .targets
+            .default();
+        assert!(
+            pixi.run_dependencies()
+                .unwrap()
+                .get(&simple_app)
+                .unwrap()
+                .iter()
+                .any(PixiSpec::is_source)
+        );
     }
 
     #[test]
-    fn a_synthetic_manifest_without_tool_pixi_has_no_feature() {
+    fn a_source_dependency_needs_the_declared_preview() {
+        let manifest = parse(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.dependencies]\n# simple-app = { git = \"https://github.com/prefix-dev/pixi-build-testsuite.git\" }\n# /// end-conda-script\n",
+        )
+        .unwrap()
+        .unwrap();
+
+        insta::assert_snapshot!(
+            format_diagnostic(&manifest.into_workspace_manifest(None).unwrap_err()),
+            @r#"
+         × conda source dependencies are not allowed without enabling the 'pixi-build' preview flag
+         ╰─▶ conda source dependencies are not allowed without enabling the 'pixi-build' preview flag
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:5:16]
+        4 │ # [tool.pixi.dependencies]
+        5 │ # simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git" }
+          ·                ─────────────────────────────────┬────────────────────────────────
+          ·                                                 ╰── source dependency specified here
+        6 │ # /// end-conda-script
+          ╰────
+         help: Run `pixi workspace preview add pixi-build` to enable the preview flag
+        "#
+        );
+    }
+
+    #[test]
+    fn a_block_without_tool_pixi_dependencies_has_only_the_default_feature() {
         let manifest = parse(
             "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# /// end-conda-script\n",
         )
         .unwrap()
         .unwrap();
 
-        insta::assert_snapshot!(manifest.synthetic_manifest().unwrap(), @r#"
-        [workspace]
-        name = "example"
-        channels = ["conda-forge"]
-        platforms = []
-        "#);
+        let (workspace, _) = manifest.into_workspace_manifest(None).unwrap();
+        assert_eq!(workspace.all_features().count(), 1);
+        assert_eq!(workspace.environments.iter().count(), 1);
     }
 
     #[test]
@@ -1019,15 +1248,87 @@ mod tests {
         insta::assert_snapshot!(parse_error(
             "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.tasks]\n# test = \"pytest\"\n# /// end-conda-script\n"
         ), @r#"
-         × conda-script blocks do not support `tool.pixi.tasks`
-         ╰─▶ conda-script blocks do not support `tool.pixi.tasks`
+         × scripts do not support `tool.pixi.tasks`
+         ╰─▶ scripts do not support `tool.pixi.tasks`
           ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:4:14]
         3 │ # entrypoint = "python ${SCRIPT}"
         4 │ # [tool.pixi.tasks]
           ·              ─────
         5 │ # test = "pytest"
           ╰────
-         help: a script represents one implicit default environment
+         help: a script represents one implicit default environment; `tool.pixi` accepts `activation`, `constraints`, `dependencies`, `exclude-newer`, `pypi-dependencies`, `pypi-exclude-newer`, `target`,
+               `workspace`
+        "#);
+    }
+
+    #[test]
+    fn errors_on_a_feature_table() {
+        insta::assert_snapshot!(parse_error(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.feature.test.dependencies]\n# pytest = \"*\"\n# [tool.pixi.environments]\n# test = [\"test\"]\n# /// end-conda-script\n"
+        ), @r#"
+         × scripts do not support `tool.pixi.feature` and `tool.pixi.environments`
+         ╰─▶ scripts do not support `tool.pixi.feature` and `tool.pixi.environments`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:4:14]
+        3 │ # entrypoint = "python ${SCRIPT}"
+        4 │ # [tool.pixi.feature.test.dependencies]
+          ·              ───────
+        5 │ # pytest = "*"
+        6 │ # [tool.pixi.environments]
+          ·              ────────────
+        7 │ # test = ["test"]
+          ╰────
+         help: a script represents one implicit default environment; `tool.pixi` accepts `activation`, `constraints`, `dependencies`, `exclude-newer`, `pypi-dependencies`, `pypi-exclude-newer`, `target`,
+               `workspace`
+        "#);
+    }
+
+    #[test]
+    fn errors_on_workspace_channels_in_tool_pixi() {
+        insta::assert_snapshot!(parse_error(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.workspace]\n# channels = [\"bioconda\"]\n# /// end-conda-script\n"
+        ), @r#"
+         × scripts do not support `tool.pixi.workspace.channels`
+         ╰─▶ scripts do not support `tool.pixi.workspace.channels`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:5:3]
+        4 │ # [tool.pixi.workspace]
+        5 │ # channels = ["bioconda"]
+          ·   ────────
+        6 │ # /// end-conda-script
+          ╰────
+         help: a conda-script block declares its channels at the top level
+        "#);
+    }
+
+    #[test]
+    fn errors_on_system_requirements() {
+        insta::assert_snapshot!(parse_error(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.system-requirements]\n# cuda = \"12\"\n# /// end-conda-script\n"
+        ), @r#"
+         × scripts do not support `tool.pixi.system-requirements`
+         ╰─▶ scripts do not support `tool.pixi.system-requirements`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:4:14]
+        3 │ # entrypoint = "python ${SCRIPT}"
+        4 │ # [tool.pixi.system-requirements]
+          ·              ───────────────────
+        5 │ # cuda = "12"
+          ╰────
+         help: a script without `platforms` resolves for the virtual packages of the machine it runs on; declare `platforms` with their virtual packages to pin a target instead
+        "#);
+    }
+
+    #[test]
+    fn typed_errors_in_tool_pixi_point_into_the_file() {
+        insta::assert_snapshot!(parse_error(
+            "# /// conda-script\n# channels = [\"conda-forge\"]\n# entrypoint = \"python ${SCRIPT}\"\n# [tool.pixi.dependencies]\n# bad-package = \"!invalid!\"\n# /// end-conda-script\n"
+        ), @r#"
+         × invalid operator '!'
+         ╰─▶ invalid operator '!'
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.c:5:18]
+        4 │ # [tool.pixi.dependencies]
+        5 │ # bad-package = "!invalid!"
+          ·                  ─────────
+        6 │ # /// end-conda-script
+          ╰────
         "#);
     }
 

--- a/crates/pixi_manifest/src/script/conda/metadata.rs
+++ b/crates/pixi_manifest/src/script/conda/metadata.rs
@@ -1,18 +1,28 @@
-use std::{fmt::Display, hash::Hash, str::FromStr};
+use std::str::FromStr;
 
 use indexmap::IndexMap;
 use itertools::Itertools;
-use pixi_pypi_spec::{PixiPypiSpec, PypiPackageName};
 use pixi_spec::PixiSpec;
 use pixi_toml::{TomlFromStr, TomlWith, custom_error, custom_error_message_with_help};
 use rattler_conda_types::{NamedChannelOrUrl, PackageName, VersionSpec};
 use toml_span::{
-    DeserError, ErrorKind, Spanned, Value,
+    DeserError, ErrorKind, Span, Spanned, Value,
     de_helpers::{TableHelper, expected},
-    value::ValueInner,
+    value::{Key, Table, ValueInner},
 };
 
 use super::entrypoint::Entrypoint;
+use crate::{
+    ManifestKind, PackageDependencySpec, PrioritizedChannel, TomlError,
+    discovery::{RequiresPixiCheck, check_requires_pixi_early},
+    script::tool_pixi::{ScriptKind, validate_tool_pixi},
+    toml::{TomlManifest, TomlWorkspace},
+    utils::{
+        PixiSpanned,
+        inheritable_package_map::{InheritablePackageMap, InheritableSpec},
+        package_map::DependencyTable,
+    },
+};
 
 /// The dependency keys the `conda-script` specification allows.
 const ALLOWED_DEPENDENCY_KEYS: &[&str] = &[
@@ -34,7 +44,7 @@ const ALLOWED_DEPENDENCY_KEYS: &[&str] = &[
 /// also allows `when`, which pixi cannot attach to a URL spec yet.
 const URL_COMPATIBLE_KEYS: &[&str] = &["url", "md5", "sha256"];
 
-/// The parsed content of a `conda-script` block.
+/// The fields of a `conda-script` block that the specification defines.
 #[derive(Debug, Clone)]
 pub struct CondaScriptMetadata {
     /// The conda channels the dependencies are solved from.
@@ -43,31 +53,26 @@ pub struct CondaScriptMetadata {
     pub entrypoint: Entrypoint,
     /// The conda dependencies declared in `[dependencies]`.
     pub dependencies: IndexMap<PackageName, PixiSpec>,
-    /// The pixi-specific configuration under `[tool.pixi]`.
-    pub pixi: PixiTool,
 }
 
-/// The `[tool.pixi]` table of a `conda-script` block.
-#[derive(Debug, Clone, Default)]
-pub struct PixiTool {
-    /// Conda dependencies in pixi's native spec syntax. They merge with the
-    /// `[dependencies]` table the way pixi merges features: both specs reach
-    /// the solver.
-    pub dependencies: IndexMap<PackageName, PixiSpec>,
-    /// PyPI packages added to the environment.
-    pub pypi_dependencies: IndexMap<PypiPackageName, PixiPypiSpec>,
+/// A block parsed into the specification's fields and the manifest pixi
+/// builds the environment from.
+pub(crate) struct ParsedBlock {
+    pub(crate) metadata: CondaScriptMetadata,
+    pub(crate) requires_pixi: RequiresPixiCheck,
+    /// `[dependencies]` in the shape of a manifest dependency table, with
+    /// spans pointing into the block.
+    pub(crate) dependencies: Option<PixiSpanned<DependencyTable>>,
+    /// `tool.pixi` parsed as a manifest whose workspace carries the block's
+    /// channels.
+    pub(crate) manifest: TomlManifest,
 }
 
-impl CondaScriptMetadata {
-    pub(crate) fn from_toml_str(text: &str) -> Result<Self, DeserError> {
+impl ParsedBlock {
+    pub(crate) fn from_toml_str(text: &str) -> Result<Self, TomlError> {
         let mut value = toml_span::parse(text)?;
-        <Self as toml_span::Deserialize>::deserialize(&mut value)
-    }
-}
-
-impl<'de> toml_span::Deserialize<'de> for CondaScriptMetadata {
-    fn deserialize(value: &mut Value<'de>) -> Result<Self, DeserError> {
-        let mut th = TableHelper::new(value)?;
+        let requires_pixi = check_requires_pixi_early(&value, ManifestKind::CondaScript);
+        let mut th = TableHelper::new(&mut value)?;
         let mut errors = DeserError { errors: Vec::new() };
 
         let channels = th
@@ -82,26 +87,30 @@ impl<'de> toml_span::Deserialize<'de> for CondaScriptMetadata {
         let entrypoint = th.required::<Entrypoint>("entrypoint").ok();
 
         let dependencies = match th.take("dependencies") {
-            Some((_, mut value)) => match dependency_table(&mut value, conda_script_spec) {
-                Ok(dependencies) => dependencies,
-                Err(table_errors) => {
-                    errors.merge(table_errors);
-                    IndexMap::new()
+            Some((_, mut value)) => {
+                let span = value.span;
+                match dependency_table(&mut value) {
+                    Ok(dependencies) => Some((span, dependencies)),
+                    Err(table_errors) => {
+                        errors.merge(table_errors);
+                        None
+                    }
                 }
-            },
-            None => IndexMap::new(),
+            }
+            None => None,
         };
 
         let pixi = match th.take("tool") {
-            Some((_, mut value)) => match tool_table(&mut value) {
+            Some((_, mut tool)) => match pixi_tool_value(&mut tool) {
                 Ok(pixi) => pixi,
                 Err(tool_errors) => {
                     errors.merge(tool_errors);
-                    PixiTool::default()
+                    None
                 }
             },
-            None => PixiTool::default(),
+            None => None,
         };
+        let pixi = pixi.unwrap_or_else(|| Value::new(ValueInner::Table(Table::new())));
 
         if let Err(finalize_errors) = th.finalize(None) {
             errors.merge(finalize_errors);
@@ -124,41 +133,59 @@ impl<'de> toml_span::Deserialize<'de> for CondaScriptMetadata {
         }
 
         if !errors.errors.is_empty() {
-            return Err(errors);
+            return Err(errors.into());
         }
+        validate_tool_pixi(&pixi, ScriptKind::CondaScript)?;
+
+        let channels: Vec<NamedChannelOrUrl> = channels
+            .expect("missing channels were reported above")
+            .value
+            .into_iter()
+            .map(|channel| channel.value)
+            .collect();
+        let manifest = tool_pixi_manifest(pixi, &channels).map_err(TomlError::from)?;
+        let (dependencies, specs) = match dependencies {
+            Some((span, dependencies)) => (
+                Some(PixiSpanned {
+                    span: Some(span.start..span.end),
+                    value: dependencies.table,
+                }),
+                dependencies.specs,
+            ),
+            None => (None, IndexMap::new()),
+        };
 
         Ok(Self {
-            channels: channels
-                .expect("missing channels were reported above")
-                .value
-                .into_iter()
-                .map(|channel| channel.value)
-                .collect(),
-            entrypoint: entrypoint.expect("a missing entrypoint was reported above"),
+            requires_pixi,
+            metadata: CondaScriptMetadata {
+                channels,
+                entrypoint: entrypoint.expect("a missing entrypoint was reported above"),
+                dependencies: specs,
+            },
             dependencies,
-            pixi,
+            manifest,
         })
     }
 }
 
-/// Parses a `name = <spec>` table, rejecting names that collide after
+/// The block's `[dependencies]`, both as plain specs and as a manifest
+/// dependency table.
+struct BlockDependencies {
+    specs: IndexMap<PackageName, PixiSpec>,
+    table: DependencyTable,
+}
+
+/// Parses `[dependencies]`, rejecting names that collide after
 /// normalization.
-fn dependency_table<'de, Name, Spec>(
-    value: &mut Value<'de>,
-    parse_spec: impl Fn(&mut Value<'de>) -> Result<Spec, DeserError>,
-) -> Result<IndexMap<Name, Spec>, DeserError>
-where
-    Name: FromStr + Hash + Eq + Clone,
-    Name::Err: Display,
-{
+fn dependency_table(value: &mut Value<'_>) -> Result<BlockDependencies, DeserError> {
     let table = match value.take() {
         ValueInner::Table(table) => table,
         inner => return Err(expected("a table", inner, value.span).into()),
     };
 
     let mut errors = DeserError { errors: Vec::new() };
-    let mut result: IndexMap<Name, Spec> = IndexMap::new();
-    let mut name_spans: IndexMap<Name, toml_span::Span> = IndexMap::new();
+    let mut specs = IndexMap::new();
+    let mut manifest_table = InheritablePackageMap::default();
     for (key, mut value) in table.into_iter().sorted_by_key(|(key, _)| key.span.start) {
         if key.name.is_empty() {
             errors.errors.push(custom_error(
@@ -167,7 +194,7 @@ where
             ));
             continue;
         }
-        let name = match Name::from_str(&key.name) {
+        let name = match PackageName::from_str(&key.name) {
             Ok(name) => name,
             Err(_) => {
                 errors.errors.push(custom_error(
@@ -180,28 +207,44 @@ where
                 continue;
             }
         };
-        if let Some(first) = name_spans.get(&name) {
+        if let Some(first) = manifest_table.name_spans.get(&name) {
             errors.errors.push(toml_span::Error {
                 kind: ErrorKind::DuplicateKey {
                     key: key.name.into_owned(),
-                    first: *first,
+                    first: Span::new(first.start, first.end),
                 },
                 span: key.span,
                 line_info: None,
             });
             continue;
         }
-        name_spans.insert(name.clone(), key.span);
-        match parse_spec(&mut value) {
+        let value_span = value.span;
+        match conda_script_spec(&mut value) {
             Ok(spec) => {
-                result.insert(name, spec);
+                manifest_table.specs.insert(
+                    name.clone(),
+                    InheritableSpec::Direct(Box::new(PackageDependencySpec::from(spec.clone()))),
+                );
+                manifest_table
+                    .name_spans
+                    .insert(name.clone(), key.span.start..key.span.end);
+                manifest_table
+                    .value_spans
+                    .insert(name.clone(), value_span.start..value_span.end);
+                specs.insert(name, spec);
             }
             Err(spec_errors) => errors.merge(spec_errors),
         }
     }
 
     if errors.errors.is_empty() {
-        Ok(result)
+        Ok(BlockDependencies {
+            specs,
+            table: DependencyTable {
+                specs: manifest_table,
+                ..DependencyTable::default()
+            },
+        })
     } else {
         Err(errors)
     }
@@ -278,83 +321,57 @@ fn conda_script_spec(value: &mut Value<'_>) -> Result<PixiSpec, DeserError> {
     Ok(spec)
 }
 
-/// Parses the `[tool]` table: `pixi` is interpreted, every other tool's
-/// table is ignored without looking inside it.
-fn tool_table(value: &mut Value<'_>) -> Result<PixiTool, DeserError> {
-    let table = match value.take() {
+/// Takes `pixi` out of the `[tool]` table; every other tool's table is
+/// ignored without looking inside it.
+fn pixi_tool_value<'de>(tool: &mut Value<'de>) -> Result<Option<Value<'de>>, DeserError> {
+    let table = match tool.take() {
         ValueInner::Table(table) => table,
-        inner => return Err(expected("a table", inner, value.span).into()),
+        inner => return Err(expected("a table", inner, tool.span).into()),
     };
-
-    for (key, mut value) in table {
-        if key.name == "pixi" {
-            return pixi_tool_table(&mut value);
-        }
-    }
-    Ok(PixiTool::default())
+    Ok(table
+        .into_iter()
+        .find(|(key, _)| key.name == "pixi")
+        .map(|(_, pixi)| pixi))
 }
 
-fn pixi_tool_table(value: &mut Value<'_>) -> Result<PixiTool, DeserError> {
-    let mut th = TableHelper::new(value)?;
-    let mut errors = DeserError { errors: Vec::new() };
-
-    let dependencies = match th.take("dependencies") {
-        Some((_, mut value)) => {
-            match dependency_table(
-                &mut value,
-                <PixiSpec as toml_span::Deserialize>::deserialize,
-            ) {
-                Ok(dependencies) => dependencies,
-                Err(table_errors) => {
-                    errors.merge(table_errors);
-                    IndexMap::new()
+/// Parses `tool.pixi` with the manifest parser and gives its workspace the
+/// block's channels.
+///
+/// The workspace parser requires `channels`, which a block declares at its
+/// top level instead; a placeholder satisfies the parser until the block's
+/// channels replace it.
+fn tool_pixi_manifest(
+    mut pixi: Value<'_>,
+    channels: &[NamedChannelOrUrl],
+) -> Result<TomlManifest, DeserError> {
+    if let ValueInner::Table(mut table) = pixi.take() {
+        if let Some(workspace) = table.get_mut("workspace") {
+            match workspace.take() {
+                ValueInner::Table(mut workspace_table) => {
+                    workspace_table.insert(
+                        Key {
+                            name: "channels".into(),
+                            span: Span::default(),
+                        },
+                        Value::new(ValueInner::Array(Vec::new())),
+                    );
+                    workspace.set(ValueInner::Table(workspace_table));
                 }
+                other => workspace.set(other),
             }
         }
-        None => IndexMap::new(),
-    };
-
-    let pypi_dependencies = match th.take("pypi-dependencies") {
-        Some((_, mut value)) => {
-            match dependency_table(
-                &mut value,
-                <PixiPypiSpec as toml_span::Deserialize>::deserialize,
-            ) {
-                Ok(dependencies) => dependencies,
-                Err(table_errors) => {
-                    errors.merge(table_errors);
-                    IndexMap::new()
-                }
-            }
-        }
-        None => IndexMap::new(),
-    };
-
-    // Put the unclaimed keys back so each can be reported as unsupported.
-    if let Err(finalize_errors) = th.finalize(Some(value)) {
-        errors.merge(finalize_errors);
-    }
-    if let Some(table) = value.as_table() {
-        for key in table.keys().sorted_by_key(|key| key.span.start) {
-            errors.errors.push(custom_error(
-                custom_error_message_with_help(
-                    &format!(
-                        "conda-script blocks do not support `tool.pixi.{}`",
-                        key.name
-                    ),
-                    "a script represents one implicit default environment",
-                ),
-                key.span,
-            ));
-        }
+        pixi.set(ValueInner::Table(table));
     }
 
-    if errors.errors.is_empty() {
-        Ok(PixiTool {
-            dependencies,
-            pypi_dependencies,
-        })
-    } else {
-        Err(errors)
-    }
+    let mut manifest = <TomlManifest as toml_span::Deserialize>::deserialize(&mut pixi)?;
+    let workspace = manifest.workspace.get_or_insert_with(|| PixiSpanned {
+        span: None,
+        value: TomlWorkspace::default(),
+    });
+    workspace.value.channels = channels
+        .iter()
+        .cloned()
+        .map(PrioritizedChannel::from)
+        .collect();
+    Ok(manifest)
 }

--- a/crates/pixi_manifest/src/script/conda/mod.rs
+++ b/crates/pixi_manifest/src/script/conda/mod.rs
@@ -18,5 +18,5 @@ pub use document::CondaScriptManifestDocument;
 pub use entrypoint::{Entrypoint, EntrypointSelector};
 pub use error::{CondaScriptError, EnvelopeError, MetadataError};
 pub use manifest::CondaScriptManifest;
-pub use metadata::{CondaScriptMetadata, PixiTool};
+pub use metadata::CondaScriptMetadata;
 pub use templates::{CondaScriptTemplate, supported_extensions, template_for_extension};

--- a/crates/pixi_manifest/src/script/mod.rs
+++ b/crates/pixi_manifest/src/script/mod.rs
@@ -4,11 +4,13 @@
 //! files use the standardized PEP 723 `script` block, while files of any
 //! language can use the `conda-script` block. The `block` module
 //! holds the machinery both kinds share: comment-prefix stripping, source
-//! maps for diagnostics, and serializing edits back into the block.
+//! maps for diagnostics, and serializing edits back into the block. The
+//! `tool_pixi` module holds the subset of `tool.pixi` both kinds accept.
 
 mod block;
 pub mod conda;
 mod pep723;
+mod tool_pixi;
 
 pub use pep723::{
     ScriptManifest, ScriptManifestDocument, ScriptManifestError, ScriptMetadataError,

--- a/crates/pixi_manifest/src/script/pep723.rs
+++ b/crates/pixi_manifest/src/script/pep723.rs
@@ -9,9 +9,12 @@ use miette::{Diagnostic, LabeledSpan, NamedSource, SourceCode};
 use thiserror::Error;
 use toml_edit::{Array, DocumentMut, Item, Table, Value};
 
-use super::block::{
-    BlockSourceMap, LineEnding, MetadataLine, extract_script_header, serialize_block,
-    without_line_ending,
+use super::{
+    block::{
+        BlockSourceMap, LineEnding, MetadataLine, extract_script_header, serialize_block,
+        without_line_ending,
+    },
+    tool_pixi::{ScriptKind, UnsupportedKey, finish, unsupported_tool_pixi_keys},
 };
 use crate::{
     TomlError, Warning, WorkspaceManifest,
@@ -526,7 +529,7 @@ fn inline_pyproject(
 ) -> Result<InlinePyProject, ScriptManifestError> {
     let metadata = script.metadata();
     let metadata_document = script.metadata_document()?;
-    validate_subset(&metadata_document)?;
+    validate_subset(script)?;
 
     let mut prefix = format!("[project]\nname = {}\n", Value::from(project_name));
     if !metadata_document.contains_key("dependencies") {
@@ -568,103 +571,38 @@ fn ensure_pixi_workspace(pyproject: &mut DocumentMut) -> Result<(), ScriptManife
     Ok(())
 }
 
-fn validate_subset(metadata: &DocumentMut) -> Result<(), ScriptManifestError> {
-    let unsupported_root = metadata
-        .as_table()
-        .iter()
-        .map(|(key, _)| key)
-        .filter(|key| !matches!(*key, "dependencies" | "requires-python" | "tool"))
-        .map(str::to_owned)
-        .collect::<Vec<_>>();
-    if !unsupported_root.is_empty() {
-        return Err(ScriptManifestError::UnsupportedFields(unsupported_root));
-    }
-
-    let Some(pixi) = metadata
-        .get("tool")
-        .and_then(Item::as_table_like)
-        .and_then(|tool| tool.get("pixi"))
-        .and_then(Item::as_table_like)
-    else {
+/// Rejects metadata outside the subset pixi interprets: the two portable
+/// fields and the script subset of `tool.pixi`.
+fn validate_subset(script: &ScriptManifest) -> Result<(), ScriptManifestError> {
+    let metadata = toml_span::parse(script.metadata())
+        .map_err(|error| script.metadata_error(error.into(), 0))?;
+    let Some(table) = metadata.as_table() else {
         return Ok(());
     };
 
-    // Reported on its own, ahead of the generic sweep: the machine's virtual
-    // packages already reach a script that declares no `platforms`, and a
-    // script that declares them carries its requirements on the platform.
-    if pixi.contains_key("system-requirements") {
-        return Err(ScriptManifestError::SystemRequirementsUnsupported);
+    let mut keys = table
+        .keys()
+        .filter(|key| !matches!(key.name.as_ref(), "dependencies" | "requires-python" | "tool"))
+        .map(|key| {
+            UnsupportedKey::new(
+                key.name.as_ref(),
+                "a PEP 723 block holds `dependencies`, `requires-python` and `tool`; pixi-specific settings go under `tool.pixi`",
+                key.span,
+            )
+        })
+        .collect::<Vec<_>>();
+    if let Some(pixi) = table
+        .get("tool")
+        .and_then(toml_span::Value::as_table)
+        .and_then(|tool| tool.get("pixi"))
+    {
+        keys.extend(
+            unsupported_tool_pixi_keys(pixi, ScriptKind::Pep723)
+                .map_err(|error| script.metadata_error(error, 0))?,
+        );
     }
 
-    let mut unsupported = unsupported_keys(
-        pixi,
-        "tool.pixi",
-        &[
-            "activation",
-            "constraints",
-            "dependencies",
-            "pypi-dependencies",
-            "target",
-            "workspace",
-        ],
-    );
-
-    if let Some(workspace) = pixi.get("workspace").and_then(Item::as_table_like) {
-        unsupported.extend(unsupported_keys(
-            workspace,
-            "tool.pixi.workspace",
-            &[
-                "channel-priority",
-                "channels",
-                "platforms",
-                "preview",
-                "pypi-options",
-                "requires-pixi",
-                "solve-strategy",
-            ],
-        ));
-    }
-
-    if let Some(targets) = pixi.get("target").and_then(Item::as_table_like) {
-        for (selector, target) in targets.iter() {
-            let path = format!("tool.pixi.target.{selector}");
-            let Some(target) = target.as_table_like() else {
-                unsupported.push(path);
-                continue;
-            };
-            unsupported.extend(unsupported_keys(
-                target,
-                &path,
-                &[
-                    "activation",
-                    "constraints",
-                    "dependencies",
-                    "pypi-dependencies",
-                ],
-            ));
-        }
-    }
-
-    if unsupported.is_empty() {
-        Ok(())
-    } else {
-        unsupported.sort();
-        unsupported.dedup();
-        Err(ScriptManifestError::UnsupportedFields(unsupported))
-    }
-}
-
-fn unsupported_keys(
-    table: &dyn toml_edit::TableLike,
-    prefix: &str,
-    allowed: &[&str],
-) -> Vec<String> {
-    table
-        .iter()
-        .map(|(key, _)| key)
-        .filter(|key| !allowed.contains(key))
-        .map(|key| format!("{prefix}.{key}"))
-        .collect()
+    finish(keys).map_err(|error| script.metadata_error(error, 0))
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -696,16 +634,6 @@ pub enum ScriptManifestError {
 
     #[error("the editable script document is missing its project table")]
     InvalidEditableDocument,
-
-    #[error("PEP 723 scripts do not support: {}", .0.join(", "))]
-    #[diagnostic(help("A script represents one implicit default environment."))]
-    UnsupportedFields(Vec<String>),
-
-    #[error("PEP 723 scripts do not support `[tool.pixi.system-requirements]`")]
-    #[diagnostic(help(
-        "a script without `platforms` is resolved for the virtual packages of the machine it runs on. To pin a target instead, run `pixi workspace platform add --script <PATH> --auto-detect`"
-    ))]
-    SystemRequirementsUnsupported,
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -1093,9 +1021,18 @@ print("hello")
         assert_eq!(manifest.environments.iter().count(), 1);
     }
 
+    /// The diagnostic for a block whose `tool.pixi` leaves the script
+    /// subset, rendered against the script.
+    fn subset_error(contents: &str) -> String {
+        let script = ScriptManifest::from_source(example_script_path(), contents.as_bytes())
+            .unwrap()
+            .unwrap();
+        format_diagnostic(&script.into_workspace_manifest().unwrap_err())
+    }
+
     #[test]
     fn rejects_workspace_only_concepts() {
-        let (_directory, path) = script(
+        insta::assert_snapshot!(subset_error(
             r#"# /// script
 # dependencies = []
 #
@@ -1104,34 +1041,30 @@ print("hello")
 #
 # [tool.pixi.feature.test.dependencies]
 # pytest = "*"
-#
-# [tool.pixi.target.linux-64.host-dependencies]
-# python = "*"
 # ///
-"#,
-        );
-
-        let error = ScriptManifest::from_path(path)
-            .unwrap()
-            .unwrap()
-            .into_workspace_manifest()
-            .unwrap_err();
-        let ScriptManifestError::UnsupportedFields(fields) = error else {
-            panic!("unexpected error: {error}");
-        };
-        assert_eq!(
-            fields,
-            [
-                "tool.pixi.feature",
-                "tool.pixi.target.linux-64.host-dependencies",
-                "tool.pixi.target.linux-64.tasks"
-            ]
-        );
+"#
+        ), @r#"
+         × scripts do not support `tool.pixi.target.linux-64.tasks` and `tool.pixi.feature`
+         ╰─▶ scripts do not support `tool.pixi.target.linux-64.tasks` and `tool.pixi.feature`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.py:4:30]
+        3 │ #
+        4 │ # [tool.pixi.target.linux-64.tasks]
+          ·                              ─────
+        5 │ # test = "pytest"
+        6 │ #
+        7 │ # [tool.pixi.feature.test.dependencies]
+          ·              ───────
+        8 │ # pytest = "*"
+          ╰────
+         help: a script represents one implicit default environment; `tool.pixi.target.linux-64` accepts `activation`, `constraints`, `dependencies`, `pypi-dependencies`
+               a script represents one implicit default environment; `tool.pixi` accepts `activation`, `constraints`, `dependencies`, `exclude-newer`, `pypi-dependencies`, `pypi-exclude-newer`, `target`,
+               `workspace`
+        "#);
     }
 
     #[test]
     fn rejects_unknown_pixi_fields_with_an_explicit_allowlist() {
-        let (_directory, path) = script(
+        insta::assert_snapshot!(subset_error(
             r#"# /// script
 # dependencies = []
 #
@@ -1139,50 +1072,103 @@ print("hello")
 # channels = []
 # platforms = []
 # description = "not execution metadata"
-#
-# [tool.pixi.target.linux-64.tasks]
-# test = "pytest"
 # ///
-"#,
-        );
+"#
+        ), @r#"
+         × scripts do not support `tool.pixi.workspace.description`
+         ╰─▶ scripts do not support `tool.pixi.workspace.description`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.py:7:3]
+        6 │ # platforms = []
+        7 │ # description = "not execution metadata"
+          ·   ───────────
+        8 │ # ///
+          ╰────
+         help: a script represents one implicit default environment; `tool.pixi.workspace` accepts `channel-priority`, `conda-pypi-map`, `exclude-newer`, `platforms`, `preview`, `pypi-options`, `requires-
+               pixi`, `solve-strategy`
+        "#);
+    }
 
-        let error = ScriptManifest::from_path(path)
-            .unwrap()
-            .unwrap()
-            .into_workspace_manifest()
-            .unwrap_err();
-        let ScriptManifestError::UnsupportedFields(fields) = error else {
-            panic!("unexpected error: {error}");
-        };
-        assert_eq!(
-            fields,
-            [
-                "tool.pixi.target.linux-64.tasks",
-                "tool.pixi.workspace.description"
-            ]
-        );
+    #[test]
+    fn rejects_unknown_top_level_fields() {
+        insta::assert_snapshot!(subset_error(
+            r#"# /// script
+# dependencies = []
+# platforms = ["linux-64"]
+# ///
+"#
+        ), @r#"
+         × scripts do not support `platforms`
+         ╰─▶ scripts do not support `platforms`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.py:3:3]
+        2 │ # dependencies = []
+        3 │ # platforms = ["linux-64"]
+          ·   ─────────
+        4 │ # ///
+          ╰────
+         help: a PEP 723 block holds `dependencies`, `requires-python` and `tool`; pixi-specific settings go under `tool.pixi`
+        "#);
     }
 
     #[test]
     fn rejects_system_requirements() {
-        let (_directory, path) = script(
+        insta::assert_snapshot!(subset_error(
             r#"# /// script
 # dependencies = []
 #
 # [tool.pixi.system-requirements]
 # cuda = "12"
 # ///
+"#
+        ), @r#"
+         × scripts do not support `tool.pixi.system-requirements`
+         ╰─▶ scripts do not support `tool.pixi.system-requirements`
+          ╭─[<CARGO_ROOT>/crates/pixi_manifest/example.py:4:14]
+        3 │ #
+        4 │ # [tool.pixi.system-requirements]
+          ·              ───────────────────
+        5 │ # cuda = "12"
+          ╰────
+         help: a script without `platforms` resolves for the virtual packages of the machine it runs on; declare `platforms` with their virtual packages to pin a target instead
+        "#);
+    }
+
+    #[test]
+    fn accepts_resolver_options_and_exclude_newer_tables() {
+        let (_directory, path) = script(
+            r#"# /// script
+# dependencies = []
+#
+# [tool.pixi.workspace]
+# channels = ["conda-forge"]
+# exclude-newer = "2025-01-01"
+# conda-pypi-map = { conda-forge = "mapping.json" }
+#
+# [tool.pixi.dependencies]
+# zlib = "*"
+#
+# [tool.pixi.exclude-newer]
+# zlib = "0d"
+#
+# [tool.pixi.pypi-exclude-newer]
+# requests = "0d"
+# ///
 "#,
         );
 
-        let error = ScriptManifest::from_path(path)
-            .unwrap()
-            .unwrap()
-            .into_workspace_manifest()
-            .unwrap_err();
+        let script = ScriptManifest::from_path(path).unwrap().unwrap();
+        let (manifest, _) = script.into_workspace_manifest().unwrap();
+        assert!(manifest.workspace.exclude_newer.is_some());
         assert!(
-            matches!(error, ScriptManifestError::SystemRequirementsUnsupported),
-            "unexpected error: {error}"
+            manifest
+                .workspace
+                .exclude_newer_package_overrides
+                .contains_key(&PackageName::from_str("zlib").unwrap())
+        );
+        assert!(
+            manifest
+                .workspace
+                .pypi_exclude_newer_package_overrides
+                .contains_key(&PypiPackageName::from_str("requests").unwrap())
         );
     }
 

--- a/crates/pixi_manifest/src/script/tool_pixi.rs
+++ b/crates/pixi_manifest/src/script/tool_pixi.rs
@@ -1,0 +1,213 @@
+//! The subset of `tool.pixi` a script block may carry.
+//!
+//! A script represents one implicit default environment, so the tables that
+//! shape a workspace with several environments, packages or tasks have no
+//! meaning in it. Both block kinds share this allowlist; they only differ in
+//! where channels are declared.
+
+use itertools::Itertools;
+use miette::{LabeledSpan, SourceSpan};
+use toml_span::{Span, Value, value::Table};
+
+use crate::{GenericError, TomlError};
+
+/// The keys `tool.pixi` accepts in a script block.
+const TOOL_PIXI_KEYS: &[&str] = &[
+    "activation",
+    "constraints",
+    "dependencies",
+    "exclude-newer",
+    "pypi-dependencies",
+    "pypi-exclude-newer",
+    "target",
+    "workspace",
+];
+
+/// The keys `tool.pixi.workspace` accepts in a script block, `channels`
+/// aside.
+const WORKSPACE_KEYS: &[&str] = &[
+    "channel-priority",
+    "conda-pypi-map",
+    "exclude-newer",
+    "platforms",
+    "preview",
+    "pypi-options",
+    "requires-pixi",
+    "solve-strategy",
+];
+
+/// The keys `tool.pixi.target.<selector>` accepts in a script block.
+const TARGET_KEYS: &[&str] = &[
+    "activation",
+    "constraints",
+    "dependencies",
+    "pypi-dependencies",
+];
+
+const ONE_ENVIRONMENT: &str = "a script represents one implicit default environment";
+
+/// The kind of block `tool.pixi` sits in, which decides where channels live.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScriptKind {
+    /// Channels are declared under `tool.pixi.workspace`.
+    Pep723,
+    /// Channels are declared at the top level of the block.
+    CondaScript,
+}
+
+/// A key a script block cannot hold.
+pub(crate) struct UnsupportedKey {
+    path: String,
+    span: Span,
+    help: String,
+}
+
+impl UnsupportedKey {
+    pub(crate) fn new(path: impl Into<String>, help: impl Into<String>, span: Span) -> Self {
+        Self {
+            path: path.into(),
+            span,
+            help: help.into(),
+        }
+    }
+}
+
+/// Rejects every key of `tool.pixi` outside the script subset, reporting
+/// all of them in one diagnostic.
+pub(crate) fn validate_tool_pixi(pixi: &Value<'_>, kind: ScriptKind) -> Result<(), TomlError> {
+    finish(unsupported_tool_pixi_keys(pixi, kind)?)
+}
+
+/// The keys of `tool.pixi` outside the script subset.
+///
+/// Fails only when `tool.pixi` is not a table.
+pub(crate) fn unsupported_tool_pixi_keys(
+    pixi: &Value<'_>,
+    kind: ScriptKind,
+) -> Result<Vec<UnsupportedKey>, TomlError> {
+    let Some(table) = pixi.as_table() else {
+        return Err(GenericError::new("`tool.pixi` must be a table")
+            .with_span(pixi.span.start..pixi.span.end)
+            .into());
+    };
+
+    let mut keys = Vec::new();
+    for (key, value) in table {
+        let path = format!("tool.pixi.{}", key.name);
+        match key.name.as_ref() {
+            "system-requirements" => keys.push(UnsupportedKey::new(
+                path,
+                "a script without `platforms` resolves for the virtual packages of the machine it runs on; declare `platforms` with their virtual packages to pin a target instead",
+                key.span,
+            )),
+            "workspace" => {
+                if let Some(workspace) = value.as_table() {
+                    keys.extend(unsupported_workspace_keys(workspace, &path, kind));
+                }
+            }
+            "target" => {
+                if let Some(targets) = value.as_table() {
+                    for (selector, target) in targets {
+                        if let Some(target) = target.as_table() {
+                            let path = format!("{path}.{}", selector.name);
+                            keys.extend(unsupported_keys(target, &path, TARGET_KEYS));
+                        }
+                    }
+                }
+            }
+            name if TOOL_PIXI_KEYS.contains(&name) => {}
+            _ => keys.push(UnsupportedKey::new(
+                path,
+                accepted_keys_help("tool.pixi", TOOL_PIXI_KEYS),
+                key.span,
+            )),
+        }
+    }
+    Ok(keys)
+}
+
+fn unsupported_workspace_keys(
+    workspace: &Table<'_>,
+    path: &str,
+    kind: ScriptKind,
+) -> Vec<UnsupportedKey> {
+    workspace
+        .keys()
+        .filter_map(|key| match key.name.as_ref() {
+            "channels" => match kind {
+                ScriptKind::Pep723 => None,
+                ScriptKind::CondaScript => Some(UnsupportedKey::new(
+                    format!("{path}.channels"),
+                    "a conda-script block declares its channels at the top level",
+                    key.span,
+                )),
+            },
+            name if WORKSPACE_KEYS.contains(&name) => None,
+            name => Some(UnsupportedKey::new(
+                format!("{path}.{name}"),
+                accepted_keys_help(path, WORKSPACE_KEYS),
+                key.span,
+            )),
+        })
+        .collect()
+}
+
+/// Every key of `table` outside `allowed`, reported with the path it was
+/// found under.
+pub(crate) fn unsupported_keys(
+    table: &Table<'_>,
+    path: &str,
+    allowed: &[&str],
+) -> Vec<UnsupportedKey> {
+    table
+        .keys()
+        .filter(|key| !allowed.contains(&key.name.as_ref()))
+        .map(|key| {
+            UnsupportedKey::new(
+                format!("{path}.{}", key.name),
+                accepted_keys_help(path, allowed),
+                key.span,
+            )
+        })
+        .collect()
+}
+
+fn accepted_keys_help(table: &str, allowed: &[&str]) -> String {
+    format!(
+        "{ONE_ENVIRONMENT}; `{table}` accepts {}",
+        allowed.iter().map(|key| format!("`{key}`")).join(", ")
+    )
+}
+
+/// Turns the collected keys into one diagnostic that underlines each of
+/// them in source order, with the help of every distinct reason.
+pub(crate) fn finish(mut keys: Vec<UnsupportedKey>) -> Result<(), TomlError> {
+    if keys.is_empty() {
+        return Ok(());
+    }
+    keys.sort_by_key(|key| key.span.start);
+
+    let paths = keys
+        .iter()
+        .map(|key| format!("`{}`", key.path))
+        .collect_vec();
+    let listed = match paths.split_last() {
+        Some((last, [])) => last.clone(),
+        Some((last, rest)) => format!("{} and {last}", rest.join(", ")),
+        None => unreachable!("the list of keys is not empty"),
+    };
+    let labels = keys.iter().map(|key| {
+        LabeledSpan::new_primary_with_span(
+            None,
+            SourceSpan::new(key.span.start.into(), key.span.end - key.span.start),
+        )
+    });
+    let help = keys.iter().map(|key| key.help.as_str()).unique().join("\n");
+
+    Err(
+        GenericError::new(format!("scripts do not support {listed}"))
+            .with_labels(labels)
+            .with_help(help)
+            .into(),
+    )
+}

--- a/crates/pixi_manifest/src/toml/mod.rs
+++ b/crates/pixi_manifest/src/toml/mod.rs
@@ -32,7 +32,7 @@ pub use manifest::TomlManifest;
 use miette::LabeledSpan;
 pub use package::{PackageDefaults, PackageError, TomlPackage, WorkspacePackageProperties};
 pub use platform::{InlineVirtualPackage, TomlPlatform, inline_virtual_package_specs};
-pub use preview::TomlPreview;
+pub use preview::{KnownOrUnknownPreviewFlag, TomlPreview};
 pub use pyproject::PyProjectToml;
 pub use run_exports::TomlRunExports;
 pub use target::TomlTarget;

--- a/crates/pixi_manifest/src/toml/workspace.rs
+++ b/crates/pixi_manifest/src/toml/workspace.rs
@@ -92,7 +92,7 @@ pub struct TomlWorkspaceTarget {
 }
 
 /// The TOML representation of the `[[workspace]]` section in a pixi manifest.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TomlWorkspace {
     // In TOML the workspace name can be empty. It is a required field though, but this is enforced
     // when converting the TOML model to the actual manifest. When using a PyProject we want to use

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -71,12 +71,21 @@ PEP 723 defines two portable fields:
 Pixi reads those fields and extends them with a focused subset of
 `tool.pixi`:
 
-- `tool.pixi.workspace` configures channels, platforms, and resolver options.
+- `tool.pixi.workspace` configures channels, platforms, and resolver options
+  such as `exclude-newer`, `channel-priority` or `solve-strategy`.
 - `tool.pixi.dependencies` lists Conda packages.
 - `tool.pixi.pypi-dependencies` represents PyPI requirements that need
   Pixi-specific fields, such as an index or editable installation.
+- `tool.pixi.constraints` and `tool.pixi.activation` hold constraints and
+  activation settings.
 - `tool.pixi.target.<platform>` holds platform-specific dependencies,
   constraints, and activation settings.
+- `tool.pixi.exclude-newer` and `tool.pixi.pypi-exclude-newer` override the
+  cutoff date per package.
+
+Every other key under `tool.pixi` is rejected with an error pointing at it,
+since a script has one implicit environment and no features, tasks or
+packages.
 
 Other PEP 723 tools can use the portable fields and ignore `tool.pixi`. In the
 example above, another tool can install `httpx`, but only Pixi also provides

--- a/docs/tutorials/conda_script.md
+++ b/docs/tutorials/conda_script.md
@@ -180,11 +180,22 @@ The entrypoint runs in the directory `pixi run` was invoked from, so relative pa
 
 ## Pixi-specific configuration
 
-Tables under `[tool.*]` belong to the named tool. Pixi reads `[tool.pixi]`
-the same way as in a `pyproject.toml`, restricted to one implicit
-environment: `[tool.pixi.dependencies]` for specs in pixi's native syntax,
-including [source dependencies](../build/dependency_types.md), and
-`[tool.pixi.pypi-dependencies]` for PyPI packages.
+Tables under `[tool.*]` belong to the named tool.
+Pixi reads `[tool.pixi]` the same way as in a `pyproject.toml`, restricted to what one implicit environment needs.
+[PEP 723 scripts](../python/scripts.md) accept the same subset:
+
+- `[tool.pixi.dependencies]` holds conda specs in pixi's native syntax, including [source dependencies](../build/dependency_types.md), which need the `pixi-build` preview declared under `[tool.pixi.workspace]`.
+- `[tool.pixi.pypi-dependencies]` holds PyPI packages.
+- `[tool.pixi.constraints]`, `[tool.pixi.activation]` and `[tool.pixi.target.<platform>]` hold constraints, activation settings and platform-specific dependencies.
+- `[tool.pixi.exclude-newer]` and `[tool.pixi.pypi-exclude-newer]` override the cutoff date per package.
+- `[tool.pixi.workspace]` holds resolver options: `platforms`, `channel-priority`, `solve-strategy`, `exclude-newer`, `conda-pypi-map`, `pypi-options`, `preview` and `requires-pixi`.
+  Channels stay in the block's `channels`, so `tool.pixi.workspace.channels` is rejected.
+
+A script without `platforms` resolves for the machine it runs on.
+Declaring them pins the script to those platforms, which lets `pixi lock --script` produce a lock file for other machines.
+
+Every other key is rejected with an error pointing at it: features, environments, tasks and package sections have no meaning in a single implicit environment.
+The deprecated `system-requirements` table is rejected too, since a script either takes the virtual packages of the machine or declares them on its `platforms`.
 
 `[tool.pixi.dependencies]` merges with `[dependencies]` the way pixi merges features: every spec applies.
 A source dependency there composes with a version constraint in `[dependencies]`, so tools that only implement the conda-script specification still see a solvable script:
@@ -192,6 +203,9 @@ A source dependency there composes with a version constraint in `[dependencies]`
 ```toml
 [dependencies]
 simple-app = "0.1.*"
+
+[tool.pixi.workspace]
+preview = ["pixi-build"]
 
 [tool.pixi.dependencies]
 simple-app = { git = "https://github.com/prefix-dev/pixi-build-testsuite.git", subdirectory = "tests/data/pixi_build/minimal-backend-workspaces/pixi-build-python" }

--- a/tests/integration_python/test_conda_script.py
+++ b/tests/integration_python/test_conda_script.py
@@ -175,6 +175,44 @@ def test_entrypoint_syntax_errors_are_reported(pixi: Path, tmp_pixi_workspace: P
     )
 
 
+def test_requires_pixi_is_enforced(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "requires-pixi.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "echo ok"
+#
+# [tool.pixi.workspace]
+# requires-pixi = ">=999"
+# /// end-conda-script
+""")
+
+    verify_cli_command(
+        [pixi, "workspace", "platform", "list", "--script", script, "--json"],
+        ExitCode.FAILURE,
+        stderr_contains=[
+            "this project requires pixi '>=999'",
+            "this version requirement is not satisfied",
+        ],
+    )
+
+
+def test_implicit_platform_accepts_matching_target(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "target.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "echo ok"
+#
+# [tool.pixi.target.{CURRENT_PLATFORM}.dependencies]
+# zlib = "*"
+# /// end-conda-script
+""")
+
+    verify_cli_command(
+        [pixi, "workspace", "platform", "list", "--script", script, "--json"],
+        stderr_excludes="does not match any of the platforms supported by the workspace",
+    )
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(sys.platform == "win32", reason="signals are a Unix concept")
 def test_a_signal_sent_to_pixi_reaches_the_entrypoint(pixi: Path, tmp_pixi_workspace: Path) -> None:
@@ -290,6 +328,91 @@ sys.exit(1)
         cwd=tmp_pixi_workspace,
     )
     assert not (tmp_pixi_workspace / "marker").exists()
+
+
+SOURCE_DEPENDENCY_BLOCK = f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "simple-app"
+#
+# [dependencies]
+# simple-app = "{{version}}"
+#
+# [tool.pixi.workspace]
+# preview = ["pixi-build"]
+#
+# [tool.pixi.dependencies]
+# simple-app = {{{{ git = "https://github.com/prefix-dev/pixi-build-testsuite.git", subdirectory = "tests/data/pixi_build/minimal-backend-workspaces/pixi-build-python" }}}}
+# /// end-conda-script
+"""
+
+
+@pytest.mark.slow
+def test_a_binary_spec_constrains_a_source_dependency(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """Both specs of the package reach the solver: the source spec in
+    `[tool.pixi.dependencies]` provides the candidate and the binary spec in
+    `[dependencies]` constrains its version. The preview declared under
+    `[tool.pixi.workspace]` lets the source dependency build."""
+    script = tmp_pixi_workspace / "source.code"
+    script.write_text(SOURCE_DEPENDENCY_BLOCK.format(version="0.1.*"))
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        stdout_contains="Build backend works",
+    )
+
+    script.write_text(SOURCE_DEPENDENCY_BLOCK.format(version="0.2.*"))
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains="0.2",
+    )
+
+
+@pytest.mark.slow
+def test_tool_pixi_tables_shape_the_environment(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """`tool.pixi` is read like a manifest: activation applies to the
+    entrypoint and the workspace options reach the solver."""
+    script = tmp_pixi_workspace / "tool.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python -c \\"import os; print(os.environ['GREETING'])\\""
+#
+# [dependencies]
+# python = "3.13.*"
+#
+# [tool.pixi.workspace]
+# exclude-newer = "2030-01-01"
+#
+# [tool.pixi.activation.env]
+# GREETING = "hello from tool.pixi"
+# /// end-conda-script
+""")
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        stdout_contains="hello from tool.pixi",
+    )
+
+
+def test_run_rejects_workspace_only_tables(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    script = tmp_pixi_workspace / "feature.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}}"
+#
+# [tool.pixi.feature.test.dependencies]
+# pytest = "*"
+# /// end-conda-script
+""")
+
+    verify_cli_command(
+        [pixi, "run", "--experimental", "--script", script],
+        ExitCode.FAILURE,
+        stderr_contains=[
+            "scripts do not support `tool.pixi.feature`",
+            "one implicit default environment",
+        ],
+    )
 
 
 @pytest.mark.slow
@@ -456,3 +579,28 @@ def test_add_then_remove_pypi_round_trips(pixi: Path, tmp_pixi_workspace: Path) 
 
     verify_cli_command([pixi, "remove", "--script", script, "--no-install", "--pypi", "six"])
     assert "six" not in script.read_text()
+
+
+def test_remove_edits_the_block_dependencies(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    """The block's `[dependencies]` are the default feature, which is where
+    `pixi remove` looks for a conda dependency."""
+    script = tmp_pixi_workspace / "remove.code"
+    script.write_text(f"""# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}}"
+#
+# [dependencies]
+# python = "3.13.*"
+# zlib = "*"
+#
+# [tool.pixi.activation.env]
+# GREETING = "kept"
+# /// end-conda-script
+""")
+
+    verify_cli_command([pixi, "remove", "--script", script, "--no-install", "zlib"])
+
+    contents = script.read_text()
+    assert "zlib" not in contents
+    assert '# python = "3.13.*"' in contents
+    assert '# GREETING = "kept"' in contents


### PR DESCRIPTION
- PEP 723 and conda-script blocks accept the same subset of `tool.pixi`:
  - `activation`
  - `constraints`
  - `dependencies`
  - `pypi-dependencies`
  - `target`
  - `workspace`
  - `exclude-newer`
  - `pypi-exclude-newer`
- `tool.pixi.workspace` takes the resolver options and now also `exclude-newer` and `conda-pypi-map`.
- Everything else (`feature`, `environments`, `tasks`, `package`, the deprecated `system-requirements`, ...) is rejected with one diagnostic that underlines every offending key in the script and lists what the table accepts. The PEP 723 error used to be a plain list without locations
- Docs for both script kinds list the subset

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude


