### PR TITLE
perf: build macOS ARM64 releases with PGO

### DIFF
--- a/.github/workflows/pgo-macos.yml
+++ b/.github/workflows/pgo-macos.yml
@@ -1,0 +1,123 @@
+name: PGO macOS
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/pgo-macos.yml"
+      - ".github/workflows/release.yml"
+      - "scripts/build_pgo.py"
+      - "scripts/pgo/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 1
+  CARGO_PROFILE_RELEASE_LTO: "fat"
+  CARGO_PROFILE_RELEASE_OPT_LEVEL: 3
+  CARGO_PROFILE_RELEASE_STRIP: symbols
+
+jobs:
+  build:
+    name: Build ${{ matrix.mode }} binary
+    runs-on: nscloud-macos-sequoia-arm64-12x28
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [baseline, pgo]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ matrix.mode == 'baseline' && github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
+        with:
+          environments: release
+          activate-environment: true
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: "1.95.0"
+          target: aarch64-apple-darwin
+          cache: false
+          rustflags: ""
+
+      - name: Set build options
+        run: pixi run -e release build-options --target aarch64-apple-darwin
+
+      - name: Install LLVM tools
+        if: matrix.mode == 'pgo'
+        run: rustup component add llvm-tools-preview
+
+      - name: Build baseline binary
+        if: matrix.mode == 'baseline'
+        run: |
+          cargo build \
+            --locked \
+            --release \
+            --manifest-path crates/pixi/Cargo.toml \
+            --features self_update,performance \
+            --bin pixi \
+            --target aarch64-apple-darwin
+
+      - name: Build PGO binary
+        if: matrix.mode == 'pgo'
+        run: python scripts/build_pgo.py --target aarch64-apple-darwin
+
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pixi-macos-aarch64-${{ matrix.mode }}-${{ github.sha }}
+          path: target/aarch64-apple-darwin/release/pixi
+          retention-days: 14
+
+  compare:
+    name: Compare binaries
+    needs: build
+    runs-on: nscloud-macos-sequoia-arm64-12x28
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
+        with:
+          environments: release
+          activate-environment: true
+
+      - name: Download baseline binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pixi-macos-aarch64-baseline-${{ github.sha }}
+          path: benchmark/baseline
+
+      - name: Download PGO binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: pixi-macos-aarch64-pgo-${{ github.sha }}
+          path: benchmark/pgo
+
+      - name: Compare binaries
+        run: |
+          chmod +x benchmark/baseline/pixi benchmark/pgo/pixi
+          python scripts/compare_pgo.py \
+            --baseline benchmark/baseline/pixi \
+            --pgo benchmark/pgo/pixi \
+            --output benchmark/comparison.json
+
+      - name: Upload comparison
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pixi-macos-aarch64-comparison-${{ github.sha }}
+          path: benchmark/comparison.json
+          retention-days: 14

--- a/.github/workflows/pgo.yml
+++ b/.github/workflows/pgo.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build PGO binary
         if: matrix.mode == 'pgo'
-        run: python scripts/build_pgo.py
+        run: python scripts/build_pgo.py --target x86_64-unknown-linux-musl
 
       - name: Upload binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,24 +65,31 @@ jobs:
           - target: x86_64-unknown-linux-musl
             runner: nscloud-ubuntu-24.04-amd64-16x32
             builder: zigbuild
+            pgo: true
           - target: aarch64-unknown-linux-musl
             runner: 8core_ubuntu_latest_runner
             builder: zigbuild
+            pgo: false
           - target: riscv64gc-unknown-linux-gnu
             runner: 8core_ubuntu_latest_runner
             builder: zigbuild
+            pgo: false
           - target: x86_64-apple-darwin
             runner: namespace-profile-macos-15-arm64-6
             builder: build
+            pgo: false
           - target: aarch64-apple-darwin
-            runner: namespace-profile-macos-15-arm64-6
+            runner: nscloud-macos-sequoia-arm64-12x28
             builder: build
+            pgo: true
           - target: x86_64-pc-windows-msvc
             runner: namespace-profile-windows-2022-x86-64-8
             builder: build
+            pgo: false
           - target: aarch64-pc-windows-msvc
             runner: namespace-profile-windows-2022-x86-64-8
             builder: build
+            pgo: false
     env:
       PUBLISHING: ${{ needs.prepare.outputs.publishing }}
       # macOS codesigning / notarization.
