### PR TITLE
perf: build Linux x64 releases with PGO

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - windows_arm64_2025_large
     - windows_x64_2025_large
     - namespace-profile-*
+    - nscloud-*
 
 paths:
   .github/workflows/release.yml:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,26 +63,26 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-musl
-            runner: namespace-profile-ubuntu-24-04-x86-64-8
-            builder: zigbuild
+            runner: nscloud-ubuntu-24.04-amd64-16x32
+            pgo: true
           - target: aarch64-unknown-linux-musl
             runner: 8core_ubuntu_latest_runner
-            builder: zigbuild
+            pgo: false
           - target: riscv64gc-unknown-linux-gnu
             runner: 8core_ubuntu_latest_runner
-            builder: zigbuild
+            pgo: false
           - target: x86_64-apple-darwin
             runner: namespace-profile-macos-15-arm64-6
-            builder: build
+            pgo: false
           - target: aarch64-apple-darwin
             runner: namespace-profile-macos-15-arm64-6
-            builder: build
+            pgo: false
           - target: x86_64-pc-windows-msvc
             runner: namespace-profile-windows-2022-x86-64-8
-            builder: build
+            pgo: false
           - target: aarch64-pc-windows-msvc
             runner: namespace-profile-windows-2022-x86-64-8
-            builder: build
+            pgo: false
     env:
       PUBLISHING: ${{ needs.prepare.outputs.publishing }}
       # macOS codesigning / notarization.
@@ -122,19 +122,13 @@ jobs:
       - name: Set build options
         run: pixi run -e release build-options --target ${{ matrix.target }}
 
+      - name: Install LLVM tools
+        if: matrix.pgo
+        run: rustup component add llvm-tools-preview
+
       - name: Build
         shell: bash
-        env:
-          CARGO_PROFILE_RELEASE_LTO: fat
-        run: |
-          builder=${{ matrix.builder }}
-          cargo "$builder" \
-            --locked \
-            --release \
-            --manifest-path crates/pixi/Cargo.toml \
-            --features self_update,performance \
-            --bin pixi \
-            --target ${{ matrix.target }}
+        run: python scripts/build_pgo.py --target ${{ matrix.target }} ${{ matrix.pgo && '--pgo' || '' }}
 
       - name: Codesign and notarize macOS binary
         if: contains(matrix.target, 'apple-darwin') && env.PUBLISHING == 'true'

