### PR TITLE
feat: add remote url support to conda-script

### DIFF
--- a/crates/pixi_cli/src/conda_script.rs
+++ b/crates/pixi_cli/src/conda_script.rs
@@ -12,13 +12,12 @@ use pixi_core::{
     },
 };
 use pixi_manifest::WithWarnings;
-use pixi_manifest::script::conda::CondaScriptManifest;
+use pixi_manifest::script::conda::{CondaScriptManifest, Entrypoint};
 use pixi_script_shell::{ShellContext, execute_sequence, parse_sequence};
 use pixi_task::get_task_env;
 use tracing::Level;
 
 use crate::{
-    process_exit,
     run::{Args, run_future_forwarding_signals},
     shared::install_platform::resolve_install_platform,
 };
@@ -37,8 +36,8 @@ pub(crate) fn detect_with_fallback(
 
 /// Whether the contents carry a conda-script block, well-formed or not.
 ///
-/// Transient script sources use this to explain that conda-script files only
-/// run from local paths, instead of reporting a missing PEP 723 block.
+/// Stdin uses this to report unsupported conda-script blocks instead of a
+/// missing PEP 723 block.
 pub(crate) fn looks_like_conda_script(contents: &[u8]) -> bool {
     !matches!(
         CondaScriptManifest::from_source("conda-script-probe", contents),
@@ -46,23 +45,41 @@ pub(crate) fn looks_like_conda_script(contents: &[u8]) -> bool {
     )
 }
 
-/// Solves and installs the environment of a `conda-script` file, then runs
-/// its entrypoint through the mini-shell with the CLI arguments appended.
-pub(crate) async fn execute_run(
-    manifest: CondaScriptManifest,
-    args: Args,
-    config: pixi_config::Config,
+pub(crate) fn ensure_enabled(
+    experimental: bool,
+    config: &pixi_config::Config,
+    source: &str,
 ) -> miette::Result<()> {
-    let script_path = manifest.path().to_owned();
-    let entrypoint = manifest.metadata().entrypoint.clone();
+    if !experimental && !config.experimental_conda_script() {
+        return Err(miette::miette!(
+            help = "conda-script support is experimental; opt in with `pixi config set experimental.conda-script true --global`, or add `--experimental` to this run",
+            "{source} contains a conda-script block"
+        ));
+    }
+    if !experimental {
+        eprintln!(
+            "warning: Running {source} through `experimental.conda-script`, a draft format that may still change",
+        );
+    }
+    Ok(())
+}
 
+/// Solves and installs the environment of a `conda-script` file, then runs
+/// its entrypoint through the mini-shell, returning its exit code so callers
+/// can clean up downloaded files before exiting.
+pub(crate) async fn execute_run(
+    workspace: WithWarnings<Workspace>,
+    entrypoint: Entrypoint,
+    args: Args,
+) -> miette::Result<i32> {
     let WithWarnings {
         value: workspace,
         warnings,
-    } = Workspace::from_conda_script(manifest, config)?;
+    } = workspace;
     for warning in warnings {
         tracing::warn!("{warning}");
     }
+    let script_path = workspace.workspace.provenance.path.clone();
     sanity_check_workspace(&workspace).await?;
 
     let environment = workspace.default_environment();
@@ -162,7 +179,7 @@ pub(crate) async fn execute_run(
                 .bold()
         );
         print_command(command);
-        return Ok(());
+        return Ok(0);
     }
 
     if allow_installs {
@@ -215,14 +232,20 @@ pub(crate) async fn execute_run(
         cwd: std::env::current_dir().into_diagnostic()?,
         kill_signal: kill_signal.clone(),
     };
+    // Interactive SIGINT reaches the child directly. Keep Pixi alive long
+    // enough to remove a downloaded script before propagating its exit.
+    #[cfg(unix)]
+    let _interrupt = workspace
+        .persistent_lock_file_path()
+        .is_none()
+        .then(|| tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()))
+        .transpose()
+        .into_diagnostic()?;
     let code = run_future_forwarding_signals(
         kill_signal,
         execute_sequence(&sequence, &args.task, &context),
     )
     .await
     .map_err(Report::new)?;
-    if code != 0 {
-        process_exit::exit_with_code(code);
-    }
-    Ok(())
+    Ok(code)
 }

--- a/crates/pixi_cli/src/run.rs
+++ b/crates/pixi_cli/src/run.rs
@@ -46,8 +46,8 @@ use crate::cli_config::{
 };
 use crate::process_exit;
 use crate::run_script::{
-    RunScriptInput, STDIN_SCRIPT_COMMAND, StdinScriptCommand, prepare_remote_script,
-    prepare_stdin_script, transient_script_cache_key,
+    RemoteScriptManifest, RunScriptInput, STDIN_SCRIPT_COMMAND, StdinScriptCommand,
+    prepare_remote_script, prepare_stdin_script, transient_script_cache_key,
 };
 use crate::shared::install_platform::resolve_install_platform;
 
@@ -188,7 +188,7 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
         .map(RunScriptInput::classify);
     let requested_lock_file_usage = args.lock_and_install_config.lock_file_usage()?;
     let global_config_source = args.config_source.source();
-    let mut _remote_script_file = None;
+    let mut _remote_script_directory = None;
     let mut stdin_script_command = None;
     let workspace = match script_input {
         Some(RunScriptInput::Remote(url)) => {
@@ -196,24 +196,49 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             let root = std::env::current_dir().into_diagnostic()?;
             let config = pixi_config::Config::load_with(&root, &global_config_source)
                 .merge_config(cli_config);
-            let prepared = prepare_remote_script(url, &config, &root).await?;
+            let prepared = prepare_remote_script(url, &config, &root, args.experimental).await?;
             let cache_key =
                 transient_script_cache_key(b"remote", prepared.original_url.as_str().as_bytes());
+            let manifest = match prepared.manifest {
+                RemoteScriptManifest::Pep723(manifest) => manifest,
+                RemoteScriptManifest::CondaScript(manifest) => {
+                    let entrypoint = manifest.metadata().entrypoint.clone();
+                    let workspace = Workspace::from_transient_conda_script(
+                        manifest,
+                        config,
+                        root,
+                        &prepared.cache_name,
+                        &cache_key,
+                    )?;
+                    if not_hidden {
+                        global_multi_progress()
+                            .set_draw_target(ProgressDrawTarget::stderr_with_hz(20));
+                    }
+                    let code =
+                        crate::conda_script::execute_run(workspace, entrypoint, args).await?;
+                    drop(prepared.directory);
+                    if code != 0 {
+                        process_exit::exit_with_code(code);
+                    }
+                    return Ok(());
+                }
+            };
+            let script_path = manifest.path().to_owned();
             let WithWarnings {
                 value: workspace,
                 warnings,
             } = Workspace::from_transient_script(
-                prepared.manifest,
+                manifest,
                 config,
                 root,
-                prepared.file.path().to_owned(),
+                script_path,
                 &prepared.cache_name,
                 &cache_key,
             )?;
             for warning in warnings {
                 tracing::warn!("{warning}");
             }
-            _remote_script_file = Some(prepared.file);
+            _remote_script_directory = Some(prepared.directory);
             workspace
         }
         Some(RunScriptInput::Stdin) => {
@@ -259,24 +284,21 @@ pub async fn execute(mut args: Args) -> miette::Result<()> {
             // A conda-script block takes this file off the PEP 723 path; a
             // file with both kinds of block is rejected by the detection.
             if let Some(manifest) = crate::conda_script::detect_with_fallback(&path, opted_in)? {
-                if !opted_in {
-                    return Err(miette::miette!(
-                        help = "conda-script support is experimental; opt in with `pixi config set experimental.conda-script true --global`, or add `--experimental` to this run",
-                        "{} contains a conda-script block",
-                        path.display()
-                    ));
-                }
-                if !args.experimental {
-                    eprintln!(
-                        "{}Running {} through `experimental.conda-script`, a draft format that may still change",
-                        console::style(console::Emoji("⚠️ ", "warning: ")).yellow(),
-                        path.display(),
-                    );
-                }
+                crate::conda_script::ensure_enabled(
+                    args.experimental,
+                    &config,
+                    &path.display().to_string(),
+                )?;
                 if not_hidden {
                     global_multi_progress().set_draw_target(ProgressDrawTarget::stderr_with_hz(20));
                 }
-                return crate::conda_script::execute_run(manifest, args, config).await;
+                let entrypoint = manifest.metadata().entrypoint.clone();
+                let workspace = Workspace::from_conda_script(manifest, config)?;
+                let code = crate::conda_script::execute_run(workspace, entrypoint, args).await?;
+                if code != 0 {
+                    process_exit::exit_with_code(code);
+                }
+                return Ok(());
             }
             WorkspaceLocator::for_cli()
                 .with_global_config_source(global_config_source)

--- a/crates/pixi_cli/src/run_script.rs
+++ b/crates/pixi_cli/src/run_script.rs
@@ -10,11 +10,12 @@ use deno_task_shell::{ExecutableCommand, FutureExecuteResult, ShellCommand, Shel
 use miette::{IntoDiagnostic, WrapErr};
 use pixi_config::Config;
 use pixi_manifest::script::ScriptManifest;
+use pixi_manifest::script::conda::CondaScriptManifest;
 use pixi_utils::reqwest::build_reqwest_clients;
 use reqwest::header::ACCEPT;
 use reqwest_middleware::{ClientWithMiddleware, RequestBuilder};
 use serde::Deserialize;
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 use url::Url;
 
 #[derive(Debug)]
@@ -111,9 +112,14 @@ pub(crate) fn prepare_stdin_script(
     })
 }
 
+pub(crate) enum RemoteScriptManifest {
+    Pep723(ScriptManifest),
+    CondaScript(CondaScriptManifest),
+}
+
 pub(crate) struct PreparedRemoteScript {
-    pub(crate) file: NamedTempFile,
-    pub(crate) manifest: ScriptManifest,
+    pub(crate) directory: TempDir,
+    pub(crate) manifest: RemoteScriptManifest,
     pub(crate) original_url: Url,
     pub(crate) cache_name: String,
 }
@@ -122,6 +128,7 @@ pub(crate) async fn prepare_remote_script(
     original_url: Url,
     config: &Config,
     root: &Path,
+    experimental: bool,
 ) -> miette::Result<PreparedRemoteScript> {
     let safe_original_url = safe_url(&original_url);
     let (_, client) = build_reqwest_clients(Some(config), None)?;
@@ -138,10 +145,23 @@ pub(crate) async fn prepare_remote_script(
 
     let final_url = response.url().clone();
     let cache_name = friendly_name(&final_url);
-    let mut file = tempfile::Builder::new()
-        .prefix(&format!("{cache_name}-"))
-        .suffix(".py")
-        .tempfile()
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("pixi-script-");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        builder.permissions(std::fs::Permissions::from_mode(0o700));
+    }
+    let directory = builder
+        .tempdir()
+        .into_diagnostic()
+        .wrap_err("failed to create a temporary directory for the remote script")?;
+    let filename = Path::new(final_url.path())
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("script");
+    let path = directory.path().join(filename);
+    let mut file = fs_err::File::create(&path)
         .into_diagnostic()
         .wrap_err("failed to create a temporary file for the remote script")?;
     while let Some(chunk) = response
@@ -156,34 +176,38 @@ pub(crate) async fn prepare_remote_script(
     file.flush()
         .into_diagnostic()
         .wrap_err("failed to flush the downloaded script")?;
+    drop(file);
 
-    let contents = fs_err::read(file.path())
+    let contents = fs_err::read(&path)
         .into_diagnostic()
         .wrap_err("failed to read the downloaded script")?;
-    let manifest = ScriptManifest::from_source_with_context(
-        file.path().to_owned(),
+    let python_path = directory.path().join("script.py");
+    let manifest = if let Some(manifest) = ScriptManifest::from_source_with_context(
+        python_path.clone(),
         &contents,
         safe_original_url.clone(),
         root.to_owned(),
         cache_name.clone(),
-    )?
-    .ok_or_else(|| {
-        if crate::conda_script::looks_like_conda_script(&contents) {
-            miette::miette!(
-                help = "conda-script blocks run from local files: download the script and run `pixi run --experimental --script <PATH>`",
-                "the remote script at {safe_original_url} contains a conda-script block, which only runs from a local file"
-            )
-        } else {
+    )? {
+        // Keep PEP 723 execution independent of the URL's filename.
+        if path != python_path {
+            fs_err::rename(&path, &python_path).into_diagnostic()?;
+        }
+        RemoteScriptManifest::Pep723(manifest)
+    } else {
+        let manifest = CondaScriptManifest::from_source(&path, &contents)?.ok_or_else(|| {
             miette::miette!(
                 help =
                     "Download the script and initialize it locally with `pixi init --script <PATH>`.",
                 "the remote script at {safe_original_url} does not contain a PEP 723 metadata block"
             )
-        }
-    })?;
+        })?;
+        crate::conda_script::ensure_enabled(experimental, config, &safe_original_url)?;
+        RemoteScriptManifest::CondaScript(manifest)
+    };
 
     Ok(PreparedRemoteScript {
-        file,
+        directory,
         manifest,
         original_url,
         cache_name,

--- a/crates/pixi_core/src/workspace/mod.rs
+++ b/crates/pixi_core/src/workspace/mod.rs
@@ -535,7 +535,7 @@ impl Workspace {
             Some(implicit_script_platforms(Some(&lock_file_path))?)
         };
         let (manifest, warnings) = script
-            .into_workspace_manifest(implicit_platforms)
+            .into_workspace_manifest(implicit_platforms, &root)
             .map_err(Box::new)?;
 
         let cache_root = config
@@ -543,6 +543,49 @@ impl Workspace {
             .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?;
         let workspace_script = WorkspaceScript::for_local_conda_script(script, &cache_root);
 
+        let workspace = manifest.with_provenance(ManifestProvenance::new(
+            script_path,
+            ManifestKind::CondaScript,
+        ));
+
+        Ok(WithWarnings::from(Self::from_parsed(
+            workspace,
+            None,
+            root,
+            config,
+            WorkspaceStorage::Script(workspace_script),
+        ))
+        .with_warnings(warnings))
+    }
+
+    /// Construct an isolated workspace for a downloaded `conda-script` file.
+    pub fn from_transient_conda_script(
+        script: CondaScriptManifest,
+        config: Config,
+        root: PathBuf,
+        cache_name: &str,
+        cache_key: &[u8],
+    ) -> Result<WithWarnings<Self>, ScriptWorkspaceError> {
+        let script_path = script.path().to_owned();
+        let script_config = script.workspace_config().map_err(Box::new)?;
+        let implicit_platforms = if script_config.platforms_explicit {
+            None
+        } else {
+            Some(implicit_script_platforms(None)?)
+        };
+        let (manifest, warnings) = script
+            .into_workspace_manifest(implicit_platforms, &root)
+            .map_err(Box::new)?;
+        let cache_root = config
+            .cache_dir_for(CacheKind::ExecEnvironments)
+            .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?;
+        let workspace_script = WorkspaceScript::for_transient(
+            ScriptSource::CondaScript(Box::new(script)),
+            &cache_root,
+            cache_name,
+            cache_key,
+            &root,
+        );
         let workspace = manifest.with_provenance(ManifestProvenance::new(
             script_path,
             ManifestKind::CondaScript,
@@ -591,7 +634,7 @@ impl Workspace {
             .cache_dir_for(CacheKind::ExecEnvironments)
             .map_err(|error| ScriptWorkspaceError::CacheDirectory(error.to_string()))?;
         let workspace_script = WorkspaceScript::for_transient(
-            script_manifest,
+            ScriptSource::Pep723(Box::new(script_manifest)),
             &cache_root,
             cache_name,
             cache_key,

--- a/crates/pixi_core/src/workspace/workspace_script.rs
+++ b/crates/pixi_core/src/workspace/workspace_script.rs
@@ -71,14 +71,14 @@ impl WorkspaceScript {
     }
 
     pub(super) fn for_transient(
-        manifest: ScriptManifest,
+        source: ScriptSource,
         cache_root: &Path,
         cache_name: &str,
         cache_key: &[u8],
         root: &Path,
     ) -> Self {
         Self {
-            source: ScriptSource::Pep723(Box::new(manifest)),
+            source,
             pixi_dir: cache_root.join(transient_cache_name(cache_name, cache_key, root)),
             lock_file_path: None,
         }
@@ -410,28 +410,28 @@ mod tests {
         scoped_key.extend_from_slice(key);
         let digest = xxh3_64(&scoped_key);
         let first = WorkspaceScript::for_transient(
-            manifest(&script_path),
+            super::ScriptSource::Pep723(Box::new(manifest(&script_path))),
             &cache_root,
             "HTTPS://example.com/example.py",
             key,
             &root,
         );
         let first_again = WorkspaceScript::for_transient(
-            manifest(&script_path),
+            super::ScriptSource::Pep723(Box::new(manifest(&script_path))),
             &cache_root,
             "HTTPS://example.com/example.py",
             key,
             &root,
         );
         let second = WorkspaceScript::for_transient(
-            manifest(&script_path),
+            super::ScriptSource::Pep723(Box::new(manifest(&script_path))),
             &cache_root,
             "HTTPS://example.com/example.py",
             b"second key",
             &root,
         );
         let other_root = WorkspaceScript::for_transient(
-            manifest(&script_path),
+            super::ScriptSource::Pep723(Box::new(manifest(&script_path))),
             &cache_root,
             "HTTPS://example.com/example.py",
             key,
@@ -458,8 +458,13 @@ mod tests {
         let mut scoped_key = root.as_os_str().as_encoded_bytes().to_vec();
         scoped_key.push(0);
         scoped_key.extend_from_slice(key);
-        let script =
-            WorkspaceScript::for_transient(manifest(&script_path), &cache_root, "://", key, &root);
+        let script = WorkspaceScript::for_transient(
+            super::ScriptSource::Pep723(Box::new(manifest(&script_path))),
+            &cache_root,
+            "://",
+            key,
+            &root,
+        );
         let expected = cache_root.join(format!("{:016x}", xxh3_64(&scoped_key)));
 
         assert_eq!(expected, script.pixi_dir());

--- a/crates/pixi_manifest/src/script/conda/manifest.rs
+++ b/crates/pixi_manifest/src/script/conda/manifest.rs
@@ -331,6 +331,7 @@ impl CondaScriptManifest {
     pub fn into_workspace_manifest(
         &self,
         implicit_platforms: Option<IndexSet<PixiPlatform>>,
+        root: &Path,
     ) -> Result<(WorkspaceManifest, Vec<Warning>), CondaScriptError> {
         let ParsedBlock {
             dependencies,
@@ -382,10 +383,6 @@ impl CondaScriptManifest {
             });
         }
 
-        let root = self
-            .path
-            .parent()
-            .expect("an absolute script path always has a parent");
         let (workspace, package, warnings) = manifest
             .into_workspace_manifest(
                 ExternalWorkspaceProperties::default(),
@@ -605,7 +602,9 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let (workspace, warnings) = manifest.into_workspace_manifest(None).unwrap();
+        let (workspace, warnings) = manifest
+            .into_workspace_manifest(None, manifest.path().parent().unwrap())
+            .unwrap();
         assert!(warnings.is_empty());
         let target = workspace.default_feature().targets.default();
         let simple_app = workspace
@@ -655,7 +654,9 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let (workspace, warnings) = manifest.into_workspace_manifest(None).unwrap();
+        let (workspace, warnings) = manifest
+            .into_workspace_manifest(None, manifest.path().parent().unwrap())
+            .unwrap();
         assert!(warnings.is_empty());
         assert_eq!(
             workspace
@@ -780,7 +781,9 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let (workspace, warnings) = manifest.into_workspace_manifest(None).unwrap();
+        let (workspace, warnings) = manifest
+            .into_workspace_manifest(None, manifest.path().parent().unwrap())
+            .unwrap();
         assert!(warnings.is_empty());
         assert_eq!(workspace.workspace.name.as_deref(), Some("example"));
         assert_eq!(
@@ -837,7 +840,7 @@ mod tests {
         .unwrap();
 
         insta::assert_snapshot!(
-            format_diagnostic(&manifest.into_workspace_manifest(None).unwrap_err()),
+            format_diagnostic(&manifest.into_workspace_manifest(None, manifest.path().parent().unwrap()).unwrap_err()),
             @r#"
          × conda source dependencies are not allowed without enabling the 'pixi-build' preview flag
          ╰─▶ conda source dependencies are not allowed without enabling the 'pixi-build' preview flag
@@ -861,7 +864,9 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        let (workspace, _) = manifest.into_workspace_manifest(None).unwrap();
+        let (workspace, _) = manifest
+            .into_workspace_manifest(None, manifest.path().parent().unwrap())
+            .unwrap();
         assert_eq!(workspace.all_features().count(), 1);
         assert_eq!(workspace.environments.iter().count(), 1);
     }

--- a/docs/python/scripts.md
+++ b/docs/python/scripts.md
@@ -151,6 +151,8 @@ on every invocation and executed from a secure temporary `.py` file, while
 their environment is reused from Pixi's cache. Relative paths in remote
 metadata resolve from the directory where Pixi was invoked.
 
+URLs also support [`conda-script` blocks](../tutorials/conda_script.md).
+
 Remote inputs are execution-only: commands that edit, inspect, export, or lock
 a script continue to require a local path. A remote script has no adjacent lock
 file, so it cannot be run with `--locked` or `--frozen`.

--- a/docs/tutorials/conda_script.md
+++ b/docs/tutorials/conda_script.md
@@ -30,6 +30,15 @@ $ pixi run --script main.R
 
 Pixi solves the dependencies, installs the environment into its cache and runs the entrypoint inside it.
 
+You can also run a script directly from an HTTP or HTTPS URL, including a GitHub Gist:
+
+```shell
+pixi run --experimental --script https://gist.github.com/ruben-arts/1dba132edbf91adcd604f12fbd181683
+```
+
+Pixi downloads the script into a temporary directory, preserving its filename, and reuses the cached environment.
+The [remote script rules](../python/scripts.md#run-the-script) also apply here.
+
 ## More languages
 
 Ideally, dependencies also come from a conda channel.

--- a/tests/integration_python/test_script.py
+++ b/tests/integration_python/test_script.py
@@ -31,7 +31,7 @@ def remote_script_server(source: str) -> Iterator[tuple[str, list[str]]]:
                 )
                 self.end_headers()
                 return
-            if self.path == "/extensionless":
+            if self.path in {"/extensionless", "/script.txt", "/example.main.kts"}:
                 body = source.encode()
                 self.send_response(200)
                 self.send_header("Content-Length", str(len(body)))
@@ -103,7 +103,8 @@ def test_pixi_run_script_requires_inline_metadata(pixi: Path, tmp_pixi_workspace
 
 
 @pytest.mark.slow
-def test_pixi_run_remote_script(pixi: Path, tmp_pixi_workspace: Path) -> None:
+@pytest.mark.parametrize("script_path", ["redirect", "script.txt"])
+def test_pixi_run_remote_script(pixi: Path, tmp_pixi_workspace: Path, script_path: str) -> None:
     source = f'''# /// script
 # requires-python = ">=3.11"
 # dependencies = []
@@ -127,7 +128,7 @@ print(json.dumps({{
                 pixi,
                 "run",
                 "--script",
-                f"{base_url}/redirect",
+                f"{base_url}/{script_path}",
                 "first",
                 "--second",
             ],
@@ -139,8 +140,73 @@ print(json.dumps({{
     assert payload["cwd"] == str(tmp_pixi_workspace)
     assert payload["file"].endswith(".py")
     assert not Path(payload["file"]).exists()
-    assert requests == ["/redirect", "/extensionless"]
+    assert requests == (
+        ["/redirect", "/extensionless"] if script_path == "redirect" else ["/script.txt"]
+    )
     assert_no_workspace_state_created(tmp_pixi_workspace)
+
+
+@pytest.mark.slow
+def test_pixi_run_remote_conda_script(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    source = f'''# /// conda-script
+# channels = ["{CONDA_FORGE_CHANNEL}"]
+# entrypoint = "python ${{SCRIPT}} ${{CACHE}}"
+# [dependencies]
+# python = "3.13.*"
+# /// end-conda-script
+import json
+import os
+import sys
+from pathlib import Path
+
+counter = Path(sys.argv[1]) / "counter"
+runs = int(counter.read_text()) + 1 if counter.exists() else 1
+counter.write_text(str(runs))
+print(json.dumps({{
+    "runs": runs,
+    "argv": sys.argv[2:],
+    "cwd": os.getcwd(),
+    "file": __file__,
+    "prefix": sys.prefix,
+}}))
+sys.exit(1 if "--fail" in sys.argv else 0)
+'''
+    with remote_script_server(source) as (base_url, requests):
+        command = [pixi, "run", "--experimental", "--script", f"{base_url}/example.main.kts"]
+        first = verify_cli_command(command + ["first", "--second"], cwd=tmp_pixi_workspace)
+        second = verify_cli_command(
+            command + ["--", "--fail"], ExitCode.FAILURE, cwd=tmp_pixi_workspace
+        )
+
+    payloads = [
+        json.loads(next(line for line in output.stdout.splitlines() if line.startswith("{")))
+        for output in (first, second)
+    ]
+    assert payloads[0]["argv"] == ["first", "--second"]
+    assert payloads[1]["runs"] == payloads[0]["runs"] + 1
+    assert payloads[0]["prefix"] == payloads[1]["prefix"]
+    for payload in payloads:
+        assert payload["cwd"] == str(tmp_pixi_workspace)
+        assert Path(payload["file"]).name == "example.main.kts"
+        assert not Path(payload["file"]).exists()
+        assert not Path(payload["file"] + ".pixi.lock").exists()
+    assert requests == ["/example.main.kts"] * 2
+    assert_no_workspace_state_created(tmp_pixi_workspace)
+
+
+def test_remote_conda_script_requires_opt_in(pixi: Path, tmp_pixi_workspace: Path) -> None:
+    source = """# /// conda-script
+# channels = ["conda-forge"]
+# entrypoint = "python ${SCRIPT}"
+# /// end-conda-script
+"""
+    with remote_script_server(source) as (base_url, _):
+        verify_cli_command(
+            [pixi, "run", "--no-config", "--script", f"{base_url}/extensionless"],
+            ExitCode.FAILURE,
+            stderr_contains=["conda-script block", "--experimental"],
+            cwd=tmp_pixi_workspace,
+        )
 
 
 def test_pixi_run_remote_script_reports_http_errors_and_rejects_locks(


### PR DESCRIPTION
### Description

Adding the ability to use `pixi run --script` with a URL to a HTTP(S) file or GitHub Gist url. Just like the `pep723` scripts already support.

### How Has This Been Tested?

Tested with this gist: https://gist.github.com/ruben-arts/1dba132edbf91adcd604f12fbd181683 and a local Kotlin script hosted on a local server.

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: `omp` with OpenAI Astra

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
- [x] I have verified that changes that would impact the JSON schema have been made in `schema/model.py`.
