### PR TITLE
perf: build Linux x64 releases with PGO

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - windows_arm64_2025_large
     - windows_x64_2025_large
     - namespace-profile-*
+    - nscloud-*
 
 paths:
   .github/workflows/release.yml:

--- a/.github/workflows/pgo.yml
+++ b/.github/workflows/pgo.yml
@@ -1,0 +1,81 @@
+name: PGO
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/pgo.yml"
+      - ".github/workflows/release.yml"
+      - "scripts/build_pgo.py"
+      - "scripts/pgo/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+  CARGO_PROFILE_RELEASE_LTO: "fat"
+  CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
+  CARGO_PROFILE_RELEASE_STRIP: symbols
+
+jobs:
+  build:
+    name: Build ${{ matrix.mode }} binary
+    runs-on: nscloud-ubuntu-24.04-amd64-16x32
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [baseline, pgo]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ matrix.mode == 'baseline' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
+        with:
+          environments: release
+          activate-environment: true
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: "1.95.0"
+          target: x86_64-unknown-linux-musl
+          cache: false
+          rustflags: ""
+
+      - name: Set build options
+        run: pixi run -e release build-options --target x86_64-unknown-linux-musl
+
+      - name: Install LLVM tools
+        if: matrix.mode == 'pgo'
+        run: rustup component add llvm-tools-preview
+
+      - name: Build baseline binary
+        if: matrix.mode == 'baseline'
+        run: |
+          cargo zigbuild \
+            --locked \
+            --release \
+            --manifest-path crates/pixi/Cargo.toml \
+            --features self_update,performance \
+            --bin pixi \
+            --target x86_64-unknown-linux-musl
+
+      - name: Build PGO binary
+        if: matrix.mode == 'pgo'
+        run: python scripts/build_pgo.py
+
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pixi-linux-x86_64-${{ matrix.mode }}-${{ github.sha }}
+          path: target/x86_64-unknown-linux-musl/release/pixi
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            runner: namespace-profile-ubuntu-24-04-x86-64-8
+            runner: nscloud-ubuntu-24.04-amd64-16x32
             builder: zigbuild
           - target: aarch64-unknown-linux-musl
             runner: 8core_ubuntu_latest_runner
@@ -122,7 +122,16 @@ jobs:
       - name: Set build options
         run: pixi run -e release build-options --target ${{ matrix.target }}
 
+      - name: Install LLVM tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: rustup component add llvm-tools-preview
+
+      - name: Build with PGO
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: python scripts/build_pgo.py
+
       - name: Build
+        if: matrix.target != 'x86_64-unknown-linux-musl'
         shell: bash
         env:
           CARGO_PROFILE_RELEASE_LTO: fat

--- a/scripts/build_pgo.py
+++ b/scripts/build_pgo.py
@@ -1,0 +1,199 @@
+"""Build the Linux x86-64 release binary with profile-guided optimization."""
+
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TARGET = "x86_64-unknown-linux-musl"
+ZIG_TARGET = "x86_64-linux-musl"
+TRAINING_MANIFEST = ROOT / "scripts" / "pgo" / "pixi.toml"
+
+CARGO_ARGS = [
+    "--locked",
+    "--release",
+    "--manifest-path",
+    str(ROOT / "crates" / "pixi" / "Cargo.toml"),
+    "--features",
+    "self_update,performance",
+    "--bin",
+    "pixi",
+    "--target",
+    TARGET,
+]
+
+
+def run(command: list[str], *, env: dict[str, str], quiet: bool = False) -> None:
+    if quiet:
+        result = subprocess.run(command, env=env, text=True, capture_output=True)
+        if result.returncode == 0:
+            return
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, command)
+
+    subprocess.run(command, env=env, check=True)
+
+
+def rust_host() -> str:
+    output = subprocess.check_output(["rustc", "-vV"], text=True)
+    for line in output.splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise RuntimeError("rustc did not report its host target")
+
+
+def llvm_profdata() -> Path:
+    sysroot = Path(subprocess.check_output(["rustc", "--print", "sysroot"], text=True).strip())
+    executable = sysroot / "lib" / "rustlib" / rust_host() / "bin" / "llvm-profdata"
+    if not executable.is_file():
+        raise FileNotFoundError(
+            f"{executable} not found; install it with `rustup component add llvm-tools-preview`"
+        )
+    return executable
+
+
+def encoded_rustflags(profile_flag: str) -> str:
+    if encoded_flags := os.environ.get("CARGO_ENCODED_RUSTFLAGS"):
+        return f"{encoded_flags}\x1f{profile_flag}"
+    return "\x1f".join([*shlex.split(os.environ.get("RUSTFLAGS", "")), profile_flag])
+
+
+def write_zig_wrapper(path: Path, compiler: str) -> None:
+    # Zig 0.16 treats rustc's `-u __llvm_profile_runtime` as an input file.
+    # Passing the same option directly to the linker keeps the PGO runtime alive.
+    path.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+rewritten=()
+while (($#)); do
+  if [[ "$1" == "-u" && $# -ge 2 ]]; then
+    rewritten+=("-Wl,-u,$2")
+    shift 2
+  else
+    rewritten+=("$1")
+    shift
+  fi
+done
+exec cargo-zigbuild zig {compiler} -- -g -fno-sanitize=all -target {ZIG_TARGET} "${{rewritten[@]}}"
+"""
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def instrumented_build(target_dir: Path, profile_dir: Path, working_dir: Path) -> Path:
+    wrappers = working_dir / "wrappers"
+    wrappers.mkdir(parents=True)
+    cc_wrapper = wrappers / "zigcc"
+    cxx_wrapper = wrappers / "zigcxx"
+    ar_wrapper = wrappers / "zigar"
+    write_zig_wrapper(cc_wrapper, "cc")
+    write_zig_wrapper(cxx_wrapper, "c++")
+    ar_wrapper.write_text(
+        '#!/usr/bin/env bash\nset -euo pipefail\nexec cargo-zigbuild zig ar -- "$@"\n'
+    )
+    ar_wrapper.chmod(ar_wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    target_env_name = TARGET.replace("-", "_")
+    env = os.environ.copy()
+    env.pop("RUSTFLAGS", None)
+    env.update(
+        {
+            "CARGO_INCREMENTAL": "0",
+            "CARGO_TARGET_DIR": str(target_dir),
+            "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER": str(cc_wrapper),
+            f"CC_{target_env_name}": str(cc_wrapper),
+            f"CXX_{target_env_name}": str(cxx_wrapper),
+            f"AR_{target_env_name}": str(ar_wrapper),
+            "CARGO_ENCODED_RUSTFLAGS": encoded_rustflags(f"-Cprofile-generate={profile_dir}"),
+        }
+    )
+    run(["cargo", "build", *CARGO_ARGS], env=env)
+    return target_dir / TARGET / "release" / "pixi"
+
+
+def train(binary: Path, profile_dir: Path, working_dir: Path) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "LLVM_PROFILE_FILE": str(profile_dir / "pixi-%m-%p.profraw"),
+            "PIXI_CACHE_DIR": str(working_dir / "cache"),
+            "PIXI_HOME": str(working_dir / "home"),
+            "PIXI_NO_CONFIG": "true",
+            "PIXI_NO_PROGRESS": "true",
+            "PIXI_COLOR": "never",
+        }
+    )
+    manifest = str(TRAINING_MANIFEST)
+    workloads = [
+        ["--version"],
+        ["--help"],
+        ["task", "list", "-m", manifest],
+        ["workspace", "environment", "list", "-m", manifest],
+        ["lock", "--dry-run", "-m", manifest],
+        ["shell-hook", "--as-is", "-m", manifest],
+        ["global", "list"],
+    ]
+    for arguments in workloads:
+        run([str(binary), *arguments], env=env, quiet=True)
+
+
+def optimized_build(target_dir: Path, profile_data: Path) -> Path:
+    env = os.environ.copy()
+    env.pop("RUSTFLAGS", None)
+    env.update(
+        {
+            "CARGO_INCREMENTAL": "0",
+            "CARGO_TARGET_DIR": str(target_dir),
+            "CARGO_ENCODED_RUSTFLAGS": encoded_rustflags(f"-Cprofile-use={profile_data}"),
+        }
+    )
+    run(["cargo", "zigbuild", *CARGO_ARGS], env=env)
+    return target_dir / TARGET / "release" / "pixi"
+
+
+def main() -> None:
+    if shutil.which("cargo-zigbuild") is None:
+        raise FileNotFoundError("cargo-zigbuild is required")
+    if not TRAINING_MANIFEST.is_file():
+        raise FileNotFoundError(TRAINING_MANIFEST)
+
+    target_dir = Path(os.environ.get("CARGO_TARGET_DIR", ROOT / "target")).resolve()
+    working_dir = target_dir / "pgo"
+    instrumented_target_dir = working_dir / "instrumented"
+    optimized_target_dir = working_dir / "optimized"
+    profile_dir = working_dir / "profiles"
+    profile_data = working_dir / "pixi.profdata"
+
+    shutil.rmtree(working_dir, ignore_errors=True)
+    profile_dir.mkdir(parents=True)
+
+    print("Building instrumented Pixi binary")
+    instrumented_binary = instrumented_build(instrumented_target_dir, profile_dir, working_dir)
+
+    print("Training instrumented Pixi binary")
+    train(instrumented_binary, profile_dir, working_dir)
+
+    print("Merging PGO profiles")
+    raw_profiles = list(profile_dir.glob("*.profraw"))
+    if not raw_profiles:
+        raise RuntimeError("training did not produce any PGO profiles")
+    subprocess.run(
+        [str(llvm_profdata()), "merge", "--output", str(profile_data), *raw_profiles],
+        check=True,
+    )
+
+    print("Building PGO-optimized Pixi binary")
+    optimized_binary = optimized_build(optimized_target_dir, profile_data)
+    binary = target_dir / TARGET / "release" / "pixi"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(optimized_binary, binary)
+    print(binary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pgo/pixi.toml
+++ b/scripts/pgo/pixi.toml
@@ -1,0 +1,37 @@
+[workspace]
+name = "pixi-pgo-training"
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
+
+[dependencies]
+python = "3.13.*"
+numpy = "*"
+pandas = "*"
+scipy = "*"
+scikit-learn = "*"
+matplotlib = "*"
+jupyterlab = "*"
+fastapi = "*"
+uvicorn = "*"
+pytest = "*"
+ruff = "*"
+
+[feature.analysis.dependencies]
+dask = "*"
+xarray = "*"
+polars = "*"
+
+[feature.docs.dependencies]
+sphinx = "*"
+myst-parser = "*"
+furo = "*"
+
+[environments]
+default = []
+analysis = ["analysis"]
+docs = ["docs"]
+full = ["analysis", "docs"]
+
+[tasks]
+check = "ruff check ."
+test = "pytest"


### PR DESCRIPTION
## Description

Use LLVM PGO for the x86_64 Linux release. The training workload covers startup, workspace discovery, lock solving, shell activation, and global state.

The instrumented build needs the 32 GB runner. It was killed for running out of memory on the previous 16 GB runner.

## Results

Compared the baseline and PGO artifacts from [CI run 33892861548](https://github.com/prefix-dev/pixi/actions/runs/33892861548):

| Metric | Baseline | PGO | Change |
| --- | ---: | ---: | ---: |
| Representative suite, wall time | — | — | -10.2% |
| Representative suite, CPU time | — | — | -6.4% |
| Held-out solve, wall time | 1,009.89 ms | 822.23 ms | -18.6% |
| Held-out solve, CPU time | 3,691.91 ms | 3,331.37 ms | -9.8% |
| Binary size | 79.98 MB | 64.73 MB | -19.1% |
| Gzip size | 34.16 MB | 29.17 MB | -14.6% |
| CI build job | 16m 55s | 38m 50s | 2.3x |

Times are medians from alternating runs in WSL. The suite result is the equal-weight geometric mean across version, help, task listing, environment listing, and a held-out multi-platform solve.

## Testing

- PGO artifact workflow completed successfully
- actionlint on both changed workflows
- Ruff and ty on scripts/build_pgo.py
- Exercised the training corpus and Zig linker wrapper.