### PR TITLE
fix(tasks): stop doubling backslashes in quoted task arguments

### DIFF
--- a/crates/pixi_manifest/src/task.rs
+++ b/crates/pixi_manifest/src/task.rs
@@ -876,9 +876,11 @@ pub fn quote(in_str: &str) -> Cow<'_, str> {
         let mut out: String = String::with_capacity(in_str.len() + 2);
         out.push('"');
         for c in in_str.chars() {
-            match c {
-                '"' | '\\' => out.push('\\'),
-                _ => (),
+            // Only `"` is escaped. `deno_task_shell` does not unescape `\\` to
+            // `\` inside double quotes the way POSIX shells do, so escaping a
+            // backslash here would deliver two of them to the process (#5054).
+            if c == '"' {
+                out.push('\\');
             }
             out.push(c);
         }
@@ -1118,6 +1120,14 @@ mod tests {
             "PATH=\"$PATH;build/Debug\""
         );
         assert_eq!(quote("name=[64,64]"), "\"name=[64,64]\"");
+        // `deno_task_shell` keeps a backslash literal inside double quotes, so
+        // it must be emitted as-is rather than doubled (#5054).
+        assert_eq!(quote("a\\d+ b"), "\"a\\d+ b\"");
+        assert_eq!(
+            quote("C:\\Users\\me\\My Documents"),
+            "\"C:\\Users\\me\\My Documents\""
+        );
+        assert_eq!(quote("both \\ and \" here"), "\"both \\ and \\\" here\"");
     }
 
     #[test]


### PR DESCRIPTION
### Description

`quote` escapes a backslash as `\\`, but `deno_task_shell` -- the reader at the other end -- does not unescape `\\` back to `\` inside double quotes the way POSIX shells do, so every literal backslash in a quoted argument reaches the process twice.

Same root cause as #5054. The fix for the CLI-arg path (#5063) added `join_args_with_single_quotes`, whose doc comment names this behaviour, but the manifest `cmd = [...]` path still goes through `quote`. Single-quoting isn't a drop-in here -- `quote` deliberately keeps `$` expandable (`test_quote` pins `quote("$PATH") == "$PATH"`) -- so this escapes only `"`, which deno does unescape.

`cmd = ["grep", "-E", 'a\d+ b']` reaches grep as `a\\d+ b`; `'C:\Users\me\My Documents'` loses every separator. `pixi task add` persists the same output.

### How Has This Been Tested?

`cargo test -p pixi_manifest`: 610 passed, 1 failed (`tojson_stays_json`), identical on pristine `main` here. Reverting only the source change fails the new `test_quote` assertions.

Corpus round-tripped through the pinned `deno_task_shell` 0.33.3 parser: current 4 ok / 4 wrong / 2 parse-error; this PR 8 ok / 0 wrong / 2 parse-error. Those 2 are values *ending* in a backslash -- unrepresentable in a deno double-quoted string, failing identically before and after.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (claude-opus-5)

### Checklist:
- [x] I have added sufficient tests to cover my changes.
