### PR TITLE
fix(pixi-build-rust): scope cross-compile C flags

### DIFF
--- a/crates/pixi_build_rust/src/build_script.j2
+++ b/crates/pixi_build_rust/src/build_script.j2
@@ -30,6 +30,16 @@ if exist "%PREFIX%\Library\include\openssl" {{ export("OPENSSL_DIR", env("PREFIX
 {{ export("RUSTC_WRAPPER", "sccache") }}
 {%- endif %}
 
+{# cc-rs concatenates generic flags into both host and target compilations.
+   During cross-compilation conda's generic flags belong only to the target. -#}
+{% if is_bash -%}
+if [ "$BUILD" != "$HOST" ]; then
+    export TARGET_CFLAGS="$CFLAGS${TARGET_CFLAGS:+ $TARGET_CFLAGS}"
+    export TARGET_CXXFLAGS="$CXXFLAGS${TARGET_CXXFLAGS:+ $TARGET_CXXFLAGS}"
+    unset CFLAGS CXXFLAGS
+fi
+{% endif -%}
+
 {{ export("CARGO", bin_path ~ "cargo") }}
 {{ export("RUSTC", bin_path ~ "rustc") }}
 {{ export("RUSTDOC", bin_path ~ "rustdoc") }}

--- a/crates/pixi_build_rust/src/build_script.rs
+++ b/crates/pixi_build_rust/src/build_script.rs
@@ -39,6 +39,18 @@ mod test {
     }
 
     #[test]
+    fn test_cross_compile_flags_are_target_scoped() {
+        let script = render(true, false);
+        assert!(script.contains(
+            r#"if [ "$BUILD" != "$HOST" ]; then
+    export TARGET_CFLAGS="$CFLAGS${TARGET_CFLAGS:+ $TARGET_CFLAGS}"
+    export TARGET_CXXFLAGS="$CXXFLAGS${TARGET_CXXFLAGS:+ $TARGET_CXXFLAGS}"
+    unset CFLAGS CXXFLAGS
+fi"#
+        ));
+    }
+
+    #[test]
     fn test_build_script_bash() {
         insta::assert_snapshot!(render(true, false), @r###"
         if [ -d "$PREFIX/include/openssl" ]; then
@@ -47,6 +59,11 @@ mod test {
 
 
 
+        if [ "$BUILD" != "$HOST" ]; then
+            export TARGET_CFLAGS="$CFLAGS${TARGET_CFLAGS:+ $TARGET_CFLAGS}"
+            export TARGET_CXXFLAGS="$CXXFLAGS${TARGET_CXXFLAGS:+ $TARGET_CXXFLAGS}"
+            unset CFLAGS CXXFLAGS
+        fi
         export CARGO="$BUILD_PREFIX/bin/cargo"
         export RUSTC="$BUILD_PREFIX/bin/rustc"
         export RUSTDOC="$BUILD_PREFIX/bin/rustdoc"
@@ -80,6 +97,11 @@ mod test {
 
         export RUSTC_WRAPPER="sccache"
 
+        if [ "$BUILD" != "$HOST" ]; then
+            export TARGET_CFLAGS="$CFLAGS${TARGET_CFLAGS:+ $TARGET_CFLAGS}"
+            export TARGET_CXXFLAGS="$CXXFLAGS${TARGET_CXXFLAGS:+ $TARGET_CXXFLAGS}"
+            unset CFLAGS CXXFLAGS
+        fi
         export CARGO="$BUILD_PREFIX/bin/cargo"
         export RUSTC="$BUILD_PREFIX/bin/rustc"
         export RUSTDOC="$BUILD_PREFIX/bin/rustdoc"


### PR DESCRIPTION
## Summary

- move conda's generic `CFLAGS`/`CXXFLAGS` into Cargo/cc-rs's target-scoped variables while cross-compiling
- unset the generic variables so they cannot leak into native proc-macro and build-dependency compilations
- preserve existing `TARGET_CFLAGS`/`TARGET_CXXFLAGS` after the conda target flags

`cc-rs` concatenates generic and target-specific flags. On an aarch64 build machine targeting linux-64, this made the native aarch64 compiler receive x86 flags such as `-march=nocona -mtune=haswell`.

This avoids compiler wrappers and architecture-specific flag filtering. Native builds are unchanged because the generated block only runs when conda's `BUILD` and `HOST` differ.

## Tests

- `cargo test -p pixi-build-rust`
- `cargo clippy -p pixi-build-rust --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Closes #6942
