### PR TITLE
refactor: return CLI exit codes from main

### DIFF
--- a/crates/pixi/src/main.rs
+++ b/crates/pixi/src/main.rs
@@ -2,8 +2,9 @@
 // project. https://github.com/rust-lang/rust/issues/64402
 #[cfg(feature = "pixi_allocator")]
 extern crate pixi_allocator;
+use std::process::ExitCode;
 
-pub fn main() -> miette::Result<()> {
+pub fn main() -> miette::Result<ExitCode> {
     // We often run out of stack space when running the CLI. This is especially an
     // issue for debug builds.
     //

--- a/crates/pixi_cli/src/command_info.rs
+++ b/crates/pixi_cli/src/command_info.rs
@@ -5,8 +5,9 @@ use pixi_config::pixi_home;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::PathBuf;
+use std::process::ExitCode;
 
-use super::{Args, Command, get_styles};
+use super::{Args, Command, get_styles, process_exit};
 
 /// Get all built-in command names including aliases (discovered dynamically from clap)
 fn get_builtin_commands_with_aliases() -> Vec<String> {
@@ -103,51 +104,39 @@ pub fn find_external_subcommand(cmd: &str) -> Option<PathBuf> {
 }
 
 /// Execute an external subcommand
-pub fn execute_external_command(args: Vec<String>) -> miette::Result<()> {
-    // There should be always at least one argument, the command itself.
-    // but we dont want to panic on runtime, so we handle it as a error.
-    let cmd = args
+pub fn execute_external_command(args: Vec<String>) -> miette::Result<ExitCode> {
+    let command_name = args
         .first()
         .ok_or_else(|| miette::miette!("No external subcommand was passed"))?;
+    let command_args = &args[1..];
 
-    // The rest of the arguments are passed to the external command
-    // and we don't mind if there are no additional arguments.
-    let cmd_args = &args[1..];
-
-    if let Some(path) = find_external_subcommand(cmd) {
-        // ignore any ctrl-c signals
+    if let Some(path) = find_external_subcommand(command_name) {
         ctrlc::set_handler(move || {})
             .into_diagnostic()
             .wrap_err("Couldn't set the ctrl-c handler")?;
 
         let mut command = std::process::Command::new(&path);
-        command.args(cmd_args);
-
-        imp::execute_command(command)?;
-
-        Ok(())
+        command.args(command_args);
+        imp::execute_command(command)
     } else {
-        // Generate suggestions for similar commands
-        let mut suggestions = find_similar_commands(cmd);
-
+        let mut suggestions = find_similar_commands(command_name);
         let styles = get_styles();
-
-        // get the styles for invalid and valid commands
         let invalid = styles.get_invalid();
         let tip = styles.get_valid();
-
-        let mut error_msg = format!("unrecognized subcommand '{invalid}{cmd}{invalid:#}'");
+        let mut message = format!("unrecognized subcommand '{invalid}{command_name}{invalid:#}'");
 
         if let Some(most_similar) = suggestions.pop() {
-            error_msg.push_str(&format!(
+            message.push_str(&format!(
                 "\n\n  {tip}tip{tip:#}: a similar subcommand exists: '{tip}{most_similar}{tip:#}'",
             ));
         }
 
-        Command::command()
+        let error = Command::command()
             .styles(styles)
-            .error(clap::error::ErrorKind::InvalidSubcommand, error_msg)
-            .exit();
+            .error(clap::error::ErrorKind::InvalidSubcommand, message);
+        let exit_code = process_exit::exit_code_from_code(error.exit_code());
+        pixi_utils::io::ignore_broken_pipe(error.print()).into_diagnostic()?;
+        Ok(exit_code)
     }
 }
 
@@ -177,15 +166,14 @@ fn search_directories() -> Option<Vec<PathBuf>> {
 mod imp {
     use std::os::unix::process::CommandExt;
 
-    pub(crate) fn execute_command(mut cmd: std::process::Command) -> miette::Result<()> {
-        let err = cmd.exec();
-        // if calling exec fails, we error out
-        // otherwise, the child process replaces the current process
-        // and we don't reach this point
+    pub(crate) fn execute_command(
+        mut command: std::process::Command,
+    ) -> miette::Result<std::process::ExitCode> {
+        let error = command.exec();
         Err(miette::miette!(
             "Failed to execute command '{}': {}",
-            cmd.get_program().to_string_lossy(),
-            err
+            command.get_program().to_string_lossy(),
+            error
         ))
     }
 }
@@ -197,20 +185,20 @@ mod imp {
     /// On windows, we will rely on spawning the child process
     /// using `CreateProcess``
     /// and waiting for it to complete, since we cannot use `exec`.
-    pub(crate) fn execute_command(mut cmd: std::process::Command) -> miette::Result<()> {
-        let mut child = cmd.spawn().into_diagnostic().wrap_err(format!(
+    pub(crate) fn execute_command(
+        mut command: std::process::Command,
+    ) -> miette::Result<std::process::ExitCode> {
+        let mut child = command.spawn().into_diagnostic().wrap_err(format!(
             "Couldn't spawn the child process {}",
-            cmd.get_program().to_string_lossy()
+            command.get_program().to_string_lossy()
         ))?;
 
-        // Wait for the child process to complete
         let status = child.wait().into_diagnostic().wrap_err(format!(
             "Couldn't wait for the child process {}",
-            cmd.get_program().to_string_lossy()
+            command.get_program().to_string_lossy()
         ))?;
 
-        // Exit with the same status code as the child process
-        std::process::exit(status.code().unwrap_or(1));
+        Ok(super::process_exit::exit_code_from_status(status))
     }
 }
 

--- a/crates/pixi_cli/src/config.rs
+++ b/crates/pixi_cli/src/config.rs
@@ -178,13 +178,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             if out.is_empty() {
                 eprintln!("Configuration not set");
             }
-            writeln!(std::io::stdout(), "{out}")
-                .map_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                    e
-                })
+            pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{out}"))
                 .into_diagnostic()?;
         }
         Subcommand::Prepend(args) => alter_config(

--- a/crates/pixi_cli/src/exec.rs
+++ b/crates/pixi_cli/src/exec.rs
@@ -1,4 +1,6 @@
-use std::{collections::BTreeSet, collections::HashMap, path::Path, str::FromStr};
+use std::{
+    collections::BTreeSet, collections::HashMap, path::Path, process::ExitCode, str::FromStr,
+};
 
 use clap::{Parser, ValueHint};
 use indexmap::IndexSet;
@@ -74,7 +76,7 @@ pub struct Args {
 }
 
 /// CLI entry point for `pixi exec`
-pub async fn execute(args: Args) -> miette::Result<()> {
+pub async fn execute(args: Args) -> miette::Result<ExitCode> {
     let config = Config::with_cli_config(&args.config);
     let cache_dir = pixi_config::get_cache_dir().context("failed to determine cache directory")?;
 
@@ -129,10 +131,6 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     // Get environment variables from the activation
     let mut activation_env = run_activation(&prefix).await?;
 
-    // `pixi exec` replaces the process below, so flush notices after all pixi
-    // output rather than relying on the top-level command dispatcher.
-    pixi_reporters::display_channel_notices();
-
     // Collect unique package names for environment naming
     let package_names: BTreeSet<String> = display_names.into_iter().collect();
 
@@ -181,9 +179,8 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_context(|| format!("failed to execute '{}'", command))?;
 
     // Mirror the child's exit (including signal deaths like SIGSEGV) so the
-    // parent shell sees the same outcome it would if the child had run
-    // directly.
-    process_exit::exit_with_status(status);
+    // parent shell sees the same outcome it would if the child had run directly.
+    Ok(process_exit::exit_code_from_status(status))
 }
 
 /// Creates a prefix for the `pixi exec` command.

--- a/crates/pixi_cli/src/info.rs
+++ b/crates/pixi_cli/src/info.rs
@@ -598,26 +598,14 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     };
 
     if args.json {
-        writeln!(
+        pixi_utils::io::ignore_broken_pipe(writeln!(
             std::io::stdout(),
             "{}",
             serde_json::to_string_pretty(&info).into_diagnostic()?
-        )
-        .map_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-            e
-        })
+        ))
         .into_diagnostic()?;
     } else {
-        writeln!(std::io::stdout(), "{info}")
-            .map_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-                e
-            })
+        pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{info}"))
             .into_diagnostic()?;
     }
 

--- a/crates/pixi_cli/src/lib.rs
+++ b/crates/pixi_cli/src/lib.rs
@@ -16,7 +16,7 @@ use pixi_consts::consts;
 use pixi_core::environment::LockFileUsage;
 use pixi_progress::global_multi_progress;
 
-use std::{env, io::IsTerminal};
+use std::{env, io::IsTerminal, process::ExitCode};
 use tracing::level_filters::LevelFilter;
 
 pub mod add;
@@ -247,54 +247,48 @@ impl LockFileUsageConfig {
     }
 }
 
-pub async fn execute() -> miette::Result<()> {
-    let args = Args::parse();
+pub async fn execute() -> miette::Result<ExitCode> {
+    let args = match Args::try_parse() {
+        Ok(args) => args,
+        Err(error) => {
+            let exit_code = process_exit::exit_code_from_code(error.exit_code());
+            pixi_utils::io::ignore_broken_pipe(error.print()).into_diagnostic()?;
+            return Ok(exit_code);
+        }
+    };
 
-    // Extract values we need before moving args
     let no_progress = args.no_progress();
-
     set_console_colors(&args);
 
     let use_colors = console::colors_enabled_stderr();
     let in_ci = matches!(env::var("CI").as_deref(), Ok("1" | "true"));
     let no_wrap = matches!(env::var("PIXI_NO_WRAP").as_deref(), Ok("1" | "true"));
-    // Set up the default miette handler based on whether we want colors or not.
     miette::set_hook(Box::new(move |_| {
         Box::new(
             miette::MietteHandlerOpts::default()
                 .color(use_colors)
                 .with_syntax_highlighting(miette_arborium::MietteHighlighter::new())
-                // Don't wrap lines in CI environments or when explicitly specified to avoid
-                // breaking logs and tests.
                 .wrap_lines(!in_ci && !no_wrap)
                 .build(),
         )
     }))?;
 
-    // Hide all progress bars if the user requested it.
     if no_progress {
         global_multi_progress().set_draw_target(ProgressDrawTarget::hidden());
     }
 
-    // Handle `--list`: print installed commands and exit 0
     if args.list {
         print_installed_commands();
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
 
-    // Setup logging for the application.
     setup_logging(&args, use_colors)?;
-
-    // The quiet flag silences the reports of `pixi global` as well as the
-    // logging.
     pixi_global::report::set_verbosity(args.global_options.report_verbosity());
 
     let (Some(command), global_options) = (args.command, args.global_options) else {
-        // match CI expectations
-        std::process::exit(2);
+        return Ok(ExitCode::from(2));
     };
 
-    // Execute the command
     execute_command(command, &global_options).await
 }
 
@@ -373,49 +367,50 @@ fn setup_logging(args: &Args, use_colors: bool) -> miette::Result<()> {
 pub async fn execute_command(
     command: Command,
     global_options: &GlobalOptions,
-) -> miette::Result<()> {
+) -> miette::Result<ExitCode> {
     let result = match command {
-        Command::Completion(cmd) => completion::execute(cmd),
-        Command::Config(cmd) => config::execute(cmd).await,
-        Command::Init(cmd) => init::execute(cmd).await,
-        Command::Add(cmd) => add::execute(cmd).await,
-        Command::Clean(cmd) => clean::execute(cmd).await,
+        Command::Completion(cmd) => completion::execute(cmd).map(|()| ExitCode::SUCCESS),
+        Command::Config(cmd) => config::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Init(cmd) => init::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Add(cmd) => add::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Clean(cmd) => clean::execute(cmd).await.map(|()| ExitCode::SUCCESS),
         Command::Run(cmd) => run::execute(cmd).await,
-        Command::Global(cmd) => global::execute(cmd).await,
-        Command::Auth(cmd) => rattler::cli::auth::execute(cmd).await.into_diagnostic(),
-        Command::Install(cmd) => install::execute(cmd).await,
-        Command::Reinstall(cmd) => reinstall::execute(cmd).await,
+        Command::Global(cmd) => global::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Auth(cmd) => rattler::cli::auth::execute(cmd)
+            .await
+            .into_diagnostic()
+            .map(|()| ExitCode::SUCCESS),
+        Command::Install(cmd) => install::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Reinstall(cmd) => reinstall::execute(cmd).await.map(|()| ExitCode::SUCCESS),
         Command::Shell(cmd) => shell::execute(cmd).await,
-        Command::ShellHook(cmd) => shell_hook::execute(cmd).await,
-        Command::Task(cmd) => task::execute(cmd).await,
-        Command::Info(cmd) => info::execute(cmd).await,
-        Command::Import(cmd) => import::execute(cmd).await,
-        Command::Publish(cmd) => publish::execute(cmd).await,
-        Command::Upload(cmd) => upload::execute(cmd).await,
-        Command::Search(cmd) => search::execute(cmd).await,
+        Command::ShellHook(cmd) => shell_hook::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Task(cmd) => task::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Info(cmd) => info::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Import(cmd) => import::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Publish(cmd) => publish::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Upload(cmd) => upload::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Search(cmd) => search::execute(cmd).await.map(|()| ExitCode::SUCCESS),
         Command::Workspace(cmd) => workspace::execute(cmd).await,
-        Command::Remove(cmd) => remove::execute(cmd).await,
+        Command::Remove(cmd) => remove::execute(cmd).await.map(|()| ExitCode::SUCCESS),
         #[cfg(feature = "self_update")]
-        Command::SelfUpdate(cmd) => self_update::execute(cmd, global_options).await,
+        Command::SelfUpdate(cmd) => self_update::execute(cmd, global_options)
+            .await
+            .map(|()| ExitCode::SUCCESS),
         #[cfg(not(feature = "self_update"))]
-        Command::SelfUpdate(cmd) => self_update::execute_stub(cmd, global_options).await,
-        Command::List(cmd) => list::execute(cmd).await,
-        Command::Tree(cmd) => tree::execute(cmd).await,
-        Command::Update(cmd) => update::execute(cmd).await,
-        Command::Upgrade(cmd) => upgrade::execute(cmd).await,
-        Command::Lock(cmd) => lock::execute(cmd).await,
+        Command::SelfUpdate(cmd) => self_update::execute_stub(cmd, global_options)
+            .await
+            .map(|()| ExitCode::SUCCESS),
+        Command::List(cmd) => list::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Tree(cmd) => tree::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Update(cmd) => update::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Upgrade(cmd) => upgrade::execute(cmd).await.map(|()| ExitCode::SUCCESS),
+        Command::Lock(cmd) => lock::execute(cmd).await.map(|()| ExitCode::SUCCESS),
         Command::Exec(args) => exec::execute(args).await,
-        Command::Build(args) => build::execute(args).await,
+        Command::Build(args) => build::execute(args).await.map(|()| ExitCode::SUCCESS),
         Command::External(args) => command_info::execute_external_command(args),
     };
 
-    // Notices are deferred to here so they cannot get lost among progress bars
-    // and other output. They are shown whether or not the command succeeded: a
-    // channel advisory is most relevant to someone whose command just failed.
     pixi_reporters::display_channel_notices();
-
-    // Failures caused by offline mode get a hint attached that explains how to
-    // get out of it.
     result.map_err(offline::attach_offline_hint)
 }
 

--- a/crates/pixi_cli/src/process_exit.rs
+++ b/crates/pixi_cli/src/process_exit.rs
@@ -1,5 +1,4 @@
-//! Helpers for exiting the pixi process so that the parent shell observes the
-//! same outcome as the child command we executed.
+//! Helpers for returning executed command outcomes from `main`.
 //!
 //! On Unix, when a child is killed by a signal (e.g. SIGSEGV), the parent's
 //! shell only prints messages like "Segmentation fault" if its own child
@@ -9,35 +8,43 @@
 //! original behaviour we restore the default disposition for the signal and
 //! re-raise it on ourselves.
 
-use std::process::ExitStatus;
+use std::process::{ExitCode, ExitStatus};
 
-/// Exit the current process mirroring how `status` terminated.
-pub fn exit_with_status(status: ExitStatus) -> ! {
+/// Convert `status` to a portable code returned by the pixi process.
+///
+/// [`ExitCode`] only accepts values through `u8`, so larger platform-specific
+/// child statuses are returned as [`ExitCode::FAILURE`].
+pub fn exit_code_from_status(status: ExitStatus) -> ExitCode {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
         if let Some(signal) = status.signal() {
-            exit_via_signal(signal);
+            return exit_code_from_signal(signal);
         }
     }
-    std::process::exit(status.code().unwrap_or(1));
+    exit_code_from_code(status.code().unwrap_or(1))
 }
 
-/// Like [`exit_with_status`] but for callers that only have a numeric exit
-/// code where signal deaths were already encoded as `128 + signal_number`
-/// (the POSIX shell convention also used by `deno_task_shell`).
-pub fn exit_with_code(code: i32) -> ! {
+/// Convert a numeric child exit code to the code returned by the pixi process.
+///
+/// Signal deaths may already be encoded as `128 + signal_number`, following
+/// the POSIX shell convention used by `deno_task_shell`.
+pub fn exit_code_from_code(code: i32) -> ExitCode {
     #[cfg(unix)]
     {
         if let Some(signal) = code.checked_sub(128).filter(|s| (1..=64).contains(s)) {
-            exit_via_signal(signal);
+            return exit_code_from_signal(signal);
         }
     }
-    std::process::exit(code);
+    numeric_exit_code(code)
+}
+
+fn numeric_exit_code(code: i32) -> ExitCode {
+    u8::try_from(code).map_or(ExitCode::FAILURE, ExitCode::from)
 }
 
 #[cfg(unix)]
-fn exit_via_signal(signal: i32) -> ! {
+fn exit_code_from_signal(signal: i32) -> ExitCode {
     // SAFETY: `signal(2)` and `raise(3)` are async-signal-safe and have no
     // Rust-level invariants to uphold.
     unsafe {
@@ -46,5 +53,5 @@ fn exit_via_signal(signal: i32) -> ! {
     }
     // If raise() somehow returned (e.g. signal was blocked higher up), fall
     // back to the conventional encoded exit code.
-    std::process::exit(128 + signal);
+    numeric_exit_code(128 + signal)
 }

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -3,7 +3,7 @@ use std::{
     convert::identity,
     ffi::OsString,
     io::Read,
-    string::String,
+    process::ExitCode,
 };
 
 #[cfg(unix)]
@@ -166,7 +166,7 @@ impl Args {
 /// CLI entry point for `pixi run`
 /// When running the sigints are ignored and child can react to them. As it
 /// pleases.
-pub async fn execute(mut args: Args) -> miette::Result<()> {
+pub async fn execute(mut args: Args) -> miette::Result<ExitCode> {
     args.validate_script_options()?;
 
     // Following statements don't spawn any progress bar, so set
@@ -217,10 +217,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                     let code =
                         crate::conda_script::execute_run(workspace, entrypoint, args).await?;
                     drop(prepared.directory);
-                    if code != 0 {
-                        process_exit::exit_with_code(code);
-                    }
-                    return Ok(());
+                    return Ok(process_exit::exit_code_from_code(code));
                 }
             };
             let script_path = manifest.path().to_owned();
@@ -295,10 +292,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                 let entrypoint = manifest.metadata().entrypoint.clone();
                 let workspace = Workspace::from_conda_script(manifest, config)?;
                 let code = crate::conda_script::execute_run(workspace, entrypoint, args).await?;
-                if code != 0 {
-                    process_exit::exit_with_code(code);
-                }
-                return Ok(());
+                return Ok(process_exit::exit_code_from_code(code));
             }
             WorkspaceLocator::for_cli()
                 .with_global_config_source(global_config_source)
@@ -350,7 +344,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
     // Print all available tasks if no task is provided
     if args.task.is_empty() {
         command_not_found(&workspace, explicit_environment);
-        return Ok(());
+        return Ok(ExitCode::SUCCESS);
     }
 
     // We expect progress bar to be used afterwards, so set draw
@@ -673,7 +667,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
                 if code == 127 {
                     command_not_found(&workspace, explicit_environment.clone());
                 }
-                process_exit::exit_with_code(code);
+                return Ok(process_exit::exit_code_from_code(code));
             }
             Err(err) => return Err(err.into()),
         }
@@ -692,7 +686,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             .into_diagnostic()?;
     }
 
-    Ok(())
+    Ok(ExitCode::SUCCESS)
 }
 
 /// Called when a command was not found.
@@ -840,17 +834,6 @@ fn reset_cursor() {
     let term = console::Term::stdout();
     let _ = term.show_cursor();
 }
-
-// /// Exit the process with the appropriate exit code for a SIGINT.
-// fn exit_process_on_sigint() {
-//     // https://learn.microsoft.com/en-us/cpp/c-runtime-library/signal-constants
-//     #[cfg(target_os = "windows")]
-//     std::process::exit(3);
-//
-//     // POSIX compliant OSs: 128 + SIGINT (2)
-//     #[cfg(not(target_os = "windows"))]
-//     std::process::exit(130);
-// }
 
 /// Runs a task future forwarding any signals received to the process.
 ///

--- a/crates/pixi_cli/src/shared/tree.rs
+++ b/crates/pixi_cli/src/shared/tree.rs
@@ -267,7 +267,7 @@ pub fn print_package(
     } else {
         format!("(extra: {})", via_extras.join(", "))
     };
-    writeln!(
+    pixi_utils::io::ignore_broken_pipe(writeln!(
         handle,
         "{}{} {} {}{}",
         prefix,
@@ -282,15 +282,7 @@ pub fn print_package(
         },
         console::style(extras_label).fg(Color::Cyan),
         if visited { " (*)" } else { "" }
-    )
-    .map_err(|e| {
-        if e.kind() == std::io::ErrorKind::BrokenPipe {
-            // Exit gracefully
-            std::process::exit(0);
-        } else {
-            e
-        }
-    })
+    ))
     .into_diagnostic()
     .wrap_err("Failed to write package information")
 }

--- a/crates/pixi_cli/src/shell.rs
+++ b/crates/pixi_cli/src/shell.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Write, path::PathBuf};
+use std::{collections::HashMap, io::Write, path::PathBuf, process::ExitCode};
 
 use clap::Parser;
 use miette::IntoDiagnostic;
@@ -321,7 +321,7 @@ async fn start_nu_shell(
     Ok(process.wait().into_diagnostic()?.code())
 }
 
-pub async fn execute(args: Args) -> miette::Result<()> {
+pub async fn execute(args: Args) -> miette::Result<ExitCode> {
     let config = args
         .activation_config
         .merge_config(args.prompt_config.into())
@@ -457,16 +457,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         }
     };
 
-    // This function exits the process rather than returning, so the flush in
-    // the top-level command dispatcher never runs for `pixi shell`.
-    pixi_reporters::display_channel_notices();
-
     match res {
-        Ok(Some(code)) => std::process::exit(code),
-        Ok(None) => std::process::exit(0),
-        Err(e) => {
-            eprintln!("Error starting shell: {e}");
-            std::process::exit(1);
+        Ok(Some(code)) => Ok(crate::process_exit::exit_code_from_code(code)),
+        Ok(None) => Ok(ExitCode::SUCCESS),
+        Err(error) => {
+            eprintln!("Error starting shell: {error}");
+            Ok(ExitCode::FAILURE)
         }
     }
 }

--- a/crates/pixi_cli/src/task.rs
+++ b/crates/pixi_cli/src/task.rs
@@ -385,17 +385,11 @@ fn print_tasks(
     }
 
     let mut stdout = std::io::stdout();
-    if let Err(error) = stdout
-        .write_all(output.as_bytes())
-        .and_then(|()| stdout.flush())
-    {
-        if error.kind() == std::io::ErrorKind::BrokenPipe {
-            std::process::exit(0);
-        }
-        return Err(error);
-    }
-
-    Ok(())
+    pixi_utils::io::ignore_broken_pipe(
+        stdout
+            .write_all(output.as_bytes())
+            .and_then(|()| stdout.flush()),
+    )
 }
 
 pub async fn execute(args: Args) -> miette::Result<()> {
@@ -442,12 +436,7 @@ async fn list_tasks(
             .dedup()
             .map(|name| name.as_str())
             .join(" ");
-        writeln!(std::io::stdout(), "{unformatted}")
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
+        pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{unformatted}"))
             .into_diagnostic()?;
 
         return Ok(());
@@ -511,12 +500,7 @@ fn print_tasks_json(project: &Workspace) -> miette::Result<()> {
 
     let json_string =
         serde_json::to_string_pretty(&env_feature_task_map).expect("Failed to serialize tasks");
-    writeln!(std::io::stdout(), "{json_string}")
-        .inspect_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-        })
+    pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{json_string}"))
         .into_diagnostic()?;
 
     Ok(())

--- a/crates/pixi_cli/src/workspace/activation.rs
+++ b/crates/pixi_cli/src/workspace/activation.rs
@@ -383,11 +383,7 @@ async fn list(
         output.push_str(&format!("No {what} found {scope}.\n"));
     }
 
-    let _ = write!(std::io::stdout(), "{output}").inspect_err(|e| {
-        if e.kind() == std::io::ErrorKind::BrokenPipe {
-            std::process::exit(0);
-        }
-    });
+    let _ = pixi_utils::io::ignore_broken_pipe(write!(std::io::stdout(), "{output}"));
 
     Ok(())
 }

--- a/crates/pixi_cli/src/workspace/channel.rs
+++ b/crates/pixi_cli/src/workspace/channel.rs
@@ -152,20 +152,15 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         Command::List(args) => {
             let environments = workspace_ctx.list_channel().await;
             for (env_name, channels) in environments {
-                let _ = writeln!(
+                let _ = pixi_utils::io::ignore_broken_pipe(writeln!(
                     std::io::stdout(),
                     "{} {}",
                     console::style("Environment:").bold().bright(),
                     env_name.fancy_display()
-                )
-                .inspect_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                });
+                ));
 
                 for channel in channels {
-                    let _ = writeln!(
+                    let _ = pixi_utils::io::ignore_broken_pipe(writeln!(
                         std::io::stdout(),
                         "- {}",
                         if args.urls {
@@ -177,12 +172,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
                         } else {
                             channel.to_string()
                         }
-                    )
-                    .inspect_err(|e| {
-                        if e.kind() == std::io::ErrorKind::BrokenPipe {
-                            std::process::exit(0);
-                        }
-                    });
+                    ));
                 }
             }
             Ok(())

--- a/crates/pixi_cli/src/workspace/dependencies.rs
+++ b/crates/pixi_cli/src/workspace/dependencies.rs
@@ -198,12 +198,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             } else {
                 format_workspace_dependencies(dependencies)?
             };
-            writeln!(std::io::stdout(), "{output}")
-                .inspect_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                })
+            pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{output}"))
                 .into_diagnostic()?;
             Ok(())
         }

