### PR TITLE
fix(dispatcher): add PrefixPlatformMismatchError for source build prefixes

### DIFF
--- a/crates/pixi_command_dispatcher/src/errors.rs
+++ b/crates/pixi_command_dispatcher/src/errors.rs
@@ -5,6 +5,7 @@ use pixi_record::VariantValue;
 use pixi_spec::{SourceLocationSpec, SpecConversionError};
 use rattler_conda_types::{
     ChannelUrl, ConvertSubdirError, InvalidPackageNameError, PackageName, ParseChannelError,
+    Platform,
 };
 use rattler_repodata_gateway::RunExportExtractorError;
 use thiserror::Error;
@@ -46,6 +47,10 @@ pub enum SourceBuildError {
 
     #[error("failed to install the host environment")]
     InstallHostEnvironment(#[source] Arc<InstallPixiEnvironmentError>),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PrefixPlatformMismatch(#[from] PrefixPlatformMismatchError),
 
     #[error(
         "The build backend does not provide an output matching '{name}' with variants: {}.",
@@ -92,6 +97,88 @@ pub enum SourceBuildError {
 
     #[error(transparent)]
     GlobSet(Arc<pixi_glob::GlobSetError>),
+}
+
+/// The two prefixes a source build installs its resolved dependencies
+/// into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceBuildPrefixKind {
+    /// Holds the build dependencies; runs on the build platform.
+    Build,
+    /// Holds the host dependencies; targets the host platform.
+    Host,
+}
+
+impl std::fmt::Display for SourceBuildPrefixKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceBuildPrefixKind::Build => write!(f, "build"),
+            SourceBuildPrefixKind::Host => write!(f, "host"),
+        }
+    }
+}
+
+/// Where a record that is installed into a build or host prefix came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrefixRecordOrigin {
+    /// Pixi's solver picked the record for the environment.
+    Solved,
+    /// A nested source build produced the record for the environment.
+    Built,
+}
+
+/// A record resolved for one platform was about to be installed into a
+/// build or host prefix of another platform.
+///
+/// The build and host environments of a source record are solved
+/// separately from the prefixes they are later installed into. When the
+/// two disagree, the prefix ends up with binaries that cannot run (or be
+/// linked against) on the platform the build backend is told about, which
+/// otherwise surfaces as an opaque failure deep inside the build script.
+#[derive(Debug, Clone, Error)]
+#[error(
+    "cannot install '{}' ({subdir}) into the {kind} environment of '{}', which is for '{expected}'",
+    package.as_normalized(),
+    source_package.as_normalized()
+)]
+pub struct PrefixPlatformMismatchError {
+    /// The prefix the record was about to be installed into.
+    pub kind: SourceBuildPrefixKind,
+    /// The source package whose build or host environment the prefix is.
+    pub source_package: PackageName,
+    /// The record whose subdir does not match.
+    pub package: PackageName,
+    /// Where the record came from.
+    pub origin: PrefixRecordOrigin,
+    /// The subdir the record was resolved for.
+    pub subdir: String,
+    /// The platform of the prefix.
+    pub expected: Platform,
+}
+
+impl Diagnostic for PrefixPlatformMismatchError {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        let package = self.package.as_normalized();
+        let help = match self.origin {
+            PrefixRecordOrigin::Solved => format!(
+                "'{package}' was picked for '{}' while pixi solved the {} environment of '{}' for \
+                 '{}'; this is a bug in pixi's cross-compilation platform tracking, please report \
+                 it at https://github.com/prefix-dev/pixi/issues together with the output of \
+                 `pixi -vv <command>`",
+                self.subdir,
+                self.kind,
+                self.source_package.as_normalized(),
+                self.expected
+            ),
+            PrefixRecordOrigin::Built => format!(
+                "'{package}' is a source dependency that was built for this environment; its build \
+                 backend was asked to build for '{}' but produced a '{}' package, please report \
+                 this to the maintainers of that backend",
+                self.expected, self.subdir
+            ),
+        };
+        Some(Box::new(help))
+    }
 }
 
 impl From<InvalidPackageNameError> for SourceBuildError {

--- a/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
+++ b/crates/pixi_command_dispatcher/src/install_pixi/ext.rs
@@ -16,6 +16,7 @@ use rattler_conda_types::{PackageName, Platform, RepoDataRecord};
 use crate::BuildProfile;
 use crate::CommandDispatcherError;
 use crate::CondaPackageFormat;
+use crate::SourceBuildError;
 use crate::cache::markers::{SourceBuildArtifactsDir, SourceBuildWorkspacesDir};
 use crate::compute_data::{
     HasAllowExecuteLinkScripts, HasAllowLinkOptions, HasIoConcurrencySemaphore, HasPackageCache,
@@ -187,13 +188,16 @@ async fn install_inner(
             };
             // A failed cross-build is usually the platform mismatch, not the
             // recipe. Compare the real machine: installs set build_platform to the target.
+            // A prefix platform mismatch already carries more specific help.
             let host_platform = shared.build_environment.host_platform;
             let machine = Platform::current();
             sub_ctx
                 .compute(&SourceBuildKey::new(build_spec))
                 .await
                 .map_err(|err| {
-                    let help = (host_platform != machine).then(|| {
+                    let is_cross_build = host_platform != machine;
+                    let has_own_help = matches!(err, SourceBuildError::PrefixPlatformMismatch(_));
+                    let help = (is_cross_build && !has_own_help).then(|| {
                         format!(
                             "The package was being built for platform '{host_platform}' on a \
                              '{machine}' machine; cross-building source packages often fails. \

--- a/crates/pixi_command_dispatcher/src/keys/source_build.rs
+++ b/crates/pixi_command_dispatcher/src/keys/source_build.rs
@@ -18,7 +18,8 @@ use pixi_record::{PixiRecord, UnresolvedPixiRecord, UnresolvedSourceRecord, Vari
 use pixi_spec::{ResolvedExcludeNewer, SourceAnchor, SourceSpec};
 use pixi_variant::VariantSelector;
 use rattler_conda_types::{
-    ChannelUrl, PackageRecord, RepoDataRecord, package::DistArchiveIdentifier, prefix::Prefix,
+    ChannelUrl, PackageName, PackageRecord, Platform, RepoDataRecord,
+    package::DistArchiveIdentifier, prefix::Prefix,
 };
 use rattler_digest::Sha256Hash;
 use tracing::instrument;
@@ -35,7 +36,8 @@ use crate::{
     BackendSourceBuildPrefix, BackendSourceBuildSpec, BackendSourceBuildV1Method, BuildEnvironment,
     BuildProfile, CommandDispatcherError, CommandDispatcherErrorResultExt,
     InstallPixiEnvironmentExt, InstallPixiEnvironmentSpec, InstantiateBackendKey,
-    ProjectModelOverrides, SourceBuildError,
+    PrefixPlatformMismatchError, PrefixRecordOrigin, ProjectModelOverrides, SourceBuildError,
+    SourceBuildPrefixKind,
     build::{Dependencies, PixiRunExports, convert_extra_dependencies},
     compute_data::{HasGateway, HasIoConcurrencySemaphore},
 };
@@ -323,7 +325,7 @@ async fn compute_inner(
                 install_prefix(
                     ctx,
                     &spec,
-                    InstallTarget::Build,
+                    SourceBuildPrefixKind::Build,
                     directories.build_prefix.clone(),
                     spec.record.build_packages.clone(),
                     &build_source_dep_records,
@@ -334,7 +336,7 @@ async fn compute_inner(
                 install_prefix(
                     ctx,
                     &spec,
-                    InstallTarget::Host,
+                    SourceBuildPrefixKind::Host,
                     directories.host_prefix.clone(),
                     spec.record.host_packages.clone(),
                     &host_source_dep_records,
@@ -692,18 +694,12 @@ async fn fetch_matching_output(
         })
 }
 
-#[derive(Copy, Clone)]
-enum InstallTarget {
-    Build,
-    Host,
-}
-
 /// Install a build or host environment into `prefix`, returning the
 /// fully-resolved `RepoDataRecord`s that end up inside.
 async fn install_prefix(
     ctx: &mut ComputeCtx,
     spec: &SourceBuildSpec,
-    target: InstallTarget,
+    target: SourceBuildPrefixKind,
     prefix_path: PathBuf,
     packages: Vec<UnresolvedPixiRecord>,
     resolved_source_deps: &std::collections::HashMap<
@@ -727,35 +723,45 @@ async fn install_prefix(
         return Ok((Vec::new(), None));
     }
     let build_environment = match target {
-        InstallTarget::Build => spec.build_environment.to_build_from_build(),
-        InstallTarget::Host => spec.build_environment.clone(),
+        SourceBuildPrefixKind::Build => spec.build_environment.to_build_from_build(),
+        SourceBuildPrefixKind::Host => spec.build_environment.clone(),
     };
     let label = match target {
-        InstallTarget::Build => format!("{} (build)", spec.record.name().as_source()),
-        InstallTarget::Host => format!("{} (host)", spec.record.name().as_source()),
+        SourceBuildPrefixKind::Build => format!("{} (build)", spec.record.name().as_source()),
+        SourceBuildPrefixKind::Host => format!("{} (host)", spec.record.name().as_source()),
     };
     // Substitute every source entry with the binary record its build
     // produced. Handing the installer the pre-built binaries keeps it
     // from launching another build of the same package with different
     // build parameters (a different package format, notably).
     let mut records = Vec::with_capacity(packages.len());
-    let install_records = packages
-        .into_iter()
-        .map(|record| match record {
-            UnresolvedPixiRecord::Binary(binary) => {
-                records.push((*binary).clone());
-                UnresolvedPixiRecord::Binary(binary)
-            }
+    let mut install_records = Vec::with_capacity(packages.len());
+    for package in packages {
+        let (record, origin) = match package {
+            UnresolvedPixiRecord::Binary(binary) => (binary, PrefixRecordOrigin::Solved),
             UnresolvedPixiRecord::Source(source) => {
                 let built = resolved_source_deps
                     .get(source.name())
                     .expect("source dependency should have been built by recurse_source_deps")
                     .clone();
-                records.push((*built).clone());
-                UnresolvedPixiRecord::Binary(built)
+                (built, PrefixRecordOrigin::Built)
             }
-        })
-        .collect();
+        };
+        // The records were solved (or built) for
+        // `build_environment.host_platform`; a record of another platform
+        // means the platform tracking upstream went wrong, and installing it
+        // would only produce an opaque failure once the build script tries
+        // to run or link against it.
+        verify_record_matches_platform(
+            target,
+            spec.record.name(),
+            &record,
+            origin,
+            build_environment.host_platform,
+        )?;
+        records.push((*record).clone());
+        install_records.push(UnresolvedPixiRecord::Binary(record));
+    }
     let install_spec = InstallPixiEnvironmentSpec {
         name: label,
         records: install_records,
@@ -776,12 +782,38 @@ async fn install_prefix(
         .install_pixi_environment(install_spec)
         .await
         .map_err_with(|e| match target {
-            InstallTarget::Build => SourceBuildError::InstallBuildEnvironment(Arc::new(e)),
-            InstallTarget::Host => SourceBuildError::InstallHostEnvironment(Arc::new(e)),
+            SourceBuildPrefixKind::Build => SourceBuildError::InstallBuildEnvironment(Arc::new(e)),
+            SourceBuildPrefixKind::Host => SourceBuildError::InstallHostEnvironment(Arc::new(e)),
         })
         .map_err(unwrap_dispatcher_err)?;
 
     Ok((records, Some(result)))
+}
+
+/// Check that `record` is for `platform` (or `noarch`) before it is
+/// installed into the `kind` prefix of `source_package`. A record whose
+/// subdir is not a known platform is left alone; it is not ours to judge.
+fn verify_record_matches_platform(
+    kind: SourceBuildPrefixKind,
+    source_package: &PackageName,
+    record: &RepoDataRecord,
+    origin: PrefixRecordOrigin,
+    platform: Platform,
+) -> Result<(), PrefixPlatformMismatchError> {
+    let Ok(subdir) = record.package_record.subdir.parse::<Platform>() else {
+        return Ok(());
+    };
+    if subdir != Platform::NoArch && subdir != platform {
+        return Err(PrefixPlatformMismatchError {
+            kind,
+            source_package: source_package.clone(),
+            package: record.package_record.name.clone(),
+            origin,
+            subdir: record.package_record.subdir.clone(),
+            expected: platform,
+        });
+    }
+    Ok(())
 }
 
 /// Read index.json out of the freshly-built `.conda` and synthesize a
@@ -874,5 +906,120 @@ impl Directories {
             build_prefix,
             host_prefix,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miette::Diagnostic;
+    use rattler_conda_types::VersionWithSource;
+
+    use super::*;
+
+    fn package_b() -> PackageName {
+        PackageName::new_unchecked("package_b")
+    }
+
+    fn record(name: &str, subdir: &str) -> RepoDataRecord {
+        let mut package_record = PackageRecord::new(
+            PackageName::new_unchecked(name),
+            "1.0.0".parse::<VersionWithSource>().unwrap(),
+            "h0".into(),
+        );
+        package_record.subdir = subdir.into();
+        RepoDataRecord {
+            package_record,
+            identifier: DistArchiveIdentifier::try_from_filename(&format!("{name}-1.0.0-h0.conda"))
+                .unwrap(),
+            url: Url::parse(&format!(
+                "https://example.com/{subdir}/{name}-1.0.0-h0.conda"
+            ))
+            .unwrap(),
+            channel: None,
+        }
+    }
+
+    fn verify(
+        kind: SourceBuildPrefixKind,
+        record: &RepoDataRecord,
+        origin: PrefixRecordOrigin,
+    ) -> Result<(), PrefixPlatformMismatchError> {
+        verify_record_matches_platform(kind, &package_b(), record, origin, Platform::Linux64)
+    }
+
+    fn help(err: &PrefixPlatformMismatchError) -> String {
+        err.help().expect("the error carries a help").to_string()
+    }
+
+    #[test]
+    fn records_of_the_prefix_platform_and_noarch_pass() {
+        for record in [record("libfoo", "linux-64"), record("pyfoo", "noarch")] {
+            for origin in [PrefixRecordOrigin::Solved, PrefixRecordOrigin::Built] {
+                verify(SourceBuildPrefixKind::Host, &record, origin)
+                    .expect("records of the prefix platform and noarch records are fine");
+            }
+        }
+    }
+
+    #[test]
+    fn solved_record_of_a_foreign_platform_is_a_pixi_bug() {
+        let err = verify(
+            SourceBuildPrefixKind::Build,
+            &record("python", "osx-arm64"),
+            PrefixRecordOrigin::Solved,
+        )
+        .expect_err("an osx-arm64 record must not be installed into a linux-64 prefix");
+
+        assert_eq!(err.kind, SourceBuildPrefixKind::Build);
+        assert_eq!(err.source_package, package_b());
+        assert_eq!(err.package.as_normalized(), "python");
+        assert_eq!(err.origin, PrefixRecordOrigin::Solved);
+        assert_eq!(err.subdir, "osx-arm64");
+        assert_eq!(err.expected, Platform::Linux64);
+        assert_eq!(
+            err.to_string(),
+            "cannot install 'python' (osx-arm64) into the build environment of 'package_b', which \
+             is for 'linux-64'"
+        );
+        assert_eq!(
+            help(&err),
+            "'python' was picked for 'osx-arm64' while pixi solved the build environment of \
+             'package_b' for 'linux-64'; this is a bug in pixi's cross-compilation platform \
+             tracking, please report it at https://github.com/prefix-dev/pixi/issues together \
+             with the output of `pixi -vv <command>`"
+        );
+    }
+
+    #[test]
+    fn built_record_of_a_foreign_platform_is_a_backend_bug() {
+        let err = verify(
+            SourceBuildPrefixKind::Host,
+            &record("libbar", "osx-arm64"),
+            PrefixRecordOrigin::Built,
+        )
+        .expect_err("an osx-arm64 record must not be installed into a linux-64 prefix");
+
+        assert_eq!(err.origin, PrefixRecordOrigin::Built);
+        assert_eq!(
+            err.to_string(),
+            "cannot install 'libbar' (osx-arm64) into the host environment of 'package_b', which \
+             is for 'linux-64'"
+        );
+        assert_eq!(
+            help(&err),
+            "'libbar' is a source dependency that was built for this environment; its build \
+             backend was asked to build for 'linux-64' but produced a 'osx-arm64' package, please \
+             report this to the maintainers of that backend"
+        );
+    }
+
+    #[test]
+    fn record_with_unknown_subdir_is_ignored() {
+        verify(
+            SourceBuildPrefixKind::Host,
+            &record("mystery", "not-a-platform"),
+            PrefixRecordOrigin::Solved,
+        )
+        .expect("a subdir that is not a platform is not checked");
     }
 }

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -105,7 +105,8 @@ pub use ephemeral_env::{
     EphemeralEnvError, EphemeralEnvKey, EphemeralEnvSpec, InstalledEphemeralEnv,
 };
 pub use errors::{
-    MissingChannelError, SolvePixiEnvironmentError, SourceBuildError, SourceMetadataError,
+    MissingChannelError, PrefixPlatformMismatchError, PrefixRecordOrigin,
+    SolvePixiEnvironmentError, SourceBuildError, SourceBuildPrefixKind, SourceMetadataError,
     SourceRecordError,
 };
 pub use injected_config::{

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -3354,6 +3354,143 @@ pub async fn test_source_build_key_dedups_across_parallel_installs() {
     );
 }
 
+/// A record of another platform in the build or host environment of a
+/// source package is rejected before anything is installed into the
+/// prefix, with a diagnostic that names the record, the prefix and the
+/// package being built. Install `package-b` for a foreign platform with a
+/// record of this machine's platform smuggled into its host environment,
+/// the shape an upstream platform-tracking bug produces.
+#[tokio::test]
+pub async fn test_prefix_platform_mismatch_is_reported_before_installing() {
+    use pixi_command_dispatcher::{
+        InstallPixiEnvironmentError, PrefixRecordOrigin, SourceBuildError, SourceBuildPrefixKind,
+    };
+    use pixi_record::UnresolvedPixiRecord;
+    use rattler_conda_types::{
+        PackageRecord, RepoDataRecord, VersionWithSource, package::DistArchiveIdentifier,
+    };
+
+    let root_dir = workspaces_dir().join("host-dependency");
+    let tempdir = test_tempdir();
+    let (tool_platform, tool_virtual_packages) = tool_platform();
+    // Cross-install so the generic "retry without --platform" hint would
+    // apply; the specific error must stand on its own.
+    let target_platform = match tool_platform {
+        Platform::OsxArm64 => Platform::Linux64,
+        _ => Platform::OsxArm64,
+    };
+    let build_env = BuildEnvironment::simple(target_platform, vec![]);
+
+    let dispatcher = CommandDispatcher::builder()
+        .with_root_dir(to_abs_dir(root_dir.clone()))
+        .with_cache_dirs(default_cache_dirs().with_workspace(to_abs_dir(tempdir.path())))
+        .with_executor(Executor::Serial)
+        .with_tool_platform(tool_platform, tool_virtual_packages)
+        .with_backend_overrides(BackendOverride::from_memory(
+            PassthroughBackend::instantiator(),
+        ))
+        .finish();
+
+    let records = run_pixi_solve(
+        &dispatcher,
+        SolvePixiEnvironmentSpec {
+            dependencies: DependencyMap::from_iter([(
+                "package-b".parse().unwrap(),
+                PathSpec::new("package-b").into(),
+            )]),
+            env_ref: env_ref_of(vec![], build_env.clone()),
+            ..empty_pixi_env_spec()
+        },
+    )
+    .await
+    .map_err(|e| format_diagnostic(&e))
+    .expect("solve should succeed");
+
+    let mut smuggled = PackageRecord::new(
+        PackageName::new_unchecked("libfoo"),
+        "1.0.0".parse::<VersionWithSource>().unwrap(),
+        "h0".into(),
+    );
+    smuggled.subdir = tool_platform.to_string();
+    let smuggled = RepoDataRecord {
+        package_record: smuggled,
+        identifier: DistArchiveIdentifier::try_from_filename("libfoo-1.0.0-h0.conda").unwrap(),
+        url: Url::parse(&format!(
+            "https://example.com/{tool_platform}/libfoo-1.0.0-h0.conda"
+        ))
+        .unwrap(),
+        channel: None,
+    };
+    let records: Vec<UnresolvedPixiRecord> = records
+        .into_iter()
+        .map(|record| match to_unresolved(record) {
+            UnresolvedPixiRecord::Source(source)
+                if source.name().as_normalized() == "package-b" =>
+            {
+                let mut source = (*source).clone();
+                source
+                    .host_packages
+                    .push(UnresolvedPixiRecord::Binary(Arc::new(smuggled.clone())));
+                UnresolvedPixiRecord::Source(Arc::new(source))
+            }
+            other => other,
+        })
+        .collect();
+
+    let prefix = Prefix::create(tempdir.path().join("prefix")).unwrap();
+    let Err(err) = dispatcher
+        .install_pixi_environment(InstallPixiEnvironmentSpec {
+            build_environment: build_env,
+            ..InstallPixiEnvironmentSpec::new(records, prefix)
+        })
+        .await
+    else {
+        panic!("a record of another platform must not be installed");
+    };
+
+    let CommandDispatcherError::Failed(InstallPixiEnvironmentError::BuildUnresolvedSourceError(
+        built,
+        _,
+        SourceBuildError::PrefixPlatformMismatch(mismatch),
+        generic_help,
+    )) = &err
+    else {
+        panic!("unexpected error: {}", format_diagnostic(&err));
+    };
+    assert_eq!(built.as_normalized(), "package-b");
+    assert_eq!(mismatch.kind, SourceBuildPrefixKind::Host);
+    assert_eq!(mismatch.source_package.as_normalized(), "package-b");
+    assert_eq!(mismatch.package.as_normalized(), "libfoo");
+    assert_eq!(mismatch.origin, PrefixRecordOrigin::Solved);
+    assert_eq!(mismatch.subdir, tool_platform.to_string());
+    assert_eq!(mismatch.expected, target_platform);
+    assert_eq!(
+        mismatch.to_string(),
+        format!(
+            "cannot install 'libfoo' ({tool_platform}) into the host environment of 'package-b', \
+             which is for '{target_platform}'"
+        )
+    );
+    assert!(
+        generic_help.is_none(),
+        "the generic cross-build hint must not be added on top of the specific error"
+    );
+
+    // What the user sees. The specific help lives on the inner error and
+    // reaches the report through the wrapping install error; rendering
+    // wraps long lines, so compare with whitespace collapsed.
+    let rendered = format_diagnostic(&err);
+    let flat = rendered.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(flat.contains(&mismatch.to_string()), "{rendered}");
+    assert!(
+        flat.contains(
+            "this is a bug in pixi's cross-compilation platform tracking, please report it"
+        ),
+        "{rendered}"
+    );
+    assert!(!flat.contains("Retry without '--platform'"), "{rendered}");
+}
+
 /// Two parallel `InstantiateBackendKey` computes for the same backend
 /// spec should resolve to a single backend instantiation. Backends are
 /// frequently shared across environments (workspace + per-package


### PR DESCRIPTION
Before installing the resolved build or host packages of a source build
into their prefix, verify that every record was resolved for the platform
of that prefix (or is noarch). A mismatch used to surface only deep inside
the build script, e.g. as "Exec format error" when an activation script
executed a binary of the wrong architecture (see #6846). It now fails
before anything is installed, with a diagnostic that says which record
cannot go into whose prefix:

  cannot install 'python' (osx-arm64) into the build environment of
  'package_b', which is for 'linux-64'

The error records where the offending record came from. A record pixi's
solver picked points to a bug in pixi's platform tracking and asks for a
report; a record produced by a nested source build means the backend was
asked to build for one platform and produced another, and the help says
so instead of blaming pixi. Installing a source package for another
platform no longer adds its generic "retry without --platform" hint on
top of this error, which already carries more specific advice.

The private InstallTarget enum becomes the public SourceBuildPrefixKind so
the error can name the prefix it concerns.

Unit tests cover the check itself: records of the prefix platform and
noarch records pass, a record of another platform is rejected with the
help matching its origin, and a subdir that is not a known platform is
left alone. An integration test installs package-b of the host-dependency
workspace for a foreign platform with a record of this machine's platform
smuggled into its host environment and checks the error a caller sees.

Part of a stacked series for #6846. First PR of the stack.