--- a/scripts/build_pgo.py
+++ b/scripts/build_pgo.py
@@ -1,0 +1,380 @@
+"""Build a Pixi release binary, using PGO when requested and runnable."""
+
+import argparse
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT: Path = Path(__file__).resolve().parent.parent
+LINUX_MUSL_TARGET: str = "x86_64-unknown-linux-musl"
+ZIG_TARGET: str = "x86_64-linux-musl"
+# The Linux release targets are cross-compiled from an x86_64 glibc runner and
+# link through Zig; every other target builds with its native toolchain.
+ZIGBUILD_TARGETS: frozenset[str] = frozenset(
+    {
+        LINUX_MUSL_TARGET,
+        "aarch64-unknown-linux-musl",
+        "riscv64gc-unknown-linux-gnu",
+    }
+)
+TRAINING_MANIFEST: Path = ROOT / "scripts" / "pgo" / "pixi.toml"
+
+
+@dataclass(frozen=True)
+class BuildOptions:
+    target: str
+    features: str
+    no_default_features: bool
+    auditable: bool
+
+
+class Arguments(argparse.Namespace):
+    target: str
+    features: str
+    no_default_features: bool
+    auditable: bool
+    pgo: bool
+    output: Path | None
+
+
+def cargo_args(options: BuildOptions) -> list[str]:
+    arguments = [
+        "--locked",
+        "--release",
+        "--manifest-path",
+        str(ROOT / "crates" / "pixi" / "Cargo.toml"),
+    ]
+    if options.no_default_features:
+        arguments.append("--no-default-features")
+    if options.features:
+        arguments.extend(["--features", options.features])
+    arguments.extend(
+        [
+            "--bin",
+            "pixi",
+            "--target",
+            options.target,
+        ]
+    )
+    return arguments
+
+
+def cargo_build_command(options: BuildOptions, *, zig_wrappers: bool) -> list[str]:
+    """Cargo subcommand for a release build.
+
+    `cargo-zigbuild` provides the cross toolchain, unless the caller already
+    placed Zig wrappers for the compiler, archiver, and linker in the
+    environment.
+    """
+    if options.auditable:
+        return ["cargo", "auditable", "build"]
+    if zig_wrappers or options.target not in ZIGBUILD_TARGETS:
+        return ["cargo", "build"]
+    return ["cargo", "zigbuild"]
+
+
+def binary_path(target_dir: Path, target: str) -> Path:
+    executable = "pixi.exe" if target.endswith("-pc-windows-msvc") else "pixi"
+    return target_dir / target / "release" / executable
+
+
+def can_train(target: str, host: str) -> bool:
+    return target == host or (target == LINUX_MUSL_TARGET and host == "x86_64-unknown-linux-gnu")
+
+
+def release_build(target_dir: Path, options: BuildOptions) -> Path:
+    env: dict[str, str] = os.environ.copy()
+    env["CARGO_TARGET_DIR"] = str(target_dir)
+    run([*cargo_build_command(options, zig_wrappers=False), *cargo_args(options)], env=env)
+    return binary_path(target_dir, options.target)
+
+
+def copy_output(binary: Path, output: Path | None) -> None:
+    destination = output.resolve() if output else binary.resolve()
+    if destination != binary.resolve():
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(binary, destination)
+    print(destination)
+
+
+def run(command: list[str], *, env: dict[str, str], quiet: bool = False) -> None:
+    if quiet:
+        result: subprocess.CompletedProcess[str] = subprocess.run(
+            command,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, command)
+
+    subprocess.run(command, env=env, check=True)
+
+
+def rust_host() -> str:
+    output: str = subprocess.check_output(["rustc", "-vV"], text=True)
+    for line in output.splitlines():
+        if line.startswith("host: "):
+            return line.removeprefix("host: ")
+    raise RuntimeError("rustc did not report its host target")
+
+
+def llvm_profdata() -> Path:
+    sysroot = Path(subprocess.check_output(["rustc", "--print", "sysroot"], text=True).strip())
+    executable_name = "llvm-profdata.exe" if os.name == "nt" else "llvm-profdata"
+    executable = sysroot / "lib" / "rustlib" / rust_host() / "bin" / executable_name
+    if not executable.is_file():
+        raise FileNotFoundError(
+            f"{executable} not found; install it with `rustup component add llvm-tools-preview`"
+        )
+    return executable
+
+
+def encoded_rustflags(profile_flag: str, target: str) -> str:
+    if encoded_flags := os.environ.get("CARGO_ENCODED_RUSTFLAGS"):
+        flags: list[str] = [encoded_flags]
+    else:
+        flags = shlex.split(os.environ.get("RUSTFLAGS", ""))
+    # CARGO_ENCODED_RUSTFLAGS overrides the target rustflags in .cargo/config.toml.
+    if target.endswith("-pc-windows-msvc"):
+        flags.append("-Ctarget-feature=+crt-static")
+    flags.append(profile_flag)
+    return "\x1f".join(flags)
+
+
+def pgo_environment(target_dir: Path, profile_flag: str, target: str) -> dict[str, str]:
+    env: dict[str, str] = os.environ.copy()
+    env.pop("RUSTFLAGS", None)
+    env.update(
+        {
+            "CARGO_INCREMENTAL": "0",
+            "CARGO_TARGET_DIR": str(target_dir),
+            "CARGO_ENCODED_RUSTFLAGS": encoded_rustflags(profile_flag, target),
+        }
+    )
+    if target.endswith("-apple-darwin"):
+        for variable in ("CFLAGS", "CXXFLAGS"):
+            env[variable] = " ".join(
+                filter(
+                    None,
+                    (
+                        env.get(variable),
+                        "-fno-profile-generate -fno-profile-use",
+                    ),
+                )
+            )
+    return env
+
+
+def write_zig_wrapper(path: Path, compiler: str) -> None:
+    # Zig 0.16 treats rustc's `-u __llvm_profile_runtime` as an input file.
+    # Passing the same option directly to the linker keeps the PGO runtime alive.
+    path.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+rewritten=()
+while (($#)); do
+  if [[ "$1" == "-u" && $# -ge 2 ]]; then
+    rewritten+=("-Wl,-u,$2")
+    shift 2
+  else
+    rewritten+=("$1")
+    shift
+  fi
+done
+exec cargo-zigbuild zig {compiler} -- -g -fno-sanitize=all -target {ZIG_TARGET} "${{rewritten[@]}}"
+"""
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def instrumented_build(
+    target_dir: Path,
+    profile_dir: Path,
+    working_dir: Path,
+    options: BuildOptions,
+) -> Path:
+    env = pgo_environment(
+        target_dir,
+        f"-Cprofile-generate={profile_dir}",
+        options.target,
+    )
+
+    # Only the musl target trains, and its instrumented build needs the wrapper
+    # that keeps the LLVM profile runtime alive.
+    zig_wrappers = options.target == LINUX_MUSL_TARGET
+    if zig_wrappers:
+        wrappers = working_dir / "wrappers"
+        wrappers.mkdir(parents=True)
+        cc_wrapper = wrappers / "zigcc"
+        cxx_wrapper = wrappers / "zigcxx"
+        ar_wrapper = wrappers / "zigar"
+        write_zig_wrapper(cc_wrapper, "cc")
+        write_zig_wrapper(cxx_wrapper, "c++")
+        ar_wrapper.write_text(
+            '#!/usr/bin/env bash\nset -euo pipefail\nexec cargo-zigbuild zig ar -- "$@"\n'
+        )
+        ar_wrapper.chmod(ar_wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        target_env_name = options.target.replace("-", "_")
+        env.update(
+            {
+                "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER": str(cc_wrapper),
+                f"CC_{target_env_name}": str(cc_wrapper),
+                f"CXX_{target_env_name}": str(cxx_wrapper),
+                f"AR_{target_env_name}": str(ar_wrapper),
+            }
+        )
+
+    run(
+        [*cargo_build_command(options, zig_wrappers=zig_wrappers), *cargo_args(options)],
+        env=env,
+    )
+    return binary_path(target_dir, options.target)
+
+
+def train(binary: Path, profile_dir: Path, working_dir: Path) -> None:
+    env: dict[str, str] = os.environ.copy()
+    env.update(
+        {
+            "LLVM_PROFILE_FILE": str(profile_dir / "pixi-%m-%p.profraw"),
+            "PIXI_CACHE_DIR": str(working_dir / "cache"),
+            "PIXI_HOME": str(working_dir / "home"),
+            "PIXI_NO_CONFIG": "true",
+            "PIXI_NO_PROGRESS": "true",
+            "PIXI_COLOR": "never",
+        }
+    )
+    manifest = str(TRAINING_MANIFEST)
+    workloads: list[list[str]] = [
+        ["--version"],
+        ["--help"],
+        ["task", "list", "-m", manifest],
+        ["workspace", "environment", "list", "-m", manifest],
+        ["lock", "--dry-run", "-m", manifest],
+        ["shell-hook", "--as-is", "-m", manifest],
+        ["global", "list"],
+    ]
+    for arguments in workloads:
+        run([str(binary), *arguments], env=env, quiet=True)
+
+
+def optimized_build(
+    target_dir: Path,
+    profile_data: Path,
+    options: BuildOptions,
+) -> Path:
+    env = pgo_environment(
+        target_dir,
+        f"-Cprofile-use={profile_data}",
+        options.target,
+    )
+    run([*cargo_build_command(options, zig_wrappers=False), *cargo_args(options)], env=env)
+    return binary_path(target_dir, options.target)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, help="Rust target triple")
+    parser.add_argument(
+        "--features",
+        default="self_update,performance",
+        help="Comma-separated Cargo features",
+    )
+    parser.add_argument(
+        "--no-default-features",
+        action="store_true",
+        help="Disable Cargo's default features",
+    )
+    parser.add_argument(
+        "--auditable",
+        action="store_true",
+        help="Build through cargo-auditable",
+    )
+    parser.add_argument(
+        "--pgo",
+        action="store_true",
+        help="Use PGO when the target can run on this host",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Copy the release binary to this path",
+    )
+    args = parser.parse_args(namespace=Arguments())
+    options = BuildOptions(
+        target=args.target,
+        features=args.features,
+        no_default_features=args.no_default_features,
+        auditable=args.auditable,
+    )
+
+    host = rust_host()
+    use_pgo = args.pgo and can_train(options.target, host)
+    if args.pgo and not use_pgo:
+        print(f"Target {options.target} cannot run on host {host}; building without PGO")
+    if (
+        options.target in ZIGBUILD_TARGETS
+        and not options.auditable
+        and shutil.which("cargo-zigbuild") is None
+    ):
+        raise FileNotFoundError(f"cargo-zigbuild is required to build {options.target}")
+    if options.auditable and shutil.which("cargo-auditable") is None:
+        raise FileNotFoundError("cargo-auditable is required")
+
+    target_dir = Path(os.environ.get("CARGO_TARGET_DIR", ROOT / "target")).resolve()
+    if not use_pgo:
+        print("Building Pixi binary without PGO")
+        copy_output(release_build(target_dir, options), args.output)
+        return
+
+    if not TRAINING_MANIFEST.is_file():
+        raise FileNotFoundError(TRAINING_MANIFEST)
+    if os.name == "nt":
+        working_dir = Path(os.environ.get("RUNNER_TEMP", target_dir.anchor)) / "pixi-pgo"
+    else:
+        working_dir = target_dir / "pgo" / options.target
+    instrumented_target_dir = working_dir / "i"
+    optimized_target_dir = working_dir / "o"
+    profile_dir = working_dir / "profiles"
+    profile_data = working_dir / "pixi.profdata"
+
+    shutil.rmtree(working_dir, ignore_errors=True)
+    profile_dir.mkdir(parents=True)
+
+    print("Building instrumented Pixi binary")
+    instrumented_binary = instrumented_build(
+        instrumented_target_dir,
+        profile_dir,
+        working_dir,
+        options,
+    )
+
+    print("Training instrumented Pixi binary")
+    train(instrumented_binary, profile_dir, working_dir)
+
+    print("Merging PGO profiles")
+    raw_profiles: list[Path] = list(profile_dir.glob("*.profraw"))
+    if not raw_profiles:
+        raise RuntimeError("training did not produce any PGO profiles")
+    subprocess.run(
+        [str(llvm_profdata()), "merge", "--output", str(profile_data), *raw_profiles],
+        check=True,
+    )
+
+    print("Building PGO-optimized Pixi binary")
+    optimized_binary = optimized_build(optimized_target_dir, profile_data, options)
+    copy_output(optimized_binary, args.output or binary_path(target_dir, options.target))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pgo/pixi.toml
+++ b/scripts/pgo/pixi.toml
@@ -1,0 +1,42 @@
+[workspace]
+name = "pixi-pgo-training"
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
+
+[dependencies]
+python = "3.13.*"
+numpy = "*"
+pandas = "*"
+scipy = "*"
+scikit-learn = "*"
+matplotlib = "*"
+jupyterlab = "*"
+fastapi = "*"
+uvicorn = "*"
+pytest = "*"
+ruff = "*"
+
+[pypi-dependencies]
+black = { version = ">=24,<27", extras = ["jupyter"] }
+flask = ">=3,<4"
+pytest-timeout = ">=2,<3"
+
+[feature.analysis.dependencies]
+dask = "*"
+xarray = "*"
+polars = "*"
+
+[feature.docs.dependencies]
+sphinx = "*"
+myst-parser = "*"
+furo = "*"
+
+[environments]
+default = []
+analysis = ["analysis"]
+docs = ["docs"]
+full = ["analysis", "docs"]
+
+[tasks]
+check = "ruff check ."
+test = "pytest"


### PR DESCRIPTION
### Description

Use LLVM PGO for the x86_64 Linux release. The training workload covers startup, workspace discovery, lock solving, shell activation, and global state, on a manifest that mixes conda and PyPI dependencies so the PyPI resolve and install paths are profiled too.

Every release target now goes through the same script. `scripts/build_pgo.py` picks the Cargo subcommand, trains only when the target can actually run on the build host, and otherwise builds the target exactly as the workflow did before. That drops the `builder` matrix key and the second Cargo invocation from the workflow; a target opts into profiling with `pgo: true`. This PR turns it on for x86_64 Linux only.

`cargo-zigbuild` is only needed for the cross-compiled Linux targets, so the script only selects and requires it there. Everything else builds with `cargo build`, and conda-forge can pass `--auditable`, `--features`, `--no-default-features`, and `--output` to reuse the same entry point.

The instrumented build needs the 32 GB runner. It was killed for running out of memory on the previous 16 GB runner. The temporary PGO workflow used for the measurements below has been removed.

Stacked on #6975.

#### Results

Compared the baseline and PGO artifacts from [CI run 33892861548](https://github.com/prefix-dev/pixi/actions/runs/33892861548):

| Metric | Baseline | PGO | Change |
| --- | ---: | ---: | ---: |
| Representative suite, wall time | — | — | -10.2% |
| Representative suite, CPU time | — | — | -6.4% |
| Held-out solve, wall time | 1,009.89 ms | 822.23 ms | -18.6% |
| Held-out solve, CPU time | 3,691.91 ms | 3,331.37 ms | -9.8% |
| Binary size | 79.98 MB | 64.73 MB | -19.1% |
| Gzip size | 34.16 MB | 29.17 MB | -14.6% |
| CI build job | 16m 55s | 38m 50s | 2.3x |

Times are medians from alternating runs in WSL, using the cross-compiled musl artifact that CI produced. The suite result is the equal-weight geometric mean across version, help, task listing, environment listing, and a held-out multi-platform solve.

These measurements were collected before the PyPI dependencies were added to the training manifest.

#### Cross-compiled artifacts

The Linux artifacts are cross-compiled through Zig, so I ran the ones from the release dry-run in WSL, using qemu-user for the foreign architectures:

| Artifact | Check | Result |
| --- | --- | --- |
| `x86_64-unknown-linux-musl` (PGO) | native | `--version`, `info`, and a full mixed conda + PyPI solve of the training manifest in 4.3s |
| `aarch64-unknown-linux-musl` | `qemu-aarch64` | same solve in 12.2s, plus `task list` and `workspace environment list` |
| `riscv64gc-unknown-linux-gnu` | `qemu-riscv64` + Ubuntu riscv64 sysroot | `--version`, `info`, `task list`, `workspace environment list` |

The riscv64 binary cannot reach the network under emulation, but `getent ahostsv4` fails the same way inside the emulated sysroot while it works on the host, so that is qemu's NSS handling and not the binary.

I also re-measured the two musl artifacts from the comparison run (same commit, baseline vs PGO) in WSL with hyperfine:

| Workload | Baseline | PGO | Change |
| --- | ---: | ---: | ---: |
| `--version` | 6.9 ms | 6.5 ms | -6% |
| `task list` | 65.5 ms | 65.0 ms | -1% |
| `lock --dry-run`, warm cache | 1.530 s | 1.354 s | -12% |

So the cross-compiled PGO binary runs and is faster; startup and manifest parsing are dominated by process setup and I/O, and the solve is where the profile pays off.

### How Has This Been Tested?

- Ran a [dry-run of the release workflow](https://github.com/prefix-dev/pixi/actions/runs/34451288442) on this stack: all seven targets built, packaged, and uploaded through the script
- Ran those Linux artifacts in WSL, natively and under qemu-user, as described above
- Benchmarked the baseline and PGO musl artifacts against each other in WSL with hyperfine
- Ran the training `lock --dry-run` workload across every environment and platform; it resolves `black[jupyter]`, `flask`, and `pytest-timeout` from PyPI next to the conda packages
- Built and ran a native Windows release through the non-PGO path
- Checked the Cargo subcommand and training eligibility per target with a throwaway script
- Ran actionlint on the release workflow, and Ruff and ty on the script

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