@@ -123,15 +130,15 @@ jobs:
         run: pixi run -e release build-options --target ${{ matrix.target }}
 
       - name: Install LLVM tools
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+        if: matrix.pgo
         run: rustup component add llvm-tools-preview
 
       - name: Build with PGO
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: python scripts/build_pgo.py
+        if: matrix.pgo
+        run: python scripts/build_pgo.py --target ${{ matrix.target }}
 
       - name: Build
-        if: matrix.target != 'x86_64-unknown-linux-musl'
+        if: ${{ !matrix.pgo }}
         shell: bash
         env:
           CARGO_PROFILE_RELEASE_LTO: fat

--- a/scripts/build_pgo.py
+++ b/scripts/build_pgo.py
@@ -1,5 +1,6 @@
-"""Build the Linux x86-64 release binary with profile-guided optimization."""
+"""Build a host-native Pixi release binary with profile-guided optimization."""
 
+import argparse
 import os
 import shlex
 import shutil
@@ -9,22 +10,29 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-TARGET = "x86_64-unknown-linux-musl"
+LINUX_MUSL_TARGET = "x86_64-unknown-linux-musl"
 ZIG_TARGET = "x86_64-linux-musl"
 TRAINING_MANIFEST = ROOT / "scripts" / "pgo" / "pixi.toml"
 
-CARGO_ARGS = [
-    "--locked",
-    "--release",
-    "--manifest-path",
-    str(ROOT / "crates" / "pixi" / "Cargo.toml"),
-    "--features",
-    "self_update,performance",
-    "--bin",
-    "pixi",
-    "--target",
-    TARGET,
-]
+
+def cargo_args(target: str) -> list[str]:
+    return [
+        "--locked",
+        "--release",
+        "--manifest-path",
+        str(ROOT / "crates" / "pixi" / "Cargo.toml"),
+        "--features",
+        "self_update,performance",
+        "--bin",
+        "pixi",
+        "--target",
+        target,
+    ]
+
+
+def binary_path(target_dir: Path, target: str) -> Path:
+    executable = "pixi.exe" if target.endswith("-pc-windows-msvc") else "pixi"
+    return target_dir / target / "release" / executable
 
 
 def run(command: list[str], *, env: dict[str, str], quiet: bool = False) -> None:
@@ -63,6 +71,30 @@ def encoded_rustflags(profile_flag: str) -> str:
     return "\x1f".join([*shlex.split(os.environ.get("RUSTFLAGS", "")), profile_flag])
 
 
