### PR TITLE
feat(dispatcher): show the build platform of nested derived environments

### DIFF
--- a/crates/pixi_command_dispatcher/src/environment/env_ref.rs
+++ b/crates/pixi_command_dispatcher/src/environment/env_ref.rs
@@ -165,7 +165,16 @@ impl EnvironmentRef {
     pub fn display_platform(&self) -> String {
         match self {
             EnvironmentRef::Workspace(ws) => ws.platform().to_string(),
-            EnvironmentRef::Derived { parent, .. } => parent.display_platform(),
+            EnvironmentRef::Derived {
+                parent,
+                platform: DerivedPlatform::Host,
+                ..
+            } => parent.display_platform(),
+            EnvironmentRef::Derived {
+                parent,
+                platform: DerivedPlatform::Build,
+                ..
+            } => parent.display_build_platform(),
             EnvironmentRef::Ephemeral(eph) => eph.spec.build_environment.host_platform.to_string(),
         }
     }
@@ -187,6 +196,26 @@ impl DerivedParent {
         match self {
             DerivedParent::Workspace(ws) => ws.platform().to_string(),
             DerivedParent::Ephemeral(eph) => eph.spec.build_environment.host_platform.to_string(),
+        }
+    }
+
+    /// Display-only *build* platform for this parent, without registry
+    /// access.
+    pub fn display_build_platform(&self) -> String {
+        match self {
+            DerivedParent::Workspace(ws) => ws.build_platform().to_string(),
+            DerivedParent::Ephemeral(eph) => eph.spec.build_environment.build_platform.to_string(),
+        }
+    }
+
+    /// Whether this parent builds on a different platform than it targets.
+    fn is_cross_compiling(&self) -> bool {
+        match self {
+            DerivedParent::Workspace(ws) => ws.is_cross_compiling(),
+            DerivedParent::Ephemeral(eph) => {
+                eph.spec.build_environment.host_platform
+                    != eph.spec.build_environment.build_platform
+            }
         }
     }
 }
@@ -240,8 +269,16 @@ impl fmt::Display for EnvironmentRef {
                 parent,
                 package,
                 kind,
-                ..
-            } => write!(f, "{kind} of {} in {}", package.as_normalized(), parent),
+                platform,
+            } => {
+                write!(f, "{kind} of {} in {}", package.as_normalized(), parent)?;
+                // Only worth mentioning when it differs from the parent's
+                // own platform.
+                if *platform == DerivedPlatform::Build && parent.is_cross_compiling() {
+                    write!(f, " (build platform {})", parent.display_build_platform())?;
+                }
+                Ok(())
+            }
             EnvironmentRef::Ephemeral(eph) => write!(
                 f,
                 "{}@{}",
@@ -365,6 +402,88 @@ mod tests {
             .derived(pkg("a"), DerivedEnvKind::Host)
             .derived(pkg("b"), DerivedEnvKind::Host);
         assert_eq!(resolve(&nested).build_environment, parent_env);
+    }
+
+    #[test]
+    fn display_reports_the_build_platform_of_nested_build_environments() {
+        let (parent, _) = cross_parent();
+        let nested = parent
+            .derived(pkg("a"), DerivedEnvKind::Build)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        assert_eq!(nested.display_platform(), "linux-64");
+        assert_eq!(
+            nested.to_string(),
+            "Host of b in publish@osx-arm64 (build platform linux-64)"
+        );
+    }
+
+    #[test]
+    fn display_of_direct_build_environments_reports_the_build_platform() {
+        let (parent, _) = cross_parent();
+        let build = parent.derived(pkg("a"), DerivedEnvKind::Build);
+        assert_eq!(build.display_platform(), "linux-64");
+        assert_eq!(
+            build.to_string(),
+            "Build of a in publish@osx-arm64 (build platform linux-64)"
+        );
+    }
+
+    #[test]
+    fn display_of_host_environments_has_no_suffix() {
+        let (parent, _) = cross_parent();
+        let nested = parent
+            .derived(pkg("a"), DerivedEnvKind::Host)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        assert_eq!(nested.display_platform(), "osx-arm64");
+        assert_eq!(nested.to_string(), "Host of b in publish@osx-arm64");
+    }
+
+    #[test]
+    fn display_of_cross_compiling_workspace_parents_reports_the_build_platform() {
+        let (_, build_environment) = cross_parent();
+        let registry = WorkspaceEnvRegistry::new();
+        let workspace = EnvironmentRef::Workspace(registry.allocate(
+            "default".to_string(),
+            Platform::OsxArm64.to_string(),
+            EnvironmentSpec {
+                channels: vec![],
+                build_environment,
+                variants: VariantConfig::default(),
+                exclude_newer: None,
+                channel_priority: ChannelPriority::Strict,
+            },
+        ));
+        let nested = workspace
+            .derived(pkg("a"), DerivedEnvKind::Build)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        assert_eq!(nested.display_platform(), "linux-64");
+        assert_eq!(
+            nested.to_string(),
+            "Host of b in default@osx-arm64 (build platform linux-64)"
+        );
+
+        let host = workspace.derived(pkg("a"), DerivedEnvKind::Host);
+        assert_eq!(host.display_platform(), "osx-arm64");
+        assert_eq!(host.to_string(), "Host of a in default@osx-arm64");
+    }
+
+    #[test]
+    fn display_of_native_parents_never_has_a_suffix() {
+        let native = EnvironmentRef::Ephemeral(EphemeralEnv::new(
+            "test",
+            EnvironmentSpec {
+                channels: vec![],
+                build_environment: BuildEnvironment::simple(Platform::Linux64, vec![]),
+                variants: VariantConfig::default(),
+                exclude_newer: None,
+                channel_priority: ChannelPriority::Strict,
+            },
+        ));
+        let nested = native
+            .derived(pkg("a"), DerivedEnvKind::Build)
+            .derived(pkg("b"), DerivedEnvKind::Host);
+        assert_eq!(nested.display_platform(), "linux-64");
+        assert_eq!(nested.to_string(), "Host of b in test@linux-64");
     }
 
     #[test]

--- a/crates/pixi_command_dispatcher/src/environment/registry.rs
+++ b/crates/pixi_command_dispatcher/src/environment/registry.rs
@@ -78,7 +78,11 @@ impl WorkspaceEnvRegistry {
             u32::try_from(inner.entries.len()).expect("too many workspace envs allocated"),
         );
         inner.entries.push(Arc::new(key.spec.clone()));
-        let env_ref = WorkspaceEnvRef::new(id, key.name.clone(), key.platform.clone());
+        let build_environment = &key.spec.build_environment;
+        let build_platform = (build_environment.build_platform != build_environment.host_platform)
+            .then(|| build_environment.build_platform.to_string());
+        let env_ref =
+            WorkspaceEnvRef::new(id, key.name.clone(), key.platform.clone(), build_platform);
         inner.refs_by_key.insert(key, env_ref.clone());
         env_ref
     }

