### PR TITLE
fix: concurrency config set correctly targets concurrency config

### DIFF
--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -3894,6 +3894,20 @@ UNUSED = "unused"
         assert_eq!(config.max_concurrent_solves(), 5);
         assert_eq!(config.max_concurrent_downloads(), 25);
 
+        // Test concurrency full update (issue #6666)
+        config.pypi_config.index_url = Some(Url::parse("https://my-index.test").unwrap());
+        config
+            .set("concurrency", Some(r#"{"solves": 10, "downloads": 50}"#.to_string()))
+            .unwrap();
+        assert_eq!(config.concurrency.solves, 10);
+        assert_eq!(config.concurrency.downloads, 50);
+        assert_eq!(config.pypi_config.index_url, Some(Url::parse("https://my-index.test").unwrap()));
+
+        config.set("concurrency", None).unwrap();
+        assert_eq!(config.concurrency.solves, ConcurrencyConfig::default().solves);
+        assert_eq!(config.concurrency.downloads, ConcurrencyConfig::default().downloads);
+        assert_eq!(config.pypi_config.index_url, Some(Url::parse("https://my-index.test").unwrap()));
+
         // Test tls-no-verify
         config
             .set("tls-no-verify", Some("true".to_string()))

--- a/crates/pixi_config/src/lib.rs
+++ b/crates/pixi_config/src/lib.rs
@@ -2508,9 +2508,9 @@ impl Config {
             key if key.starts_with("concurrency") => {
                 if key == "concurrency" {
                     if let Some(value) = value {
-                        self.pypi_config = serde_json::de::from_str(&value).into_diagnostic()?;
+                        self.concurrency = serde_json::de::from_str(&value).into_diagnostic()?;
                     } else {
-                        self.pypi_config = PyPIConfig::default();
+                        self.concurrency = ConcurrencyConfig::default();
                     }
                     return Ok(());
                 } else if !key.starts_with("concurrency.") {


### PR DESCRIPTION
Fixes #6666

This PR fixes a bug where `pixi config set concurrency` was incorrectly targeting `self.pypi_config` instead of `self.concurrency` when setting the entire concurrency object. 

Added regression tests to ensure `pixi config set concurrency` properly updates the concurrency values and leaves `pypi-config` unmodified.