+def pgo_environment(target_dir: Path, profile_flag: str, target: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("RUSTFLAGS", None)
+    env.update(
+        {
+            "CARGO_INCREMENTAL": "0",
+            "CARGO_TARGET_DIR": str(target_dir),
+            "CARGO_ENCODED_RUSTFLAGS": encoded_rustflags(profile_flag),
+        }
+    )
+    if target.endswith("-apple-darwin"):
+        for variable in ("CFLAGS", "CXXFLAGS"):
+            env[variable] = " ".join(
+                filter(
+                    None,
+                    (
+                        env.get(variable),
+                        "-fno-profile-generate -fno-profile-use",
+                    ),
+                )
+            )
+    return env
+
+
 def write_zig_wrapper(path: Path, compiler: str) -> None:
     # Zig 0.16 treats rustc's `-u __llvm_profile_runtime` as an input file.
     # Passing the same option directly to the linker keeps the PGO runtime alive.
@@ -85,35 +117,34 @@ exec cargo-zigbuild zig {compiler} -- -g -fno-sanitize=all -target {ZIG_TARGET} 
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def instrumented_build(target_dir: Path, profile_dir: Path, working_dir: Path) -> Path:
-    wrappers = working_dir / "wrappers"
-    wrappers.mkdir(parents=True)
-    cc_wrapper = wrappers / "zigcc"
-    cxx_wrapper = wrappers / "zigcxx"
-    ar_wrapper = wrappers / "zigar"
-    write_zig_wrapper(cc_wrapper, "cc")
-    write_zig_wrapper(cxx_wrapper, "c++")
-    ar_wrapper.write_text(
-        '#!/usr/bin/env bash\nset -euo pipefail\nexec cargo-zigbuild zig ar -- "$@"\n'
-    )
-    ar_wrapper.chmod(ar_wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+def instrumented_build(target_dir: Path, profile_dir: Path, working_dir: Path, target: str) -> Path:
+    env = pgo_environment(target_dir, f"-Cprofile-generate={profile_dir}", target)
 
-    target_env_name = TARGET.replace("-", "_")
-    env = os.environ.copy()
-    env.pop("RUSTFLAGS", None)
-    env.update(
-        {
-            "CARGO_INCREMENTAL": "0",
-            "CARGO_TARGET_DIR": str(target_dir),
-            "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER": str(cc_wrapper),
-            f"CC_{target_env_name}": str(cc_wrapper),
-            f"CXX_{target_env_name}": str(cxx_wrapper),
-            f"AR_{target_env_name}": str(ar_wrapper),
-            "CARGO_ENCODED_RUSTFLAGS": encoded_rustflags(f"-Cprofile-generate={profile_dir}"),
-        }
-    )
-    run(["cargo", "build", *CARGO_ARGS], env=env)
-    return target_dir / TARGET / "release" / "pixi"
+    if target == LINUX_MUSL_TARGET:
+        wrappers = working_dir / "wrappers"
+        wrappers.mkdir(parents=True)
+        cc_wrapper = wrappers / "zigcc"
+        cxx_wrapper = wrappers / "zigcxx"
+        ar_wrapper = wrappers / "zigar"
+        write_zig_wrapper(cc_wrapper, "cc")
+        write_zig_wrapper(cxx_wrapper, "c++")
+        ar_wrapper.write_text(
+            '#!/usr/bin/env bash\nset -euo pipefail\nexec cargo-zigbuild zig ar -- "$@"\n'
+        )
+        ar_wrapper.chmod(ar_wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        target_env_name = target.replace("-", "_")
+        env.update(
+            {
+                "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER": str(cc_wrapper),
+                f"CC_{target_env_name}": str(cc_wrapper),
+                f"CXX_{target_env_name}": str(cxx_wrapper),
+                f"AR_{target_env_name}": str(ar_wrapper),
+            }
+        )
+
+    run(["cargo", "build", *cargo_args(target)], env=env)
+    return binary_path(target_dir, target)
 
 
 def train(binary: Path, profile_dir: Path, working_dir: Path) -> None:
@@ -142,28 +173,28 @@ def train(binary: Path, profile_dir: Path, working_dir: Path) -> None:
         run([str(binary), *arguments], env=env, quiet=True)
 
 
-def optimized_build(target_dir: Path, profile_data: Path) -> Path:
-    env = os.environ.copy()
-    env.pop("RUSTFLAGS", None)
-    env.update(
-        {
-            "CARGO_INCREMENTAL": "0",
-            "CARGO_TARGET_DIR": str(target_dir),
-            "CARGO_ENCODED_RUSTFLAGS": encoded_rustflags(f"-Cprofile-use={profile_data}"),
-        }
-    )
-    run(["cargo", "zigbuild", *CARGO_ARGS], env=env)
-    return target_dir / TARGET / "release" / "pixi"
+def optimized_build(target_dir: Path, profile_data: Path, target: str) -> Path:
+    env = pgo_environment(target_dir, f"-Cprofile-use={profile_data}", target)
+    builder = "zigbuild" if target == LINUX_MUSL_TARGET else "build"
+    run(["cargo", builder, *cargo_args(target)], env=env)
+    return binary_path(target_dir, target)
 
 
 def main() -> None:
-    if shutil.which("cargo-zigbuild") is None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, help="Host-native Rust target triple")
+    args = parser.parse_args()
+
+    host = rust_host()
+    if args.target not in (host, LINUX_MUSL_TARGET):
+        parser.error(f"PGO training requires the host-native target {host}, got {args.target}")
+    if args.target == LINUX_MUSL_TARGET and shutil.which("cargo-zigbuild") is None:
         raise FileNotFoundError("cargo-zigbuild is required")
     if not TRAINING_MANIFEST.is_file():
         raise FileNotFoundError(TRAINING_MANIFEST)
 
     target_dir = Path(os.environ.get("CARGO_TARGET_DIR", ROOT / "target")).resolve()
-    working_dir = target_dir / "pgo"
+    working_dir = target_dir / "pgo" / args.target
     instrumented_target_dir = working_dir / "instrumented"
     optimized_target_dir = working_dir / "optimized"
     profile_dir = working_dir / "profiles"
@@ -173,7 +204,9 @@ def main() -> None:
     profile_dir.mkdir(parents=True)
 
     print("Building instrumented Pixi binary")
-    instrumented_binary = instrumented_build(instrumented_target_dir, profile_dir, working_dir)
+    instrumented_binary = instrumented_build(
+        instrumented_target_dir, profile_dir, working_dir, args.target
+    )
 
     print("Training instrumented Pixi binary")
     train(instrumented_binary, profile_dir, working_dir)
@@ -188,8 +221,8 @@ def main() -> None:
     )
 
     print("Building PGO-optimized Pixi binary")
-    optimized_binary = optimized_build(optimized_target_dir, profile_data)
-    binary = target_dir / TARGET / "release" / "pixi"
+    optimized_binary = optimized_build(optimized_target_dir, profile_data, args.target)
+    binary = binary_path(target_dir, args.target)
     binary.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(optimized_binary, binary)
     print(binary)

--- a/scripts/compare_pgo.py
+++ b/scripts/compare_pgo.py
@@ -1,0 +1,234 @@
+"""Compare baseline and PGO Pixi binaries with warmed, isolated workspaces."""
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypedDict
+
+ROOT = Path(__file__).resolve().parent.parent
+TRAINING_MANIFEST = ROOT / "scripts" / "pgo" / "pixi.toml"
+HELD_OUT_MANIFEST = ROOT / "scripts" / "pgo" / "benchmark.toml"
+
+
+@dataclass(frozen=True)
+class Workload:
+    name: str
+    arguments: tuple[str, ...]
+    held_out: bool = False
+
+
+class TimingResult(TypedDict):
+    baseline_ms: float
+    pgo_ms: float
+    change_percent: float
+
+
+class WorkloadResult(TimingResult):
+    name: str
+    held_out: bool
+
+
+class BinarySizeResult(TypedDict):
+    baseline_bytes: int
+    pgo_bytes: int
+    change_percent: float
+
+
+class Results(TypedDict):
+    rounds: int
+    workloads: list[WorkloadResult]
+    training_suite: TimingResult
+    binary_size: BinarySizeResult
+
+
+def benchmark_environment(root: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PIXI_CACHE_DIR": str(root / "cache"),
+            "PIXI_HOME": str(root / "home"),
+            "PIXI_NO_CONFIG": "true",
+            "PIXI_NO_PROGRESS": "true",
+            "PIXI_COLOR": "never",
+        }
+    )
+    return environment
+
+
+def run_once(binary: Path, workload: Workload, environment: dict[str, str]) -> float:
+    started = time.perf_counter_ns()
+    result = subprocess.run(
+        [str(binary), *workload.arguments],
+        env=environment,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=300,
+    )
+    elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000
+    if result.returncode != 0:
+        diagnostic = subprocess.run(
+            [str(binary), *workload.arguments],
+            env=environment,
+            text=True,
+            capture_output=True,
+            timeout=300,
+        )
+        raise RuntimeError(
+            f"{workload.name} failed with exit code {result.returncode}:\n"
+            f"{diagnostic.stdout}{diagnostic.stderr}"
+        )
+    return elapsed_ms
+
+
+def change_percent(baseline: float, pgo: float) -> float:
+    return ((pgo / baseline) - 1) * 100
+
+
+def format_summary(results: Results) -> str:
+    lines = [
+        "## PGO comparison",
+        "",
+        "Negative deltas are improvements.",
+        "",
+        "| Workload | Baseline | PGO | Delta |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for workload in results["workloads"]:
+        lines.append(
+            f"| {workload['name']} | {workload['baseline_ms']:.1f} ms | "
+            f"{workload['pgo_ms']:.1f} ms | {workload['change_percent']:+.1f}% |"
+        )
+
+    suite = results["training_suite"]
+    size = results["binary_size"]
+    lines.extend(
+        [
+            f"| **Training suite** | **{suite['baseline_ms']:.1f} ms** | "
+            f"**{suite['pgo_ms']:.1f} ms** | **{suite['change_percent']:+.1f}%** |",
+            f"| Binary size | {size['baseline_bytes'] / 1_048_576:.1f} MiB | "
+            f"{size['pgo_bytes'] / 1_048_576:.1f} MiB | {size['change_percent']:+.1f}% |",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--pgo", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--rounds", type=int, default=7)
+    args = parser.parse_args()
+
+    baseline = args.baseline.resolve()
+    pgo = args.pgo.resolve()
+    for binary in (baseline, pgo):
+        if not binary.is_file():
+            raise FileNotFoundError(binary)
+    if args.rounds < 1:
+        parser.error("--rounds must be at least 1")
+
+    with tempfile.TemporaryDirectory(prefix="pixi-pgo-benchmark-") as temporary_directory:
+        temporary_root = Path(temporary_directory)
+        variants: dict[str, tuple[Path, dict[str, str]]] = {}
+        workloads_by_variant: dict[str, list[Workload]] = {}
+        for name, binary in (("baseline", baseline), ("pgo", pgo)):
+            variant_root = temporary_root / name
+            variant_root.mkdir()
+            training_manifest = variant_root / "training" / "pixi.toml"
+            held_out_manifest = variant_root / "held-out" / "pixi.toml"
+            training_manifest.parent.mkdir()
+            held_out_manifest.parent.mkdir()
+            shutil.copy2(TRAINING_MANIFEST, training_manifest)
+            shutil.copy2(HELD_OUT_MANIFEST, held_out_manifest)
+            variants[name] = (binary, benchmark_environment(variant_root))
+            workloads_by_variant[name] = [
+                Workload("version", ("--version",)),
+                Workload("help", ("--help",)),
+                Workload("task list", ("task", "list", "-m", str(training_manifest))),
+                Workload(
+                    "environment list",
+                    ("workspace", "environment", "list", "-m", str(training_manifest)),
+                ),
+                Workload("training solve", ("lock", "--dry-run", "-m", str(training_manifest))),
+                Workload("shell hook", ("shell-hook", "--as-is", "-m", str(training_manifest))),
+                Workload("global list", ("global", "list")),
+                Workload(
+                    "held-out solve",
+                    ("lock", "--dry-run", "-m", str(held_out_manifest)),
+                    held_out=True,
+                ),
+            ]
+
+        samples: dict[str, dict[str, list[float]]] = {
+            workload.name: {"baseline": [], "pgo": []}
+            for workload in workloads_by_variant["baseline"]
+        }
+        for workload_index, baseline_workload in enumerate(workloads_by_variant["baseline"]):
+            pgo_workload = workloads_by_variant["pgo"][workload_index]
+            for variant_name, workload in (("baseline", baseline_workload), ("pgo", pgo_workload)):
+                binary, environment = variants[variant_name]
+                run_once(binary, workload, environment)
+
+            for round_index in range(args.rounds):
+                order = ("baseline", "pgo") if round_index % 2 == 0 else ("pgo", "baseline")
+                for variant_name in order:
+                    workload = workloads_by_variant[variant_name][workload_index]
+                    binary, environment = variants[variant_name]
+                    samples[workload.name][variant_name].append(
+                        run_once(binary, workload, environment)
+                    )
+
+    workload_results: list[WorkloadResult] = []
+    for workload in workloads_by_variant["baseline"]:
+        baseline_ms = statistics.median(samples[workload.name]["baseline"])
+        pgo_ms = statistics.median(samples[workload.name]["pgo"])
+        workload_results.append(
+            {
+                "name": workload.name,
+                "held_out": workload.held_out,
+                "baseline_ms": baseline_ms,
+                "pgo_ms": pgo_ms,
+                "change_percent": change_percent(baseline_ms, pgo_ms),
+            }
+        )
+
+    training_results = [result for result in workload_results if not result["held_out"]]
+    training_baseline_ms = sum(result["baseline_ms"] for result in training_results)
+    training_pgo_ms = sum(result["pgo_ms"] for result in training_results)
+    baseline_size = baseline.stat().st_size
+    pgo_size = pgo.stat().st_size
+    results: Results = {
+        "rounds": args.rounds,
+        "workloads": workload_results,
+        "training_suite": {
+            "baseline_ms": training_baseline_ms,
+            "pgo_ms": training_pgo_ms,
+            "change_percent": change_percent(training_baseline_ms, training_pgo_ms),
+        },
+        "binary_size": {
+            "baseline_bytes": baseline_size,
+            "pgo_bytes": pgo_size,
+            "change_percent": change_percent(baseline_size, pgo_size),
+        },
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    summary = format_summary(results)
+    print(summary)
+    if github_summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(github_summary).open("a", encoding="utf-8") as summary_file:
+            summary_file.write(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pgo/benchmark.toml
+++ b/scripts/pgo/benchmark.toml
@@ -1,0 +1,25 @@
+[workspace]
+name = "pixi-pgo-benchmark"
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
+
+[dependencies]
+python = "3.12.*"
+httpx = "*"
+rich = "*"
+sqlalchemy = "*"
+typer = "*"
+
+[feature.server.dependencies]
+flask = "*"
+starlette = "*"
+
+[feature.data.dependencies]
+duckdb = "*"
+pyarrow = "*"
+
+[environments]
+default = []
+server = ["server"]
+data = ["data"]
+full = ["server", "data"]


### PR DESCRIPTION
## Description

Extend the PGO release build to native macOS ARM64. The x86_64 macOS artifact stays on the existing cross-compiled path.

The shared driver now selects the native Cargo build for macOS and keeps the Zig workaround limited to Linux musl. A separate workflow builds the stack base without macOS PGO and this branch with it.

Stacked on #6954. I’ll add the artifact comparison once CI finishes.

## Testing

- Actionlint on the release and PGO workflows
- Ruff and ty on scripts/build_pgo.py
- Exercised platform dispatch and profile flag handling

AI assistance: Used Codex to implement and review the change.