### PR TITLE
refactor(dispatcher): track the platform of a derived environment explicitly

### DIFF
--- a/crates/pixi_command_dispatcher/src/environment/env_ref.rs
+++ b/crates/pixi_command_dispatcher/src/environment/env_ref.rs
@@ -24,7 +24,12 @@ pub enum EnvironmentRef {
     Derived {
         parent: DerivedParent,
         package: PackageName,
+        /// The relation of this environment to `package`: its build or
+        /// its host environment. Used for labels (traces, cycle frames).
         kind: DerivedEnvKind,
+        /// Which of the parent's platforms this environment is solved
+        /// for. This is what [`EnvironmentRef::resolve`] applies.
+        platform: DerivedPlatform,
     },
 
     /// One-off spec that does not live in the registry. Content-hashed;
@@ -48,16 +53,19 @@ impl EnvironmentRef {
                 parent: DerivedParent::Workspace(w.clone()),
                 package,
                 kind: derived_env_kind,
+                platform: DerivedPlatform::of_kind(derived_env_kind),
             },
             EnvironmentRef::Derived { parent, .. } => Self::Derived {
                 parent: parent.clone(),
                 package,
                 kind: derived_env_kind,
+                platform: DerivedPlatform::of_kind(derived_env_kind),
             },
             EnvironmentRef::Ephemeral(eph) => Self::Derived {
                 parent: DerivedParent::Ephemeral(eph.clone()),
                 package,
                 kind: derived_env_kind,
+                platform: DerivedPlatform::of_kind(derived_env_kind),
             },
         }
     }
