### PR TITLE
fix(dispatcher): keep nested derived environments on the build platform

### DIFF
--- a/crates/pixi_command_dispatcher/src/environment/env_ref.rs
+++ b/crates/pixi_command_dispatcher/src/environment/env_ref.rs
@@ -40,13 +40,18 @@ pub enum EnvironmentRef {
 
 impl EnvironmentRef {
     /// Construct a [`Derived`](EnvironmentRef::Derived) env rooted in
-    /// `self`. When `self` is already `Derived`, the chain is flattened
-    /// by inheriting the inner `parent` and taking the outer `kind`.
-    /// This is correct because the kind transforms compose trivially on
-    /// `build_environment`: `Host` is the identity (clones the parent's
-    /// build_environment) and `Build` is absorbing (`to_build_from_build`
-    /// folds any parent down to build). Other spec fields pass through
-    /// unchanged.
+    /// `self`.
+    ///
+    /// When `self` is already `Derived`, the chain is flattened: the new
+    /// ref inherits the inner `parent`, takes the outer `kind` as its
+    /// label, and composes the platform transforms. `Host` is the identity
+    /// on the parent's `build_environment` and `Build` is absorbing
+    /// (`to_build_from_build` folds any parent down to the build
+    /// platform), so the composed [`DerivedPlatform`] is `Build` as soon
+    /// as any derivation in the chain was a `Build` derivation: a package
+    /// solved inside a build environment runs on the build platform, and
+    /// so do its own build and host dependencies. Other spec fields pass
+    /// through unchanged.
     pub fn derived(&self, package: PackageName, derived_env_kind: DerivedEnvKind) -> Self {
         match self {
             EnvironmentRef::Workspace(w) => Self::Derived {
@@ -55,11 +60,16 @@ impl EnvironmentRef {
                 kind: derived_env_kind,
                 platform: DerivedPlatform::of_kind(derived_env_kind),
             },
-            EnvironmentRef::Derived { parent, .. } => Self::Derived {
+            EnvironmentRef::Derived {
+                parent, platform, ..
+            } => Self::Derived {
                 parent: parent.clone(),
                 package,
                 kind: derived_env_kind,
-                platform: DerivedPlatform::of_kind(derived_env_kind),
+                platform: match platform {
+                    DerivedPlatform::Build => DerivedPlatform::Build,
+                    DerivedPlatform::Host => DerivedPlatform::of_kind(derived_env_kind),
+                },
             },
             EnvironmentRef::Ephemeral(eph) => Self::Derived {
                 parent: DerivedParent::Ephemeral(eph.clone()),
@@ -251,5 +261,121 @@ impl fmt::Display for DerivedParent {
                 eph.name, eph.spec.build_environment.host_platform
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rattler_conda_types::{GenericVirtualPackage, Platform};
+    use rattler_solve::ChannelPriority;
+
+    use pixi_utils::variants::VariantConfig;
+
+    use super::*;
+    use crate::{BuildEnvironment, environment::WorkspaceEnvRegistry};
+
+    fn virtual_package(name: &str) -> GenericVirtualPackage {
+        GenericVirtualPackage {
+            name: name.parse().unwrap(),
+            version: "1".parse().unwrap(),
+            build_string: "0".into(),
+        }
+    }
+
+    /// A cross-compiling parent: host and build differ in platform and in
+    /// virtual packages, so a swapped transform is observable.
+    fn cross_parent() -> (EnvironmentRef, BuildEnvironment) {
+        let build_environment = BuildEnvironment {
+            host_platform: Platform::OsxArm64,
+            host_virtual_packages: vec![virtual_package("__osx")],
+            build_platform: Platform::Linux64,
+            build_virtual_packages: vec![virtual_package("__glibc")],
+        };
+        let env_ref = EnvironmentRef::Ephemeral(EphemeralEnv::new(
+            "publish",
+            EnvironmentSpec {
+                channels: vec![],
+                build_environment: build_environment.clone(),
+                variants: VariantConfig::default(),
+                exclude_newer: None,
+                channel_priority: ChannelPriority::Strict,
+            },
+        ));
+        (env_ref, build_environment)
+    }
+
+    fn resolve(env_ref: &EnvironmentRef) -> Arc<EnvironmentSpec> {
+        // Ephemeral parents never touch the registry.
+        env_ref.resolve(&WorkspaceEnvRegistry::new())
+    }
+
+    fn pkg(name: &str) -> PackageName {
+        PackageName::new_unchecked(name)
+    }
+
+    #[test]
+    fn build_then_host_stays_on_the_build_platform() {
+        let (parent, parent_env) = cross_parent();
+        let nested = parent
+            .derived(pkg("a"), DerivedEnvKind::Build)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+
+        assert_eq!(
+            resolve(&nested).build_environment,
+            parent_env.to_build_from_build(),
+            "the host env of a build dependency is the build platform"
+        );
+        let EnvironmentRef::Derived { kind, platform, .. } = &nested else {
+            panic!("expected a derived env");
+        };
+        assert_eq!(*kind, DerivedEnvKind::Host, "the label keeps the relation");
+        assert_eq!(*platform, DerivedPlatform::Build);
+    }
+
+    #[test]
+    fn host_then_build_moves_to_the_build_platform() {
+        let (parent, parent_env) = cross_parent();
+        let nested = parent
+            .derived(pkg("a"), DerivedEnvKind::Host)
+            .derived(pkg("b"), DerivedEnvKind::Build);
+        assert_eq!(
+            resolve(&nested).build_environment,
+            parent_env.to_build_from_build()
+        );
+    }
+
+    #[test]
+    fn build_then_build_stays_on_the_build_platform() {
+        let (parent, parent_env) = cross_parent();
+        let nested = parent
+            .derived(pkg("a"), DerivedEnvKind::Build)
+            .derived(pkg("b"), DerivedEnvKind::Build);
+        assert_eq!(
+            resolve(&nested).build_environment,
+            parent_env.to_build_from_build()
+        );
+    }
+
+    #[test]
+    fn host_then_host_keeps_the_parent_environment() {
+        let (parent, parent_env) = cross_parent();
+        let nested = parent
+            .derived(pkg("a"), DerivedEnvKind::Host)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        assert_eq!(resolve(&nested).build_environment, parent_env);
+    }
+
+    #[test]
+    fn refs_differing_only_in_platform_are_distinct_keys() {
+        let (parent, _) = cross_parent();
+        let via_build = parent
+            .derived(pkg("a"), DerivedEnvKind::Build)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        let via_host = parent
+            .derived(pkg("a"), DerivedEnvKind::Host)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        assert_ne!(via_build, via_host);
     }
 }

--- a/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
+++ b/crates/pixi_command_dispatcher/src/keys/resolve_source_record.rs
@@ -20,12 +20,12 @@ use pixi_record::{
 use pixi_spec::{BinarySpec, PixiSpec, SourceAnchor, SourceLocationSpec};
 use pixi_spec_containers::DependencyMap;
 use pixi_variant::VariantValue;
-use rattler_conda_types::{PackageName, PackageRecord, package::RunExportsJson};
+use rattler_conda_types::{PackageName, PackageRecord, Platform, package::RunExportsJson};
 use rattler_solve::SolveStrategy;
 
 use crate::{
-    BuildBackendMetadataSpec, DerivedEnvKind, EnvironmentRef, InstalledSourceHints, PtrArc,
-    SourceRecordError, SourceRecordReporterSpec,
+    BuildBackendMetadataSpec, BuildEnvOf, DerivedEnvKind, EnvironmentRef, InstalledSourceHints,
+    PtrArc, SourceRecordError, SourceRecordReporterSpec,
     build::{Dependencies, PinnedSourceCodeLocation, PixiRunExports, convert_extra_dependencies},
     compute_data::{HasGateway, HasSourceRecordReporter},
     cycle::CycleEnvironment,
@@ -515,6 +515,20 @@ async fn nested_solve(
         return Ok(vec![]);
     }
 
+    let nested_env_ref = env_ref.derived(pkg_name.clone(), kind);
+    // The hint describes a locked copy of this package, but hints are keyed
+    // by name and source location only, while a package that is a build
+    // dependency of one package and a host dependency of another is
+    // resolved once per platform. The hint may therefore belong to the
+    // copy of the other platform. The solver treats installed records as
+    // locked candidates and would pick them, so keep only the records that
+    // fit the platform this environment is solved for.
+    let host_platform = ctx
+        .compute(&BuildEnvOf(nested_env_ref.clone()))
+        .await
+        .host_platform;
+    let installed = installed_records_for_platform(installed, host_platform);
+
     let nested_spec = SolvePixiEnvironmentSpec {
         dependencies: dependencies
             .dependencies
@@ -536,7 +550,7 @@ async fn nested_solve(
         installed_source_hints: installed_source_hints.clone(),
         strategy: SolveStrategy::default(),
         preferred_build_source: Arc::clone(preferred_build_source),
-        env_ref: env_ref.derived(pkg_name.clone(), kind),
+        env_ref: nested_env_ref,
         // A nested build/host env solves binary/source build deps; inline
         // definitions apply only to the consumer's direct dependencies.
         inline_packages: Default::default(),
@@ -656,5 +670,85 @@ impl LifecycleKind for SourceRecordReporterLifecycle {
 
     fn on_finished<'r>(active: Active<'r, Self::Reporter<'r>, Self::Id>) {
         active.reporter.on_finished(active.id);
+    }
+}
+
+/// The records of `installed` that can be part of an environment solved
+/// for `platform`: records of that platform, `noarch` records, and records
+/// whose subdir is not a known platform (those are not ours to judge).
+fn installed_records_for_platform(
+    installed: Arc<[UnresolvedPixiRecord]>,
+    platform: Platform,
+) -> Arc<[UnresolvedPixiRecord]> {
+    let fits = |record: &UnresolvedPixiRecord| match record
+        .package_record()
+        .and_then(|record| record.subdir.parse::<Platform>().ok())
+    {
+        Some(subdir) => subdir == Platform::NoArch || subdir == platform,
+        None => true,
+    };
+    if installed.iter().all(fits) {
+        return installed;
+    }
+    installed
+        .iter()
+        .filter(|record| fits(record))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use rattler_conda_types::{RepoDataRecord, VersionWithSource, package::DistArchiveIdentifier};
+    use url::Url;
+
+    use super::*;
+
+    fn binary(name: &str, subdir: &str) -> UnresolvedPixiRecord {
+        let mut package_record = PackageRecord::new(
+            PackageName::new_unchecked(name),
+            "1.0.0".parse::<VersionWithSource>().unwrap(),
+            "h0".into(),
+        );
+        package_record.subdir = subdir.into();
+        UnresolvedPixiRecord::Binary(Arc::new(RepoDataRecord {
+            package_record,
+            identifier: DistArchiveIdentifier::try_from_filename(&format!("{name}-1.0.0-h0.conda"))
+                .unwrap(),
+            url: Url::parse(&format!(
+                "https://example.com/{subdir}/{name}-1.0.0-h0.conda"
+            ))
+            .unwrap(),
+            channel: None,
+        }))
+    }
+
+    fn names(records: &[UnresolvedPixiRecord]) -> Vec<&str> {
+        records.iter().map(|r| r.name().as_normalized()).collect()
+    }
+
+    #[test]
+    fn records_of_the_platform_noarch_and_unknown_subdirs_are_kept() {
+        let installed: Arc<[_]> = Arc::from([
+            binary("libfoo", "linux-64"),
+            binary("pyfoo", "noarch"),
+            binary("mystery", "not-a-platform"),
+        ]);
+        let kept = installed_records_for_platform(installed.clone(), Platform::Linux64);
+        assert!(
+            Arc::ptr_eq(&kept, &installed),
+            "nothing to drop, nothing copied"
+        );
+    }
+
+    #[test]
+    fn records_of_another_platform_are_dropped() {
+        let installed: Arc<[_]> = Arc::from([
+            binary("libfoo", "linux-64"),
+            binary("dummy-b", "osx-arm64"),
+            binary("pyfoo", "noarch"),
+        ]);
+        let kept = installed_records_for_platform(installed, Platform::Linux64);
+        assert_eq!(names(&kept), ["libfoo", "pyfoo"]);
     }
 }

--- a/crates/pixi_command_dispatcher/tests/integration/main.rs
+++ b/crates/pixi_command_dispatcher/tests/integration/main.rs
@@ -1162,6 +1162,191 @@ pub async fn test_manifest_strong_run_export_propagates_from_build_dependency() 
     );
 }
 
+/// Regression test for <https://github.com/prefix-dev/pixi/issues/6846>.
+///
+/// `package_a` has the source package `package_b` as a build *and* a host
+/// dependency, the shape the ROS backend produces for every `package.xml`
+/// dependency. When cross-compiling, the build-dependency copy of
+/// `package_b` runs on the build platform, so its own host environment must
+/// be solved for the build platform too, while the host-dependency copy
+/// targets the host platform. The nested derivation used to lose the build
+/// platform, labelling the build copy with the build platform but solving
+/// its host environment for the target.
+#[tokio::test]
+pub async fn test_cross_compile_build_dependency_is_solved_for_build_platform() {
+    let tempdir = test_tempdir();
+    let dispatcher = cross_build_dependency_dispatcher(&tempdir);
+    let records = solve_cross_build_dependency(&dispatcher, vec![]).await;
+    assert_package_b_copies_are_on_their_platforms(&records);
+}
+
+/// Re-solving with the previous solution as the installed hint, the way a
+/// re-lock does, must keep both copies of `package_b` on their platforms.
+/// Installed-record hints are keyed by package name and source location
+/// only, so both copies share one hint and one of the two nested solves is
+/// seeded with the other copy's host packages. Those must not be locked in.
+#[tokio::test]
+pub async fn test_cross_compile_build_dependency_survives_a_resolve_with_hints() {
+    let tempdir = test_tempdir();
+    let dispatcher = cross_build_dependency_dispatcher(&tempdir);
+    let first = solve_cross_build_dependency(&dispatcher, vec![]).await;
+    let second =
+        solve_cross_build_dependency(&dispatcher, first.into_iter().map(to_unresolved).collect())
+            .await;
+    assert_package_b_copies_are_on_their_platforms(&second);
+}
+
+/// A dispatcher rooted in the `cross-build-dependency` workspace.
+fn cross_build_dependency_dispatcher(tempdir: &tempfile::TempDir) -> CommandDispatcher {
+    let (tool_platform, tool_virtual_packages) = tool_platform();
+    let root_dir = workspaces_dir().join("cross-build-dependency");
+    CommandDispatcher::builder()
+        .with_root_dir(to_abs_dir(root_dir))
+        .with_cache_dirs(default_cache_dirs().with_workspace(to_abs_dir(tempdir.path())))
+        .with_executor(Executor::Serial)
+        .with_tool_platform(tool_platform, tool_virtual_packages)
+        .with_backend_overrides(BackendOverride::from_memory(
+            PassthroughBackend::instantiator(),
+        ))
+        .finish()
+}
+
+/// Solve `package_a` of the `cross-build-dependency` workspace for osx-arm64
+/// from linux-64, seeded with `installed` and the hints derived from it.
+/// Both platforms are pinned so the test does not depend on the machine it
+/// runs on.
+async fn solve_cross_build_dependency(
+    dispatcher: &CommandDispatcher,
+    installed: Vec<pixi_record::UnresolvedPixiRecord>,
+) -> Vec<pixi_record::PixiRecord> {
+    let channel_dir = cargo_workspace_dir().join("tests/data/channels/channels/dummy_channel_1");
+    let channel: ChannelUrl = Url::from_directory_path(&channel_dir).unwrap().into();
+    let build_environment = BuildEnvironment {
+        host_platform: Platform::OsxArm64,
+        host_virtual_packages: vec![],
+        build_platform: Platform::Linux64,
+        build_virtual_packages: vec![],
+    };
+    let (installed, installed_source_hints) = installed_with_hints(installed);
+    run_pixi_solve(
+        dispatcher,
+        SolvePixiEnvironmentSpec {
+            dependencies: DependencyMap::from_iter([(
+                "package_a".parse().unwrap(),
+                PathSpec::new("package_a").into(),
+            )]),
+            installed,
+            installed_source_hints,
+            env_ref: env_ref_of(vec![channel], build_environment),
+            ..empty_pixi_env_spec()
+        },
+    )
+    .await
+    .map_err(|e| format_diagnostic(&e))
+    .expect("the cross-compiling solve should succeed")
+}
+
+/// The build copy of `package_b` and everything in its host environment is
+/// on linux-64; the host copy and its host environment target osx-arm64.
+fn assert_package_b_copies_are_on_their_platforms(records: &[pixi_record::PixiRecord]) {
+    let package_a = records
+        .iter()
+        .find_map(|r| {
+            r.as_source()
+                .filter(|s| s.package_record().name.as_normalized() == "package_a")
+        })
+        .expect("package_a source record is in the solution");
+    assert_eq!(package_a.package_record().subdir, "osx-arm64");
+
+    // The build copy of package_b runs on the build platform, and so does
+    // everything in its host environment.
+    let package_b_for_build = source_dependency(&package_a.build_packages, "package_b");
+    assert_eq!(
+        package_b_for_build.package_record().unwrap().subdir,
+        "linux-64"
+    );
+    let package_b_for_build_source = package_b_for_build.as_source().unwrap();
+    assert_eq!(
+        package_b_for_build_source.variants()["target_platform"].to_string(),
+        "linux-64"
+    );
+    assert_eq!(
+        subdirs(&package_b_for_build_source.host_packages),
+        vec!["linux-64"],
+        "the host environment of a build dependency must be solved for the build platform"
+    );
+    assert_eq!(
+        build_string(&package_b_for_build_source.host_packages, "dummy-b"),
+        "hb0f4dca_0",
+        "the linux-64 build of dummy-b"
+    );
+
+    // The host copy of package_b targets the host platform.
+    let package_b_for_host = source_dependency(&package_a.host_packages, "package_b");
+    assert_eq!(
+        package_b_for_host.package_record().unwrap().subdir,
+        "osx-arm64"
+    );
+    let package_b_for_host_source = package_b_for_host.as_source().unwrap();
+    assert_eq!(
+        package_b_for_host_source.variants()["target_platform"].to_string(),
+        "osx-arm64"
+    );
+    assert_eq!(
+        subdirs(&package_b_for_host_source.host_packages),
+        vec!["osx-arm64"]
+    );
+    assert_eq!(
+        build_string(&package_b_for_host_source.host_packages, "dummy-b"),
+        "h60d57d3_0",
+        "the osx-arm64 build of dummy-b"
+    );
+}
+
+/// The source dependency called `name` among `packages`.
+fn source_dependency<'a>(
+    packages: &'a [pixi_record::UnresolvedPixiRecord],
+    name: &str,
+) -> &'a pixi_record::UnresolvedPixiRecord {
+    packages
+        .iter()
+        .find(|r| {
+            r.as_source()
+                .is_some_and(|s| s.name().as_normalized() == name)
+        })
+        .unwrap_or_else(|| panic!("{name} should be a source dependency"))
+}
+
+/// The distinct subdirs of `packages`, in sorted order.
+fn subdirs(packages: &[pixi_record::UnresolvedPixiRecord]) -> Vec<String> {
+    let mut subdirs: Vec<String> = packages
+        .iter()
+        .map(|r| {
+            r.package_record()
+                .expect("build/host packages are fully resolved")
+                .subdir
+                .clone()
+        })
+        .collect();
+    subdirs.sort();
+    subdirs.dedup();
+    subdirs
+}
+
+/// The build string of the binary package `name` among `packages`.
+fn build_string(packages: &[pixi_record::UnresolvedPixiRecord], name: &str) -> String {
+    packages
+        .iter()
+        .find_map(|r| {
+            r.as_binary()
+                .filter(|b| b.package_record.name.as_normalized() == name)
+        })
+        .unwrap_or_else(|| panic!("{name} should be a binary dependency"))
+        .package_record
+        .build
+        .clone()
+}
+
 /// A package can receive the same source dependency through two channels at
 /// once: implied by a run-export of a build/host env record (carrying the
 /// *pinned* source location) and explicitly through its own run-exports

--- a/tests/data/workspaces/cross-build-dependency/README.md
+++ b/tests/data/workspaces/cross-build-dependency/README.md
@@ -1,0 +1,8 @@
+Workspace for the cross-compilation regression test of
+<https://github.com/prefix-dev/pixi/issues/6846>.
+
+`package_a` depends on the source package `package_b` in both its build and
+its host section, the shape the ROS backend produces for every `package.xml`
+dependency. `package_b` has a binary host dependency (`dummy-b`, from the
+`dummy_channel_1` test channel) so the platform its host environment is
+solved for is observable. Both packages produce platform-specific outputs.

--- a/tests/data/workspaces/cross-build-dependency/package_a/pixi.toml
+++ b/tests/data/workspaces/cross-build-dependency/package_a/pixi.toml
@@ -1,0 +1,19 @@
+[package]
+name = "package_a"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+# Platform-specific outputs, so the subdir of every record shows which
+# platform it was solved for.
+[package.build.config]
+noarch = false
+
+# The same sibling in both buckets: the build copy runs on the build
+# platform, the host copy targets the host platform.
+[package.build-dependencies]
+package_b = { path = "../package_b" }
+
+[package.host-dependencies]
+package_b = { path = "../package_b" }

--- a/tests/data/workspaces/cross-build-dependency/package_b/pixi.toml
+++ b/tests/data/workspaces/cross-build-dependency/package_b/pixi.toml
@@ -1,0 +1,14 @@
+[package]
+name = "package_b"
+version = "0.1.0"
+
+[package.build]
+backend = { name = "in-memory", version = "*" }
+
+[package.build.config]
+noarch = false
+
+# A binary dependency that exists for several platforms, so the platform of
+# this package's host environment is observable in the solved records.
+[package.host-dependencies]
+dummy-b = "*"

--- a/tests/data/workspaces/cross-build-dependency/pixi.toml
+++ b/tests/data/workspaces/cross-build-dependency/pixi.toml
@@ -1,0 +1,4 @@
+[workspace]
+channels = []
+platforms = []
+preview = ["pixi-build"]


### PR DESCRIPTION
`EnvironmentRef::derived` flattens a derived-of-derived chain but used to
keep only the outermost kind. A host environment derived inside a build
environment therefore fell back to the parent's host platform: when
cross-compiling, a source package that is a build dependency of another
package had its record labelled with the build platform while its host
packages were solved for the target platform. The build backend then saw
a "native" build whose host prefix held foreign binaries, which failed
with "Exec format error" as soon as an activation script ran one of them.

Compose the platform transform instead: once a derivation in the chain
targets the build platform, every further derivation does too. The label
(`kind`) still describes the immediate relation, so traces and cycle
errors are unchanged.

A source package can now be resolved once per platform, while
installed-record hints are keyed by package name and source location
only. The build copy and the host copy of such a dependency share one
hint, so one of the two nested solves would be seeded with the other
copy's build and host packages, and the solver locks installed records
in. Drop records of another platform from the hint before each nested
solve; noarch records and records whose subdir is not a known platform
stay.

The `cross-build-dependency` test workspace has `package_a` depend on the
source package `package_b` in both its build and its host section, the
shape the ROS backend produces for a package.xml <depend>. Solving it for
osx-arm64 from linux-64 must label the build copy of `package_b` linux-64
and solve its host environment for linux-64, while the host copy targets
osx-arm64; the `dummy-b` binary from the `dummy_channel_1` test channel
makes each host environment's platform observable through its build
string. A second test feeds the first solution back in as installed
records, the way a re-lock does, and expects the same result.

Fixes #6846

Part of a stacked series for #6846. Based on #6985; review only the last commit.