### PR TITLE
chore: bump version to v0.79.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### [0.79.0] - 2026-09-03
+#### ✨ Highlights
+
+Pixi now has better support for RISC-V by setting the default virtual packages.
+
+And we've extended the CLI to include `pixi install --script` and `pixi workspace dependencies add`.
+
+#### Added
+
+- Add `pixi workspace dependencies` CLI by @ruben-arts in [#6917](https://github.com/prefix-dev/pixi/pull/6917)
+- Install script environments without running by @manzt in [#6923](https://github.com/prefix-dev/pixi/pull/6923)
+- Set `__glibc` default to 2.39 on linux-riscv64 by @pavelzw in [#6914](https://github.com/prefix-dev/pixi/pull/6914)
+
+
+#### Changed
+
+- Restore static MSVC CRT in Windows builds by @baszalmstra in [#6919](https://github.com/prefix-dev/pixi/pull/6919)
+
+
+#### Documentation
+
+- Mention named platforms in pixi-pack by @pavelzw in [#6927](https://github.com/prefix-dev/pixi/pull/6927)
+
+
+#### Fixed
+
+- Bump astral_async_http_range_reader to 0.11.1 by @baszalmstra in [#6941](https://github.com/prefix-dev/pixi/pull/6941)
+
+
+
 ### [0.78.0] - 2026-08-28
 #### ✨ Highlights
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,8 @@ authors:
   - given-names: Julian
     family-names: Hofer
     email: julian.hofer@protonmail.com
-repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.78.0'
-url: 'https://pixi.sh/v0.78.0'
+repository-code: 'https://github.com/prefix-dev/pixi/releases/tag/v0.79.0'
+url: 'https://pixi.sh/v0.79.0'
 abstract: >-
   A cross-platform, language agnostic, package/project
   management tool for development in virtual environments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5967,7 +5967,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "astral-reqwest-middleware",
  "async-trait",

--- a/crates/pixi/Cargo.toml
+++ b/crates/pixi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pixi"
-version = "0.78.0"
+version = "0.79.0"
 authors.workspace = true
 edition.workspace = true
 description = "A package management and workflow tool"

--- a/crates/pixi_consts/src/consts.rs
+++ b/crates/pixi_consts/src/consts.rs
@@ -16,7 +16,7 @@ pub const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 pub const CONFIG_FILE: &str = "config.toml";
 pub const PIXI_VERSION: &str = match option_env!("PIXI_VERSION") {
     Some(v) => v,
-    None => "0.78.0",
+    None => "0.79.0",
 };
 pub const PREFIX_FILE_NAME: &str = "pixi_env_prefix";
 pub const ENVIRONMENTS_DIR: &str = "envs";

--- a/docs/deployment/container.md
+++ b/docs/deployment/container.md
@@ -31,7 +31,7 @@ It also makes use of `pixi shell-hook` to not rely on Pixi being installed in th
     For more examples, take a look at [pavelzw/pixi-docker-example](https://github.com/pavelzw/pixi-docker-example).
 
 ```Dockerfile
-FROM ghcr.io/prefix-dev/pixi:0.78.0 AS build
+FROM ghcr.io/prefix-dev/pixi:0.79.0 AS build
 
 # copy source code, pixi.toml and pixi.lock to the container
 WORKDIR /app

--- a/docs/integration/ci/github_actions.md
+++ b/docs/integration/ci/github_actions.md
@@ -10,7 +10,7 @@ We created [prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi) to 
 ```yaml
 - uses: prefix-dev/setup-pixi@v0.10.0
   with:
-    pixi-version: v0.78.0
+    pixi-version: v0.79.0
     cache: true
     auth-host: prefix.dev
     auth-token: ${{ secrets.PREFIX_DEV_TOKEN }}

--- a/docs/integration/editor/vscode.md
+++ b/docs/integration/editor/vscode.md
@@ -42,7 +42,7 @@ Then, create the following two files in the `.devcontainer` directory:
 ```dockerfile title=".devcontainer/Dockerfile"
 FROM mcr.microsoft.com/devcontainers/base:jammy
 
-ARG PIXI_VERSION=v0.78.0
+ARG PIXI_VERSION=v0.79.0
 
 RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
     && chmod +x /usr/local/bin/pixi \

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -22,7 +22,7 @@
 .LINK
     https://github.com/prefix-dev/pixi
 .NOTES
-    Version: v0.78.0
+    Version: v0.79.0
 #>
 param (
     [string] $PixiVersion = 'latest',

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -eu
-# Version: v0.78.0
+# Version: v0.79.0
 
 __wrap__() {
     # Function to mask username and password in URLs for safe printing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ quote-style = "double"
 github_url = "https://github.com/prefix-dev/pixi"
 
 [tool.tbump.version]
-current = "0.78.0"
+current = "0.79.0"
 
 # Example of a semver regexp.
 # Make sure this matches current_version before

--- a/schema/pyproject/partial-pixi.json
+++ b/schema/pyproject/partial-pixi.json
@@ -266,7 +266,7 @@
       "description": "The workspace's metadata information"
     }
   },
-  "$comment": "Generated from `pixi` v0.78.0",
+  "$comment": "Generated from `pixi` v0.79.0",
   "$defs": {
     "Activation": {
       "title": "Activation",

--- a/schema/pyproject/schema.json
+++ b/schema/pyproject/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.78.0/schema/manifest/pyproject/schema.json",
+  "$id": "https://pixi.sh/v0.79.0/schema/manifest/pyproject/schema.json",
   "title": "`pyproject.toml` manifest file for `pixi`",
   "description": "A `pyproject.toml` with `[tool.pixi]`.",
   "type": "object",

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://pixi.sh/v0.78.0/schema/manifest/schema.json",
+  "$id": "https://pixi.sh/v0.79.0/schema/manifest/schema.json",
   "title": "`pixi.toml` manifest file",
   "description": "The configuration for a [`pixi`](https://pixi.sh) project.",
   "type": "object",
@@ -10,7 +10,7 @@
       "title": "Schema",
       "description": "The schema identifier for the project's configuration",
       "type": "string",
-      "default": "https://pixi.sh/v0.78.0/schema/manifest/schema.json",
+      "default": "https://pixi.sh/v0.79.0/schema/manifest/schema.json",
       "format": "uri-reference"
     },
     "activation": {

--- a/tests/integration_python/common.py
+++ b/tests/integration_python/common.py
@@ -15,7 +15,7 @@ from rattler import Platform
 # Regex pattern to match ANSI escape sequences
 ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 
-PIXI_VERSION = "0.78.0"
+PIXI_VERSION = "0.79.0"
 
 
 ALL_PLATFORMS = '["linux-64", "osx-64", "osx-arm64", "win-64", "linux-ppc64le", "linux-aarch64"]'


### PR DESCRIPTION
### [0.79.0] - 2026-09-03
#### ✨ Highlights

Pixi now has better support for RISC-V by setting the default virtual packages.

And we've extended the CLI to include `pixi install --script` and `pixi workspace dependencies add`.

#### Added

- Add `pixi workspace dependencies` CLI by @ruben-arts in [#6917](https://github.com/prefix-dev/pixi/pull/6917)
- Install script environments without running by @manzt in [#6923](https://github.com/prefix-dev/pixi/pull/6923)
- Set `__glibc` default to 2.39 on linux-riscv64 by @pavelzw in [#6914](https://github.com/prefix-dev/pixi/pull/6914)


#### Changed

- Restore static MSVC CRT in Windows builds by @baszalmstra in [#6919](https://github.com/prefix-dev/pixi/pull/6919)


#### Documentation

- Mention named platforms in pixi-pack by @pavelzw in [#6927](https://github.com/prefix-dev/pixi/pull/6927)


#### Fixed

- Bump astral_async_http_range_reader to 0.11.1 by @baszalmstra in [#6941](https://github.com/prefix-dev/pixi/pull/6941)