@@ -124,11 +132,13 @@ impl EnvironmentRef {
     pub fn resolve(&self, registry: &WorkspaceEnvRegistry) -> Arc<EnvironmentSpec> {
         match self {
             EnvironmentRef::Workspace(ws) => registry.get(ws.id()),
-            EnvironmentRef::Derived { parent, kind, .. } => {
+            EnvironmentRef::Derived {
+                parent, platform, ..
+            } => {
                 let parent_spec = parent.resolve(registry);
-                let build_environment = match kind {
-                    DerivedEnvKind::Build => parent_spec.build_environment.to_build_from_build(),
-                    DerivedEnvKind::Host => parent_spec.build_environment.clone(),
+                let build_environment = match platform {
+                    DerivedPlatform::Build => parent_spec.build_environment.to_build_from_build(),
+                    DerivedPlatform::Host => parent_spec.build_environment.clone(),
                 };
                 Arc::new(EnvironmentSpec {
                     build_environment,
@@ -171,18 +181,45 @@ impl DerivedParent {
     }
 }
 
-/// Which derived environment a [`EnvironmentRef::Derived`] represents.
-/// The build/host derivation is a pure function of the parent
-/// [`BuildEnvironment`](crate::BuildEnvironment).
+/// The relation of a [`EnvironmentRef::Derived`] environment to its
+/// package: the environment its build backend runs in, or the
+/// environment the built package targets. Labels traces and cycle
+/// frames; the platform the environment is solved for is
+/// [`DerivedPlatform`].
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Display)]
 pub enum DerivedEnvKind {
-    /// Environment used to run the build backend itself. Derived via
+    /// Environment used to run the build backend itself.
+    Build,
+
+    /// Environment the built package targets.
+    Host,
+}
+
+/// Which of the parent's two platforms a [`EnvironmentRef::Derived`]
+/// environment is solved for.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum DerivedPlatform {
+    /// The parent's build platform: the parent's `BuildEnvironment` is
+    /// folded with
     /// [`BuildEnvironment::to_build_from_build`](crate::BuildEnvironment::to_build_from_build).
     Build,
 
-    /// Environment the built package targets. Today this is a clone of
-    /// the parent `BuildEnvironment`.
+    /// The parent's host platform: the parent's `BuildEnvironment` is
+    /// used unchanged.
     Host,
+}
+
+impl DerivedPlatform {
+    /// The platform a `kind` environment is solved for when its parent is
+    /// solved for the parent's own host platform: the build environment
+    /// runs on the build platform, the host environment targets the host
+    /// platform.
+    pub fn of_kind(kind: DerivedEnvKind) -> Self {
+        match kind {
+            DerivedEnvKind::Build => DerivedPlatform::Build,
+            DerivedEnvKind::Host => DerivedPlatform::Host,
+        }
+    }
 }
 
 impl fmt::Display for EnvironmentRef {
@@ -193,6 +230,7 @@ impl fmt::Display for EnvironmentRef {
                 parent,
                 package,
                 kind,
+                ..
             } => write!(f, "{kind} of {} in {}", package.as_normalized(), parent),
             EnvironmentRef::Ephemeral(eph) => write!(
                 f,

--- a/crates/pixi_command_dispatcher/src/environment/mod.rs
+++ b/crates/pixi_command_dispatcher/src/environment/mod.rs
@@ -10,7 +10,7 @@ mod registry;
 mod spec;
 mod workspace_env_ref;
 
-pub use env_ref::{DerivedEnvKind, DerivedParent, EnvironmentRef, EphemeralEnv};
+pub use env_ref::{DerivedEnvKind, DerivedParent, DerivedPlatform, EnvironmentRef, EphemeralEnv};
 pub use projections::{BuildEnvOf, ChannelsOf, ExcludeNewerOf, VariantsOf};
 pub use registry::{HasWorkspaceEnvRegistry, WorkspaceEnvRegistry};
 pub use spec::EnvironmentSpec;

--- a/crates/pixi_command_dispatcher/src/environment/projections.rs
+++ b/crates/pixi_command_dispatcher/src/environment/projections.rs
@@ -91,7 +91,7 @@ mod tests {
     use super::*;
     use crate::{
         BuildEnvironment,
-        environment::{DerivedEnvKind, DerivedParent, EnvironmentSpec, WorkspaceEnvRegistry},
+        environment::{DerivedEnvKind, EnvironmentSpec, WorkspaceEnvRegistry},
     };
 
     fn channel(url: &str) -> ChannelUrl {
@@ -179,11 +179,8 @@ mod tests {
             spec_with_channels(vec![channel("https://example.com/parent/")]),
         );
 
-        let derived = EnvironmentRef::Derived {
-            parent: DerivedParent::Workspace(parent),
-            package: PackageName::new_unchecked("foo"),
-            kind: DerivedEnvKind::Build,
-        };
+        let derived = EnvironmentRef::Workspace(parent)
+            .derived(PackageName::new_unchecked("foo"), DerivedEnvKind::Build);
 
         let channels = engine.compute(&ChannelsOf(derived)).await.unwrap();
         assert_eq!(
@@ -203,14 +200,17 @@ mod tests {
         };
         let mut spec = spec_with_channels(vec![]);
         spec.build_environment = parent_build_env.clone();
-        let parent = registry.allocate("default".to_string(), Platform::Linux64.to_string(), spec);
+        let parent = EnvironmentRef::Workspace(registry.allocate(
+            "default".to_string(),
+            Platform::Linux64.to_string(),
+            spec,
+        ));
 
         let derived_build = engine
-            .compute(&BuildEnvOf(EnvironmentRef::Derived {
-                parent: DerivedParent::Workspace(parent.clone()),
-                package: PackageName::new_unchecked("foo"),
-                kind: DerivedEnvKind::Build,
-            }))
+            .compute(&BuildEnvOf(parent.derived(
+                PackageName::new_unchecked("foo"),
+                DerivedEnvKind::Build,
+            )))
             .await
             .unwrap();
         assert_eq!(
@@ -220,11 +220,10 @@ mod tests {
         );
 
         let derived_host = engine
-            .compute(&BuildEnvOf(EnvironmentRef::Derived {
-                parent: DerivedParent::Workspace(parent),
-                package: PackageName::new_unchecked("foo"),
-                kind: DerivedEnvKind::Host,
-            }))
+            .compute(&BuildEnvOf(parent.derived(
+                PackageName::new_unchecked("foo"),
+                DerivedEnvKind::Host,
+            )))
             .await
             .unwrap();
         assert_eq!(

--- a/crates/pixi_command_dispatcher/src/lib.rs
+++ b/crates/pixi_command_dispatcher/src/lib.rs
@@ -97,9 +97,9 @@ pub use dev_source_metadata::{
 };
 pub use discovered_backend::DiscoveredBackendKey;
 pub use environment::{
-    BuildEnvOf, ChannelsOf, DerivedEnvKind, DerivedParent, EnvironmentRef, EnvironmentSpec,
-    EphemeralEnv, ExcludeNewerOf, HasWorkspaceEnvRegistry, VariantsOf, WorkspaceEnvId,
-    WorkspaceEnvRef, WorkspaceEnvRegistry,
+    BuildEnvOf, ChannelsOf, DerivedEnvKind, DerivedParent, DerivedPlatform, EnvironmentRef,
+    EnvironmentSpec, EphemeralEnv, ExcludeNewerOf, HasWorkspaceEnvRegistry, VariantsOf,
+    WorkspaceEnvId, WorkspaceEnvRef, WorkspaceEnvRegistry,
 };
 pub use ephemeral_env::{
     EphemeralEnvError, EphemeralEnvKey, EphemeralEnvSpec, InstalledEphemeralEnv,


### PR DESCRIPTION
A derived environment carries a `kind` (is it the build or the host
environment of `package`) that doubles as the transform applied to the
parent's BuildEnvironment. Split the two: `kind` keeps labelling the
relation, the new `platform: DerivedPlatform` says which of the parent's
platforms the environment is solved for, and `resolve()` reads the latter.
`DerivedPlatform::of_kind` names the mapping from a kind to the platform
of an environment derived directly from a parent that is solved for its
own host platform; it is not a general conversion.

The projection tests build their derived environments through
`EnvironmentRef::derived` so they exercise the constructor that assigns
the platform.

No behaviour change: `platform` is always derived from `kind` for now.

Part of a stacked series for #6846. Based on #6984; review only the last commit.