--- a/crates/pixi_cli/src/workspace/description.rs
+++ b/crates/pixi_cli/src/workspace/description.rs
@@ -53,12 +53,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         Command::Get => {
             // Print the description if it exists
             if let Some(description) = workspace_ctx.description().await {
-                writeln!(std::io::stdout(), "{description}")
-                    .inspect_err(|e| {
-                        if e.kind() == std::io::ErrorKind::BrokenPipe {
-                            std::process::exit(0);
-                        }
-                    })
+                pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{description}"))
                     .into_diagnostic()?;
             }
         }

--- a/crates/pixi_cli/src/workspace/environment.rs
+++ b/crates/pixi_cli/src/workspace/environment.rs
@@ -90,22 +90,16 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             let envs = workspace_ctx.list_environments().await;
             if list_args.machine_readable {
                 let names = envs.iter().map(|e| e.name().as_str()).join(" ");
-                writeln!(std::io::stdout(), "{names}")
-                    .inspect_err(|e| {
-                        if e.kind() == std::io::ErrorKind::BrokenPipe {
-                            std::process::exit(0);
-                        }
-                    })
+                pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{names}"))
                     .into_diagnostic()?;
                 return Ok(());
             }
-            writeln!(std::io::stdout(), "{}", format_environment_list(&envs))
-                .inspect_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                })
-                .into_diagnostic()?;
+            pixi_utils::io::ignore_broken_pipe(writeln!(
+                std::io::stdout(),
+                "{}",
+                format_environment_list(&envs)
+            ))
+            .into_diagnostic()?;
         }
         Command::Add(args) => {
             workspace_ctx

--- a/crates/pixi_cli/src/workspace/feature.rs
+++ b/crates/pixi_cli/src/workspace/feature.rs
@@ -64,12 +64,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             } else {
                 format_feature_list(&features)
             };
