### PR TITLE
ci: upgrade Pixi dependencies with GitHub Actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":maintainLockFilesMonthly"],
   "schedule": ["on tuesday"],
-  "enabledManagers": ["github-actions", "pixi", "cargo"],
+  "enabledManagers": ["github-actions", "cargo"],
   "commitMessagePrefix": "chore(ci):",
   "ignorePaths": ["**/examples/**", "**/docs/**", "**/tests/**"],
   "labels": ["dependencies"],
@@ -17,21 +17,6 @@
       "description": "We run multiple macOS runner versions on purpose since 13 runs on x86_64",
       "matchPackageNames": "macos",
       "matchManagers": ["github-actions"],
-      "enabled": false
-    },
-    {
-      "groupName": "Pixi",
-      "matchManagers": ["pixi"]
-    },
-    {
-      "groupName": "Pixi-Lock",
-      "matchManagers": ["pixi"],
-      "matchUpdateTypes": ["lockFileMaintenance"]
-    },
-    {
-      "description": "We want to update Rust manually and keep it in sync with rust-toolchain",
-      "matchPackageNames": ["rust", "rust-src"],
-      "matchManagers": ["pixi"],
       "enabled": false
     },
     {

--- a/.github/workflows/upgrade-pixi.yml
+++ b/.github/workflows/upgrade-pixi.yml
@@ -33,6 +33,7 @@ jobs:
           pixi upgrade --exclude rust --exclude rust-src --json > "$RUNNER_TEMP/pixi-diff.json"
       - name: Render dependency changes
         # Avoid parsing the workspace's TOML 1.1 manifest with the converter's TOML 1.0 parser.
+        # TODO: Remove this workaround once Python 3.15 is released and available to the converter.
         working-directory: ${{ runner.temp }}
         shell: bash
         run: pixi exec pixi-diff-to-markdown < pixi-diff.json > pixi-diff.md

--- a/.github/workflows/upgrade-pixi.yml
+++ b/.github/workflows/upgrade-pixi.yml
@@ -1,0 +1,60 @@
+name: Upgrade Pixi dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Wednesdays at 05:00 UTC.
+    - cron: "0 5 * * 3"
+
+permissions: {}
+
+concurrency:
+  group: upgrade-pixi
+
+jobs:
+  upgrade-pixi:
+    if: github.repository == 'prefix-dev/pixi'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@d3f436a425481402e6a95a1d1fc10331c708cd9e # v0.10.2
+        with:
+          run-install: false
+      - name: Upgrade Pixi dependencies
+        shell: bash
+        run: |
+          # Keep Rust in sync with rust-toolchain through manual upgrades.
+          pixi upgrade --exclude rust --exclude rust-src --json > "$RUNNER_TEMP/pixi-diff.json"
+      - name: Render dependency changes
+        # Avoid parsing the workspace's TOML 1.1 manifest with the converter's TOML 1.0 parser.
+        working-directory: ${{ runner.temp }}
+        shell: bash
+        run: pixi exec pixi-diff-to-markdown < pixi-diff.json > pixi-diff.md
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.PIXI_UPGRADE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PIXI_UPGRADE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: "chore(ci): Upgrade Pixi dependencies"
+          title: "chore(ci): Upgrade Pixi dependencies"
+          body-path: ${{ runner.temp }}/pixi-diff.md
+          branch: upgrade-pixi
+          base: main
+          labels: dependencies
+          delete-branch: true
+          add-paths: |
+            pixi.toml
+            pixi.lock

--- a/pixi.toml
+++ b/pixi.toml
@@ -673,6 +673,7 @@ env = { AWS_LC_SYS_CMAKE_BUILDER = "1" }
 [package.build-dependencies]
 cmake = ">=4,<5"
 pkg-config = ">=0.29.2,<0.30"
+rust = "==1.95.0"
 
 [package.build-dependencies."if(linux)"]
 clang = ">=22.1.3,<23"


### PR DESCRIPTION
### Description

- Replace Renovate's Pixi manager with a workflow based on the [Pixi CI guide](https://pixi.prefix.dev/latest/integration/ci/updates_github_actions/), using `pixi upgrade` and committing both `pixi.toml` and `pixi.lock`.
- Run weekly on Wednesdays at 05:00 UTC, starting September 9 if merged beforehand. Allow manual runs as well.
- Pin Rust to `==1.95.0` and exclude `rust` and `rust-src` from automatic upgrades.
- Render the dependency summary outside the workspace because the converter's TOML parser cannot read our TOML 1.1 manifest.
- Authenticate with a GitHub App so generated PRs trigger CI without depending on a personal account.

### How Has This Been Tested?

- Run the repository upgrade with `--dry-run` and render its JSON with `pixi-diff-to-markdown`.
- Run both workflow shell steps in a temporary workspace: ripgrep upgrades from 13.0.0 to 15.2.0 in the manifest and lock, both Rust exclusions remain at 1.85.0, and the Markdown contains the version change. Environment installation was disabled for this smoke test.
- Verify the next scheduled event is September 9, 2026 at 05:00 UTC.
- Run `pixi run actionlint`, `pixi run zizmor`, `pixi run dprint-check .github/workflows/upgrade-pixi.yml`, and `pixi run toml-lint pixi.toml`.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.

Tools: Codex in Oh My Pi

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas