### PR TITLE
docs: explain how source build-dependencies are built when cross-compiling

### DIFF
--- a/docs/build/cross_compilation.md
+++ b/docs/build/cross_compilation.md
@@ -331,6 +331,17 @@ For the `stub` package, output should be
 
 ---
 
+## Source build dependencies
+
+The rules above are about one package. When a workspace package depends on another *source* package of the workspace, the platform that dependency is built for depends on the section it is listed in:
+
+- A source package under `host-dependencies` or `run-dependencies` is built for the target platform, like the package that depends on it.
+- A source package under `build-dependencies` runs during the build, so it is built natively for the build platform. Its own build and host environments are solved for the build platform as well.
+
+A package that is both published in its own right and a build dependency of another published package is therefore built twice during a cross-compiling `pixi publish`: once for the target platform and once for the build platform. That is expected. A backend that lists a dependency in both the build and the host section, as [`pixi-build-ros`](backends/pixi-build-ros.md) does for a `<depend>` in `package.xml`, triggers this for every such workspace sibling.
+
+---
+
 ## Summary
 
 | Issue | Solution |


### PR DESCRIPTION
A source package listed under build-dependencies is built natively for the
build platform, together with its own build and host environments, while
host and run source dependencies target the host platform. Spell this out
in the cross-compilation guide as a section of its own, including the
consequence that a workspace sibling which is both published and a build
dependency is built twice, as it is for a package.xml <depend> with the
ROS backend.

Part of a stacked series for #6846. Based on #6987; review only the last commit.