-            writeln!(std::io::stdout(), "{output}")
-                .inspect_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                })
+            pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{output}"))
                 .into_diagnostic()?;
         }
         Command::Remove(args) => {

--- a/crates/pixi_cli/src/workspace/mod.rs
+++ b/crates/pixi_cli/src/workspace/mod.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use clap::Parser;
 use itertools::Itertools;
 use pixi_manifest::Feature;
@@ -46,23 +48,23 @@ pub struct Args {
     pub workspace_config: WorkspaceConfig,
 }
 
-pub async fn execute(cmd: Args) -> miette::Result<()> {
+pub async fn execute(cmd: Args) -> miette::Result<ExitCode> {
     match cmd.command {
-        Command::Activation(args) => activation::execute(args).await?,
-        Command::Channel(args) => channel::execute(args).await?,
-        Command::Dependencies(args) => dependencies::execute(args).await?,
-        Command::Description(args) => description::execute(args).await?,
-        Command::Platform(args) => platform::execute(args).await?,
-        Command::Version(args) => version::execute(args).await?,
-        Command::Environment(args) => environment::execute(args).await?,
-        Command::Feature(args) => feature::execute(args).await?,
-        Command::Export(cmd) => export::execute(cmd).await?,
-        Command::Name(args) => name::execute(args).await?,
-        Command::Preview(args) => preview::execute(args).await?,
-        Command::Register(args) => register::execute(args).await?,
-        Command::RequiresPixi(args) => requires_pixi::execute(args).await?,
-    };
-    Ok(())
+        Command::Activation(args) => activation::execute(args).await,
+        Command::Channel(args) => channel::execute(args).await,
+        Command::Dependencies(args) => dependencies::execute(args).await,
+        Command::Description(args) => description::execute(args).await,
+        Command::Platform(args) => platform::execute(args).await,
+        Command::Version(args) => version::execute(args).await,
+        Command::Environment(args) => environment::execute(args).await,
+        Command::Feature(args) => feature::execute(args).await,
+        Command::Export(cmd) => export::execute(cmd).await,
+        Command::Name(args) => name::execute(args).await,
+        Command::Preview(args) => preview::execute(args).await,
+        Command::Register(args) => register::execute(args).await,
+        Command::RequiresPixi(args) => return requires_pixi::execute(args).await,
+    }?;
+    Ok(ExitCode::SUCCESS)
 }
 
 /// Indented detail lines describing a feature's content (dependencies,

--- a/crates/pixi_cli/src/workspace/name.rs
+++ b/crates/pixi_cli/src/workspace/name.rs
@@ -47,13 +47,12 @@ pub async fn execute(args: Args) -> miette::Result<()> {
     let workspace_ctx = cli_context(workspace);
 
     match args.command {
-        Command::Get => writeln!(std::io::stdout(), "{}", workspace_ctx.name().await)
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
-            .into_diagnostic()?,
+        Command::Get => pixi_utils::io::ignore_broken_pipe(writeln!(
+            std::io::stdout(),
+            "{}",
+            workspace_ctx.name().await
+        ))
+        .into_diagnostic()?,
         Command::Set(args) => workspace_ctx.set_name(&args.name).await?,
     }
 

--- a/crates/pixi_cli/src/workspace/platform.rs
+++ b/crates/pixi_cli/src/workspace/platform.rs
@@ -761,12 +761,7 @@ async fn execute_list(
             .map(|p| p.name().as_str())
             .collect::<Vec<_>>()
             .join(" ");
-        writeln!(std::io::stdout(), "{names}")
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
+        pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{names}"))
             .into_diagnostic()?;
         return Ok(());
     }

--- a/crates/pixi_cli/src/workspace/preview.rs
+++ b/crates/pixi_cli/src/workspace/preview.rs
@@ -106,13 +106,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             let workspace_ctx = cli_context(located?);
             let mut stdout = std::io::stdout();
             for flag in workspace_ctx.preview_flags().await {
-                writeln!(stdout, "{flag}")
-                    .inspect_err(|e| {
-                        if e.kind() == std::io::ErrorKind::BrokenPipe {
-                            std::process::exit(0);
-                        }
-                    })
-                    .into_diagnostic()?;
+                pixi_utils::io::ignore_broken_pipe(writeln!(stdout, "{flag}")).into_diagnostic()?;
             }
             Ok(())
         }

--- a/crates/pixi_cli/src/workspace/register.rs
+++ b/crates/pixi_cli/src/workspace/register.rs
@@ -73,13 +73,7 @@ pub async fn execute(args: Args) -> miette::Result<()> {
             } else {
                 toml_edit::ser::to_string_pretty(&workspaces).into_diagnostic()?
             };
-            writeln!(std::io::stdout(), "{out}")
-                .map_err(|e| {
-                    if e.kind() == std::io::ErrorKind::BrokenPipe {
-                        std::process::exit(0);
-                    }
-                    e
-                })
+            pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{out}"))
                 .into_diagnostic()?;
         }
         Some(Command::Remove(remove_args)) => {

--- a/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/mod.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 pub mod get;
 pub mod set;
 pub mod unset;
@@ -37,7 +39,7 @@ pub enum Command {
     Verify,
 }
 
-pub async fn execute(args: Args) -> miette::Result<()> {
+pub async fn execute(args: Args) -> miette::Result<ExitCode> {
     let is_verify = matches!(args.command, Command::Verify);
     let workspace_locator = WorkspaceLocator::for_cli()
         .with_global_config_source(args.config_source.source())
@@ -45,11 +47,10 @@ pub async fn execute(args: Args) -> miette::Result<()> {
         .with_ignore_pixi_version_check(!is_verify);
 
     match args.command {
-        Command::Get => get::execute(workspace_locator.locate()?).await?,
-        Command::Set(args) => set::execute(workspace_locator.locate()?, args).await?,
-        Command::Unset => unset::execute(workspace_locator.locate()?).await?,
-        Command::Verify => verify::execute(workspace_locator.locate().map(|_| ()))?,
-    }
-
-    Ok(())
+        Command::Get => get::execute(workspace_locator.locate()?).await,
+        Command::Set(args) => set::execute(workspace_locator.locate()?, args).await,
+        Command::Unset => unset::execute(workspace_locator.locate()?).await,
+        Command::Verify => return verify::execute(workspace_locator.locate().map(|_| ())),
+    }?;
+    Ok(ExitCode::SUCCESS)
 }

--- a/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
+++ b/crates/pixi_cli/src/workspace/requires_pixi/verify.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use pixi_core::WorkspaceLocatorError;
 
 /// exit code:
@@ -5,14 +7,14 @@ use pixi_core::WorkspaceLocatorError;
 ///   1: failed to parse manifest
 ///   2: failed to parse command line arguments
 ///   4: current pixi version is old
-pub fn execute(result: Result<(), WorkspaceLocatorError>) -> miette::Result<()> {
+pub fn execute(result: Result<(), WorkspaceLocatorError>) -> miette::Result<ExitCode> {
     match result {
-        Ok(()) => Ok(()),
-        Err(WorkspaceLocatorError::PixiVersionMismatch(e)) => {
+        Ok(()) => Ok(ExitCode::SUCCESS),
+        Err(WorkspaceLocatorError::PixiVersionMismatch(error)) => {
             eprintln!(
                 "Error:   {}{}",
                 console::style(console::Emoji("× ", "")).red(),
-                e
+                error
             );
 
             #[cfg(feature = "self_update")]
@@ -20,7 +22,7 @@ pub fn execute(result: Result<(), WorkspaceLocatorError>) -> miette::Result<()> 
                 eprintln!();
                 eprintln!(
                     "Install a version of pixi that satisfies '{}' with:\n  pixi self-update --version <version>\n(a plain `pixi self-update` installs the latest version, which may not satisfy this requirement)",
-                    e.requires_pixi
+                    error.requires_pixi
                 );
             }
 
@@ -29,12 +31,12 @@ pub fn execute(result: Result<(), WorkspaceLocatorError>) -> miette::Result<()> 
                 eprintln!();
                 eprintln!(
                     "Please update pixi using your system package manager or reinstall it.\n\
-             See: https://pixi.sh/latest/installation/"
+                     See: https://pixi.sh/latest/installation/"
                 );
             }
 
-            std::process::exit(4);
+            Ok(ExitCode::from(4))
         }
-        Err(e) => Err(e.into()),
+        Err(error) => Err(error.into()),
     }
 }

--- a/crates/pixi_cli/src/workspace/version/get.rs
+++ b/crates/pixi_cli/src/workspace/version/get.rs
@@ -10,12 +10,7 @@ pub struct Args {}
 pub async fn execute(workspace: Workspace, _args: Args) -> miette::Result<()> {
     // Print the version if it exists
     if let Some(version) = workspace.workspace.value.workspace.version {
-        writeln!(std::io::stdout(), "{version}")
-            .inspect_err(|e| {
-                if e.kind() == std::io::ErrorKind::BrokenPipe {
-                    std::process::exit(0);
-                }
-            })
+        pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{version}"))
             .into_diagnostic()?;
     }
     Ok(())

--- a/crates/pixi_global/src/list.rs
+++ b/crates/pixi_global/src/list.rs
@@ -118,12 +118,7 @@ pub async fn list_global_environments_json(
 
     let json_string =
         serde_json::to_string_pretty(&environments).expect("cannot serialize environments to JSON");
-    writeln!(std::io::stdout(), "{json_string}")
-        .inspect_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-        })
+    pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{json_string}"))
         .into_diagnostic()?;
 
     Ok(())
@@ -131,13 +126,7 @@ pub async fn list_global_environments_json(
 
 /// Write a line to stdout, treating a closed pipe as a normal end of output.
 fn write_stdout(line: &str) -> miette::Result<()> {
-    writeln!(std::io::stdout(), "{line}")
-        .inspect_err(|e| {
-            if e.kind() == std::io::ErrorKind::BrokenPipe {
-                std::process::exit(0);
-            }
-        })
-        .into_diagnostic()
+    pixi_utils::io::ignore_broken_pipe(writeln!(std::io::stdout(), "{line}")).into_diagnostic()
 }
 
 fn format_mapping(mapping: &Mapping) -> Item {

--- a/crates/pixi_utils/src/io.rs
+++ b/crates/pixi_utils/src/io.rs
@@ -1,0 +1,9 @@
+use std::io;
+
+/// Treat a closed output pipe as successful completion.
+pub fn ignore_broken_pipe(result: io::Result<()>) -> io::Result<()> {
+    match result {
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        result => result,
+    }
+}

--- a/crates/pixi_utils/src/lib.rs
+++ b/crates/pixi_utils/src/lib.rs
@@ -4,6 +4,7 @@ pub mod conda_environment_file;
 mod environment_fingerprint;
 mod environment_lock;
 pub mod indicatif;
+pub mod io;
 pub mod prefix;
 mod prefix_guard;
 pub mod reproducible;

--- a/tests/integration_python/test_main_cli.py
+++ b/tests/integration_python/test_main_cli.py
@@ -3,6 +3,7 @@ import os
 import platform
 import shlex
 import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,34 @@ def test_pixi(pixi: Path) -> None:
         [pixi], ExitCode.INCORRECT_USAGE, stdout_excludes=f"[version {PIXI_VERSION}]"
     )
     verify_cli_command([pixi, "--version"], stdout_contains=PIXI_VERSION)
+
+
+def test_pixi_broken_output_pipe(pixi: Path) -> None:
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    try:
+        help_result = subprocess.run(
+            [pixi, "--help"],
+            stdout=write_fd,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    finally:
+        os.close(write_fd)
+    assert help_result.returncode == ExitCode.SUCCESS
+
+    read_fd, write_fd = os.pipe()
+    os.close(read_fd)
+    try:
+        error_result = subprocess.run(
+            [pixi, "--definitely-invalid"],
+            stdout=subprocess.DEVNULL,
+            stderr=write_fd,
+            check=False,
+        )
+    finally:
+        os.close(write_fd)
+    assert error_result.returncode == ExitCode.INCORRECT_USAGE
 
 
 @pytest.mark.slow


### PR DESCRIPTION
### Description

Windows needs a normal return from `main` to flush PGO data. The CLI currently calls `std::process::exit` from command handlers, which skips profile teardown on Windows.

This threads `ExitCode` through command dispatch, tasks, shell and exec commands, conda-script entrypoints, external commands, and version gating. Unix signal exits are still re-raised at the `main` boundary, while broken pipes return normally.

`ExitCode` only exposes portable `u8` values on stable Rust. Windows-specific child statuses above 255 therefore map to failure instead of preserving the full 32-bit value.

### How Has This Been Tested?

- Ran `cargo check -p pixi` and `cargo build -p pixi` on Linux
- Ran `cargo build --workspace` on Windows
- Ran `cargo build -p pixi --target x86_64-pc-windows-msvc` after rebasing onto current `main`
- Checked that `--version` and `--help` return 0, while clap errors return 2 on Windows
- Checked that external commands preserve exit code 2 and tasks preserve exit code 12 on Windows
- Ran the broken stdout and stderr pipe integration test on Windows
- Ran the conda-script failing-entrypoint integration test on Windows
- Checked Unix signal identity for external commands and tasks with SIGINT, SIGKILL, and SIGTERM

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