--- a/crates/pixi_command_dispatcher/src/environment/workspace_env_ref.rs
+++ b/crates/pixi_command_dispatcher/src/environment/workspace_env_ref.rs
@@ -39,11 +39,24 @@ pub(super) struct WorkspaceEnvInner {
     pub(super) id: WorkspaceEnvId,
     pub(super) name: String,
     pub(super) platform: String,
+    /// The platform the environment builds on, when it is not the
+    /// platform it targets. `None` for the common, native case.
+    pub(super) build_platform: Option<String>,
 }
 
 impl WorkspaceEnvRef {
-    pub(super) fn new(id: WorkspaceEnvId, name: String, platform: String) -> Self {
-        Self(Arc::new(WorkspaceEnvInner { id, name, platform }))
+    pub(super) fn new(
+        id: WorkspaceEnvId,
+        name: String,
+        platform: String,
+        build_platform: Option<String>,
+    ) -> Self {
+        Self(Arc::new(WorkspaceEnvInner {
+            id,
+            name,
+            platform,
+            build_platform,
+        }))
     }
 
     #[inline]
@@ -59,6 +72,21 @@ impl WorkspaceEnvRef {
     #[inline]
     pub fn platform(&self) -> &str {
         &self.0.platform
+    }
+
+    /// Display label of the platform the environment builds on. The same
+    /// as [`platform`](Self::platform) unless the environment
+    /// cross-compiles.
+    #[inline]
+    pub fn build_platform(&self) -> &str {
+        self.0.build_platform.as_deref().unwrap_or(&self.0.platform)
+    }
+
+    /// Whether the environment builds on a different platform than it
+    /// targets.
+    #[inline]
+    pub fn is_cross_compiling(&self) -> bool {
+        self.0.build_platform.is_some()
     }
 }
 
@@ -85,7 +113,12 @@ mod tests {
     use super::*;
 
     fn mk(id: u32, name: &str, platform: Platform) -> WorkspaceEnvRef {
-        WorkspaceEnvRef::new(WorkspaceEnvId(id), name.to_string(), platform.to_string())
+        WorkspaceEnvRef::new(
+            WorkspaceEnvId(id),
+            name.to_string(),
+            platform.to_string(),
+            None,
+        )
     }
 
     fn hash_of(ws: &WorkspaceEnvRef) -> u64 {


### PR DESCRIPTION
`display_platform()` of a derived environment reported the parent's host
platform even when the environment is solved for the build platform. Report
the build platform in that case, and let `Display` append "(build platform
<platform>)" when a nested environment targets it while the parent
cross-compiles, so traces, `-vv` logs and the solve reporter's platform
column of a cross build show which platform each nested solve is for.
Native parents render exactly as before.

A workspace environment's build platform is recorded on its
`WorkspaceEnvRef` at allocation when it differs from the platform the
environment targets, so these labels do not assume that workspace
environments never cross-compile; the registry accepts any spec.

Part of a stacked series for #6846. Based on #6986; review only the last commit.